### PR TITLE
feat: implement HTTP tool adapter for runtime

### DIFF
--- a/internal/runtime/tools/config.go
+++ b/internal/runtime/tools/config.go
@@ -42,8 +42,12 @@ type ToolEntry struct {
 
 // HTTPCfg represents HTTP configuration for a tool.
 type HTTPCfg struct {
-	Endpoint string `json:"endpoint" yaml:"endpoint"`
-	Method   string `json:"method,omitempty" yaml:"method,omitempty"`
+	Endpoint    string            `json:"endpoint" yaml:"endpoint"`
+	Method      string            `json:"method,omitempty" yaml:"method,omitempty"`
+	Headers     map[string]string `json:"headers,omitempty" yaml:"headers,omitempty"`
+	ContentType string            `json:"contentType,omitempty" yaml:"contentType,omitempty"`
+	AuthType    string            `json:"authType,omitempty" yaml:"authType,omitempty"`
+	AuthToken   string            `json:"authToken,omitempty" yaml:"authToken,omitempty"`
 }
 
 // GRPCCfg represents gRPC configuration for a tool.

--- a/internal/runtime/tools/http_adapter.go
+++ b/internal/runtime/tools/http_adapter.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// HTTPAdapterConfig contains configuration for the HTTP adapter.
+type HTTPAdapterConfig struct {
+	// Name is the adapter's unique name.
+	Name string
+
+	// Endpoint is the HTTP endpoint URL.
+	Endpoint string
+
+	// Method is the HTTP method (GET, POST, PUT, DELETE). Defaults to POST.
+	Method string
+
+	// Headers are custom HTTP headers to include in requests.
+	Headers map[string]string
+
+	// ContentType is the Content-Type header. Defaults to application/json.
+	ContentType string
+
+	// AuthType is the authentication type: "bearer", "basic", or empty for none.
+	AuthType string
+
+	// AuthToken is the authentication token or credentials.
+	// For bearer: the token value
+	// For basic: "username:password"
+	AuthToken string
+
+	// Timeout is the request timeout.
+	Timeout time.Duration
+}
+
+// HTTPAdapter implements ToolAdapter for HTTP tool endpoints.
+type HTTPAdapter struct {
+	config    HTTPAdapterConfig
+	log       logr.Logger
+	client    *http.Client
+	tools     map[string]ToolInfo
+	mu        sync.RWMutex
+	connected bool
+}
+
+// NewHTTPAdapter creates a new HTTP adapter.
+func NewHTTPAdapter(config HTTPAdapterConfig, log logr.Logger) *HTTPAdapter {
+	if config.Timeout == 0 {
+		config.Timeout = 30 * time.Second
+	}
+	if config.Method == "" {
+		config.Method = http.MethodPost
+	}
+	if config.ContentType == "" {
+		config.ContentType = "application/json"
+	}
+	return &HTTPAdapter{
+		config: config,
+		log:    log.WithValues("adapter", config.Name, "endpoint", config.Endpoint),
+		tools:  make(map[string]ToolInfo),
+	}
+}
+
+// Name returns the adapter's name.
+func (a *HTTPAdapter) Name() string {
+	return a.config.Name
+}
+
+// Connect initializes the HTTP client and validates the endpoint.
+func (a *HTTPAdapter) Connect(ctx context.Context) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	// Validate endpoint URL
+	if _, err := url.Parse(a.config.Endpoint); err != nil {
+		return fmt.Errorf("invalid endpoint URL: %w", err)
+	}
+
+	// Create HTTP client with timeout
+	a.client = &http.Client{
+		Timeout: a.config.Timeout,
+	}
+
+	// Register the tool with its name
+	// HTTP tools are single-purpose, so the adapter name is the tool name
+	a.tools[a.config.Name] = ToolInfo{
+		Name:        a.config.Name,
+		Description: fmt.Sprintf("HTTP tool at %s", a.config.Endpoint),
+		InputSchema: map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+		},
+	}
+
+	a.connected = true
+	a.log.Info("HTTP adapter connected", "method", a.config.Method)
+	return nil
+}
+
+// ListTools returns available tools from this adapter.
+func (a *HTTPAdapter) ListTools(ctx context.Context) ([]ToolInfo, error) {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+
+	tools := make([]ToolInfo, 0, len(a.tools))
+	for _, tool := range a.tools {
+		tools = append(tools, tool)
+	}
+	return tools, nil
+}
+
+// Call invokes the HTTP endpoint with the given arguments.
+func (a *HTTPAdapter) Call(ctx context.Context, name string, args map[string]any) (*ToolResult, error) {
+	a.mu.RLock()
+	client := a.client
+	connected := a.connected
+	a.mu.RUnlock()
+
+	if !connected || client == nil {
+		return nil, fmt.Errorf("adapter not connected")
+	}
+
+	a.log.V(1).Info("calling HTTP tool", "name", name, "method", a.config.Method)
+
+	// Build request
+	req, err := a.buildRequest(ctx, args)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request: %w", err)
+	}
+
+	// Execute request
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	// Check for HTTP errors
+	if resp.StatusCode >= 400 {
+		return &ToolResult{
+			Content: fmt.Sprintf("HTTP %d: %s", resp.StatusCode, string(body)),
+			IsError: true,
+		}, nil
+	}
+
+	// Parse response as JSON if possible
+	var content any
+	if err := json.Unmarshal(body, &content); err != nil {
+		// If not JSON, return as string
+		content = string(body)
+	}
+
+	return &ToolResult{
+		Content: content,
+		IsError: false,
+	}, nil
+}
+
+// buildRequest creates an HTTP request with the configured options.
+func (a *HTTPAdapter) buildRequest(ctx context.Context, args map[string]any) (*http.Request, error) {
+	var reqBody io.Reader
+	endpoint := a.config.Endpoint
+
+	method := strings.ToUpper(a.config.Method)
+
+	// For GET/DELETE, encode args as query parameters
+	// For POST/PUT/PATCH, encode args as JSON body
+	switch method {
+	case http.MethodGet, http.MethodDelete:
+		if len(args) > 0 {
+			u, err := url.Parse(endpoint)
+			if err != nil {
+				return nil, err
+			}
+			q := u.Query()
+			for k, v := range args {
+				q.Set(k, fmt.Sprintf("%v", v))
+			}
+			u.RawQuery = q.Encode()
+			endpoint = u.String()
+		}
+	default:
+		// POST, PUT, PATCH - encode as JSON body
+		if args != nil {
+			jsonBody, err := json.Marshal(args)
+			if err != nil {
+				return nil, fmt.Errorf("failed to marshal arguments: %w", err)
+			}
+			reqBody = bytes.NewReader(jsonBody)
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set Content-Type for requests with body
+	if reqBody != nil {
+		req.Header.Set("Content-Type", a.config.ContentType)
+	}
+
+	// Set custom headers
+	for k, v := range a.config.Headers {
+		req.Header.Set(k, v)
+	}
+
+	// Set authentication
+	if err := a.setAuth(req); err != nil {
+		return nil, err
+	}
+
+	return req, nil
+}
+
+// setAuth sets the authentication header on the request.
+func (a *HTTPAdapter) setAuth(req *http.Request) error {
+	switch strings.ToLower(a.config.AuthType) {
+	case "bearer":
+		if a.config.AuthToken == "" {
+			return fmt.Errorf("bearer auth requires a token")
+		}
+		req.Header.Set("Authorization", "Bearer "+a.config.AuthToken)
+	case "basic":
+		if a.config.AuthToken == "" {
+			return fmt.Errorf("basic auth requires credentials")
+		}
+		// AuthToken should be "username:password"
+		parts := strings.SplitN(a.config.AuthToken, ":", 2)
+		if len(parts) != 2 {
+			return fmt.Errorf("basic auth token must be 'username:password'")
+		}
+		req.SetBasicAuth(parts[0], parts[1])
+	case "":
+		// No authentication
+	default:
+		return fmt.Errorf("unsupported auth type: %s", a.config.AuthType)
+	}
+	return nil
+}
+
+// Close closes the adapter.
+func (a *HTTPAdapter) Close() error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.client != nil {
+		a.log.Info("closing HTTP adapter")
+		// HTTP client doesn't need explicit closing, but we clear state
+		a.client = nil
+		a.connected = false
+	}
+
+	a.tools = make(map[string]ToolInfo)
+	return nil
+}

--- a/internal/runtime/tools/http_adapter_test.go
+++ b/internal/runtime/tools/http_adapter_test.go
@@ -1,0 +1,603 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func TestHTTPAdapter_Name(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: "http://localhost:8080/api",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+	if adapter.Name() != "test-http" {
+		t.Errorf("expected name 'test-http', got %q", adapter.Name())
+	}
+}
+
+func TestHTTPAdapter_DefaultValues(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: "http://localhost:8080/api",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+	if adapter.config.Timeout != 30*time.Second {
+		t.Errorf("expected default timeout 30s, got %v", adapter.config.Timeout)
+	}
+	if adapter.config.Method != http.MethodPost {
+		t.Errorf("expected default method POST, got %q", adapter.config.Method)
+	}
+	if adapter.config.ContentType != "application/json" {
+		t.Errorf("expected default content-type application/json, got %q", adapter.config.ContentType)
+	}
+}
+
+func TestHTTPAdapter_CustomValues(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:        "test-http",
+		Endpoint:    "http://localhost:8080/api",
+		Timeout:     10 * time.Second,
+		Method:      http.MethodGet,
+		ContentType: "application/xml",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+	if adapter.config.Timeout != 10*time.Second {
+		t.Errorf("expected timeout 10s, got %v", adapter.config.Timeout)
+	}
+	if adapter.config.Method != http.MethodGet {
+		t.Errorf("expected method GET, got %q", adapter.config.Method)
+	}
+	if adapter.config.ContentType != "application/xml" {
+		t.Errorf("expected content-type application/xml, got %q", adapter.config.ContentType)
+	}
+}
+
+func TestHTTPAdapter_CallNotConnected(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: "http://localhost:8080/api",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	_, err := adapter.Call(context.Background(), "test-http", nil)
+	if err == nil {
+		t.Fatal("expected error when not connected")
+	}
+}
+
+func TestHTTPAdapter_ListToolsEmpty(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: "http://localhost:8080/api",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	// ListTools should return empty list when not connected
+	tools, err := adapter.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tools) != 0 {
+		t.Errorf("expected 0 tools, got %d", len(tools))
+	}
+}
+
+func TestHTTPAdapter_Close(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: "http://localhost:8080/api",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	// Close should not error even when not connected
+	err := adapter.Close()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestHTTPAdapter_Connect(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: "http://localhost:8080/api",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	// After connect, should have one tool
+	tools, err := adapter.ListTools(ctx)
+	if err != nil {
+		t.Fatalf("ListTools failed: %v", err)
+	}
+	if len(tools) != 1 {
+		t.Errorf("expected 1 tool, got %d", len(tools))
+	}
+	if tools[0].Name != "test-http" {
+		t.Errorf("expected tool name 'test-http', got %q", tools[0].Name)
+	}
+}
+
+func TestHTTPAdapter_ConnectInvalidURL(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: "://invalid-url",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	err := adapter.Connect(context.Background())
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestHTTPAdapter_PostRequest(t *testing.T) {
+	// Start a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected Content-Type application/json, got %s", r.Header.Get("Content-Type"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var args map[string]any
+		json.Unmarshal(body, &args)
+
+		response := map[string]any{
+			"received": args,
+			"status":   "ok",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: server.URL,
+		Method:   http.MethodPost,
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", map[string]any{"message": "hello"})
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if result.IsError {
+		t.Error("result should not be an error")
+	}
+
+	resultMap, ok := result.Content.(map[string]any)
+	if !ok {
+		t.Fatalf("unexpected result type: %T", result.Content)
+	}
+	if resultMap["status"] != "ok" {
+		t.Errorf("unexpected status: %v", resultMap["status"])
+	}
+}
+
+func TestHTTPAdapter_GetRequest(t *testing.T) {
+	// Start a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+
+		// Check query parameters
+		query := r.URL.Query()
+		if query.Get("param1") != "value1" {
+			t.Errorf("expected param1=value1, got %s", query.Get("param1"))
+		}
+
+		response := map[string]string{"result": "success"}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(response)
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: server.URL,
+		Method:   http.MethodGet,
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", map[string]any{"param1": "value1"})
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if result.IsError {
+		t.Error("result should not be an error")
+	}
+}
+
+func TestHTTPAdapter_CustomHeaders(t *testing.T) {
+	// Start a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Custom-Header") != "custom-value" {
+			t.Errorf("expected X-Custom-Header=custom-value, got %s", r.Header.Get("X-Custom-Header"))
+		}
+		if r.Header.Get("X-Another") != "another-value" {
+			t.Errorf("expected X-Another=another-value, got %s", r.Header.Get("X-Another"))
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok": true}`))
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: server.URL,
+		Headers: map[string]string{
+			"X-Custom-Header": "custom-value",
+			"X-Another":       "another-value",
+		},
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	_, err = adapter.Call(ctx, "test-http", nil)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+}
+
+func TestHTTPAdapter_BearerAuth(t *testing.T) {
+	// Start a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if auth != "Bearer my-secret-token" {
+			t.Errorf("expected Bearer auth, got %s", auth)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"authenticated": true}`))
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:      "test-http",
+		Endpoint:  server.URL,
+		AuthType:  "bearer",
+		AuthToken: "my-secret-token",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", nil)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if result.IsError {
+		t.Error("result should not be an error")
+	}
+}
+
+func TestHTTPAdapter_BasicAuth(t *testing.T) {
+	// Start a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok := r.BasicAuth()
+		if !ok {
+			t.Error("expected basic auth")
+		}
+		if user != "myuser" || pass != "mypass" {
+			t.Errorf("expected myuser:mypass, got %s:%s", user, pass)
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"authenticated": true}`))
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:      "test-http",
+		Endpoint:  server.URL,
+		AuthType:  "basic",
+		AuthToken: "myuser:mypass",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", nil)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if result.IsError {
+		t.Error("result should not be an error")
+	}
+}
+
+func TestHTTPAdapter_HTTPError(t *testing.T) {
+	// Start a mock HTTP server that returns an error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("Internal Server Error"))
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: server.URL,
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", nil)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if !result.IsError {
+		t.Error("result should be an error for HTTP 500")
+	}
+	if result.Content.(string) != "HTTP 500: Internal Server Error" {
+		t.Errorf("unexpected error message: %v", result.Content)
+	}
+}
+
+func TestHTTPAdapter_NonJSONResponse(t *testing.T) {
+	// Start a mock HTTP server that returns plain text
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("Hello, World!"))
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: server.URL,
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", nil)
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if result.IsError {
+		t.Error("result should not be an error")
+	}
+	if result.Content != "Hello, World!" {
+		t.Errorf("unexpected content: %v", result.Content)
+	}
+}
+
+func TestHTTPAdapter_InvalidBearerAuth(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:      "test-http",
+		Endpoint:  "http://localhost:8080",
+		AuthType:  "bearer",
+		AuthToken: "", // Empty token
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	_, err = adapter.Call(ctx, "test-http", nil)
+	if err == nil {
+		t.Fatal("expected error for empty bearer token")
+	}
+}
+
+func TestHTTPAdapter_InvalidBasicAuth(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:      "test-http",
+		Endpoint:  "http://localhost:8080",
+		AuthType:  "basic",
+		AuthToken: "no-colon-here", // Invalid format
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	_, err = adapter.Call(ctx, "test-http", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid basic auth format")
+	}
+}
+
+func TestHTTPAdapter_UnsupportedAuthType(t *testing.T) {
+	config := HTTPAdapterConfig{
+		Name:      "test-http",
+		Endpoint:  "http://localhost:8080",
+		AuthType:  "oauth", // Not supported
+		AuthToken: "token",
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	_, err = adapter.Call(ctx, "test-http", nil)
+	if err == nil {
+		t.Fatal("expected error for unsupported auth type")
+	}
+}
+
+func TestHTTPAdapter_DeleteRequest(t *testing.T) {
+	// Start a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", r.Method)
+		}
+
+		// Check query parameters
+		query := r.URL.Query()
+		if query.Get("id") != "123" {
+			t.Errorf("expected id=123, got %s", query.Get("id"))
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: server.URL,
+		Method:   http.MethodDelete,
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", map[string]any{"id": "123"})
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if result.IsError {
+		t.Error("result should not be an error")
+	}
+}
+
+func TestHTTPAdapter_PutRequest(t *testing.T) {
+	// Start a mock HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Errorf("expected PUT, got %s", r.Method)
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var args map[string]any
+		json.Unmarshal(body, &args)
+
+		if args["name"] != "updated" {
+			t.Errorf("expected name=updated, got %v", args["name"])
+		}
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"updated": true}`))
+	}))
+	defer server.Close()
+
+	config := HTTPAdapterConfig{
+		Name:     "test-http",
+		Endpoint: server.URL,
+		Method:   http.MethodPut,
+	}
+
+	adapter := NewHTTPAdapter(config, logr.Discard())
+
+	ctx := context.Background()
+	err := adapter.Connect(ctx)
+	if err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+	defer adapter.Close()
+
+	result, err := adapter.Call(ctx, "test-http", map[string]any{"name": "updated"})
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+	if result.IsError {
+		t.Error("result should not be an error")
+	}
+}

--- a/internal/runtime/tools/manager_test.go
+++ b/internal/runtime/tools/manager_test.go
@@ -193,13 +193,13 @@ func TestManager_LoadFromToolConfig(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Should have registered the MCP adapter (HTTP tools are skipped)
+	// Should have registered both the HTTP and MCP adapters
 	m.mu.RLock()
 	adapterCount := len(m.adapters)
 	m.mu.RUnlock()
 
-	if adapterCount != 1 {
-		t.Errorf("expected 1 adapter, got %d", adapterCount)
+	if adapterCount != 2 {
+		t.Errorf("expected 2 adapters, got %d", adapterCount)
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements Issue #62 - HTTP tool adapter for the runtime container, completing the tool adapter trio (MCP, gRPC, HTTP).

## Changes

- `internal/runtime/tools/config.go` - Extended HTTPCfg with Headers, ContentType, AuthType, AuthToken
- `internal/runtime/tools/http_adapter.go` - Full HTTP adapter implementation
- `internal/runtime/tools/http_adapter_test.go` - Comprehensive tests with httptest mock server
- `internal/runtime/tools/manager.go` - Handle ToolTypeHTTP in LoadFromToolConfig
- `internal/runtime/tools/manager_test.go` - Updated test expectations

## Features

- Support GET, POST, PUT, DELETE HTTP methods
- Custom headers configuration
- Bearer and Basic authentication
- JSON request/response handling
- Query parameters for GET/DELETE methods
- Configurable timeout (default 30s)

## Test Plan

- [x] Unit tests for adapter name, defaults, custom values
- [x] Connect and ListTools tests
- [x] POST request with JSON body
- [x] GET request with query parameters  
- [x] PUT and DELETE requests
- [x] Custom headers verification
- [x] Bearer and Basic authentication
- [x] HTTP error handling (4xx, 5xx)
- [x] Non-JSON response handling
- [x] Invalid auth configuration errors
- [x] All tests pass

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)