### PR TITLE
feat: forward multimodal messages to PromptKit runtime

### DIFF
--- a/api/proto/runtime/v1/runtime.proto
+++ b/api/proto/runtime/v1/runtime.proto
@@ -25,11 +25,16 @@ message ClientMessage {
   // session_id identifies the conversation session for state management.
   string session_id = 1;
 
-  // content is the user's message text.
+  // content is the user's message text (legacy, for backward compatibility).
+  // For multimodal messages, use the parts field instead.
   string content = 2;
 
   // metadata contains optional key-value pairs for additional context.
   map<string, string> metadata = 3;
+
+  // parts contains multimodal content parts (text, images, audio, video, files).
+  // If non-empty, this takes precedence over the content field.
+  repeated ContentPart parts = 4;
 }
 
 // ServerMessage represents a message from the runtime to the client.

--- a/internal/agent/echo_handler_test.go
+++ b/internal/agent/echo_handler_test.go
@@ -26,7 +26,9 @@ import (
 // mockResponseWriter implements facade.ResponseWriter for testing.
 type mockResponseWriter struct {
 	chunks      []string
+	chunkParts  [][]facade.ContentPart
 	doneMsg     string
+	doneParts   []facade.ContentPart
 	toolCalls   []*facade.ToolCallInfo
 	toolResults []*facade.ToolResultInfo
 	errors      []struct{ code, message string }
@@ -41,11 +43,27 @@ func (m *mockResponseWriter) WriteChunk(content string) error {
 	return nil
 }
 
+func (m *mockResponseWriter) WriteChunkWithParts(parts []facade.ContentPart) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.chunkParts = append(m.chunkParts, parts)
+	return nil
+}
+
 func (m *mockResponseWriter) WriteDone(content string) error {
 	if m.err != nil {
 		return m.err
 	}
 	m.doneMsg = content
+	return nil
+}
+
+func (m *mockResponseWriter) WriteDoneWithParts(parts []facade.ContentPart) error {
+	if m.err != nil {
+		return m.err
+	}
+	m.doneParts = parts
 	return nil
 }
 

--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -75,8 +75,12 @@ type MessageHandler interface {
 type ResponseWriter interface {
 	// WriteChunk sends a chunk of the response.
 	WriteChunk(content string) error
+	// WriteChunkWithParts sends a chunk with multi-modal content parts.
+	WriteChunkWithParts(parts []ContentPart) error
 	// WriteDone signals the response is complete.
 	WriteDone(content string) error
+	// WriteDoneWithParts signals completion with multi-modal content parts.
+	WriteDoneWithParts(parts []ContentPart) error
 	// WriteToolCall notifies of a tool call.
 	WriteToolCall(toolCall *ToolCallInfo) error
 	// WriteToolResult sends a tool result.
@@ -496,8 +500,16 @@ func (w *connResponseWriter) WriteChunk(content string) error {
 	return w.server.sendMessage(w.conn, NewChunkMessage(w.sessionID, content))
 }
 
+func (w *connResponseWriter) WriteChunkWithParts(parts []ContentPart) error {
+	return w.server.sendMessage(w.conn, NewChunkMessageWithParts(w.sessionID, parts))
+}
+
 func (w *connResponseWriter) WriteDone(content string) error {
 	return w.server.sendMessage(w.conn, NewDoneMessage(w.sessionID, content))
+}
+
+func (w *connResponseWriter) WriteDoneWithParts(parts []ContentPart) error {
+	return w.server.sendMessage(w.conn, NewDoneMessageWithParts(w.sessionID, parts))
 }
 
 func (w *connResponseWriter) WriteToolCall(toolCall *ToolCallInfo) error {

--- a/pkg/runtime/v1/runtime.pb.go
+++ b/pkg/runtime/v1/runtime.pb.go
@@ -29,10 +29,14 @@ type ClientMessage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// session_id identifies the conversation session for state management.
 	SessionId string `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	// content is the user's message text.
+	// content is the user's message text (legacy, for backward compatibility).
+	// For multimodal messages, use the parts field instead.
 	Content string `protobuf:"bytes,2,opt,name=content,proto3" json:"content,omitempty"`
 	// metadata contains optional key-value pairs for additional context.
-	Metadata      map[string]string `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	Metadata map[string]string `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// parts contains multimodal content parts (text, images, audio, video, files).
+	// If non-empty, this takes precedence over the content field.
+	Parts         []*ContentPart `protobuf:"bytes,4,rep,name=parts,proto3" json:"parts,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -84,6 +88,13 @@ func (x *ClientMessage) GetContent() string {
 func (x *ClientMessage) GetMetadata() map[string]string {
 	if x != nil {
 		return x.Metadata
+	}
+	return nil
+}
+
+func (x *ClientMessage) GetParts() []*ContentPart {
+	if x != nil {
+		return x.Parts
 	}
 	return nil
 }
@@ -812,12 +823,13 @@ var File_api_proto_runtime_v1_runtime_proto protoreflect.FileDescriptor
 
 const file_api_proto_runtime_v1_runtime_proto_rawDesc = "" +
 	"\n" +
-	"\"api/proto/runtime/v1/runtime.proto\x12\x10omnia.runtime.v1\"\xd0\x01\n" +
+	"\"api/proto/runtime/v1/runtime.proto\x12\x10omnia.runtime.v1\"\x85\x02\n" +
 	"\rClientMessage\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x18\n" +
 	"\acontent\x18\x02 \x01(\tR\acontent\x12I\n" +
-	"\bmetadata\x18\x03 \x03(\v2-.omnia.runtime.v1.ClientMessage.MetadataEntryR\bmetadata\x1a;\n" +
+	"\bmetadata\x18\x03 \x03(\v2-.omnia.runtime.v1.ClientMessage.MetadataEntryR\bmetadata\x123\n" +
+	"\x05parts\x18\x04 \x03(\v2\x1d.omnia.runtime.v1.ContentPartR\x05parts\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xa6\x02\n" +
@@ -898,23 +910,24 @@ var file_api_proto_runtime_v1_runtime_proto_goTypes = []any{
 }
 var file_api_proto_runtime_v1_runtime_proto_depIdxs = []int32{
 	12, // 0: omnia.runtime.v1.ClientMessage.metadata:type_name -> omnia.runtime.v1.ClientMessage.MetadataEntry
-	2,  // 1: omnia.runtime.v1.ServerMessage.chunk:type_name -> omnia.runtime.v1.Chunk
-	3,  // 2: omnia.runtime.v1.ServerMessage.tool_call:type_name -> omnia.runtime.v1.ToolCall
-	4,  // 3: omnia.runtime.v1.ServerMessage.tool_result:type_name -> omnia.runtime.v1.ToolResult
-	5,  // 4: omnia.runtime.v1.ServerMessage.done:type_name -> omnia.runtime.v1.Done
-	9,  // 5: omnia.runtime.v1.ServerMessage.error:type_name -> omnia.runtime.v1.Error
-	8,  // 6: omnia.runtime.v1.Done.usage:type_name -> omnia.runtime.v1.Usage
-	6,  // 7: omnia.runtime.v1.Done.parts:type_name -> omnia.runtime.v1.ContentPart
-	7,  // 8: omnia.runtime.v1.ContentPart.media:type_name -> omnia.runtime.v1.MediaContent
-	0,  // 9: omnia.runtime.v1.RuntimeService.Converse:input_type -> omnia.runtime.v1.ClientMessage
-	10, // 10: omnia.runtime.v1.RuntimeService.Health:input_type -> omnia.runtime.v1.HealthRequest
-	1,  // 11: omnia.runtime.v1.RuntimeService.Converse:output_type -> omnia.runtime.v1.ServerMessage
-	11, // 12: omnia.runtime.v1.RuntimeService.Health:output_type -> omnia.runtime.v1.HealthResponse
-	11, // [11:13] is the sub-list for method output_type
-	9,  // [9:11] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	6,  // 1: omnia.runtime.v1.ClientMessage.parts:type_name -> omnia.runtime.v1.ContentPart
+	2,  // 2: omnia.runtime.v1.ServerMessage.chunk:type_name -> omnia.runtime.v1.Chunk
+	3,  // 3: omnia.runtime.v1.ServerMessage.tool_call:type_name -> omnia.runtime.v1.ToolCall
+	4,  // 4: omnia.runtime.v1.ServerMessage.tool_result:type_name -> omnia.runtime.v1.ToolResult
+	5,  // 5: omnia.runtime.v1.ServerMessage.done:type_name -> omnia.runtime.v1.Done
+	9,  // 6: omnia.runtime.v1.ServerMessage.error:type_name -> omnia.runtime.v1.Error
+	8,  // 7: omnia.runtime.v1.Done.usage:type_name -> omnia.runtime.v1.Usage
+	6,  // 8: omnia.runtime.v1.Done.parts:type_name -> omnia.runtime.v1.ContentPart
+	7,  // 9: omnia.runtime.v1.ContentPart.media:type_name -> omnia.runtime.v1.MediaContent
+	0,  // 10: omnia.runtime.v1.RuntimeService.Converse:input_type -> omnia.runtime.v1.ClientMessage
+	10, // 11: omnia.runtime.v1.RuntimeService.Health:input_type -> omnia.runtime.v1.HealthRequest
+	1,  // 12: omnia.runtime.v1.RuntimeService.Converse:output_type -> omnia.runtime.v1.ServerMessage
+	11, // 13: omnia.runtime.v1.RuntimeService.Health:output_type -> omnia.runtime.v1.HealthResponse
+	12, // [12:14] is the sub-list for method output_type
+	10, // [10:12] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_api_proto_runtime_v1_runtime_proto_init() }

--- a/test/integration/facade_runtime_test.go
+++ b/test/integration/facade_runtime_test.go
@@ -244,7 +244,9 @@ func writePromptPack(t *testing.T, path string) {
 // mockResponseWriter implements facade.ResponseWriter for testing.
 type mockResponseWriter struct {
 	chunks      []string
+	chunkParts  [][]facade.ContentPart
 	doneMsg     string
+	doneParts   []facade.ContentPart
 	toolCalls   []*facade.ToolCallInfo
 	toolResults []*facade.ToolResultInfo
 	errors      []struct{ code, message string }
@@ -255,8 +257,18 @@ func (m *mockResponseWriter) WriteChunk(content string) error {
 	return nil
 }
 
+func (m *mockResponseWriter) WriteChunkWithParts(parts []facade.ContentPart) error {
+	m.chunkParts = append(m.chunkParts, parts)
+	return nil
+}
+
 func (m *mockResponseWriter) WriteDone(content string) error {
 	m.doneMsg = content
+	return nil
+}
+
+func (m *mockResponseWriter) WriteDoneWithParts(parts []facade.ContentPart) error {
+	m.doneParts = parts
 	return nil
 }
 


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration/infrastructure change
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Adding or improving tests

**Component(s) Affected**
- [ ] Operator
- [ ] AgentRuntime Controller
- [ ] PromptPack Controller
- [ ] ToolRegistry Controller
- [x] WebSocket Facade
- [ ] Session Store
- [ ] Helm Chart
- [ ] CRD Definitions
- [ ] Examples
- [ ] Documentation
- [ ] CI/CD
- [x] Other: gRPC Runtime Protocol

## Description

**What does this PR do?**
Updates the RuntimeHandler to convert multi-modal WebSocket messages to PromptKit's ContentPart format and forward them to the runtime via gRPC. Also forwards multimodal responses from the runtime back to WebSocket clients.

**Why is this change needed?**
Even with multi-modal protocol support in the WebSocket facade, messages need to be translated to the format expected by the PromptKit runtime. The gRPC protocol between facade and runtime must also support ContentPart messages for full multimodal support.

Fixes #148

## Changes Made

**Code Changes**
- Extended gRPC `ClientMessage` proto with `repeated ContentPart parts` field for multimodal input
- Added `WriteChunkWithParts` and `WriteDoneWithParts` methods to `ResponseWriter` interface
- Implemented multimodal methods in `connResponseWriter`
- Updated `RuntimeHandler.HandleMessage` to convert WebSocket parts to gRPC format
- Updated `RuntimeHandler.forwardResponse` to forward multimodal parts using `WriteDoneWithParts`
- Added `toGRPCContentParts` and `fromGRPCContentParts` conversion functions

**CRD Changes** (if applicable)
N/A

**Configuration Changes** (if applicable)
N/A

## Testing

**Test Coverage**
- [x] I have added unit tests for my changes
- [ ] I have added integration tests for my changes
- [ ] I have tested with envtest
- [x] Existing tests pass with my changes
- [ ] I have tested this manually on a local K8s cluster

**Manual Testing Performed**
```bash
make lint    # 0 issues
make test    # All tests pass
```

**Test Results**
- [x] All automated tests pass
- [x] Manual testing completed successfully
- [x] No regressions identified

New tests added:
- `TestRuntimeHandler_HandleMessage_MultimodalResponse` - verifies multimodal responses are forwarded correctly
- `TestRuntimeHandler_HandleMessage_MultimodalInput` - verifies multimodal inputs are sent to runtime correctly

Coverage on changed files:
- `runtime_handler.go`: 88.5%
- `server.go`: 82.9%

## Documentation

**Documentation Updates**
- [ ] I have updated relevant documentation
- [x] I have added/updated code comments
- [ ] I have updated CRD reference docs
- [ ] I have updated Helm chart documentation
- [ ] I have updated examples if needed
- [x] No documentation changes needed

## Code Quality

**Code Review Checklist**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented where needed
- [x] No debug/temporary code included
- [x] Error handling is appropriate
- [x] Kubernetes best practices followed

## Deployment

**Deployment Considerations**
- [x] No special deployment steps required
- [ ] CRD updates required (kubectl apply -f config/crd/bases/)
- [ ] Helm chart updates required
- [ ] RBAC changes required
- [ ] Dependencies need to be updated

## Additional Context

**Related Work**
- This is additive and backward compatible - existing text-only messages continue to work
- The gRPC proto changes are wire-compatible (new field added with next available number)

## Reviewer Notes

**Areas of Focus**
- Conversion logic between facade `ContentPart` and gRPC `ContentPart` types
- Handling of multimodal parts in `forwardResponse`

---

## Checklist

**Before Submitting**
- [ ] I have signed my commits with `git commit -s`
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have followed the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes