### PR TITLE
fix: address SonarCloud quality issues on main branch

### DIFF
--- a/dashboard/src/app/agents/[name]/page.tsx
+++ b/dashboard/src/app/agents/[name]/page.tsx
@@ -190,8 +190,8 @@ export default function AgentDetailPage({ params }: AgentDetailPageProps) {
                           </tr>
                         </thead>
                         <tbody>
-                          {status.conditions.map((condition, index) => (
-                            <tr key={index} className="border-b last:border-0">
+                          {status.conditions.map((condition) => (
+                            <tr key={condition.type} className="border-b last:border-0">
                               <td className="py-2 pr-4">
                                 <span
                                   className={`px-2 py-0.5 rounded text-xs font-medium ${

--- a/dashboard/src/app/tools/[name]/page.tsx
+++ b/dashboard/src/app/tools/[name]/page.tsx
@@ -250,8 +250,8 @@ export default function ToolDetailPage({ params }: PageProps) {
                 </CardHeader>
                 <CardContent>
                   <div className="space-y-3">
-                    {status.conditions.map((condition, idx) => (
-                      <div key={idx} className="flex items-start gap-3 p-3 rounded-lg bg-muted/50">
+                    {status.conditions.map((condition) => (
+                      <div key={condition.type} className="flex items-start gap-3 p-3 rounded-lg bg-muted/50">
                         {condition.status === "True" ? (
                           <CheckCircle className="h-4 w-4 text-green-500 mt-0.5" />
                         ) : (
@@ -358,10 +358,10 @@ export default function ToolDetailPage({ params }: PageProps) {
               </CardHeader>
               <CardContent>
                 <Accordion type="multiple" className="w-full">
-                  {handlers.map((handler, idx) => {
+                  {handlers.map((handler) => {
                     const Icon = getHandlerTypeIcon(handler.type);
                     return (
-                      <AccordionItem key={idx} value={`handler-${idx}`}>
+                      <AccordionItem key={handler.name} value={`handler-${handler.name}`}>
                         <AccordionTrigger className="hover:no-underline">
                           <div className="flex items-center gap-3">
                             <Icon className="h-4 w-4 text-muted-foreground" />

--- a/dashboard/src/components/agents/events-panel.tsx
+++ b/dashboard/src/components/agents/events-panel.tsx
@@ -31,13 +31,6 @@ function formatRelativeTime(timestamp: string): string {
 }
 
 /**
- * Format a timestamp to a readable date/time string.
- */
-function _formatTimestamp(timestamp: string): string {
-  return new Date(timestamp).toLocaleString();
-}
-
-/**
  * Single event row component.
  */
 function EventRow({ event }: { event: K8sEvent }) {
@@ -154,8 +147,8 @@ export function EventsPanel({ agentName, namespace }: EventsPanelProps) {
           </div>
         ) : (
           <div className="space-y-3">
-            {events.map((event, index) => (
-              <EventRow key={`${event.reason}-${event.lastTimestamp}-${index}`} event={event} />
+            {events.map((event) => (
+              <EventRow key={`${event.involvedObject.kind}-${event.involvedObject.name}-${event.reason}-${event.lastTimestamp}`} event={event} />
             ))}
           </div>
         )}

--- a/dashboard/src/components/logs/log-viewer.tsx
+++ b/dashboard/src/components/logs/log-viewer.tsx
@@ -270,9 +270,9 @@ export function LogViewer({
               {logs.length === 0 ? "No logs yet..." : "No logs match the current filters"}
             </div>
           ) : (
-            filteredLogs.map((log, index) => (
+            filteredLogs.map((log) => (
               <div
-                key={index}
+                key={`${log.timestamp.getTime()}-${log.level}-${log.container}-${log.message.slice(0, 50)}`}
                 className="flex gap-2 py-0.5 hover:bg-muted/50 rounded px-1"
               >
                 <span className="text-muted-foreground shrink-0">

--- a/dashboard/src/hooks/use-agent-console.ts
+++ b/dashboard/src/hooks/use-agent-console.ts
@@ -88,7 +88,7 @@ export function useAgentConsole({
         }
         break;
 
-      case "chunk":
+      case "chunk": {
         // Check if we need to append to existing streaming message or create new
         const currentMessages = messagesRef.current;
         const lastMsg = currentMessages[currentMessages.length - 1];
@@ -109,6 +109,7 @@ export function useAgentConsole({
           });
         }
         break;
+      }
 
       case "done":
         // Mark message as complete
@@ -157,13 +158,14 @@ export function useAgentConsole({
         }
         break;
 
-      case "error":
+      case "error": {
         // Handle error messages from the proxy or agent
         const errorMsg = message.error?.message || "Unknown error";
         const errorCode = message.error?.code || "UNKNOWN";
         console.error(`[useAgentConsole] Error from server: [${errorCode}] ${errorMsg}`);
         setStatus("error", errorMsg);
         break;
+      }
     }
   }, [addMessage, updateLastMessage, setSessionId, setStatus]);
 

--- a/pkg/metrics/llm.go
+++ b/pkg/metrics/llm.go
@@ -146,6 +146,8 @@ type LLMMetricsRecorder interface {
 // NoOpLLMMetrics is a no-op implementation for when metrics are disabled.
 type NoOpLLMMetrics struct{}
 
-// RecordRequest is a no-op.
-func (n *NoOpLLMMetrics) RecordRequest(req LLMRequestMetrics) {
+// RecordRequest is a no-op implementation that intentionally does nothing.
+// This is used when metrics collection is disabled.
+func (n *NoOpLLMMetrics) RecordRequest(_ LLMRequestMetrics) {
+	// Intentionally empty: no-op implementation for when metrics are disabled
 }


### PR DESCRIPTION
## Summary

Addresses SonarCloud quality issues reported on the main branch:

### Go Critical Fixes
- **pkg/metrics/llm.go**: Add comment explaining intentionally empty no-op function (S1186)
- **internal/runtime/server.go**: Extract `createMockProvider` helper to reduce cognitive complexity (S3776)
- **internal/facade/server.go**: Extract 7 helper methods to reduce cognitive complexity from 26 to <15 (S3776)

### TypeScript Major Fixes
- **React key issues (S6479)**: Use stable, unique keys instead of array indices:
  - `log-viewer.tsx`: Composite key from timestamp, level, container, message
  - `agents/[name]/page.tsx`: Use `condition.type` as key
  - `tools/[name]/page.tsx`: Use `condition.type` and `handler.name` as keys
  - `events-panel.tsx`: Composite key without index
- **Lexical declarations (S6836)**: Wrap switch case bodies in braces in `use-agent-console.ts`
- Remove unused `formatTimestamp` function from `events-panel.tsx`

### Tests
- Add tests for ping/pong functionality
- Add test for closed connection handling
- Add test for handler WriteError response
- Coverage on facade/server.go improved from 78% to 84%

## Test plan
- [x] All pre-commit checks pass
- [x] Go build succeeds
- [x] TypeScript build succeeds
- [x] Lint checks pass
- [x] Coverage meets 80% threshold on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)