### PR TITLE
feat: finalize operator deployment configuration

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -30,26 +30,7 @@ spec:
         control-plane: controller-manager
         app.kubernetes.io/name: omnia
     spec:
-      # TODO(user): Uncomment the following code to configure the nodeAffinity expression
-      # according to the platforms which are supported by your solution.
-      # It is considered best practice to support multiple architectures. You can
-      # build your manager image using the makefile target docker-buildx.
-      # affinity:
-      #   nodeAffinity:
-      #     requiredDuringSchedulingIgnoredDuringExecution:
-      #       nodeSelectorTerms:
-      #         - matchExpressions:
-      #           - key: kubernetes.io/arch
-      #             operator: In
-      #             values:
-      #               - amd64
-      #               - arm64
-      #               - ppc64le
-      #               - s390x
-      #           - key: kubernetes.io/os
-      #             operator: In
-      #             values:
-      #               - linux
+      # Node affinity can be configured here if needed for multi-arch support
       securityContext:
         # Projects are configured by default to adhere to the "restricted" Pod Security Standards.
         # This ensures that deployments meet the highest security requirements for Kubernetes.
@@ -84,8 +65,7 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
-        # TODO(user): Configure the resources accordingly based on the project requirements.
-        # More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+        # Resource limits for the controller manager
         resources:
           limits:
             cpu: 500m

--- a/config/samples/omnia_v1alpha1_agentruntime.yaml
+++ b/config/samples/omnia_v1alpha1_agentruntime.yaml
@@ -4,6 +4,53 @@ metadata:
   labels:
     app.kubernetes.io/name: omnia
     app.kubernetes.io/managed-by: kustomize
-  name: agentruntime-sample
+  name: customer-support-agent
 spec:
-  # TODO(user): Add fields here
+  # Reference to the PromptPack containing agent prompts
+  promptPackRef:
+    name: customer-support
+    track: stable
+  # WebSocket facade for client connections
+  facade:
+    type: websocket
+    port: 8080
+  # Optional tool registry reference
+  toolRegistryRef:
+    name: support-tools
+  # Session configuration using Redis
+  session:
+    type: redis
+    storeRef:
+      name: redis-credentials
+    ttl: "24h"
+  # Deployment configuration
+  runtime:
+    replicas: 2
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "500m"
+        memory: "512Mi"
+  # LLM provider credentials
+  providerSecretRef:
+    name: openai-credentials
+---
+# Secret containing LLM provider API key
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-credentials
+type: Opaque
+stringData:
+  api-key: "your-openai-api-key-here"
+---
+# Secret containing Redis connection URL
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-credentials
+type: Opaque
+stringData:
+  url: "redis://redis.cache.svc.cluster.local:6379"

--- a/config/samples/omnia_v1alpha1_promptpack.yaml
+++ b/config/samples/omnia_v1alpha1_promptpack.yaml
@@ -4,6 +4,30 @@ metadata:
   labels:
     app.kubernetes.io/name: omnia
     app.kubernetes.io/managed-by: kustomize
-  name: promptpack-sample
+  name: customer-support
 spec:
-  # TODO(user): Add fields here
+  # Source configuration - prompts stored in a ConfigMap
+  source:
+    type: configmap
+    configMapRef:
+      name: customer-support-prompts
+  # Semantic version for this prompt pack
+  version: "1.0.0"
+  # Rollout strategy - immediate deployment
+  rollout:
+    type: immediate
+---
+# ConfigMap containing the prompt configuration
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: customer-support-prompts
+data:
+  system.txt: |
+    You are a helpful customer support agent for TechCorp.
+    Be polite, professional, and helpful. If you cannot
+    answer a question, offer to escalate to a human agent.
+  config.yaml: |
+    model: gpt-4
+    temperature: 0.7
+    max_tokens: 1024

--- a/config/samples/omnia_v1alpha1_toolregistry.yaml
+++ b/config/samples/omnia_v1alpha1_toolregistry.yaml
@@ -4,6 +4,26 @@ metadata:
   labels:
     app.kubernetes.io/name: omnia
     app.kubernetes.io/managed-by: kustomize
-  name: toolregistry-sample
+  name: support-tools
 spec:
-  # TODO(user): Add fields here
+  tools:
+    # Tool for looking up order status
+    - name: order-lookup
+      description: Look up the status of a customer order by order ID
+      type: http
+      endpoint:
+        url: "http://orders-api.backend.svc.cluster.local:8080/api/v1/orders"
+      timeout: "10s"
+      retries: 2
+    # Tool for checking product inventory
+    - name: inventory-check
+      description: Check product availability and stock levels
+      type: http
+      endpoint:
+        # Use service discovery instead of direct URL
+        selector:
+          matchLabels:
+            app: inventory-service
+          namespace: backend
+          port: "http"
+      timeout: "5s"


### PR DESCRIPTION
## Summary

- Clean up TODO comments in manager deployment manifest
- Add comprehensive sample manifests demonstrating all CRD features

## Changes

### config/manager/manager.yaml
- Removed TODO comments about nodeAffinity (can be configured by users)
- Simplified resources comment

### config/samples/
- **omnia_v1alpha1_promptpack.yaml**: Complete PromptPack with ConfigMap source and rollout strategy
- **omnia_v1alpha1_toolregistry.yaml**: ToolRegistry with HTTP tools and service discovery
- **omnia_v1alpha1_agentruntime.yaml**: Full AgentRuntime with all configuration options plus supporting secrets

## Notes

The operator deployment was already functional via kubebuilder scaffolding:
- ✅ Manager entrypoint (cmd/main.go)
- ✅ All controllers registered
- ✅ Leader election configured
- ✅ Health/metrics endpoints
- ✅ Multi-stage Dockerfile
- ✅ RBAC configuration

This PR cleans up placeholders and adds useful examples for users.

## Test Plan

- [x] Build passes
- [x] Tests pass
- [ ] Sample manifests are valid YAML

Closes #11