### PR TITLE
feat: refactor facade to delegate to runtime via gRPC

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -17,6 +17,7 @@ RUN go mod download
 COPY cmd/ cmd/
 COPY api/ api/
 COPY internal/ internal/
+COPY pkg/ pkg/
 
 # Build the agent binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \

--- a/internal/agent/config_test.go
+++ b/internal/agent/config_test.go
@@ -278,7 +278,7 @@ func TestConfigValidate(t *testing.T) {
 			wantErr: ErrMissingPromptPack,
 		},
 		{
-			name: "missing provider key for runtime handler",
+			name: "runtime handler mode valid without provider key",
 			config: &Config{
 				AgentName:      "test-agent",
 				Namespace:      "default",
@@ -287,7 +287,7 @@ func TestConfigValidate(t *testing.T) {
 				HandlerMode:    HandlerModeRuntime,
 				SessionType:    SessionTypeMemory,
 			},
-			wantErr: ErrMissingProviderKey,
+			wantErr: nil, // Facade delegates to runtime sidecar which handles provider keys
 		},
 		{
 			name: "invalid handler mode",

--- a/internal/agent/echo_handler_test.go
+++ b/internal/agent/echo_handler_test.go
@@ -29,6 +29,7 @@ type mockResponseWriter struct {
 	doneMsg     string
 	toolCalls   []*facade.ToolCallInfo
 	toolResults []*facade.ToolResultInfo
+	errors      []struct{ code, message string }
 	err         error
 }
 
@@ -65,6 +66,10 @@ func (m *mockResponseWriter) WriteToolResult(info *facade.ToolResultInfo) error 
 }
 
 func (m *mockResponseWriter) WriteError(code, message string) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.errors = append(m.errors, struct{ code, message string }{code, message})
 	return nil
 }
 

--- a/internal/agent/runtime_handler.go
+++ b/internal/agent/runtime_handler.go
@@ -1,0 +1,153 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/altairalabs/omnia/internal/facade"
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// RuntimeHandler delegates message handling to the runtime sidecar via gRPC.
+type RuntimeHandler struct {
+	client *facade.RuntimeClient
+}
+
+// NewRuntimeHandler creates a new RuntimeHandler with the given client.
+func NewRuntimeHandler(client *facade.RuntimeClient) *RuntimeHandler {
+	return &RuntimeHandler{
+		client: client,
+	}
+}
+
+// Name returns the handler name for metrics.
+func (h *RuntimeHandler) Name() string {
+	return "runtime"
+}
+
+// HandleMessage sends the message to the runtime and streams responses back.
+func (h *RuntimeHandler) HandleMessage(
+	ctx context.Context,
+	sessionID string,
+	msg *facade.ClientMessage,
+	writer facade.ResponseWriter,
+) error {
+	// Open bidirectional stream to runtime
+	stream, err := h.client.Converse(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to open stream to runtime: %w", err)
+	}
+
+	// Convert metadata to string map
+	metadata := make(map[string]string)
+	for k, v := range msg.Metadata {
+		metadata[k] = v
+	}
+
+	// Send client message to runtime
+	grpcMsg := &runtimev1.ClientMessage{
+		SessionId: sessionID,
+		Content:   msg.Content,
+		Metadata:  metadata,
+	}
+
+	if err := stream.Send(grpcMsg); err != nil {
+		return fmt.Errorf("failed to send message to runtime: %w", err)
+	}
+
+	// Close send side to signal we're done sending
+	if err := stream.CloseSend(); err != nil {
+		return fmt.Errorf("failed to close send: %w", err)
+	}
+
+	// Receive and forward responses
+	for {
+		resp, err := stream.Recv()
+		if err == io.EOF {
+			// Stream completed normally
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error receiving from runtime: %w", err)
+		}
+
+		// Forward response to client via ResponseWriter
+		if err := h.forwardResponse(resp, writer); err != nil {
+			return fmt.Errorf("error forwarding response: %w", err)
+		}
+	}
+}
+
+// forwardResponse translates a gRPC ServerMessage to WebSocket response.
+func (h *RuntimeHandler) forwardResponse(resp *runtimev1.ServerMessage, writer facade.ResponseWriter) error {
+	switch msg := resp.Message.(type) {
+	case *runtimev1.ServerMessage_Chunk:
+		return writer.WriteChunk(msg.Chunk.Content)
+
+	case *runtimev1.ServerMessage_Done:
+		return writer.WriteDone(msg.Done.FinalContent)
+
+	case *runtimev1.ServerMessage_ToolCall:
+		// Parse arguments JSON to map
+		var args map[string]interface{}
+		if msg.ToolCall.ArgumentsJson != "" {
+			if err := json.Unmarshal([]byte(msg.ToolCall.ArgumentsJson), &args); err != nil {
+				// If parsing fails, use raw JSON as single argument
+				args = map[string]interface{}{"raw": msg.ToolCall.ArgumentsJson}
+			}
+		}
+		return writer.WriteToolCall(&facade.ToolCallInfo{
+			ID:        msg.ToolCall.Id,
+			Name:      msg.ToolCall.Name,
+			Arguments: args,
+		})
+
+	case *runtimev1.ServerMessage_ToolResult:
+		// Parse result JSON
+		var result interface{}
+		if msg.ToolResult.ResultJson != "" {
+			if err := json.Unmarshal([]byte(msg.ToolResult.ResultJson), &result); err != nil {
+				result = msg.ToolResult.ResultJson
+			}
+		}
+		toolResult := &facade.ToolResultInfo{
+			ID:     msg.ToolResult.Id,
+			Result: result,
+		}
+		if msg.ToolResult.IsError {
+			toolResult.Error = fmt.Sprintf("%v", result)
+			toolResult.Result = nil
+		}
+		return writer.WriteToolResult(toolResult)
+
+	case *runtimev1.ServerMessage_Error:
+		return writer.WriteError(msg.Error.Code, msg.Error.Message)
+
+	default:
+		// Unknown message type, ignore
+		return nil
+	}
+}
+
+// Client returns the underlying runtime client for health checks.
+func (h *RuntimeHandler) Client() *facade.RuntimeClient {
+	return h.client
+}

--- a/internal/agent/runtime_handler_test.go
+++ b/internal/agent/runtime_handler_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/altairalabs/omnia/internal/facade"
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// mockRuntimeServer implements RuntimeServiceServer for testing.
+type mockRuntimeServer struct {
+	runtimev1.UnimplementedRuntimeServiceServer
+	responses []*runtimev1.ServerMessage
+	healthy   bool
+	status    string
+}
+
+func (s *mockRuntimeServer) Converse(stream runtimev1.RuntimeService_ConverseServer) error {
+	// Receive the client message
+	_, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+
+	// Send back the configured responses
+	for _, resp := range s.responses {
+		if err := stream.Send(resp); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *mockRuntimeServer) Health(_ context.Context, _ *runtimev1.HealthRequest) (*runtimev1.HealthResponse, error) {
+	return &runtimev1.HealthResponse{
+		Healthy: s.healthy,
+		Status:  s.status,
+	}, nil
+}
+
+func startMockServer(t *testing.T, mock *mockRuntimeServer) (string, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	runtimev1.RegisterRuntimeServiceServer(server, mock)
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	cleanup := func() {
+		server.Stop()
+	}
+
+	return lis.Addr().String(), cleanup
+}
+
+func TestRuntimeHandler_Name(t *testing.T) {
+	handler := NewRuntimeHandler(nil)
+	assert.Equal(t, "runtime", handler.Name())
+}
+
+func TestRuntimeHandler_HandleMessage_Chunks(t *testing.T) {
+	mock := &mockRuntimeServer{
+		responses: []*runtimev1.ServerMessage{
+			{Message: &runtimev1.ServerMessage_Chunk{Chunk: &runtimev1.Chunk{Content: "Hello "}}},
+			{Message: &runtimev1.ServerMessage_Chunk{Chunk: &runtimev1.Chunk{Content: "world"}}},
+			{Message: &runtimev1.ServerMessage_Done{Done: &runtimev1.Done{FinalContent: "Hello world"}}},
+		},
+		healthy: true,
+	}
+
+	addr, cleanup := startMockServer(t, mock)
+	defer cleanup()
+
+	client, err := facade.NewRuntimeClient(facade.RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	handler := NewRuntimeHandler(client)
+	writer := &mockResponseWriter{}
+
+	msg := &facade.ClientMessage{
+		Content: "Hello",
+	}
+
+	err = handler.HandleMessage(context.Background(), "session-123", msg, writer)
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"Hello ", "world"}, writer.chunks)
+	assert.Equal(t, "Hello world", writer.doneMsg)
+}
+
+func TestRuntimeHandler_HandleMessage_ToolCall(t *testing.T) {
+	mock := &mockRuntimeServer{
+		responses: []*runtimev1.ServerMessage{
+			{Message: &runtimev1.ServerMessage_ToolCall{ToolCall: &runtimev1.ToolCall{
+				Id:            "call-1",
+				Name:          "weather",
+				ArgumentsJson: `{"location": "Denver"}`,
+			}}},
+			{Message: &runtimev1.ServerMessage_ToolResult{ToolResult: &runtimev1.ToolResult{
+				Id:         "call-1",
+				ResultJson: `{"temp": 72}`,
+				IsError:    false,
+			}}},
+			{Message: &runtimev1.ServerMessage_Done{Done: &runtimev1.Done{FinalContent: "It's 72°F"}}},
+		},
+		healthy: true,
+	}
+
+	addr, cleanup := startMockServer(t, mock)
+	defer cleanup()
+
+	client, err := facade.NewRuntimeClient(facade.RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	handler := NewRuntimeHandler(client)
+	writer := &mockResponseWriter{}
+
+	msg := &facade.ClientMessage{
+		Content: "What's the weather?",
+	}
+
+	err = handler.HandleMessage(context.Background(), "session-123", msg, writer)
+	require.NoError(t, err)
+
+	require.Len(t, writer.toolCalls, 1)
+	assert.Equal(t, "call-1", writer.toolCalls[0].ID)
+	assert.Equal(t, "weather", writer.toolCalls[0].Name)
+	assert.Equal(t, "Denver", writer.toolCalls[0].Arguments["location"])
+
+	require.Len(t, writer.toolResults, 1)
+	assert.Equal(t, "call-1", writer.toolResults[0].ID)
+
+	assert.Equal(t, "It's 72°F", writer.doneMsg)
+}
+
+func TestRuntimeHandler_HandleMessage_Error(t *testing.T) {
+	mock := &mockRuntimeServer{
+		responses: []*runtimev1.ServerMessage{
+			{Message: &runtimev1.ServerMessage_Error{Error: &runtimev1.Error{
+				Code:    "RATE_LIMITED",
+				Message: "Too many requests",
+			}}},
+		},
+		healthy: true,
+	}
+
+	addr, cleanup := startMockServer(t, mock)
+	defer cleanup()
+
+	client, err := facade.NewRuntimeClient(facade.RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	handler := NewRuntimeHandler(client)
+	writer := &mockResponseWriter{}
+
+	msg := &facade.ClientMessage{
+		Content: "Hello",
+	}
+
+	err = handler.HandleMessage(context.Background(), "session-123", msg, writer)
+	require.NoError(t, err)
+
+	require.Len(t, writer.errors, 1)
+	assert.Equal(t, "RATE_LIMITED", writer.errors[0].code)
+	assert.Equal(t, "Too many requests", writer.errors[0].message)
+}
+
+func TestRuntimeHandler_Client(t *testing.T) {
+	mock := &mockRuntimeServer{healthy: true, status: "ok"}
+
+	addr, cleanup := startMockServer(t, mock)
+	defer cleanup()
+
+	client, err := facade.NewRuntimeClient(facade.RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	handler := NewRuntimeHandler(client)
+	assert.Equal(t, client, handler.Client())
+
+	// Test health through the exposed client
+	resp, err := handler.Client().Health(context.Background())
+	require.NoError(t, err)
+	assert.True(t, resp.Healthy)
+	assert.Equal(t, "ok", resp.Status)
+}
+
+func TestRuntimeClient_ConnectionFailure(t *testing.T) {
+	_, err := facade.NewRuntimeClient(facade.RuntimeClientConfig{
+		Address:     "localhost:99999",
+		DialTimeout: 100 * time.Millisecond,
+	})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect to runtime")
+}
+
+func TestRuntimeClient_Health(t *testing.T) {
+	mock := &mockRuntimeServer{
+		healthy: true,
+		status:  "ready",
+	}
+
+	addr, cleanup := startMockServer(t, mock)
+	defer cleanup()
+
+	client, err := facade.NewRuntimeClient(facade.RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	resp, err := client.Health(context.Background())
+	require.NoError(t, err)
+	assert.True(t, resp.Healthy)
+	assert.Equal(t, "ready", resp.Status)
+}

--- a/internal/facade/runtime_client.go
+++ b/internal/facade/runtime_client.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// RuntimeClient wraps the gRPC client for communicating with the runtime sidecar.
+type RuntimeClient struct {
+	conn   *grpc.ClientConn
+	client runtimev1.RuntimeServiceClient
+	addr   string
+}
+
+// RuntimeClientConfig contains configuration for the runtime client.
+type RuntimeClientConfig struct {
+	// Address is the runtime gRPC server address (e.g., "localhost:9000").
+	Address string
+	// DialTimeout is the timeout for establishing the connection.
+	DialTimeout time.Duration
+}
+
+// DefaultRuntimeClientConfig returns a RuntimeClientConfig with default values.
+func DefaultRuntimeClientConfig() RuntimeClientConfig {
+	return RuntimeClientConfig{
+		Address:     "localhost:9000",
+		DialTimeout: 10 * time.Second,
+	}
+}
+
+// NewRuntimeClient creates a new RuntimeClient connected to the runtime sidecar.
+func NewRuntimeClient(cfg RuntimeClientConfig) (*RuntimeClient, error) {
+	// Use insecure credentials for localhost sidecar communication.
+	// In production, mTLS could be added for enhanced security.
+	conn, err := grpc.NewClient(cfg.Address,
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create runtime client for %s: %w", cfg.Address, err)
+	}
+
+	client := &RuntimeClient{
+		conn:   conn,
+		client: runtimev1.NewRuntimeServiceClient(conn),
+		addr:   cfg.Address,
+	}
+
+	// Verify connection with a health check
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.DialTimeout)
+	defer cancel()
+
+	_, err = client.Health(ctx)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("failed to connect to runtime at %s: %w", cfg.Address, err)
+	}
+
+	return client, nil
+}
+
+// Converse opens a bidirectional streaming RPC for conversation.
+func (c *RuntimeClient) Converse(ctx context.Context) (runtimev1.RuntimeService_ConverseClient, error) {
+	return c.client.Converse(ctx)
+}
+
+// Health checks the runtime's health status.
+func (c *RuntimeClient) Health(ctx context.Context) (*runtimev1.HealthResponse, error) {
+	return c.client.Health(ctx, &runtimev1.HealthRequest{})
+}
+
+// Close closes the gRPC connection.
+func (c *RuntimeClient) Close() error {
+	if c.conn != nil {
+		return c.conn.Close()
+	}
+	return nil
+}
+
+// Address returns the runtime address.
+func (c *RuntimeClient) Address() string {
+	return c.addr
+}

--- a/internal/facade/runtime_client_test.go
+++ b/internal/facade/runtime_client_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// mockRuntimeServer implements RuntimeServiceServer for testing.
+type mockRuntimeServer struct {
+	runtimev1.UnimplementedRuntimeServiceServer
+	healthy bool
+	status  string
+}
+
+func (s *mockRuntimeServer) Health(_ context.Context, _ *runtimev1.HealthRequest) (*runtimev1.HealthResponse, error) {
+	return &runtimev1.HealthResponse{
+		Healthy: s.healthy,
+		Status:  s.status,
+	}, nil
+}
+
+func (s *mockRuntimeServer) Converse(stream runtimev1.RuntimeService_ConverseServer) error {
+	// Simple echo for testing
+	msg, err := stream.Recv()
+	if err != nil {
+		return err
+	}
+	return stream.Send(&runtimev1.ServerMessage{
+		Message: &runtimev1.ServerMessage_Done{
+			Done: &runtimev1.Done{FinalContent: msg.Content},
+		},
+	})
+}
+
+func startTestServer(t *testing.T, mock *mockRuntimeServer) (string, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer()
+	runtimev1.RegisterRuntimeServiceServer(server, mock)
+
+	go func() {
+		_ = server.Serve(lis)
+	}()
+
+	cleanup := func() {
+		server.Stop()
+	}
+
+	return lis.Addr().String(), cleanup
+}
+
+func TestDefaultRuntimeClientConfig(t *testing.T) {
+	cfg := DefaultRuntimeClientConfig()
+
+	assert.Equal(t, "localhost:9000", cfg.Address)
+	assert.Equal(t, 10*time.Second, cfg.DialTimeout)
+}
+
+func TestNewRuntimeClient_Success(t *testing.T) {
+	mock := &mockRuntimeServer{healthy: true, status: "ready"}
+	addr, cleanup := startTestServer(t, mock)
+	defer cleanup()
+
+	client, err := NewRuntimeClient(RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	assert.NotNil(t, client)
+	assert.Equal(t, addr, client.Address())
+}
+
+func TestNewRuntimeClient_ConnectionFailure(t *testing.T) {
+	// Try to connect to a non-existent server
+	_, err := NewRuntimeClient(RuntimeClientConfig{
+		Address:     "localhost:59999",
+		DialTimeout: 100 * time.Millisecond,
+	})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to connect to runtime")
+}
+
+func TestRuntimeClient_Health(t *testing.T) {
+	mock := &mockRuntimeServer{healthy: true, status: "all systems go"}
+	addr, cleanup := startTestServer(t, mock)
+	defer cleanup()
+
+	client, err := NewRuntimeClient(RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	resp, err := client.Health(context.Background())
+	require.NoError(t, err)
+
+	assert.True(t, resp.Healthy)
+	assert.Equal(t, "all systems go", resp.Status)
+}
+
+func TestRuntimeClient_Converse(t *testing.T) {
+	mock := &mockRuntimeServer{healthy: true}
+	addr, cleanup := startTestServer(t, mock)
+	defer cleanup()
+
+	client, err := NewRuntimeClient(RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	stream, err := client.Converse(context.Background())
+	require.NoError(t, err)
+
+	// Send a message
+	err = stream.Send(&runtimev1.ClientMessage{
+		SessionId: "test-session",
+		Content:   "Hello",
+	})
+	require.NoError(t, err)
+
+	err = stream.CloseSend()
+	require.NoError(t, err)
+
+	// Receive response
+	resp, err := stream.Recv()
+	require.NoError(t, err)
+
+	done := resp.GetDone()
+	require.NotNil(t, done)
+	assert.Equal(t, "Hello", done.FinalContent)
+}
+
+func TestRuntimeClient_Close(t *testing.T) {
+	mock := &mockRuntimeServer{healthy: true}
+	addr, cleanup := startTestServer(t, mock)
+	defer cleanup()
+
+	client, err := NewRuntimeClient(RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Close should succeed
+	err = client.Close()
+	assert.NoError(t, err)
+
+	// Health check should fail after close
+	_, err = client.Health(context.Background())
+	assert.Error(t, err)
+}
+
+func TestRuntimeClient_Address(t *testing.T) {
+	mock := &mockRuntimeServer{healthy: true}
+	addr, cleanup := startTestServer(t, mock)
+	defer cleanup()
+
+	client, err := NewRuntimeClient(RuntimeClientConfig{
+		Address:     addr,
+		DialTimeout: 5 * time.Second,
+	})
+	require.NoError(t, err)
+	defer func() { _ = client.Close() }()
+
+	assert.Equal(t, addr, client.Address())
+}


### PR DESCRIPTION
## Summary

- Add `RuntimeClient` for gRPC communication with the runtime sidecar
- Create `RuntimeHandler` implementing the `MessageHandler` interface
- Translate WebSocket messages to gRPC `ClientMessage`
- Stream gRPC `ServerMessage` back to WebSocket
- Add readiness probe that checks runtime health via gRPC Health RPC
- Add `OMNIA_RUNTIME_ADDRESS` environment variable (default: `localhost:9000`)

## Handler Modes

| Mode | Description |
|------|-------------|
| `echo` | Echoes back input (for testing) |
| `demo` | Canned responses with streaming simulation (for demos) |
| `runtime` | Delegates to gRPC runtime sidecar (production) |

## Files Changed

- `internal/facade/runtime_client.go` - gRPC client wrapper
- `internal/agent/runtime_handler.go` - Handler that delegates to runtime
- `internal/agent/config.go` - Added `OMNIA_RUNTIME_ADDRESS` config
- `cmd/agent/main.go` - Updated to create RuntimeHandler and check runtime health

## Test plan

- [x] Unit tests for RuntimeHandler with mock gRPC server
- [x] Tests for message translation (chunks, tool calls, tool results, errors)
- [x] Tests for RuntimeClient connection and health check
- [ ] CI pipeline passes

Closes #48