### PR TITLE
feat: wire mock provider into Omnia runtime

### DIFF
--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -66,25 +66,26 @@ type Config struct {
 
 // Environment variable names.
 const (
-	envAgentName         = "OMNIA_AGENT_NAME"
-	envNamespace         = "OMNIA_NAMESPACE"
-	envPromptPackPath    = "OMNIA_PROMPTPACK_PATH"
-	envPromptName        = "OMNIA_PROMPT_NAME"
-	envSessionType       = "OMNIA_SESSION_TYPE"
-	envSessionURL        = "OMNIA_SESSION_URL"
-	envSessionTTL        = "OMNIA_SESSION_TTL"
-	envProviderType      = "OMNIA_PROVIDER_TYPE"
-	envProviderModel     = "OMNIA_PROVIDER_MODEL"
-	envProviderBaseURL   = "OMNIA_PROVIDER_BASE_URL"
-	envMockProvider      = "OMNIA_MOCK_PROVIDER"
-	envMockConfigPath    = "OMNIA_MOCK_CONFIG"
-	envToolsConfigPath   = "OMNIA_TOOLS_CONFIG"
-	envTracingEnabled    = "OMNIA_TRACING_ENABLED"
-	envTracingEndpoint   = "OMNIA_TRACING_ENDPOINT"
-	envTracingSampleRate = "OMNIA_TRACING_SAMPLE_RATE"
-	envTracingInsecure   = "OMNIA_TRACING_INSECURE"
-	envGRPCPort          = "OMNIA_GRPC_PORT"
-	envHealthPort        = "OMNIA_HEALTH_PORT"
+	envAgentName              = "OMNIA_AGENT_NAME"
+	envNamespace              = "OMNIA_NAMESPACE"
+	envPromptPackPath         = "OMNIA_PROMPTPACK_PATH"
+	envPromptName             = "OMNIA_PROMPT_NAME"
+	envSessionType            = "OMNIA_SESSION_TYPE"
+	envSessionURL             = "OMNIA_SESSION_URL"
+	envSessionTTL             = "OMNIA_SESSION_TTL"
+	envProviderType           = "OMNIA_PROVIDER_TYPE"
+	envProviderModel          = "OMNIA_PROVIDER_MODEL"
+	envProviderBaseURL        = "OMNIA_PROVIDER_BASE_URL"
+	envMockProvider           = "OMNIA_MOCK_PROVIDER"
+	envMockConfigPath         = "OMNIA_MOCK_CONFIG"
+	envProviderMockConfigPath = "OMNIA_PROVIDER_MOCK_CONFIG" // From additionalConfig
+	envToolsConfigPath        = "OMNIA_TOOLS_CONFIG"
+	envTracingEnabled         = "OMNIA_TRACING_ENABLED"
+	envTracingEndpoint        = "OMNIA_TRACING_ENDPOINT"
+	envTracingSampleRate      = "OMNIA_TRACING_SAMPLE_RATE"
+	envTracingInsecure        = "OMNIA_TRACING_INSECURE"
+	envGRPCPort               = "OMNIA_GRPC_PORT"
+	envHealthPort             = "OMNIA_HEALTH_PORT"
 )
 
 // Default values.
@@ -123,7 +124,7 @@ func LoadConfig() (*Config, error) {
 		Model:             os.Getenv(envProviderModel),
 		BaseURL:           os.Getenv(envProviderBaseURL),
 		MockProvider:      os.Getenv(envMockProvider) == "true",
-		MockConfigPath:    os.Getenv(envMockConfigPath),
+		MockConfigPath:    getEnvOrDefault(envMockConfigPath, os.Getenv(envProviderMockConfigPath)),
 		ToolsConfigPath:   getEnvOrDefault(envToolsConfigPath, defaultToolsConfigPath),
 		TracingEnabled:    os.Getenv(envTracingEnabled) == "true",
 		TracingEndpoint:   os.Getenv(envTracingEndpoint),
@@ -140,6 +141,12 @@ func LoadConfig() (*Config, error) {
 
 	if err := cfg.validate(); err != nil {
 		return nil, err
+	}
+
+	// Auto-enable mock provider when provider type is "mock"
+	// This allows provider.type: mock to work as a first-class selection
+	if cfg.ProviderType == string(provider.TypeMock) {
+		cfg.MockProvider = true
 	}
 
 	return cfg, nil

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"time"
 
@@ -268,6 +269,7 @@ func (s *Server) Converse(stream runtimev1.RuntimeService_ConverseServer) error 
 func (s *Server) processMessage(ctx context.Context, stream runtimev1.RuntimeService_ConverseServer, msg *runtimev1.ClientMessage) error {
 	sessionID := msg.GetSessionId()
 	content := msg.GetContent()
+	metadata := msg.GetMetadata()
 
 	// Enrich context with session ID
 	ctx = logctx.WithSessionID(ctx, sessionID)
@@ -280,7 +282,14 @@ func (s *Server) processMessage(ctx context.Context, stream runtimev1.RuntimeSer
 		defer span.End()
 	}
 
-	log.V(1).Info("processing message", "contentLength", len(content))
+	// Extract mock scenario for routing (used when mock provider is enabled)
+	scenario := ScenarioDefault
+	if s.mockProvider {
+		scenario = extractMockScenario(metadata, content)
+		log.V(1).Info("mock scenario detected", "scenario", scenario)
+	}
+
+	log.V(1).Info("processing message", "contentLength", len(content), "scenario", scenario)
 
 	// Get or create conversation for this session
 	conv, err := s.getOrCreateConversation(ctx, sessionID)
@@ -288,8 +297,17 @@ func (s *Server) processMessage(ctx context.Context, stream runtimev1.RuntimeSer
 		return fmt.Errorf("failed to get conversation: %w", err)
 	}
 
+	// For mock provider, prepend scenario context to help with response routing.
+	// The mock repository can use patterns like "[scenario:image-analysis]" to
+	// match and return appropriate canned responses.
+	messageContent := content
+	if s.mockProvider && scenario != ScenarioDefault {
+		messageContent = fmt.Sprintf("[scenario:%s] %s", scenario, content)
+		log.V(2).Info("enriched message with scenario", "scenario", scenario)
+	}
+
 	// Send the message using PromptKit SDK
-	resp, err := conv.Send(ctx, content)
+	resp, err := conv.Send(ctx, messageContent)
 	if err != nil {
 		// Event bus will record the failure metric via EventProviderCallFailed
 		return fmt.Errorf("failed to send message: %w", err)
@@ -425,6 +443,120 @@ func (s *Server) createMockProvider() (*mock.Provider, error) {
 	}
 	// Use in-memory mock provider with default responses
 	return mock.NewProvider("mock", "mock-model", false), nil
+}
+
+// Mock scenario metadata key.
+const (
+	MetadataKeyMockScenario = "mock_scenario"
+	MetadataKeyContentType  = "content_type"
+)
+
+// Default scenario identifiers.
+const (
+	ScenarioDefault       = "default"
+	ScenarioImageAnalysis = "image-analysis"
+	ScenarioAudioAnalysis = "audio-analysis"
+	ScenarioDocumentQA    = "document-qa"
+)
+
+// extractMockScenario determines the mock scenario to use based on message metadata
+// and content analysis. Priority:
+// 1. Explicit mock_scenario in metadata
+// 2. Auto-detection based on content_type metadata
+// 3. Auto-detection based on content patterns
+// 4. Default scenario
+func extractMockScenario(metadata map[string]string, content string) string {
+	// Check for explicit scenario in metadata
+	if scenario, ok := metadata[MetadataKeyMockScenario]; ok && scenario != "" {
+		return scenario
+	}
+
+	// Auto-detect based on content_type metadata
+	if contentType, ok := metadata[MetadataKeyContentType]; ok {
+		if scenario := detectScenarioFromContentType(contentType); scenario != "" {
+			return scenario
+		}
+	}
+
+	// Auto-detect based on content patterns
+	if scenario := detectScenarioFromContent(content); scenario != "" {
+		return scenario
+	}
+
+	return ScenarioDefault
+}
+
+// detectScenarioFromContentType maps content types to scenarios.
+func detectScenarioFromContentType(contentType string) string {
+	switch {
+	case isImageContentType(contentType):
+		return ScenarioImageAnalysis
+	case isAudioContentType(contentType):
+		return ScenarioAudioAnalysis
+	case isDocumentContentType(contentType):
+		return ScenarioDocumentQA
+	default:
+		return ""
+	}
+}
+
+// detectScenarioFromContent analyzes content to detect scenarios.
+// This is a fallback when metadata doesn't specify the content type.
+func detectScenarioFromContent(content string) string {
+	// Check for common patterns indicating multi-modal content
+	// These patterns might appear in content when referencing uploaded media
+	patterns := map[string]string{
+		"[image:":    ScenarioImageAnalysis,
+		"[audio:":    ScenarioAudioAnalysis,
+		"[document:": ScenarioDocumentQA,
+		"[pdf:":      ScenarioDocumentQA,
+	}
+
+	for pattern, scenario := range patterns {
+		if containsPattern(content, pattern) {
+			return scenario
+		}
+	}
+
+	return ""
+}
+
+// isImageContentType checks if a content type represents an image.
+func isImageContentType(contentType string) bool {
+	imageTypes := []string{"image/", "png", "jpg", "jpeg", "gif", "webp", "svg"}
+	for _, t := range imageTypes {
+		if containsPattern(contentType, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// isAudioContentType checks if a content type represents audio.
+func isAudioContentType(contentType string) bool {
+	audioTypes := []string{"audio/", "mp3", "wav", "ogg", "m4a", "flac"}
+	for _, t := range audioTypes {
+		if containsPattern(contentType, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// isDocumentContentType checks if a content type represents a document.
+func isDocumentContentType(contentType string) bool {
+	docTypes := []string{"application/pdf", "pdf", "document", "text/"}
+	for _, t := range docTypes {
+		if containsPattern(contentType, t) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsPattern performs case-insensitive substring check.
+func containsPattern(s, pattern string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(pattern))
 }
 
 // registerToolsWithConversation registers all available tools with a conversation.


### PR DESCRIPTION
## Summary
- Auto-enable mock provider when `provider.type: mock` is specified in AgentRuntime
- Support `mock_config` path from provider's `additionalConfig` via `OMNIA_PROVIDER_MOCK_CONFIG` env var
- Implement scenario detection with priority ordering: explicit metadata → content_type → content patterns
- Prepend scenario context to messages for mock provider routing (e.g., `[scenario:image-analysis]`)
- Add comprehensive unit tests for all scenario detection logic

## Scenario Detection
The runtime automatically detects scenarios for mock provider routing:
1. **Explicit metadata** - `mock_scenario` key in message metadata takes highest priority
2. **Content type** - Detects from `content_type` metadata (image/*, audio/*, application/pdf)
3. **Content patterns** - Fallback detection from message content (mentions of "image", "audio", "document")

Supported scenarios:
- `default` - No special handling
- `image-analysis` - For image content
- `audio-analysis` - For audio content
- `document-qa` - For PDF/document content

## Test Plan
- [x] Unit tests for config loading with mock provider auto-enable
- [x] Unit tests for `OMNIA_PROVIDER_MOCK_CONFIG` environment variable
- [x] Unit tests for scenario detection from explicit metadata
- [x] Unit tests for scenario detection from content type
- [x] Unit tests for scenario detection from content patterns
- [x] Unit tests for priority ordering of detection methods
- [x] Unit tests for helper functions (isImageContentType, isAudioContentType, isDocumentContentType)
- [x] All pre-commit checks pass

Closes #160