### PR TITLE
docs: update README and add Provider CRD documentation

### DIFF
--- a/docs/src/content/reference/provider.md
+++ b/docs/src/content/reference/provider.md
@@ -1,0 +1,252 @@
+---
+title: "Provider CRD"
+description: "Complete reference for the Provider custom resource"
+order: 4
+---
+
+# Provider CRD Reference
+
+The Provider custom resource defines a reusable LLM provider configuration that can be referenced by multiple AgentRuntimes. This enables centralized credential management and consistent model configuration across agents.
+
+## API Version
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+```
+
+## Spec Fields
+
+### `type`
+
+The LLM provider type.
+
+| Value | Description |
+|-------|-------------|
+| `claude` | Anthropic's Claude models |
+| `openai` | OpenAI's GPT models |
+| `gemini` | Google's Gemini models |
+| `auto` | Auto-detect based on available credentials |
+
+```yaml
+spec:
+  type: claude
+```
+
+### `model`
+
+The model identifier to use. If not specified, the provider's default model is used.
+
+| Provider | Example Models |
+|----------|----------------|
+| Claude | `claude-sonnet-4-20250514`, `claude-opus-4-20250514` |
+| OpenAI | `gpt-4o`, `gpt-4-turbo`, `gpt-3.5-turbo` |
+| Gemini | `gemini-pro`, `gemini-1.5-pro` |
+
+```yaml
+spec:
+  type: claude
+  model: claude-sonnet-4-20250514
+```
+
+### `secretRef`
+
+Reference to a Secret containing API credentials.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `secretRef.name` | string | Yes | Name of the Secret |
+| `secretRef.key` | string | No | Specific key to use (auto-detected if omitted) |
+
+```yaml
+spec:
+  secretRef:
+    name: llm-credentials
+```
+
+If `key` is not specified, the controller looks for provider-appropriate keys:
+- **Claude**: `ANTHROPIC_API_KEY` or `api-key`
+- **OpenAI**: `OPENAI_API_KEY` or `api-key`
+- **Gemini**: `GEMINI_API_KEY` or `api-key`
+
+### `baseURL`
+
+Override the provider's default API endpoint. Useful for proxies, Azure OpenAI, or self-hosted models.
+
+```yaml
+spec:
+  type: openai
+  baseURL: https://my-openai-proxy.internal/v1
+```
+
+### `defaults`
+
+Tuning parameters applied to all requests using this provider.
+
+| Field | Type | Range | Description |
+|-------|------|-------|-------------|
+| `temperature` | string | 0.0-2.0 | Controls randomness (lower = more focused) |
+| `topP` | string | 0.0-1.0 | Nucleus sampling threshold |
+| `maxTokens` | integer | - | Maximum tokens in response |
+
+```yaml
+spec:
+  defaults:
+    temperature: "0.7"
+    topP: "0.9"
+    maxTokens: 4096
+```
+
+### `pricing`
+
+Custom pricing for cost tracking. If not specified, PromptKit's built-in pricing is used.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `inputCostPer1K` | string | Cost per 1000 input tokens |
+| `outputCostPer1K` | string | Cost per 1000 output tokens |
+| `cachedCostPer1K` | string | Cost per 1000 cached tokens |
+
+```yaml
+spec:
+  pricing:
+    inputCostPer1K: "0.003"
+    outputCostPer1K: "0.015"
+    cachedCostPer1K: "0.0003"
+```
+
+### `validateCredentials`
+
+When enabled, the controller validates credentials with the provider during reconciliation.
+
+```yaml
+spec:
+  validateCredentials: true
+```
+
+## Status Fields
+
+### `phase`
+
+| Value | Description |
+|-------|-------------|
+| `Ready` | Provider is configured and credentials are valid |
+| `Error` | Configuration error or invalid credentials |
+
+### `conditions`
+
+| Type | Description |
+|------|-------------|
+| `Ready` | Overall readiness of the Provider |
+| `SecretValid` | Referenced Secret exists and contains required key |
+| `CredentialsValidated` | Credentials validated with provider (if enabled) |
+
+### `lastValidatedAt`
+
+Timestamp of the last successful credential validation (only set when `validateCredentials: true`).
+
+## Complete Example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: anthropic-credentials
+  namespace: agents
+stringData:
+  ANTHROPIC_API_KEY: "sk-ant-api03-..."
+---
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: claude-production
+  namespace: agents
+spec:
+  type: claude
+  model: claude-sonnet-4-20250514
+
+  secretRef:
+    name: anthropic-credentials
+
+  defaults:
+    temperature: "0.7"
+    maxTokens: 4096
+
+  pricing:
+    inputCostPer1K: "0.003"
+    outputCostPer1K: "0.015"
+
+  validateCredentials: true
+```
+
+## Using Provider in AgentRuntime
+
+Reference a Provider from an AgentRuntime using `providerRef`:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: my-agent
+spec:
+  promptPackRef:
+    name: my-prompts
+
+  providerRef:
+    name: claude-production
+    namespace: agents  # Optional, defaults to same namespace
+
+  facade:
+    type: websocket
+    port: 8080
+```
+
+## Multiple Providers
+
+You can create multiple Provider resources for different use cases:
+
+```yaml
+# Production provider with Claude Sonnet
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: claude-production
+spec:
+  type: claude
+  model: claude-sonnet-4-20250514
+  secretRef:
+    name: prod-credentials
+  defaults:
+    temperature: "0.3"  # More deterministic
+---
+# Development provider with lower-cost model
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: claude-development
+spec:
+  type: claude
+  model: claude-haiku-20250514
+  secretRef:
+    name: dev-credentials
+  defaults:
+    temperature: "0.7"
+```
+
+## Cross-Namespace References
+
+Providers can be referenced across namespaces:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: my-agent
+  namespace: app-team
+spec:
+  providerRef:
+    name: shared-claude-provider
+    namespace: shared-providers  # Provider in different namespace
+```
+
+Note: Ensure appropriate RBAC permissions are configured for cross-namespace access.

--- a/docs/src/content/tutorials/getting-started.md
+++ b/docs/src/content/tutorials/getting-started.md
@@ -90,9 +90,9 @@ kubectl get promptpack assistant-pack
 
 > **Tip**: For production use, you can author PromptPacks in YAML and compile them to JSON using the [packc](https://promptpack.org) compiler for validation and optimization.
 
-## Step 3: Configure Provider Credentials
+## Step 3: Configure the LLM Provider
 
-Create a Secret with your LLM provider API key:
+Create a Secret with your LLM provider API key, then create a Provider resource:
 
 ```yaml
 apiVersion: v1
@@ -102,11 +102,29 @@ metadata:
   namespace: default
 type: Opaque
 stringData:
-  api-key: "your-api-key-here"
+  ANTHROPIC_API_KEY: "sk-ant-..."  # Or OPENAI_API_KEY for OpenAI
+---
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: my-provider
+  namespace: default
+spec:
+  type: claude  # Or "openai", "gemini"
+  model: claude-sonnet-4-20250514
+  secretRef:
+    name: llm-credentials
 ```
 
 ```bash
-kubectl apply -f secret.yaml
+kubectl apply -f provider.yaml
+```
+
+Verify the Provider is ready:
+
+```bash
+kubectl get provider my-provider
+# Should show: my-provider   claude   claude-sonnet-4-20250514   Ready   ...
 ```
 
 > **Tip**: Don't have an API key yet? Use `handler: demo` in your AgentRuntime to test with simulated responses. See [Handler Modes](/reference/agentruntime/#handler-modes) for details.
@@ -124,8 +142,8 @@ metadata:
 spec:
   promptPackRef:
     name: assistant-pack
-  providerSecretRef:
-    name: llm-credentials
+  providerRef:
+    name: my-provider
   facade:
     type: websocket
     port: 8080
@@ -193,8 +211,10 @@ You should see responses like:
 
 ## Next Steps
 
-- Learn about [PromptPack configuration](/how-to/configure-promptpacks/)
+- Learn about [Provider configuration](/reference/provider/) for LLM settings
 - Explore [ToolRegistry](/tutorials/adding-tools/) to give your agent capabilities
 - Read about [session management](/explanation/sessions/) for stateful conversations
+- Set up [observability](/how-to/setup-observability/) for monitoring
+- Configure [autoscaling](/how-to/scale-agents/) for production workloads
 
 Congratulations! You've deployed your first AI agent with Omnia.


### PR DESCRIPTION
## Summary

- Update README with badges (CI, SonarCloud, Coverage, Go Report Card, License)
- Update README to reflect current MVP status with Quick Start guide
- Add Provider CRD reference documentation
- Update AgentRuntime docs with `providerRef` field
- Update ToolRegistry docs with MCP, HTTP, and gRPC configuration
- Update Getting Started tutorial to use Provider CRD

## Changes

### README.md
- Add project badges matching PromptKit style
- Replace "early prototyping" messaging with production-ready features
- Add Quick Start guide demonstrating Provider CRD usage
- Add architecture diagram
- Add ecosystem section linking PromptKit and PromptPack

### New: docs/src/content/reference/provider.md
- Complete Provider CRD reference following Diataxis format
- Document all spec fields (type, model, secretRef, baseURL, defaults, pricing)
- Include examples for multiple providers and cross-namespace references

### docs/src/content/reference/agentruntime.md
- Add `providerRef` section as recommended approach
- Add `provider` inline configuration section
- Update conditions to include `ProviderReady`
- Update complete example to use `providerRef`

### docs/src/content/reference/toolregistry.md
- Add MCP tool type with SSE and stdio transport examples
- Add HTTP tool configuration section
- Add gRPC tool configuration section
- Update complete example with multiple tool types

### docs/src/content/tutorials/getting-started.md
- Update to use Provider CRD instead of providerSecretRef
- Add Provider verification step
- Update Next Steps with new links

## Test plan

- [ ] Verify badges render correctly on GitHub
- [ ] Review documentation for accuracy
- [ ] Check all internal links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)