### PR TITLE
feat(dashboard): add drag-and-drop file upload to console

### DIFF
--- a/dashboard/src/components/console/agent-console.tsx
+++ b/dashboard/src/components/console/agent-console.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useCallback } from "react";
-import { Send, Trash2, Wifi, WifiOff, RefreshCw } from "lucide-react";
+import { Send, Trash2, Wifi, WifiOff, RefreshCw, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -9,6 +9,8 @@ import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { useAgentConsole } from "@/hooks";
 import { ConsoleMessage } from "./console-message";
+import { AttachmentPreview } from "./attachment-preview";
+import type { FileAttachment } from "@/types/websocket";
 
 interface AgentConsoleProps {
   agentName: string;
@@ -16,10 +18,39 @@ interface AgentConsoleProps {
   className?: string;
 }
 
+// File validation constants
+const ALLOWED_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/gif",
+  "image/webp",
+  "audio/mpeg",
+  "audio/wav",
+  "audio/ogg",
+];
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const MAX_FILES = 5;
+
+function isAllowedType(type: string): boolean {
+  return ALLOWED_TYPES.includes(type);
+}
+
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
 export function AgentConsole({ agentName, namespace, className }: Readonly<AgentConsoleProps>) {
   const [input, setInput] = useState("");
+  const [attachments, setAttachments] = useState<FileAttachment[]>([]);
+  const [isDragging, setIsDragging] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const dragCounterRef = useRef(0);
 
   // Always use mock mode for now (until K8s integration)
   const {
@@ -49,14 +80,85 @@ export function AgentConsole({ agentName, namespace, className }: Readonly<Agent
     }
   }, [messages]);
 
+  // Process dropped files
+  const processFiles = useCallback(async (files: FileList) => {
+    const validFiles: FileAttachment[] = [];
+
+    for (const file of Array.from(files)) {
+      // Validate type
+      if (!isAllowedType(file.type)) continue;
+
+      // Validate size
+      if (file.size > MAX_FILE_SIZE) continue;
+
+      // Convert to data URL
+      const dataUrl = await fileToDataUrl(file);
+
+      validFiles.push({
+        id: crypto.randomUUID(),
+        name: file.name,
+        type: file.type,
+        size: file.size,
+        dataUrl,
+      });
+    }
+
+    // Limit total files
+    setAttachments((prev) => [...prev, ...validFiles].slice(0, MAX_FILES));
+  }, []);
+
+  // Remove attachment
+  const removeAttachment = useCallback((id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id));
+  }, []);
+
+  // Drag event handlers
+  const handleDragEnter = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current++;
+    if (e.dataTransfer.types.includes("Files")) {
+      setIsDragging(true);
+    }
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    dragCounterRef.current--;
+    if (dragCounterRef.current === 0) {
+      setIsDragging(false);
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dragCounterRef.current = 0;
+      setIsDragging(false);
+
+      if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+        processFiles(e.dataTransfer.files);
+      }
+    },
+    [processFiles]
+  );
+
   // Handle send
   const handleSend = useCallback(() => {
-    if (input.trim() && status === "connected") {
+    if ((input.trim() || attachments.length > 0) && status === "connected") {
       sendMessage(input);
       setInput("");
+      setAttachments([]);
       textareaRef.current?.focus();
     }
-  }, [input, status, sendMessage]);
+  }, [input, attachments.length, status, sendMessage]);
 
   // Handle key press
   const handleKeyDown = useCallback(
@@ -98,7 +200,26 @@ export function AgentConsole({ agentName, namespace, className }: Readonly<Agent
   }[status];
 
   return (
-    <div className={cn("flex flex-col h-[600px] border rounded-lg", className)}>
+    <div
+      className={cn("flex flex-col h-[600px] border rounded-lg relative", className)}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={handleDrop}
+    >
+      {/* Drop zone overlay */}
+      {isDragging && (
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-background/80 backdrop-blur-sm border-2 border-dashed border-primary rounded-lg">
+          <div className="flex flex-col items-center gap-2 text-primary">
+            <Upload className="h-12 w-12" />
+            <p className="text-lg font-medium">Drop files here</p>
+            <p className="text-sm text-muted-foreground">
+              Images and audio files up to 10MB
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Header */}
       <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/30">
         <div className="flex items-center gap-3">
@@ -156,6 +277,15 @@ export function AgentConsole({ agentName, namespace, className }: Readonly<Agent
 
       {/* Input area */}
       <div className="p-4 border-t bg-muted/30">
+        {/* Attachment preview */}
+        {attachments.length > 0 && (
+          <AttachmentPreview
+            attachments={attachments}
+            onRemove={removeAttachment}
+            className="mb-3"
+          />
+        )}
+
         <div className="flex gap-2">
           <Textarea
             ref={textareaRef}
@@ -173,7 +303,7 @@ export function AgentConsole({ agentName, namespace, className }: Readonly<Agent
           />
           <Button
             onClick={handleSend}
-            disabled={!input.trim() || status !== "connected"}
+            disabled={(!input.trim() && attachments.length === 0) || status !== "connected"}
             className="shrink-0"
           >
             <Send className="h-4 w-4" />

--- a/dashboard/src/components/console/attachment-preview.tsx
+++ b/dashboard/src/components/console/attachment-preview.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { X, FileAudio, FileImage, File } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FileAttachment } from "@/types/websocket";
+
+interface AttachmentPreviewProps {
+  attachments: FileAttachment[];
+  onRemove?: (id: string) => void;
+  className?: string;
+  readonly?: boolean;
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getFileIcon(type: string) {
+  if (type.startsWith("image/")) return FileImage;
+  if (type.startsWith("audio/")) return FileAudio;
+  return File;
+}
+
+function isImageType(type: string): boolean {
+  return type.startsWith("image/");
+}
+
+export function AttachmentPreview({
+  attachments,
+  onRemove,
+  className,
+  readonly = false,
+}: Readonly<AttachmentPreviewProps>) {
+  if (attachments.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "flex gap-2 overflow-x-auto pb-2",
+        className
+      )}
+    >
+      {attachments.map((attachment) => {
+        const FileIcon = getFileIcon(attachment.type);
+        const isImage = isImageType(attachment.type);
+
+        return (
+          <div
+            key={attachment.id}
+            className={cn(
+              "relative group flex-shrink-0 rounded-lg border bg-muted/50 overflow-hidden",
+              isImage ? "w-20 h-20" : "flex items-center gap-2 px-3 py-2"
+            )}
+          >
+            {isImage ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={attachment.dataUrl}
+                alt={attachment.name}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <>
+                <FileIcon className="h-4 w-4 text-muted-foreground flex-shrink-0" />
+                <div className="flex flex-col min-w-0">
+                  <span className="text-xs font-medium truncate max-w-[120px]">
+                    {attachment.name}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {formatFileSize(attachment.size)}
+                  </span>
+                </div>
+              </>
+            )}
+
+            {/* Remove button */}
+            {!readonly && onRemove && (
+              <button
+                type="button"
+                onClick={() => onRemove(attachment.id)}
+                className={cn(
+                  "absolute top-1 right-1 p-0.5 rounded-full",
+                  "bg-background/80 hover:bg-destructive hover:text-destructive-foreground",
+                  "opacity-0 group-hover:opacity-100 transition-opacity",
+                  "focus:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring"
+                )}
+                aria-label={`Remove ${attachment.name}`}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            )}
+
+            {/* Image overlay with file info on hover */}
+            {isImage && (
+              <div
+                className={cn(
+                  "absolute inset-x-0 bottom-0 px-1 py-0.5",
+                  "bg-background/80 text-xs truncate",
+                  "opacity-0 group-hover:opacity-100 transition-opacity"
+                )}
+              >
+                {attachment.name}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/components/console/index.ts
+++ b/dashboard/src/components/console/index.ts
@@ -1,3 +1,4 @@
 export { AgentConsole } from "./agent-console";
+export { AttachmentPreview } from "./attachment-preview";
 export { ConsoleMessage } from "./console-message";
 export { ToolCallCard } from "./tool-call-card";

--- a/dashboard/src/types/websocket.ts
+++ b/dashboard/src/types/websocket.ts
@@ -65,6 +65,15 @@ export const ErrorCodes = {
   AGENT_NOT_FOUND: "AGENT_NOT_FOUND",
 } as const;
 
+// File attachment for messages
+export interface FileAttachment {
+  id: string;
+  name: string;
+  type: string;
+  size: number;
+  dataUrl: string; // base64 data URL for preview and sending
+}
+
 // Console message types for UI rendering
 export type ConsoleMessageRole = "user" | "assistant" | "system";
 
@@ -74,6 +83,7 @@ export interface ConsoleMessage {
   content: string;
   timestamp: Date;
   toolCalls?: ToolCallWithResult[];
+  attachments?: FileAttachment[];
   isStreaming?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Add `FileAttachment` type to websocket types
- Create `AttachmentPreview` component for displaying attached files  
- Add drag-and-drop handlers to agent console with visual drop zone overlay
- Support images (png, jpg, gif, webp) and audio (mp3, wav, ogg)
- Validate file size (max 10MB) and limit to 5 files total
- Show previews with remove buttons before sending

## UI Behavior

1. User drags file(s) over console
2. Drop zone overlay appears with "Drop files here"
3. User drops files
4. Files appear in attachment preview area above textarea
5. User can click X to remove files or send with message

## Test plan

- [x] ESLint passes
- [x] TypeScript check passes
- [x] Unit tests pass
- [ ] Manual testing: drag image over console, verify drop zone appears
- [ ] Manual testing: drop files, verify preview shows
- [ ] Manual testing: click X, verify file removed
- [ ] Manual testing: send message, verify attachments clear

Closes #154