### PR TITLE
feat: implement media URL resolution for mock responses

### DIFF
--- a/api/proto/runtime/v1/runtime.proto
+++ b/api/proto/runtime/v1/runtime.proto
@@ -89,10 +89,42 @@ message ToolResult {
 // Done signals the completion of a conversation turn.
 message Done {
   // final_content contains the complete response text (optional).
+  // For text-only responses, this contains the full response.
+  // For multimodal responses, use the parts field instead.
   string final_content = 1;
 
   // usage contains token usage statistics for this turn.
   Usage usage = 2;
+
+  // parts contains multimodal content parts (text, images, audio, video).
+  // If non-empty, this takes precedence over final_content for rich responses.
+  repeated ContentPart parts = 3;
+}
+
+// ContentPart represents a single piece of content in a multimodal message.
+message ContentPart {
+  // type indicates the content type: "text", "image", "audio", "video"
+  string type = 1;
+
+  // text contains text content (only set when type="text")
+  string text = 2;
+
+  // media contains media content (only set when type="image", "audio", or "video")
+  MediaContent media = 3;
+}
+
+// MediaContent represents media data (image, audio, video) in a message.
+message MediaContent {
+  // Exactly one of data or url should be set.
+
+  // data contains base64-encoded media data (for resolved file:// and mock:// URLs)
+  string data = 1;
+
+  // url contains the media URL (for http:// and https:// URLs that are passed through)
+  string url = 2;
+
+  // mime_type indicates the media format (e.g., "image/png", "audio/mp3")
+  string mime_type = 3;
 }
 
 // Usage contains token usage and cost information.

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	// Mock provider configuration (for testing)
 	MockProvider   bool   // Enable mock provider instead of real LLM
 	MockConfigPath string // Path to mock responses YAML file (optional)
+	MediaBasePath  string // Base path for resolving mock:// URLs to media files
 
 	// Tools configuration
 	ToolsConfigPath string // Path to tools.yaml configuration file
@@ -79,6 +80,7 @@ const (
 	envMockProvider           = "OMNIA_MOCK_PROVIDER"
 	envMockConfigPath         = "OMNIA_MOCK_CONFIG"
 	envProviderMockConfigPath = "OMNIA_PROVIDER_MOCK_CONFIG" // From additionalConfig
+	envMediaBasePath          = "OMNIA_MEDIA_BASE_PATH"
 	envToolsConfigPath        = "OMNIA_TOOLS_CONFIG"
 	envTracingEnabled         = "OMNIA_TRACING_ENABLED"
 	envTracingEndpoint        = "OMNIA_TRACING_ENDPOINT"
@@ -95,6 +97,7 @@ const (
 	defaultSessionType     = "memory"
 	defaultSessionTTL      = 24 * time.Hour
 	defaultProviderType    = "auto"
+	defaultMediaBasePath   = "/etc/omnia/media"
 	defaultToolsConfigPath = "/etc/omnia/tools/tools.yaml"
 	defaultGRPCPort        = 9000
 	defaultHealthPort      = 9001
@@ -125,6 +128,7 @@ func LoadConfig() (*Config, error) {
 		BaseURL:           os.Getenv(envProviderBaseURL),
 		MockProvider:      os.Getenv(envMockProvider) == "true",
 		MockConfigPath:    getEnvOrDefault(envMockConfigPath, os.Getenv(envProviderMockConfigPath)),
+		MediaBasePath:     getEnvOrDefault(envMediaBasePath, defaultMediaBasePath),
 		ToolsConfigPath:   getEnvOrDefault(envToolsConfigPath, defaultToolsConfigPath),
 		TracingEnabled:    os.Getenv(envTracingEnabled) == "true",
 		TracingEndpoint:   os.Getenv(envTracingEndpoint),

--- a/internal/runtime/config_test.go
+++ b/internal/runtime/config_test.go
@@ -323,3 +323,24 @@ func TestLoadConfig_TracingSampleRateNegative(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "must be between 0.0 and 1.0")
 }
+
+func TestLoadConfig_MediaBasePath(t *testing.T) {
+	t.Setenv(envAgentName, "test-agent")
+	t.Setenv(envNamespace, "test-ns")
+	t.Setenv(envMediaBasePath, "/custom/media/path")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, "/custom/media/path", cfg.MediaBasePath)
+}
+
+func TestLoadConfig_MediaBasePathDefault(t *testing.T) {
+	t.Setenv(envAgentName, "test-agent")
+	t.Setenv(envNamespace, "test-ns")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+
+	assert.Equal(t, defaultMediaBasePath, cfg.MediaBasePath)
+}

--- a/internal/runtime/media.go
+++ b/internal/runtime/media.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// URL scheme prefixes for media resolution.
+const (
+	schemeFile  = "file://"
+	schemeMock  = "mock://"
+	schemeHTTP  = "http://"
+	schemeHTTPS = "https://"
+)
+
+// MediaResolver resolves media URLs to base64-encoded data.
+type MediaResolver struct {
+	mediaBasePath string
+}
+
+// NewMediaResolver creates a new MediaResolver with the given base path.
+func NewMediaResolver(mediaBasePath string) *MediaResolver {
+	return &MediaResolver{
+		mediaBasePath: mediaBasePath,
+	}
+}
+
+// ResolveURL resolves a media URL to base64-encoded data and MIME type.
+// Supports the following URL schemes:
+//   - file:// - Reads from the local filesystem
+//   - mock:// - Resolves against the configured media base path
+//   - http:// and https:// - Returns empty data (URL should be used directly)
+//
+// Returns:
+//   - base64Data: Base64-encoded file contents (empty for http/https URLs)
+//   - mimeType: Inferred MIME type from file extension
+//   - isPassthrough: True if the URL should be passed through unchanged (http/https)
+//   - error: Any error encountered during resolution
+func (r *MediaResolver) ResolveURL(url string) (base64Data, mimeType string, isPassthrough bool, err error) {
+	switch {
+	case strings.HasPrefix(url, schemeFile):
+		path := strings.TrimPrefix(url, schemeFile)
+		return r.resolveLocalFile(path)
+
+	case strings.HasPrefix(url, schemeMock):
+		filename := strings.TrimPrefix(url, schemeMock)
+		path := filepath.Join(r.mediaBasePath, filename)
+		return r.resolveLocalFile(path)
+
+	case strings.HasPrefix(url, schemeHTTP), strings.HasPrefix(url, schemeHTTPS):
+		// HTTP/HTTPS URLs are passed through unchanged
+		mimeType := inferMIMETypeFromExtension(url)
+		return "", mimeType, true, nil
+
+	default:
+		return "", "", false, fmt.Errorf("unsupported URL scheme: %s", url)
+	}
+}
+
+// resolveLocalFile reads a local file and returns its base64-encoded contents.
+func (r *MediaResolver) resolveLocalFile(path string) (base64Data, mimeType string, isPassthrough bool, err error) {
+	// Validate the path exists
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return "", "", false, fmt.Errorf("media file not found: %s", path)
+	}
+
+	// Read the file
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", "", false, fmt.Errorf("failed to read media file %s: %w", path, err)
+	}
+
+	// Encode to base64
+	base64Data = base64.StdEncoding.EncodeToString(data)
+
+	// Infer MIME type from extension
+	mimeType = inferMIMETypeFromExtension(path)
+
+	return base64Data, mimeType, false, nil
+}
+
+// inferMIMETypeFromExtension infers the MIME type from a file path or URL extension.
+func inferMIMETypeFromExtension(path string) string {
+	// Strip query parameters from URLs
+	if idx := strings.Index(path, "?"); idx != -1 {
+		path = path[:idx]
+	}
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	// Images
+	case ".jpg", ".jpeg":
+		return "image/jpeg"
+	case ".png":
+		return "image/png"
+	case ".gif":
+		return "image/gif"
+	case ".webp":
+		return "image/webp"
+	case ".svg":
+		return "image/svg+xml"
+	case ".bmp":
+		return "image/bmp"
+	case ".ico":
+		return "image/x-icon"
+
+	// Audio
+	case ".mp3":
+		return "audio/mpeg"
+	case ".wav":
+		return "audio/wav"
+	case ".ogg", ".oga":
+		return "audio/ogg"
+	case ".flac":
+		return "audio/flac"
+	case ".aac":
+		return "audio/aac"
+	case ".m4a":
+		return "audio/mp4"
+	case ".weba":
+		return "audio/webm"
+
+	// Video
+	case ".mp4":
+		return "video/mp4"
+	case ".webm":
+		return "video/webm"
+	case ".ogv":
+		return "video/ogg"
+	case ".avi":
+		return "video/x-msvideo"
+	case ".mov":
+		return "video/quicktime"
+	case ".mkv":
+		return "video/x-matroska"
+
+	// Documents
+	case ".pdf":
+		return "application/pdf"
+
+	default:
+		return "application/octet-stream"
+	}
+}
+
+// IsMediaURL checks if a URL is a media URL that can be resolved.
+func IsMediaURL(url string) bool {
+	return strings.HasPrefix(url, schemeFile) ||
+		strings.HasPrefix(url, schemeMock) ||
+		strings.HasPrefix(url, schemeHTTP) ||
+		strings.HasPrefix(url, schemeHTTPS)
+}
+
+// IsResolvableURL checks if a URL needs to be resolved (file:// or mock://).
+// HTTP/HTTPS URLs don't need resolution - they're passed through.
+func IsResolvableURL(url string) bool {
+	return strings.HasPrefix(url, schemeFile) || strings.HasPrefix(url, schemeMock)
+}

--- a/internal/runtime/media_test.go
+++ b/internal/runtime/media_test.go
@@ -1,0 +1,267 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMediaResolver(t *testing.T) {
+	resolver := NewMediaResolver("/test/media")
+	assert.NotNil(t, resolver)
+	assert.Equal(t, "/test/media", resolver.mediaBasePath)
+}
+
+func TestMediaResolver_ResolveURL_FileScheme(t *testing.T) {
+	// Create a temp file with test content
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "test.png")
+	testContent := []byte("fake png content")
+	err := os.WriteFile(testFile, testContent, 0644)
+	require.NoError(t, err)
+
+	resolver := NewMediaResolver(tmpDir)
+
+	// Test file:// URL resolution
+	base64Data, mimeType, isPassthrough, err := resolver.ResolveURL("file://" + testFile)
+	require.NoError(t, err)
+	assert.False(t, isPassthrough)
+	assert.Equal(t, "image/png", mimeType)
+
+	// Verify base64 decoding
+	decoded, err := base64.StdEncoding.DecodeString(base64Data)
+	require.NoError(t, err)
+	assert.Equal(t, testContent, decoded)
+}
+
+func TestMediaResolver_ResolveURL_MockScheme(t *testing.T) {
+	// Create a temp dir as media base path
+	tmpDir := t.TempDir()
+	testFile := filepath.Join(tmpDir, "response.jpg")
+	testContent := []byte("fake jpeg content")
+	err := os.WriteFile(testFile, testContent, 0644)
+	require.NoError(t, err)
+
+	resolver := NewMediaResolver(tmpDir)
+
+	// Test mock:// URL resolution
+	base64Data, mimeType, isPassthrough, err := resolver.ResolveURL("mock://response.jpg")
+	require.NoError(t, err)
+	assert.False(t, isPassthrough)
+	assert.Equal(t, "image/jpeg", mimeType)
+
+	// Verify base64 decoding
+	decoded, err := base64.StdEncoding.DecodeString(base64Data)
+	require.NoError(t, err)
+	assert.Equal(t, testContent, decoded)
+}
+
+func TestMediaResolver_ResolveURL_HTTPPassthrough(t *testing.T) {
+	resolver := NewMediaResolver("/test/media")
+
+	testCases := []struct {
+		name     string
+		url      string
+		mimeType string
+	}{
+		{"http URL", "http://example.com/image.png", "image/png"},
+		{"https URL", "https://example.com/audio.mp3", "audio/mpeg"},
+		{"http with query params", "http://cdn.example.com/video.mp4?token=abc", "video/mp4"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			base64Data, mimeType, isPassthrough, err := resolver.ResolveURL(tc.url)
+			require.NoError(t, err)
+			assert.True(t, isPassthrough, "HTTP URLs should be passthrough")
+			assert.Empty(t, base64Data, "HTTP URLs should not have base64 data")
+			assert.Equal(t, tc.mimeType, mimeType)
+		})
+	}
+}
+
+func TestMediaResolver_ResolveURL_MissingFile(t *testing.T) {
+	resolver := NewMediaResolver("/test/media")
+
+	_, _, _, err := resolver.ResolveURL("file:///nonexistent/file.png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestMediaResolver_ResolveURL_UnsupportedScheme(t *testing.T) {
+	resolver := NewMediaResolver("/test/media")
+
+	_, _, _, err := resolver.ResolveURL("ftp://example.com/file.png")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported URL scheme")
+}
+
+func TestInferMIMETypeFromExtension(t *testing.T) {
+	testCases := []struct {
+		path     string
+		expected string
+	}{
+		// Images
+		{"/path/to/image.jpg", "image/jpeg"},
+		{"/path/to/image.jpeg", "image/jpeg"},
+		{"/path/to/image.png", "image/png"},
+		{"/path/to/image.gif", "image/gif"},
+		{"/path/to/image.webp", "image/webp"},
+		{"/path/to/image.svg", "image/svg+xml"},
+		{"/path/to/image.bmp", "image/bmp"},
+		{"/path/to/image.ico", "image/x-icon"},
+
+		// Audio
+		{"/path/to/audio.mp3", "audio/mpeg"},
+		{"/path/to/audio.wav", "audio/wav"},
+		{"/path/to/audio.ogg", "audio/ogg"},
+		{"/path/to/audio.flac", "audio/flac"},
+		{"/path/to/audio.aac", "audio/aac"},
+		{"/path/to/audio.m4a", "audio/mp4"},
+		{"/path/to/audio.weba", "audio/webm"},
+
+		// Video
+		{"/path/to/video.mp4", "video/mp4"},
+		{"/path/to/video.webm", "video/webm"},
+		{"/path/to/video.ogv", "video/ogg"},
+		{"/path/to/video.avi", "video/x-msvideo"},
+		{"/path/to/video.mov", "video/quicktime"},
+		{"/path/to/video.mkv", "video/x-matroska"},
+
+		// Documents
+		{"/path/to/doc.pdf", "application/pdf"},
+
+		// Unknown
+		{"/path/to/file.xyz", "application/octet-stream"},
+		{"/path/to/noextension", "application/octet-stream"},
+
+		// Case insensitive
+		{"/path/to/IMAGE.PNG", "image/png"},
+		{"/path/to/AUDIO.MP3", "audio/mpeg"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.path, func(t *testing.T) {
+			result := inferMIMETypeFromExtension(tc.path)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsMediaURL(t *testing.T) {
+	testCases := []struct {
+		url      string
+		expected bool
+	}{
+		{"file:///path/to/file.png", true},
+		{"mock://response.jpg", true},
+		{"http://example.com/image.png", true},
+		{"https://example.com/audio.mp3", true},
+		{"ftp://example.com/file.png", false},
+		{"data:image/png;base64,abc", false},
+		{"relative/path.png", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.url, func(t *testing.T) {
+			result := IsMediaURL(tc.url)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestIsResolvableURL(t *testing.T) {
+	testCases := []struct {
+		url      string
+		expected bool
+	}{
+		{"file:///path/to/file.png", true},
+		{"mock://response.jpg", true},
+		{"http://example.com/image.png", false},
+		{"https://example.com/audio.mp3", false},
+		{"ftp://example.com/file.png", false},
+		{"", false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.url, func(t *testing.T) {
+			result := IsResolvableURL(tc.url)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestMediaResolver_ResolveURL_AudioFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testCases := []struct {
+		filename string
+		mimeType string
+	}{
+		{"audio.mp3", "audio/mpeg"},
+		{"audio.wav", "audio/wav"},
+		{"audio.ogg", "audio/ogg"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.filename, func(t *testing.T) {
+			testFile := filepath.Join(tmpDir, tc.filename)
+			err := os.WriteFile(testFile, []byte("fake audio"), 0644)
+			require.NoError(t, err)
+
+			resolver := NewMediaResolver(tmpDir)
+			_, mimeType, isPassthrough, err := resolver.ResolveURL("mock://" + tc.filename)
+			require.NoError(t, err)
+			assert.False(t, isPassthrough)
+			assert.Equal(t, tc.mimeType, mimeType)
+		})
+	}
+}
+
+func TestMediaResolver_ResolveURL_VideoFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	testCases := []struct {
+		filename string
+		mimeType string
+	}{
+		{"video.mp4", "video/mp4"},
+		{"video.webm", "video/webm"},
+		{"video.ogv", "video/ogg"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.filename, func(t *testing.T) {
+			testFile := filepath.Join(tmpDir, tc.filename)
+			err := os.WriteFile(testFile, []byte("fake video"), 0644)
+			require.NoError(t, err)
+
+			resolver := NewMediaResolver(tmpDir)
+			_, mimeType, isPassthrough, err := resolver.ResolveURL("mock://" + tc.filename)
+			require.NoError(t, err)
+			assert.False(t, isPassthrough)
+			assert.Equal(t, tc.mimeType, mimeType)
+		})
+	}
+}

--- a/pkg/runtime/v1/runtime.pb.go
+++ b/pkg/runtime/v1/runtime.pb.go
@@ -406,9 +406,14 @@ func (x *ToolResult) GetIsError() bool {
 type Done struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// final_content contains the complete response text (optional).
+	// For text-only responses, this contains the full response.
+	// For multimodal responses, use the parts field instead.
 	FinalContent string `protobuf:"bytes,1,opt,name=final_content,json=finalContent,proto3" json:"final_content,omitempty"`
 	// usage contains token usage statistics for this turn.
-	Usage         *Usage `protobuf:"bytes,2,opt,name=usage,proto3" json:"usage,omitempty"`
+	Usage *Usage `protobuf:"bytes,2,opt,name=usage,proto3" json:"usage,omitempty"`
+	// parts contains multimodal content parts (text, images, audio, video).
+	// If non-empty, this takes precedence over final_content for rich responses.
+	Parts         []*ContentPart `protobuf:"bytes,3,rep,name=parts,proto3" json:"parts,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -457,6 +462,141 @@ func (x *Done) GetUsage() *Usage {
 	return nil
 }
 
+func (x *Done) GetParts() []*ContentPart {
+	if x != nil {
+		return x.Parts
+	}
+	return nil
+}
+
+// ContentPart represents a single piece of content in a multimodal message.
+type ContentPart struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// type indicates the content type: "text", "image", "audio", "video"
+	Type string `protobuf:"bytes,1,opt,name=type,proto3" json:"type,omitempty"`
+	// text contains text content (only set when type="text")
+	Text string `protobuf:"bytes,2,opt,name=text,proto3" json:"text,omitempty"`
+	// media contains media content (only set when type="image", "audio", or "video")
+	Media         *MediaContent `protobuf:"bytes,3,opt,name=media,proto3" json:"media,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ContentPart) Reset() {
+	*x = ContentPart{}
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ContentPart) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ContentPart) ProtoMessage() {}
+
+func (x *ContentPart) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ContentPart.ProtoReflect.Descriptor instead.
+func (*ContentPart) Descriptor() ([]byte, []int) {
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ContentPart) GetType() string {
+	if x != nil {
+		return x.Type
+	}
+	return ""
+}
+
+func (x *ContentPart) GetText() string {
+	if x != nil {
+		return x.Text
+	}
+	return ""
+}
+
+func (x *ContentPart) GetMedia() *MediaContent {
+	if x != nil {
+		return x.Media
+	}
+	return nil
+}
+
+// MediaContent represents media data (image, audio, video) in a message.
+type MediaContent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// data contains base64-encoded media data (for resolved file:// and mock:// URLs)
+	Data string `protobuf:"bytes,1,opt,name=data,proto3" json:"data,omitempty"`
+	// url contains the media URL (for http:// and https:// URLs that are passed through)
+	Url string `protobuf:"bytes,2,opt,name=url,proto3" json:"url,omitempty"`
+	// mime_type indicates the media format (e.g., "image/png", "audio/mp3")
+	MimeType      string `protobuf:"bytes,3,opt,name=mime_type,json=mimeType,proto3" json:"mime_type,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *MediaContent) Reset() {
+	*x = MediaContent{}
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *MediaContent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*MediaContent) ProtoMessage() {}
+
+func (x *MediaContent) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use MediaContent.ProtoReflect.Descriptor instead.
+func (*MediaContent) Descriptor() ([]byte, []int) {
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *MediaContent) GetData() string {
+	if x != nil {
+		return x.Data
+	}
+	return ""
+}
+
+func (x *MediaContent) GetUrl() string {
+	if x != nil {
+		return x.Url
+	}
+	return ""
+}
+
+func (x *MediaContent) GetMimeType() string {
+	if x != nil {
+		return x.MimeType
+	}
+	return ""
+}
+
 // Usage contains token usage and cost information.
 type Usage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -472,7 +612,7 @@ type Usage struct {
 
 func (x *Usage) Reset() {
 	*x = Usage{}
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[6]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -484,7 +624,7 @@ func (x *Usage) String() string {
 func (*Usage) ProtoMessage() {}
 
 func (x *Usage) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[6]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -497,7 +637,7 @@ func (x *Usage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Usage.ProtoReflect.Descriptor instead.
 func (*Usage) Descriptor() ([]byte, []int) {
-	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{6}
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *Usage) GetInputTokens() int32 {
@@ -534,7 +674,7 @@ type Error struct {
 
 func (x *Error) Reset() {
 	*x = Error{}
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[7]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -546,7 +686,7 @@ func (x *Error) String() string {
 func (*Error) ProtoMessage() {}
 
 func (x *Error) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[7]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -559,7 +699,7 @@ func (x *Error) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Error.ProtoReflect.Descriptor instead.
 func (*Error) Descriptor() ([]byte, []int) {
-	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{7}
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *Error) GetCode() string {
@@ -585,7 +725,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[8]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -597,7 +737,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[8]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -610,7 +750,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{8}
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{10}
 }
 
 // HealthResponse contains the health status of the runtime.
@@ -626,7 +766,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[9]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -638,7 +778,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[9]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -651,7 +791,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{9}
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *HealthResponse) GetHealthy() bool {
@@ -700,10 +840,19 @@ const file_api_proto_runtime_v1_runtime_proto_rawDesc = "" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1f\n" +
 	"\vresult_json\x18\x02 \x01(\tR\n" +
 	"resultJson\x12\x19\n" +
-	"\bis_error\x18\x03 \x01(\bR\aisError\"Z\n" +
+	"\bis_error\x18\x03 \x01(\bR\aisError\"\x8f\x01\n" +
 	"\x04Done\x12#\n" +
 	"\rfinal_content\x18\x01 \x01(\tR\ffinalContent\x12-\n" +
-	"\x05usage\x18\x02 \x01(\v2\x17.omnia.runtime.v1.UsageR\x05usage\"j\n" +
+	"\x05usage\x18\x02 \x01(\v2\x17.omnia.runtime.v1.UsageR\x05usage\x123\n" +
+	"\x05parts\x18\x03 \x03(\v2\x1d.omnia.runtime.v1.ContentPartR\x05parts\"k\n" +
+	"\vContentPart\x12\x12\n" +
+	"\x04type\x18\x01 \x01(\tR\x04type\x12\x12\n" +
+	"\x04text\x18\x02 \x01(\tR\x04text\x124\n" +
+	"\x05media\x18\x03 \x01(\v2\x1e.omnia.runtime.v1.MediaContentR\x05media\"Q\n" +
+	"\fMediaContent\x12\x12\n" +
+	"\x04data\x18\x01 \x01(\tR\x04data\x12\x10\n" +
+	"\x03url\x18\x02 \x01(\tR\x03url\x12\x1b\n" +
+	"\tmime_type\x18\x03 \x01(\tR\bmimeType\"j\n" +
 	"\x05Usage\x12!\n" +
 	"\finput_tokens\x18\x01 \x01(\x05R\vinputTokens\x12#\n" +
 	"\routput_tokens\x18\x02 \x01(\x05R\foutputTokens\x12\x19\n" +
@@ -731,7 +880,7 @@ func file_api_proto_runtime_v1_runtime_proto_rawDescGZIP() []byte {
 	return file_api_proto_runtime_v1_runtime_proto_rawDescData
 }
 
-var file_api_proto_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
+var file_api_proto_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_api_proto_runtime_v1_runtime_proto_goTypes = []any{
 	(*ClientMessage)(nil),  // 0: omnia.runtime.v1.ClientMessage
 	(*ServerMessage)(nil),  // 1: omnia.runtime.v1.ServerMessage
@@ -739,29 +888,33 @@ var file_api_proto_runtime_v1_runtime_proto_goTypes = []any{
 	(*ToolCall)(nil),       // 3: omnia.runtime.v1.ToolCall
 	(*ToolResult)(nil),     // 4: omnia.runtime.v1.ToolResult
 	(*Done)(nil),           // 5: omnia.runtime.v1.Done
-	(*Usage)(nil),          // 6: omnia.runtime.v1.Usage
-	(*Error)(nil),          // 7: omnia.runtime.v1.Error
-	(*HealthRequest)(nil),  // 8: omnia.runtime.v1.HealthRequest
-	(*HealthResponse)(nil), // 9: omnia.runtime.v1.HealthResponse
-	nil,                    // 10: omnia.runtime.v1.ClientMessage.MetadataEntry
+	(*ContentPart)(nil),    // 6: omnia.runtime.v1.ContentPart
+	(*MediaContent)(nil),   // 7: omnia.runtime.v1.MediaContent
+	(*Usage)(nil),          // 8: omnia.runtime.v1.Usage
+	(*Error)(nil),          // 9: omnia.runtime.v1.Error
+	(*HealthRequest)(nil),  // 10: omnia.runtime.v1.HealthRequest
+	(*HealthResponse)(nil), // 11: omnia.runtime.v1.HealthResponse
+	nil,                    // 12: omnia.runtime.v1.ClientMessage.MetadataEntry
 }
 var file_api_proto_runtime_v1_runtime_proto_depIdxs = []int32{
-	10, // 0: omnia.runtime.v1.ClientMessage.metadata:type_name -> omnia.runtime.v1.ClientMessage.MetadataEntry
+	12, // 0: omnia.runtime.v1.ClientMessage.metadata:type_name -> omnia.runtime.v1.ClientMessage.MetadataEntry
 	2,  // 1: omnia.runtime.v1.ServerMessage.chunk:type_name -> omnia.runtime.v1.Chunk
 	3,  // 2: omnia.runtime.v1.ServerMessage.tool_call:type_name -> omnia.runtime.v1.ToolCall
 	4,  // 3: omnia.runtime.v1.ServerMessage.tool_result:type_name -> omnia.runtime.v1.ToolResult
 	5,  // 4: omnia.runtime.v1.ServerMessage.done:type_name -> omnia.runtime.v1.Done
-	7,  // 5: omnia.runtime.v1.ServerMessage.error:type_name -> omnia.runtime.v1.Error
-	6,  // 6: omnia.runtime.v1.Done.usage:type_name -> omnia.runtime.v1.Usage
-	0,  // 7: omnia.runtime.v1.RuntimeService.Converse:input_type -> omnia.runtime.v1.ClientMessage
-	8,  // 8: omnia.runtime.v1.RuntimeService.Health:input_type -> omnia.runtime.v1.HealthRequest
-	1,  // 9: omnia.runtime.v1.RuntimeService.Converse:output_type -> omnia.runtime.v1.ServerMessage
-	9,  // 10: omnia.runtime.v1.RuntimeService.Health:output_type -> omnia.runtime.v1.HealthResponse
-	9,  // [9:11] is the sub-list for method output_type
-	7,  // [7:9] is the sub-list for method input_type
-	7,  // [7:7] is the sub-list for extension type_name
-	7,  // [7:7] is the sub-list for extension extendee
-	0,  // [0:7] is the sub-list for field type_name
+	9,  // 5: omnia.runtime.v1.ServerMessage.error:type_name -> omnia.runtime.v1.Error
+	8,  // 6: omnia.runtime.v1.Done.usage:type_name -> omnia.runtime.v1.Usage
+	6,  // 7: omnia.runtime.v1.Done.parts:type_name -> omnia.runtime.v1.ContentPart
+	7,  // 8: omnia.runtime.v1.ContentPart.media:type_name -> omnia.runtime.v1.MediaContent
+	0,  // 9: omnia.runtime.v1.RuntimeService.Converse:input_type -> omnia.runtime.v1.ClientMessage
+	10, // 10: omnia.runtime.v1.RuntimeService.Health:input_type -> omnia.runtime.v1.HealthRequest
+	1,  // 11: omnia.runtime.v1.RuntimeService.Converse:output_type -> omnia.runtime.v1.ServerMessage
+	11, // 12: omnia.runtime.v1.RuntimeService.Health:output_type -> omnia.runtime.v1.HealthResponse
+	11, // [11:13] is the sub-list for method output_type
+	9,  // [9:11] is the sub-list for method input_type
+	9,  // [9:9] is the sub-list for extension type_name
+	9,  // [9:9] is the sub-list for extension extendee
+	0,  // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_api_proto_runtime_v1_runtime_proto_init() }
@@ -782,7 +935,7 @@ func file_api_proto_runtime_v1_runtime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_proto_runtime_v1_runtime_proto_rawDesc), len(file_api_proto_runtime_v1_runtime_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   11,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},


### PR DESCRIPTION
## Summary
- Add `MediaBasePath` config option (`OMNIA_MEDIA_BASE_PATH` env var, default `/etc/omnia/media`)
- Implement `MediaResolver` for resolving mock provider media URLs:
  - `file://` URLs - read from local filesystem and encode to base64
  - `mock://` URLs - resolve against configured media base path
  - `http://` and `https://` URLs - pass through unchanged
- Extend gRPC proto with `ContentPart` and `MediaContent` messages for multimodal responses
- Update runtime to detect and resolve media parts from PromptKit responses
- Handle query parameters in URLs when inferring MIME types

## How it works
1. When mock provider returns a response with media parts (images, audio, video)
2. Runtime checks if any media URLs use `file://` or `mock://` schemes
3. For resolvable URLs, reads the file and converts to base64
4. Sends resolved content via gRPC `Done.parts` field to facade
5. HTTP/HTTPS URLs are passed through for facade to fetch directly

## Test Plan
- [x] Unit tests for `MediaResolver.ResolveURL()` with all URL schemes
- [x] Unit tests for MIME type inference (images, audio, video, documents)
- [x] Unit tests for missing file handling
- [x] Unit tests for query parameter stripping in URLs
- [x] Unit tests for `MediaBasePath` config loading
- [x] All pre-commit checks pass

Closes #161