### PR TITLE
feat: add agent scaling UI

### DIFF
--- a/api/openapi/openapi.yaml
+++ b/api/openapi/openapi.yaml
@@ -108,6 +108,42 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
+  /api/v1/agents/{namespace}/{name}/scale:
+    put:
+      tags: [agents]
+      summary: Scale an AgentRuntime
+      operationId: scaleAgent
+      parameters:
+        - name: namespace
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ScaleRequest'
+      responses:
+        '200':
+          description: Agent scaled successfully
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRuntime'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
   /api/v1/agents/{namespace}/{name}/logs:
     get:
       tags: [logs]
@@ -338,6 +374,16 @@ components:
       properties:
         error:
           type: string
+
+    ScaleRequest:
+      type: object
+      required: [replicas]
+      properties:
+        replicas:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Desired number of replicas
 
     LogEntry:
       type: object

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-collapsible": "^1.1.12",
@@ -2114,6 +2115,90 @@
       }
     },
     "node_modules/@radix-ui/react-accordion/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
       "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/dashboard/src/components/agents/index.ts
+++ b/dashboard/src/components/agents/index.ts
@@ -3,3 +3,4 @@ export { FrameworkBadge } from "./framework-badge";
 export { AgentCard } from "./agent-card";
 export { AgentTable } from "./agent-table";
 export { DeployWizard } from "./deploy-wizard";
+export { ScaleControl } from "./scale-control";

--- a/dashboard/src/components/agents/scale-control.tsx
+++ b/dashboard/src/components/agents/scale-control.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Minus, Plus, Loader2, Zap } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+
+interface ScaleControlProps {
+  currentReplicas: number;
+  desiredReplicas: number;
+  minReplicas?: number;
+  maxReplicas?: number;
+  autoscalingEnabled?: boolean;
+  autoscalingType?: "hpa" | "keda";
+  onScale: (replicas: number) => Promise<void>;
+  className?: string;
+  compact?: boolean;
+}
+
+export function ScaleControl({
+  currentReplicas,
+  desiredReplicas,
+  minReplicas = 0,
+  maxReplicas = 10,
+  autoscalingEnabled = false,
+  autoscalingType,
+  onScale,
+  className,
+  compact = false,
+}: ScaleControlProps) {
+  const [isScaling, setIsScaling] = useState(false);
+  const [pendingScale, setPendingScale] = useState<number | null>(null);
+  const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<{
+    replicas: number;
+    type: "scale-down" | "scale-to-zero";
+  } | null>(null);
+
+  const handleScale = useCallback(
+    async (newReplicas: number) => {
+      // Clamp to valid range
+      const clampedReplicas = Math.max(minReplicas, Math.min(maxReplicas, newReplicas));
+
+      // Check if we need confirmation
+      if (clampedReplicas === 0 && desiredReplicas > 0) {
+        setConfirmAction({ replicas: 0, type: "scale-to-zero" });
+        setShowConfirmDialog(true);
+        return;
+      }
+
+      if (clampedReplicas < desiredReplicas && clampedReplicas > 0) {
+        setConfirmAction({ replicas: clampedReplicas, type: "scale-down" });
+        setShowConfirmDialog(true);
+        return;
+      }
+
+      // Execute scale directly for scale up
+      setIsScaling(true);
+      setPendingScale(clampedReplicas);
+      try {
+        await onScale(clampedReplicas);
+      } finally {
+        setIsScaling(false);
+        setPendingScale(null);
+      }
+    },
+    [desiredReplicas, minReplicas, maxReplicas, onScale]
+  );
+
+  const executeScale = useCallback(
+    async (replicas: number) => {
+      setIsScaling(true);
+      setPendingScale(replicas);
+      try {
+        await onScale(replicas);
+      } finally {
+        setIsScaling(false);
+        setPendingScale(null);
+      }
+    },
+    [onScale]
+  );
+
+  const confirmScale = useCallback(async () => {
+    if (confirmAction) {
+      setShowConfirmDialog(false);
+      await executeScale(confirmAction.replicas);
+      setConfirmAction(null);
+    }
+  }, [confirmAction, executeScale]);
+
+  const cancelConfirm = useCallback(() => {
+    setShowConfirmDialog(false);
+    setConfirmAction(null);
+  }, []);
+
+  const displayReplicas = pendingScale ?? desiredReplicas;
+  const canScaleDown = displayReplicas > minReplicas && !isScaling;
+  const canScaleUp = displayReplicas < maxReplicas && !isScaling;
+
+  if (compact) {
+    return (
+      <TooltipProvider>
+        <div className={cn("flex items-center gap-1", className)}>
+          {autoscalingEnabled && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <div className="mr-1">
+                  <Zap className="h-3.5 w-3.5 text-yellow-500" />
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Autoscaling enabled ({autoscalingType?.toUpperCase()})</p>
+                <p className="text-xs text-muted-foreground">
+                  Range: {minReplicas} - {maxReplicas}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          )}
+
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => handleScale(displayReplicas - 1)}
+            disabled={!canScaleDown}
+          >
+            <Minus className="h-3 w-3" />
+          </Button>
+
+          <span className="min-w-[3rem] text-center text-sm font-medium">
+            {isScaling ? (
+              <Loader2 className="h-4 w-4 animate-spin mx-auto" />
+            ) : (
+              `${currentReplicas}/${displayReplicas}`
+            )}
+          </span>
+
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => handleScale(displayReplicas + 1)}
+            disabled={!canScaleUp}
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+
+          <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  {confirmAction?.type === "scale-to-zero"
+                    ? "Scale to Zero?"
+                    : "Scale Down?"}
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  {confirmAction?.type === "scale-to-zero"
+                    ? "This will stop all instances of the agent. The agent will not be able to process requests until scaled back up."
+                    : `This will reduce the agent from ${desiredReplicas} to ${confirmAction?.replicas} replica(s).`}
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={cancelConfirm}>Cancel</AlertDialogCancel>
+                <AlertDialogAction onClick={confirmScale}>
+                  {confirmAction?.type === "scale-to-zero" ? "Scale to Zero" : "Scale Down"}
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+      </TooltipProvider>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <div className={cn("flex flex-col gap-2", className)}>
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-muted-foreground">Replicas</span>
+            {autoscalingEnabled && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center gap-1 px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-600 dark:text-yellow-400">
+                    <Zap className="h-3 w-3" />
+                    <span className="text-xs font-medium">{autoscalingType?.toUpperCase()}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Autoscaling is enabled</p>
+                  <p className="text-xs text-muted-foreground">
+                    Range: {minReplicas} - {maxReplicas} replicas
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+          <div className="text-lg font-semibold">
+            {isScaling ? (
+              <div className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                <span className="text-muted-foreground">{pendingScale}</span>
+              </div>
+            ) : (
+              <span>
+                {currentReplicas}
+                <span className="text-muted-foreground">/{displayReplicas}</span>
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1"
+            onClick={() => handleScale(displayReplicas - 1)}
+            disabled={!canScaleDown}
+          >
+            <Minus className="h-4 w-4 mr-1" />
+            Scale Down
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1"
+            onClick={() => handleScale(displayReplicas + 1)}
+            disabled={!canScaleUp}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            Scale Up
+          </Button>
+        </div>
+
+        {autoscalingEnabled && (
+          <p className="text-xs text-muted-foreground">
+            Manual scaling will be overridden by autoscaler
+          </p>
+        )}
+
+        <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>
+                {confirmAction?.type === "scale-to-zero"
+                  ? "Scale to Zero?"
+                  : "Confirm Scale Down"}
+              </AlertDialogTitle>
+              <AlertDialogDescription>
+                {confirmAction?.type === "scale-to-zero" ? (
+                  <>
+                    This will stop all instances of the agent. The agent will not be
+                    able to process any requests until scaled back up.
+                    <br />
+                    <br />
+                    Are you sure you want to continue?
+                  </>
+                ) : (
+                  <>
+                    This will reduce the number of replicas from{" "}
+                    <strong>{desiredReplicas}</strong> to{" "}
+                    <strong>{confirmAction?.replicas}</strong>.
+                    <br />
+                    <br />
+                    This may affect the agent&apos;s ability to handle traffic.
+                  </>
+                )}
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel onClick={cancelConfirm}>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={confirmScale}
+                className={
+                  confirmAction?.type === "scale-to-zero"
+                    ? "bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    : ""
+                }
+              >
+                {confirmAction?.type === "scale-to-zero" ? "Scale to Zero" : "Scale Down"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/dashboard/src/components/ui/alert-dialog.tsx
+++ b/dashboard/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/dashboard/src/lib/api/schema.d.ts
+++ b/dashboard/src/lib/api/schema.d.ts
@@ -39,6 +39,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{namespace}/{name}/scale": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Scale an AgentRuntime */
+        put: operations["scaleAgent"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{namespace}/{name}/logs": {
         parameters: {
             query?: never;
@@ -181,6 +198,10 @@ export interface components {
     schemas: {
         Error: {
             error: string;
+        };
+        ScaleRequest: {
+            /** @description Desired number of replicas */
+            replicas: number;
         };
         LogEntry: {
             /** Format: date-time */
@@ -499,6 +520,36 @@ export interface operations {
                     "application/json": components["schemas"]["AgentRuntime"];
                 };
             };
+            404: components["responses"]["NotFound"];
+            500: components["responses"]["InternalError"];
+        };
+    };
+    scaleAgent: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                namespace: string;
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ScaleRequest"];
+            };
+        };
+        responses: {
+            /** @description Agent scaled successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AgentRuntime"];
+                };
+            };
+            400: components["responses"]["BadRequest"];
             404: components["responses"]["NotFound"];
             500: components["responses"]["InternalError"];
         };

--- a/dashboard/src/lib/mock-data.ts
+++ b/dashboard/src/lib/mock-data.ts
@@ -36,7 +36,15 @@ export const mockAgentRuntimes: AgentRuntime[] = [
       facade: { type: "websocket", port: 8080, handler: "runtime" },
       provider: { type: "claude", model: "claude-sonnet-4-20250514" },
       session: { type: "redis", ttl: "24h" },
-      runtime: { replicas: 3 },
+      runtime: {
+        replicas: 3,
+        autoscaling: {
+          enabled: true,
+          type: "keda",
+          minReplicas: 1,
+          maxReplicas: 10,
+        },
+      },
     },
     status: {
       phase: "Running",


### PR DESCRIPTION
## Summary
- Add ScaleControl component with +/- buttons for adjusting replica count
- Display current vs desired replica count on agent cards and detail page
- Confirmation dialogs for scale down and scale-to-zero operations
- Autoscaling indicator badge showing KEDA/HPA status when enabled
- API endpoint for scaling agents (`PUT /api/v1/agents/{namespace}/{name}/scale`)

## Changes
- **api/openapi/openapi.yaml**: Add scale endpoint and ScaleRequest schema
- **dashboard/src/components/agents/scale-control.tsx**: New component with compact and full modes
- **dashboard/src/app/agents/[name]/page.tsx**: Add ScaleControl to agent detail page
- **dashboard/src/components/agents/agent-card.tsx**: Add compact ScaleControl to agent cards
- **dashboard/src/lib/api/client.ts**: Add `scaleAgent()` function with demo mode support
- **dashboard/src/lib/mock-data.ts**: Add autoscaling example (KEDA) to customer-support agent

## Test plan
- [ ] Open agent list, verify scale controls appear on each card
- [ ] Click +/- buttons to scale up (no confirmation) and down (shows confirmation)
- [ ] Scale to zero and verify destructive confirmation dialog appears
- [ ] Open agent detail page, verify full scale control with autoscaling indicator
- [ ] Check customer-support agent shows KEDA autoscaling badge
- [ ] Verify scale operations invalidate queries and refresh UI

Closes #95