### PR TITLE
feat: add Tools page with ToolRegistry visualization (#91)

### DIFF
--- a/dashboard/src/app/tools/[name]/page.tsx
+++ b/dashboard/src/app/tools/[name]/page.tsx
@@ -1,0 +1,513 @@
+"use client";
+
+import { use } from "react";
+import { useSearchParams } from "next/navigation";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  ExternalLink,
+  Bot,
+  Clock,
+  Wrench,
+  Globe,
+  Server,
+  CheckCircle,
+  XCircle,
+  AlertCircle,
+  Settings,
+  FileJson,
+  Terminal,
+} from "lucide-react";
+import { Header } from "@/components/layout";
+import { StatusBadge } from "@/components/agents";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { YamlBlock } from "@/components/ui/yaml-block";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
+import { useToolRegistry } from "@/hooks";
+import { useAgents } from "@/hooks";
+import type { DiscoveredTool, HandlerDefinition } from "@/types";
+
+interface PageProps {
+  params: Promise<{ name: string }>;
+}
+
+function formatRelativeTime(timestamp?: string): string {
+  if (!timestamp) return "-";
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+function getHandlerTypeIcon(type: string) {
+  switch (type) {
+    case "http":
+      return Globe;
+    case "grpc":
+      return Server;
+    case "mcp":
+      return Terminal;
+    case "openapi":
+      return FileJson;
+    default:
+      return Wrench;
+  }
+}
+
+function ToolStatusIcon({ status }: { status: DiscoveredTool["status"] }) {
+  switch (status) {
+    case "Available":
+      return <CheckCircle className="h-4 w-4 text-green-500" />;
+    case "Unavailable":
+      return <XCircle className="h-4 w-4 text-red-500" />;
+    default:
+      return <AlertCircle className="h-4 w-4 text-yellow-500" />;
+  }
+}
+
+function getEndpointFromHandler(handler: HandlerDefinition): string {
+  if (handler.httpConfig?.endpoint) return handler.httpConfig.endpoint;
+  if (handler.grpcConfig?.endpoint) return handler.grpcConfig.endpoint;
+  if (handler.openAPIConfig?.specURL) return handler.openAPIConfig.specURL;
+  if (handler.mcpConfig?.endpoint) return handler.mcpConfig.endpoint;
+  if (handler.mcpConfig?.command) return `${handler.mcpConfig.command} ${handler.mcpConfig.args?.join(" ") || ""}`;
+  return "N/A";
+}
+
+export default function ToolDetailPage({ params }: PageProps) {
+  const { name } = use(params);
+  const searchParams = useSearchParams();
+  const namespace = searchParams.get("namespace") || "production";
+
+  const { data: registry, isLoading } = useToolRegistry(name, namespace);
+  const { data: agents } = useAgents();
+
+  // Find agents that reference this ToolRegistry
+  const usedByAgents = agents?.filter(
+    (agent) =>
+      agent.spec.toolRegistryRef?.name === name &&
+      (agent.spec.toolRegistryRef?.namespace || agent.metadata.namespace) === namespace
+  );
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col h-full">
+        <Header title={<Skeleton className="h-8 w-48" />} />
+        <div className="flex-1 p-6 space-y-6">
+          <Skeleton className="h-[200px]" />
+          <Skeleton className="h-[300px]" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!registry) {
+    return (
+      <div className="flex flex-col h-full">
+        <Header title="ToolRegistry Not Found" />
+        <div className="flex-1 p-6 flex items-center justify-center">
+          <div className="text-center">
+            <p className="text-muted-foreground mb-4">
+              ToolRegistry &quot;{name}&quot; was not found in namespace &quot;{namespace}&quot;
+            </p>
+            <Link href="/tools">
+              <Button variant="outline">
+                <ArrowLeft className="mr-2 h-4 w-4" />
+                Back to Tools
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const { metadata, spec, status } = registry;
+  const tools = status?.discoveredTools || [];
+  const availableCount = tools.filter((t) => t.status === "Available").length;
+  const totalCount = status?.discoveredToolsCount || 0;
+
+  return (
+    <div className="flex flex-col h-full">
+      <Header
+        title={
+          <div className="flex items-center gap-3">
+            <Link href="/tools">
+              <Button variant="ghost" size="icon" className="h-8 w-8">
+                <ArrowLeft className="h-4 w-4" />
+              </Button>
+            </Link>
+            <Wrench className="h-5 w-5 text-muted-foreground" />
+            <span>{metadata.name}</span>
+            <StatusBadge phase={status?.phase} />
+          </div>
+        }
+        description={`${metadata.namespace} · ${availableCount}/${totalCount} tools available`}
+      />
+
+      <div className="flex-1 p-6">
+        <Tabs defaultValue="overview" className="space-y-6">
+          <TabsList>
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="tools">Tools ({totalCount})</TabsTrigger>
+            <TabsTrigger value="handlers">Handlers ({spec.handlers.length})</TabsTrigger>
+            <TabsTrigger value="usage">Usage ({usedByAgents?.length || 0})</TabsTrigger>
+            <TabsTrigger value="config">Config</TabsTrigger>
+          </TabsList>
+
+          {/* Overview Tab */}
+          <TabsContent value="overview" className="space-y-6">
+            <div className="grid gap-6 md:grid-cols-2">
+              {/* Status Card */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Status</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Phase</span>
+                    <StatusBadge phase={status?.phase} />
+                  </div>
+                  <Separator />
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Discovered Tools</span>
+                    <span className="text-sm font-medium">{totalCount}</span>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Available</span>
+                    <Badge variant="secondary" className="text-green-600 dark:text-green-400">
+                      {availableCount}
+                    </Badge>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Unavailable</span>
+                    <Badge variant="secondary" className="text-red-600 dark:text-red-400">
+                      {totalCount - availableCount}
+                    </Badge>
+                  </div>
+                  <Separator />
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Last Discovery</span>
+                    <span className="text-sm">{formatRelativeTime(status?.lastDiscoveryTime)}</span>
+                  </div>
+                </CardContent>
+              </Card>
+
+              {/* Handler Types Card */}
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Handlers</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm text-muted-foreground">Total Handlers</span>
+                    <span className="text-sm font-medium">{spec.handlers.length}</span>
+                  </div>
+                  <Separator />
+                  <div className="space-y-2">
+                    <span className="text-sm text-muted-foreground">Handler Types</span>
+                    <div className="flex flex-wrap gap-2">
+                      {[...new Set(spec.handlers.map((h) => h.type))].map((type) => {
+                        const Icon = getHandlerTypeIcon(type);
+                        const count = spec.handlers.filter((h) => h.type === type).length;
+                        return (
+                          <Badge key={type} variant="outline" className="gap-1.5">
+                            <Icon className="h-3 w-3" />
+                            {type}
+                            <span className="text-muted-foreground">({count})</span>
+                          </Badge>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            </div>
+
+            {/* Conditions */}
+            {status?.conditions && status.conditions.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Conditions</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3">
+                    {status.conditions.map((condition, idx) => (
+                      <div key={idx} className="flex items-start gap-3 p-3 rounded-lg bg-muted/50">
+                        {condition.status === "True" ? (
+                          <CheckCircle className="h-4 w-4 text-green-500 mt-0.5" />
+                        ) : (
+                          <XCircle className="h-4 w-4 text-red-500 mt-0.5" />
+                        )}
+                        <div className="flex-1 min-w-0">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium text-sm">{condition.type}</span>
+                            <span className="text-xs text-muted-foreground">
+                              {formatRelativeTime(condition.lastTransitionTime)}
+                            </span>
+                          </div>
+                          {condition.message && (
+                            <p className="text-sm text-muted-foreground mt-1">{condition.message}</p>
+                          )}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </TabsContent>
+
+          {/* Tools Tab */}
+          <TabsContent value="tools" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Discovered Tools</CardTitle>
+                <CardDescription>
+                  Tools discovered and available from this registry
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {tools.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-8">
+                    No tools discovered yet
+                  </p>
+                ) : (
+                  <div className="space-y-4">
+                    {tools.map((tool) => (
+                      <div
+                        key={tool.name}
+                        className="p-4 rounded-lg border bg-card"
+                      >
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="flex items-start gap-3 min-w-0">
+                            <ToolStatusIcon status={tool.status} />
+                            <div className="min-w-0">
+                              <div className="flex items-center gap-2">
+                                <code className="font-medium">{tool.name}</code>
+                                <Badge variant="outline" className="text-xs">
+                                  {tool.handlerName}
+                                </Badge>
+                              </div>
+                              <p className="text-sm text-muted-foreground mt-1">
+                                {tool.description}
+                              </p>
+                              <div className="flex items-center gap-2 mt-2 text-xs text-muted-foreground">
+                                <code className="bg-muted px-1.5 py-0.5 rounded truncate max-w-[300px]">
+                                  {tool.endpoint}
+                                </code>
+                              </div>
+                              {tool.error && (
+                                <p className="text-sm text-red-500 mt-2">
+                                  Error: {tool.error}
+                                </p>
+                              )}
+                            </div>
+                          </div>
+                          <div className="text-xs text-muted-foreground shrink-0">
+                            <Clock className="h-3 w-3 inline mr-1" />
+                            {formatRelativeTime(tool.lastChecked)}
+                          </div>
+                        </div>
+
+                        {tool.inputSchema != null && (
+                          <div className="mt-4 pt-4 border-t">
+                            <div className="flex items-center gap-2 mb-2">
+                              <FileJson className="h-3.5 w-3.5 text-muted-foreground" />
+                              <span className="text-xs font-medium">Input Schema</span>
+                            </div>
+                            <pre className="text-xs bg-muted p-3 rounded overflow-auto max-h-32">
+                              {JSON.stringify(tool.inputSchema, null, 2)}
+                            </pre>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Handlers Tab */}
+          <TabsContent value="handlers" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Handler Definitions</CardTitle>
+                <CardDescription>
+                  Configured handlers for discovering and executing tools
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Accordion type="multiple" className="w-full">
+                  {spec.handlers.map((handler, idx) => {
+                    const Icon = getHandlerTypeIcon(handler.type);
+                    return (
+                      <AccordionItem key={idx} value={`handler-${idx}`}>
+                        <AccordionTrigger className="hover:no-underline">
+                          <div className="flex items-center gap-3">
+                            <Icon className="h-4 w-4 text-muted-foreground" />
+                            <span className="font-medium">{handler.name}</span>
+                            <Badge variant="outline" className="text-xs capitalize">
+                              {handler.type}
+                            </Badge>
+                          </div>
+                        </AccordionTrigger>
+                        <AccordionContent className="space-y-4">
+                          {/* Tool Definition */}
+                          {handler.tool && (
+                            <div className="space-y-2">
+                              <h4 className="text-sm font-medium flex items-center gap-2">
+                                <Wrench className="h-3.5 w-3.5" />
+                                Tool Definition
+                              </h4>
+                              <div className="bg-muted rounded-lg p-3 space-y-2">
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs text-muted-foreground w-20">Name:</span>
+                                  <code className="text-xs">{handler.tool.name}</code>
+                                </div>
+                                <div className="flex items-start gap-2">
+                                  <span className="text-xs text-muted-foreground w-20">Description:</span>
+                                  <span className="text-xs">{handler.tool.description}</span>
+                                </div>
+                              </div>
+                            </div>
+                          )}
+
+                          {/* Endpoint/Config */}
+                          <div className="space-y-2">
+                            <h4 className="text-sm font-medium flex items-center gap-2">
+                              <Settings className="h-3.5 w-3.5" />
+                              Configuration
+                            </h4>
+                            <div className="bg-muted rounded-lg p-3 space-y-2">
+                              <div className="flex items-center gap-2">
+                                <span className="text-xs text-muted-foreground w-20">Endpoint:</span>
+                                <code className="text-xs break-all">{getEndpointFromHandler(handler)}</code>
+                              </div>
+                              {handler.httpConfig?.method && (
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs text-muted-foreground w-20">Method:</span>
+                                  <Badge variant="secondary" className="text-xs">{handler.httpConfig.method}</Badge>
+                                </div>
+                              )}
+                              {handler.httpConfig?.authType && handler.httpConfig.authType !== "none" && (
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs text-muted-foreground w-20">Auth:</span>
+                                  <Badge variant="outline" className="text-xs capitalize">{handler.httpConfig.authType}</Badge>
+                                </div>
+                              )}
+                              {handler.timeout && (
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs text-muted-foreground w-20">Timeout:</span>
+                                  <span className="text-xs">{handler.timeout}</span>
+                                </div>
+                              )}
+                              {handler.retries !== undefined && (
+                                <div className="flex items-center gap-2">
+                                  <span className="text-xs text-muted-foreground w-20">Retries:</span>
+                                  <span className="text-xs">{handler.retries}</span>
+                                </div>
+                              )}
+                            </div>
+                          </div>
+
+                          {/* Input/Output Schema if defined */}
+                          {handler.tool?.inputSchema != null && (
+                            <div className="space-y-2">
+                              <h4 className="text-sm font-medium flex items-center gap-2">
+                                <FileJson className="h-3.5 w-3.5" />
+                                Input Schema
+                              </h4>
+                              <pre className="text-xs bg-muted p-3 rounded overflow-auto max-h-40">
+                                {JSON.stringify(handler.tool.inputSchema, null, 2)}
+                              </pre>
+                            </div>
+                          )}
+                        </AccordionContent>
+                      </AccordionItem>
+                    );
+                  })}
+                </Accordion>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Usage Tab */}
+          <TabsContent value="usage" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Used By</CardTitle>
+                <CardDescription>
+                  Agents that reference this ToolRegistry
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                {!usedByAgents || usedByAgents.length === 0 ? (
+                  <p className="text-sm text-muted-foreground text-center py-8">
+                    No agents are currently using this ToolRegistry
+                  </p>
+                ) : (
+                  <div className="space-y-3">
+                    {usedByAgents.map((agent) => (
+                      <Link
+                        key={agent.metadata.uid}
+                        href={`/agents/${agent.metadata.name}?namespace=${agent.metadata.namespace}`}
+                        className="flex items-center justify-between p-3 rounded-lg border hover:bg-muted/50 transition-colors"
+                      >
+                        <div className="flex items-center gap-3">
+                          <Bot className="h-4 w-4 text-muted-foreground" />
+                          <div>
+                            <span className="font-medium text-sm">{agent.metadata.name}</span>
+                            <p className="text-xs text-muted-foreground">
+                              {agent.metadata.namespace}
+                            </p>
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <StatusBadge phase={agent.status?.phase} />
+                          <ExternalLink className="h-4 w-4 text-muted-foreground" />
+                        </div>
+                      </Link>
+                    ))}
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          {/* Config Tab */}
+          <TabsContent value="config" className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Full Configuration</CardTitle>
+                <CardDescription>
+                  Complete YAML specification for this ToolRegistry
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <YamlBlock data={registry} />
+              </CardContent>
+            </Card>
+          </TabsContent>
+        </Tabs>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/tools/page.tsx
+++ b/dashboard/src/app/tools/page.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useState } from "react";
+import { Plus } from "lucide-react";
+import { Header } from "@/components/layout";
+import { ToolRegistryCard } from "@/components/tools";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useToolRegistries } from "@/hooks";
+import type { ToolRegistryPhase } from "@/types";
+
+type FilterPhase = "all" | ToolRegistryPhase;
+
+export default function ToolsPage() {
+  const [filterPhase, setFilterPhase] = useState<FilterPhase>("all");
+
+  const { data: registries, isLoading } = useToolRegistries();
+
+  const filteredRegistries =
+    filterPhase === "all"
+      ? registries
+      : registries?.filter((r) => r.status?.phase === filterPhase);
+
+  const phaseCounts = registries?.reduce(
+    (acc, registry) => {
+      const phase = registry.status?.phase;
+      if (phase === "Ready") acc.ready++;
+      else if (phase === "Degraded") acc.degraded++;
+      else if (phase === "Pending") acc.pending++;
+      else if (phase === "Failed") acc.failed++;
+      return acc;
+    },
+    { ready: 0, degraded: 0, pending: 0, failed: 0 }
+  );
+
+  // Calculate total tools across all registries
+  const totalTools = registries?.reduce(
+    (sum, r) => sum + (r.status?.discoveredToolsCount || 0),
+    0
+  ) ?? 0;
+
+  return (
+    <div className="flex flex-col h-full">
+      <Header
+        title="Tools"
+        description={`${totalTools} tools across ${registries?.length ?? 0} registries`}
+      />
+
+      <div className="flex-1 p-6 space-y-6">
+        {/* Toolbar */}
+        <div className="flex items-center justify-between">
+          <Tabs
+            value={filterPhase}
+            onValueChange={(v) => setFilterPhase(v as FilterPhase)}
+          >
+            <TabsList>
+              <TabsTrigger value="all">
+                All ({registries?.length ?? 0})
+              </TabsTrigger>
+              <TabsTrigger value="Ready">
+                Ready ({phaseCounts?.ready ?? 0})
+              </TabsTrigger>
+              <TabsTrigger value="Degraded">
+                Degraded ({phaseCounts?.degraded ?? 0})
+              </TabsTrigger>
+              <TabsTrigger value="Pending">
+                Pending ({phaseCounts?.pending ?? 0})
+              </TabsTrigger>
+              <TabsTrigger value="Failed">
+                Failed ({phaseCounts?.failed ?? 0})
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <Button size="sm">
+            <Plus className="mr-2 h-4 w-4" />
+            New ToolRegistry
+          </Button>
+        </div>
+
+        {/* Content */}
+        {isLoading ? (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {[...Array(4)].map((_, i) => (
+              <Skeleton key={i} className="h-[220px] rounded-lg" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {filteredRegistries?.map((registry) => (
+              <ToolRegistryCard key={registry.metadata.uid} registry={registry} />
+            ))}
+          </div>
+        )}
+
+        {!isLoading && filteredRegistries?.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <p className="text-muted-foreground">No ToolRegistries found</p>
+            <Button variant="outline" className="mt-4">
+              <Plus className="mr-2 h-4 w-4" />
+              Create your first ToolRegistry
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/header.tsx
+++ b/dashboard/src/components/layout/header.tsx
@@ -5,7 +5,7 @@ import { RefreshCw, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 interface HeaderProps {
-  title: string;
+  title: React.ReactNode;
   description?: string;
 }
 

--- a/dashboard/src/components/tools/index.ts
+++ b/dashboard/src/components/tools/index.ts
@@ -1,0 +1,1 @@
+export * from "./tool-registry-card";

--- a/dashboard/src/components/tools/tool-registry-card.tsx
+++ b/dashboard/src/components/tools/tool-registry-card.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import Link from "next/link";
+import { Wrench, Globe, Server, Clock, CheckCircle, XCircle, AlertCircle, Terminal, FileJson } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StatusBadge } from "@/components/agents";
+import type { ToolRegistry, DiscoveredTool } from "@/types";
+
+interface ToolRegistryCardProps {
+  registry: ToolRegistry;
+}
+
+function formatRelativeTime(timestamp?: string): string {
+  if (!timestamp) return "-";
+  const date = new Date(timestamp);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMins = Math.floor(diffMs / 60000);
+  const diffHours = Math.floor(diffMs / 3600000);
+  const diffDays = Math.floor(diffMs / 86400000);
+
+  if (diffMins < 60) return `${diffMins}m ago`;
+  if (diffHours < 24) return `${diffHours}h ago`;
+  return `${diffDays}d ago`;
+}
+
+function getHandlerTypeIcon(type: string) {
+  switch (type) {
+    case "http":
+      return Globe;
+    case "grpc":
+      return Server;
+    case "mcp":
+      return Terminal;
+    case "openapi":
+      return FileJson;
+    default:
+      return Wrench;
+  }
+}
+
+function ToolStatusIcon({ status }: { status: DiscoveredTool["status"] }) {
+  switch (status) {
+    case "Available":
+      return <CheckCircle className="h-3 w-3 text-green-500" />;
+    case "Unavailable":
+      return <XCircle className="h-3 w-3 text-red-500" />;
+    default:
+      return <AlertCircle className="h-3 w-3 text-yellow-500" />;
+  }
+}
+
+export function ToolRegistryCard({ registry }: ToolRegistryCardProps) {
+  const { metadata, spec, status } = registry;
+  const tools = status?.discoveredTools || [];
+  const availableCount = tools.filter((t) => t.status === "Available").length;
+  const totalCount = status?.discoveredToolsCount || 0;
+
+  // Get unique handler types
+  const handlerTypes = [...new Set(spec.handlers.map((h) => h.type))];
+
+  return (
+    <Link
+      href={`/tools/${metadata.name}?namespace=${metadata.namespace}`}
+    >
+      <Card className="hover:border-primary/50 transition-colors cursor-pointer h-full">
+        <CardHeader className="pb-3">
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex items-center gap-2 min-w-0">
+              <Wrench className="h-4 w-4 text-muted-foreground shrink-0" />
+              <CardTitle className="text-base truncate">{metadata.name}</CardTitle>
+            </div>
+            <StatusBadge phase={status?.phase} />
+          </div>
+          <p className="text-xs text-muted-foreground">{metadata.namespace}</p>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {/* Tool count summary */}
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Tools:</span>
+            <Badge variant="secondary" className="text-xs">
+              {availableCount}/{totalCount} available
+            </Badge>
+          </div>
+
+          {/* Handler types */}
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">Types:</span>
+            <div className="flex gap-1.5">
+              {handlerTypes.map((type) => {
+                const Icon = getHandlerTypeIcon(type);
+                return (
+                  <Badge key={type} variant="outline" className="text-xs capitalize gap-1">
+                    <Icon className="h-3 w-3" />
+                    {type}
+                  </Badge>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Tool list preview (first 3) */}
+          {tools.length > 0 && (
+            <div className="space-y-1">
+              {tools.slice(0, 3).map((tool) => (
+                <div key={tool.name} className="flex items-center gap-2 text-xs">
+                  <ToolStatusIcon status={tool.status} />
+                  <code className="text-muted-foreground truncate">{tool.name}</code>
+                </div>
+              ))}
+              {tools.length > 3 && (
+                <p className="text-xs text-muted-foreground pl-5">
+                  +{tools.length - 3} more
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Last discovery time */}
+          <div className="flex items-center justify-between text-xs text-muted-foreground pt-1 border-t">
+            <span>{spec.handlers.length} handlers</span>
+            <div className="flex items-center gap-1">
+              <Clock className="h-3 w-3" />
+              <span>Discovered {formatRelativeTime(status?.lastDiscoveryTime)}</span>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/dashboard/src/lib/mock-data.ts
+++ b/dashboard/src/lib/mock-data.ts
@@ -452,6 +452,231 @@ export const mockToolRegistries: ToolRegistry[] = [
       lastDiscoveryTime: hoursAgo(0.05),
     },
   },
+  {
+    apiVersion: "omnia.altairalabs.ai/v1alpha1",
+    kind: "ToolRegistry",
+    metadata: {
+      name: "mcp-tools",
+      namespace: "production",
+      creationTimestamp: daysAgo(5),
+      uid: "registry-003",
+    },
+    spec: {
+      handlers: [
+        {
+          name: "filesystem",
+          type: "mcp",
+          tool: {
+            name: "read_file",
+            description: "Read contents of a file from the filesystem",
+            inputSchema: {
+              type: "object",
+              properties: {
+                path: { type: "string", description: "Path to the file" },
+              },
+              required: ["path"],
+            },
+          },
+          mcpConfig: {
+            transport: "stdio",
+            command: "/usr/local/bin/mcp-filesystem",
+            args: ["--root", "/data"],
+          },
+        },
+        {
+          name: "web-search",
+          type: "mcp",
+          tool: {
+            name: "search_web",
+            description: "Search the web for information",
+            inputSchema: {
+              type: "object",
+              properties: {
+                query: { type: "string", description: "Search query" },
+                limit: { type: "number", description: "Max results", default: 10 },
+              },
+              required: ["query"],
+            },
+          },
+          mcpConfig: {
+            transport: "sse",
+            endpoint: "http://mcp-search:8080/sse",
+          },
+        },
+      ],
+    },
+    status: {
+      phase: "Ready",
+      discoveredToolsCount: 2,
+      discoveredTools: [
+        {
+          name: "read_file",
+          handlerName: "filesystem",
+          description: "Read contents of a file from the filesystem",
+          endpoint: "stdio:///usr/local/bin/mcp-filesystem",
+          status: "Available",
+          lastChecked: hoursAgo(0.2),
+          inputSchema: {
+            type: "object",
+            properties: {
+              path: { type: "string", description: "Path to the file" },
+            },
+            required: ["path"],
+          },
+        },
+        {
+          name: "search_web",
+          handlerName: "web-search",
+          description: "Search the web for information",
+          endpoint: "http://mcp-search:8080/sse",
+          status: "Available",
+          lastChecked: hoursAgo(0.2),
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string", description: "Search query" },
+              limit: { type: "number", description: "Max results", default: 10 },
+            },
+            required: ["query"],
+          },
+        },
+      ],
+      lastDiscoveryTime: hoursAgo(0.2),
+    },
+  },
+  {
+    apiVersion: "omnia.altairalabs.ai/v1alpha1",
+    kind: "ToolRegistry",
+    metadata: {
+      name: "grpc-services",
+      namespace: "production",
+      creationTimestamp: daysAgo(21),
+      uid: "registry-004",
+    },
+    spec: {
+      handlers: [
+        {
+          name: "user-service",
+          type: "grpc",
+          tool: {
+            name: "get_user",
+            description: "Retrieve user information by ID",
+            inputSchema: {
+              type: "object",
+              properties: {
+                user_id: { type: "string", description: "User ID" },
+              },
+              required: ["user_id"],
+            },
+          },
+          grpcConfig: {
+            endpoint: "user-service.default.svc.cluster.local:9090",
+            tls: true,
+          },
+          timeout: "5s",
+          retries: 3,
+        },
+        {
+          name: "notification-service",
+          type: "grpc",
+          tool: {
+            name: "send_notification",
+            description: "Send a notification to a user",
+            inputSchema: {
+              type: "object",
+              properties: {
+                user_id: { type: "string" },
+                message: { type: "string" },
+                channel: { type: "string", enum: ["email", "sms", "push"] },
+              },
+              required: ["user_id", "message", "channel"],
+            },
+          },
+          grpcConfig: {
+            endpoint: "notification-service.default.svc.cluster.local:9090",
+            tls: true,
+          },
+          timeout: "10s",
+        },
+      ],
+    },
+    status: {
+      phase: "Ready",
+      discoveredToolsCount: 2,
+      discoveredTools: [
+        {
+          name: "get_user",
+          handlerName: "user-service",
+          description: "Retrieve user information by ID",
+          endpoint: "grpc://user-service.default.svc.cluster.local:9090",
+          status: "Available",
+          lastChecked: hoursAgo(0.15),
+          inputSchema: {
+            type: "object",
+            properties: {
+              user_id: { type: "string", description: "User ID" },
+            },
+            required: ["user_id"],
+          },
+        },
+        {
+          name: "send_notification",
+          handlerName: "notification-service",
+          description: "Send a notification to a user",
+          endpoint: "grpc://notification-service.default.svc.cluster.local:9090",
+          status: "Available",
+          lastChecked: hoursAgo(0.15),
+          inputSchema: {
+            type: "object",
+            properties: {
+              user_id: { type: "string" },
+              message: { type: "string" },
+              channel: { type: "string", enum: ["email", "sms", "push"] },
+            },
+            required: ["user_id", "message", "channel"],
+          },
+        },
+      ],
+      lastDiscoveryTime: hoursAgo(0.15),
+    },
+  },
+  {
+    apiVersion: "omnia.altairalabs.ai/v1alpha1",
+    kind: "ToolRegistry",
+    metadata: {
+      name: "openapi-services",
+      namespace: "staging",
+      creationTimestamp: daysAgo(2),
+      uid: "registry-005",
+    },
+    spec: {
+      handlers: [
+        {
+          name: "petstore-api",
+          type: "openapi",
+          openAPIConfig: {
+            specURL: "https://petstore.swagger.io/v2/swagger.json",
+            baseURL: "https://petstore.swagger.io/v2",
+            operationFilter: ["getPetById", "findPetsByStatus", "addPet"],
+          },
+        },
+      ],
+    },
+    status: {
+      phase: "Pending",
+      discoveredToolsCount: 0,
+      discoveredTools: [],
+      conditions: [
+        {
+          type: "Discovered",
+          status: "False",
+          lastTransitionTime: hoursAgo(0.5),
+          reason: "SpecFetchFailed",
+          message: "Failed to fetch OpenAPI spec: connection timeout",
+        },
+      ],
+    },
+  },
 ];
 
 // Summary stats


### PR DESCRIPTION
## Summary

- Add Tools list page with card view and phase filtering
- Add Tool detail page with Overview, Tools, Handlers, Usage, and Config tabs
- Enhanced mock data with multiple handler types (HTTP, gRPC, MCP, OpenAPI)

## Features

### List Page (`/tools`)
- Card view with tool count and availability status
- Handler type badges (HTTP, gRPC, MCP, OpenAPI)
- Phase filtering (Ready/Degraded/Pending/Failed)
- Tool preview with status icons

### Detail Page (`/tools/[name]`)
- **Overview tab**: Status, tool counts, handler type summary, conditions
- **Tools tab**: Discovered tools with endpoints, descriptions, input schemas
- **Handlers tab**: Accordion view of handler configurations
- **Usage tab**: Agents referencing this ToolRegistry
- **Config tab**: Full YAML specification

### Mock Data
- 5 ToolRegistries with various handler types
- HTTP handlers (data-tools, crm-tools)
- MCP handlers (filesystem, web-search)
- gRPC handlers (user-service, notification-service)
- OpenAPI handler (petstore-api - pending state)

## Test plan

- [ ] Navigate to /tools and verify list loads
- [ ] Verify phase filtering works
- [ ] Click a ToolRegistry card to view details
- [ ] Verify all tabs render correctly
- [ ] Expand handler accordions to see configurations
- [ ] Verify "Used by" shows correct agents

Closes #91