### PR TITLE
feat(dashboard): add clipboard paste support for images in console

### DIFF
--- a/dashboard/src/components/console/agent-console.test.tsx
+++ b/dashboard/src/components/console/agent-console.test.tsx
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AgentConsole } from "./agent-console";
+
+// Mock the hooks
+vi.mock("@/hooks", () => ({
+  useAgentConsole: () => ({
+    sessionId: "test-session",
+    status: "connected",
+    messages: [],
+    error: null,
+    sendMessage: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+    clearMessages: vi.fn(),
+  }),
+}));
+
+// Mock crypto.randomUUID
+vi.stubGlobal("crypto", {
+  randomUUID: () => "test-uuid-1234",
+});
+
+describe("AgentConsole", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("paste handling", () => {
+    it("should render the console with paste-enabled textarea", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const textarea = screen.getByRole("textbox");
+      expect(textarea).toBeInTheDocument();
+      expect(textarea).toHaveAttribute(
+        "placeholder",
+        expect.stringContaining("Paste images")
+      );
+    });
+
+    it("should not prevent default for text-only paste", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const textarea = screen.getByRole("textbox");
+
+      // Create mock text item (no image)
+      const mockItem = {
+        type: "text/plain",
+        getAsFile: () => null,
+      };
+
+      const pasteEvent = {
+        clipboardData: {
+          items: [mockItem],
+        },
+        preventDefault: vi.fn(),
+      };
+
+      fireEvent.paste(textarea, pasteEvent);
+
+      // preventDefault should NOT be called for text paste
+      expect(pasteEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("should ignore unsupported image types", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const textarea = screen.getByRole("textbox");
+
+      // Create mock item with unsupported type
+      const mockItem = {
+        type: "image/bmp", // Not in ALLOWED_TYPES
+        getAsFile: () =>
+          new File(["data"], "test.bmp", { type: "image/bmp" }),
+      };
+
+      const pasteEvent = {
+        clipboardData: {
+          items: [mockItem],
+        },
+        preventDefault: vi.fn(),
+      };
+
+      fireEvent.paste(textarea, pasteEvent);
+
+      // preventDefault should NOT be called for unsupported type
+      expect(pasteEvent.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it("should ignore files that are too large", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const textarea = screen.getByRole("textbox");
+
+      // Create a mock file larger than 10MB
+      const largeFile = new File(["x".repeat(11 * 1024 * 1024)], "large.png", {
+        type: "image/png",
+      });
+      // Override size property since File doesn't actually compute it from content
+      Object.defineProperty(largeFile, "size", { value: 11 * 1024 * 1024 });
+
+      const mockItem = {
+        type: "image/png",
+        getAsFile: () => largeFile,
+      };
+
+      const pasteEvent = {
+        clipboardData: {
+          items: [mockItem],
+        },
+        preventDefault: vi.fn(),
+      };
+
+      fireEvent.paste(textarea, pasteEvent);
+
+      // preventDefault should NOT be called for oversized file
+      expect(pasteEvent.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("connection status", () => {
+    it("should show connected status badge", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      expect(screen.getByText("Connected")).toBeInTheDocument();
+    });
+
+    it("should show session ID", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      expect(screen.getByText(/Session:/)).toBeInTheDocument();
+    });
+  });
+
+  describe("input handling", () => {
+    it("should enable send button when text is entered", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const textarea = screen.getByRole("textbox");
+      // Get all buttons and find the send button (the one next to the textarea)
+      const buttons = screen.getAllByRole("button");
+      // The send button is the last button (after the textarea)
+      const sendButton = buttons[buttons.length - 1];
+
+      // Initially disabled (no input)
+      expect(sendButton).toBeDisabled();
+
+      // Type some text
+      fireEvent.change(textarea, { target: { value: "Hello" } });
+
+      // Button should be enabled
+      expect(sendButton).toBeEnabled();
+    });
+
+    it("should handle Enter key to send message", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const textarea = screen.getByRole("textbox");
+
+      // Type some text
+      fireEvent.change(textarea, { target: { value: "Hello" } });
+
+      // Press Enter (should send and clear)
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: false });
+
+      // Input should be cleared after send
+      expect(textarea).toHaveValue("");
+    });
+
+    it("should allow Shift+Enter for new line", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const textarea = screen.getByRole("textbox");
+
+      // Type some text
+      fireEvent.change(textarea, { target: { value: "Hello" } });
+
+      // Press Shift+Enter (should NOT send)
+      fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+      // Input should still have text
+      expect(textarea).toHaveValue("Hello");
+    });
+  });
+
+  describe("drag and drop", () => {
+    it("should show drop zone overlay when dragging files", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const console = screen.getByText(/Start a conversation/).closest("div")?.parentElement?.parentElement;
+
+      // Simulate drag enter with files
+      fireEvent.dragEnter(console!, {
+        dataTransfer: { types: ["Files"] },
+      });
+
+      // Drop zone overlay should be visible
+      expect(screen.getByText("Drop files here")).toBeInTheDocument();
+    });
+
+    it("should hide drop zone overlay when dragging leaves", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const console = screen.getByText(/Start a conversation/).closest("div")?.parentElement?.parentElement;
+
+      // Simulate drag enter
+      fireEvent.dragEnter(console!, {
+        dataTransfer: { types: ["Files"] },
+      });
+
+      // Simulate drag leave
+      fireEvent.dragLeave(console!, {});
+
+      // Drop zone overlay should be hidden
+      expect(screen.queryByText("Drop files here")).not.toBeInTheDocument();
+    });
+
+    it("should handle drag over without error", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const consoleElement = screen.getByText(/Start a conversation/).closest("div")?.parentElement?.parentElement;
+
+      // Simulate drag over (should not throw and element should still exist)
+      fireEvent.dragOver(consoleElement!, {});
+
+      // Console should still be rendered
+      expect(screen.getByText(/Start a conversation/)).toBeInTheDocument();
+    });
+
+    it("should handle drop event", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      const console = screen.getByText(/Start a conversation/).closest("div")?.parentElement?.parentElement;
+
+      // First enter drag mode
+      fireEvent.dragEnter(console!, {
+        dataTransfer: { types: ["Files"] },
+      });
+
+      // Then drop (with no files for simplicity)
+      fireEvent.drop(console!, {
+        dataTransfer: { files: [] },
+      });
+
+      // Drop zone should be hidden after drop
+      expect(screen.queryByText("Drop files here")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty state", () => {
+    it("should show empty state message", () => {
+      render(<AgentConsole agentName="test-agent" namespace="default" />);
+
+      expect(screen.getByText(/Start a conversation with/)).toBeInTheDocument();
+      expect(screen.getByText("test-agent")).toBeInTheDocument();
+    });
+  });
+});

--- a/dashboard/src/components/console/attachment-preview.test.tsx
+++ b/dashboard/src/components/console/attachment-preview.test.tsx
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AttachmentPreview } from "./attachment-preview";
+import type { FileAttachment } from "@/types/websocket";
+
+describe("AttachmentPreview", () => {
+  const mockImageAttachment: FileAttachment = {
+    id: "img-1",
+    name: "test-image.png",
+    type: "image/png",
+    size: 1024,
+    dataUrl: "data:image/png;base64,iVBORw0KGgo=",
+  };
+
+  const mockAudioAttachment: FileAttachment = {
+    id: "audio-1",
+    name: "test-audio.mp3",
+    type: "audio/mpeg",
+    size: 2048,
+    dataUrl: "data:audio/mpeg;base64,abc123",
+  };
+
+  const mockFileAttachment: FileAttachment = {
+    id: "file-1",
+    name: "document.pdf",
+    type: "application/pdf",
+    size: 10240,
+    dataUrl: "data:application/pdf;base64,xyz789",
+  };
+
+  describe("rendering", () => {
+    it("should return null when attachments array is empty", () => {
+      const { container } = render(<AttachmentPreview attachments={[]} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("should render image attachment as thumbnail", () => {
+      render(<AttachmentPreview attachments={[mockImageAttachment]} />);
+
+      const img = screen.getByRole("img");
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute("src", mockImageAttachment.dataUrl);
+      expect(img).toHaveAttribute("alt", mockImageAttachment.name);
+    });
+
+    it("should render audio attachment with icon and file info", () => {
+      render(<AttachmentPreview attachments={[mockAudioAttachment]} />);
+
+      expect(screen.getByText("test-audio.mp3")).toBeInTheDocument();
+      expect(screen.getByText("2.0 KB")).toBeInTheDocument();
+    });
+
+    it("should render generic file attachment with icon and file info", () => {
+      render(<AttachmentPreview attachments={[mockFileAttachment]} />);
+
+      expect(screen.getByText("document.pdf")).toBeInTheDocument();
+      expect(screen.getByText("10.0 KB")).toBeInTheDocument();
+    });
+
+    it("should render multiple attachments", () => {
+      render(
+        <AttachmentPreview
+          attachments={[mockImageAttachment, mockAudioAttachment, mockFileAttachment]}
+        />
+      );
+
+      expect(screen.getByRole("img")).toBeInTheDocument();
+      expect(screen.getByText("test-audio.mp3")).toBeInTheDocument();
+      expect(screen.getByText("document.pdf")).toBeInTheDocument();
+    });
+
+    it("should apply custom className", () => {
+      const { container } = render(
+        <AttachmentPreview
+          attachments={[mockImageAttachment]}
+          className="custom-class"
+        />
+      );
+
+      expect(container.firstChild).toHaveClass("custom-class");
+    });
+  });
+
+  describe("file size formatting", () => {
+    it("should format bytes correctly", () => {
+      const smallFile: FileAttachment = {
+        ...mockFileAttachment,
+        size: 500,
+      };
+      render(<AttachmentPreview attachments={[smallFile]} />);
+      expect(screen.getByText("500 B")).toBeInTheDocument();
+    });
+
+    it("should format kilobytes correctly", () => {
+      const kbFile: FileAttachment = {
+        ...mockFileAttachment,
+        size: 1536, // 1.5 KB
+      };
+      render(<AttachmentPreview attachments={[kbFile]} />);
+      expect(screen.getByText("1.5 KB")).toBeInTheDocument();
+    });
+
+    it("should format megabytes correctly", () => {
+      const mbFile: FileAttachment = {
+        ...mockFileAttachment,
+        size: 2 * 1024 * 1024, // 2 MB
+      };
+      render(<AttachmentPreview attachments={[mbFile]} />);
+      expect(screen.getByText("2.0 MB")).toBeInTheDocument();
+    });
+  });
+
+  describe("remove functionality", () => {
+    it("should render remove button when onRemove is provided", () => {
+      const onRemove = vi.fn();
+      render(
+        <AttachmentPreview
+          attachments={[mockImageAttachment]}
+          onRemove={onRemove}
+        />
+      );
+
+      const removeButton = screen.getByRole("button", {
+        name: `Remove ${mockImageAttachment.name}`,
+      });
+      expect(removeButton).toBeInTheDocument();
+    });
+
+    it("should call onRemove with attachment id when remove button is clicked", () => {
+      const onRemove = vi.fn();
+      render(
+        <AttachmentPreview
+          attachments={[mockImageAttachment]}
+          onRemove={onRemove}
+        />
+      );
+
+      const removeButton = screen.getByRole("button", {
+        name: `Remove ${mockImageAttachment.name}`,
+      });
+      fireEvent.click(removeButton);
+
+      expect(onRemove).toHaveBeenCalledWith(mockImageAttachment.id);
+    });
+
+    it("should not render remove button when readonly is true", () => {
+      const onRemove = vi.fn();
+      render(
+        <AttachmentPreview
+          attachments={[mockImageAttachment]}
+          onRemove={onRemove}
+          readonly={true}
+        />
+      );
+
+      expect(
+        screen.queryByRole("button", {
+          name: `Remove ${mockImageAttachment.name}`,
+        })
+      ).not.toBeInTheDocument();
+    });
+
+    it("should not render remove button when onRemove is not provided", () => {
+      render(<AttachmentPreview attachments={[mockImageAttachment]} />);
+
+      expect(
+        screen.queryByRole("button", {
+          name: `Remove ${mockImageAttachment.name}`,
+        })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("image overlay", () => {
+    it("should show filename overlay on image attachments", () => {
+      render(<AttachmentPreview attachments={[mockImageAttachment]} />);
+
+      // The filename appears in an overlay div for images
+      const filenameElements = screen.getAllByText(mockImageAttachment.name);
+      expect(filenameElements.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/dashboard/src/components/console/console-message.test.tsx
+++ b/dashboard/src/components/console/console-message.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ConsoleMessage } from "./console-message";
+import type { ConsoleMessage as ConsoleMessageType } from "@/types/websocket";
+
+describe("ConsoleMessage", () => {
+  const baseMessage: ConsoleMessageType = {
+    id: "test-1",
+    role: "user",
+    content: "Hello, agent!",
+    timestamp: new Date("2024-01-15T10:00:00Z"),
+  };
+
+  describe("text messages", () => {
+    it("should render user message with content", () => {
+      render(<ConsoleMessage message={baseMessage} />);
+      expect(screen.getByText("Hello, agent!")).toBeInTheDocument();
+    });
+
+    it("should render assistant message", () => {
+      const assistantMessage: ConsoleMessageType = {
+        ...baseMessage,
+        role: "assistant",
+        content: "How can I help you?",
+      };
+      render(<ConsoleMessage message={assistantMessage} />);
+      expect(screen.getByText("How can I help you?")).toBeInTheDocument();
+    });
+
+    it("should render system message as divider", () => {
+      const systemMessage: ConsoleMessageType = {
+        ...baseMessage,
+        role: "system",
+        content: "Connected to agent",
+      };
+      render(<ConsoleMessage message={systemMessage} />);
+      expect(screen.getByText("Connected to agent")).toBeInTheDocument();
+    });
+
+    it("should show streaming indicator when streaming", () => {
+      const streamingMessage: ConsoleMessageType = {
+        ...baseMessage,
+        role: "assistant",
+        content: "I am thinking",
+        isStreaming: true,
+      };
+      render(<ConsoleMessage message={streamingMessage} />);
+      expect(screen.getByText("I am thinking")).toBeInTheDocument();
+    });
+
+    it("should show 'Thinking...' for empty streaming message", () => {
+      const emptyStreamingMessage: ConsoleMessageType = {
+        ...baseMessage,
+        role: "assistant",
+        content: "",
+        isStreaming: true,
+      };
+      render(<ConsoleMessage message={emptyStreamingMessage} />);
+      expect(screen.getByText("Thinking...")).toBeInTheDocument();
+    });
+  });
+
+  describe("tool calls", () => {
+    it("should render tool calls", () => {
+      const messageWithTools: ConsoleMessageType = {
+        ...baseMessage,
+        role: "assistant",
+        content: "Let me check that",
+        toolCalls: [
+          {
+            id: "tool-1",
+            name: "search_database",
+            arguments: { query: "test" },
+            status: "success",
+            result: { found: true },
+          },
+        ],
+      };
+
+      render(<ConsoleMessage message={messageWithTools} />);
+
+      expect(screen.getByText("search_database")).toBeInTheDocument();
+    });
+  });
+
+  describe("timestamp", () => {
+    it("should display formatted time", () => {
+      render(<ConsoleMessage message={baseMessage} />);
+
+      // Time should be formatted (exact format depends on locale)
+      // Just check that something time-like is present
+      const timeElements = screen.getAllByText(/\d{1,2}:\d{2}/);
+      expect(timeElements.length).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #155

- Add `handlePaste` callback that extracts images from clipboard data
- Support PNG, JPEG, WebP, and GIF formats (same as drag-and-drop)
- Validate file size (max 10MB) before processing
- Generate unique filenames for pasted images (e.g., `pasted-image-1704893123456.png`)
- Allow normal text paste to work (only intercept when image data is present)
- Update placeholder text to mention paste support

## Test plan

- [x] Unit tests added for paste handling (text-only, unsupported types, oversized files)
- [x] Unit tests added for drag-and-drop functionality
- [x] Unit tests added for AttachmentPreview component
- [x] Unit tests added for ConsoleMessage component
- [x] All 170 tests pass with 88.7% coverage
- [ ] Manual test: Copy image to clipboard, paste in console, verify preview appears
- [ ] Manual test: Paste text, verify normal paste behavior works
- [ ] Manual test: Take screenshot (Cmd+Shift+4), paste, verify it appears