### PR TITLE
feat(facade): add streaming media response support (#151)

### DIFF
--- a/internal/agent/echo_handler_test.go
+++ b/internal/agent/echo_handler_test.go
@@ -99,6 +99,10 @@ func (m *mockResponseWriter) WriteUploadComplete(_ *facade.UploadCompleteInfo) e
 	return m.err
 }
 
+func (m *mockResponseWriter) WriteMediaChunk(_ *facade.MediaChunkInfo) error {
+	return m.err
+}
+
 func TestNewEchoHandler(t *testing.T) {
 	handler := NewEchoHandler()
 	if handler == nil {

--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -92,6 +92,10 @@ type ResponseWriter interface {
 	WriteUploadReady(uploadReady *UploadReadyInfo) error
 	// WriteUploadComplete notifies the client that an upload is complete.
 	WriteUploadComplete(uploadComplete *UploadCompleteInfo) error
+	// WriteMediaChunk sends a streaming media chunk to the client.
+	// Used for streaming audio/video responses where playback can begin
+	// before the entire media is generated.
+	WriteMediaChunk(mediaChunk *MediaChunkInfo) error
 }
 
 // Server is a WebSocket server for agent communication.
@@ -596,4 +600,8 @@ func (w *connResponseWriter) WriteUploadReady(uploadReady *UploadReadyInfo) erro
 
 func (w *connResponseWriter) WriteUploadComplete(uploadComplete *UploadCompleteInfo) error {
 	return w.server.sendMessage(w.conn, NewUploadCompleteMessage(w.sessionID, uploadComplete))
+}
+
+func (w *connResponseWriter) WriteMediaChunk(mediaChunk *MediaChunkInfo) error {
+	return w.server.sendMessage(w.conn, NewMediaChunkMessage(w.sessionID, mediaChunk))
 }

--- a/test/integration/facade_runtime_test.go
+++ b/test/integration/facade_runtime_test.go
@@ -294,3 +294,7 @@ func (m *mockResponseWriter) WriteUploadReady(_ *facade.UploadReadyInfo) error {
 func (m *mockResponseWriter) WriteUploadComplete(_ *facade.UploadCompleteInfo) error {
 	return nil
 }
+
+func (m *mockResponseWriter) WriteMediaChunk(_ *facade.MediaChunkInfo) error {
+	return nil
+}


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Configuration/infrastructure change
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Adding or improving tests

**Component(s) Affected**
- [ ] Operator
- [ ] AgentRuntime Controller
- [ ] PromptPack Controller
- [ ] ToolRegistry Controller
- [x] WebSocket Facade
- [ ] Session Store
- [ ] Helm Chart
- [ ] CRD Definitions
- [ ] Examples
- [x] Documentation
- [ ] CI/CD
- [ ] Other: ___________

## Description

**What does this PR do?**
Adds support for streaming media responses from agents, allowing audio/video to be delivered in chunks as it's generated. This enables playback to begin while generation continues, reducing perceived latency for TTS (text-to-speech) and video generation use cases.

**Why is this change needed?**
When agents generate audio (TTS) or video, waiting for the entire file before sending creates latency. Streaming allows playback to begin while generation continues, providing a better user experience.

Fixes #151

## Changes Made

**Code Changes**
- Add `MediaChunkInfo` struct with fields: `media_id`, `sequence`, `is_last`, `data`, `mime_type`
- Add `MessageTypeMediaChunk` message type ("media_chunk")
- Add `MediaChunk` field to `ServerMessage` struct
- Add `NewMediaChunkMessage` helper constructor function
- Add `WriteMediaChunk` method to `ResponseWriter` interface
- Implement `WriteMediaChunk` in `connResponseWriter`
- Update mock `ResponseWriter` implementations in test files

**CRD Changes** (if applicable)
N/A - No CRD changes required.

**Configuration Changes** (if applicable)
N/A - No configuration changes required.

## Testing

**Test Coverage**
- [x] I have added unit tests for my changes
- [ ] I have added integration tests for my changes
- [ ] I have tested with envtest
- [x] Existing tests pass with my changes
- [ ] I have tested this manually on a local K8s cluster

**Manual Testing Performed**
```bash
make test
make lint
```

**Test Results**
- [x] All automated tests pass
- [x] Manual testing completed successfully
- [x] No regressions identified

Coverage:
- protocol.go: 100%
- server.go: 84.2%

## Documentation

**Documentation Updates**
- [x] I have updated relevant documentation
- [x] I have added/updated code comments
- [ ] I have updated CRD reference docs
- [ ] I have updated Helm chart documentation
- [ ] I have updated examples if needed
- [ ] No documentation changes needed

Updated `docs/src/content/docs/reference/websocket-protocol.md` with:
- `media_chunk` server message documentation
- Field descriptions and JSON example
- Client implementation guidance
- "With Streaming Media Response" flow diagram

## Code Quality

**Code Review Checklist**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented where needed
- [x] No debug/temporary code included
- [x] Error handling is appropriate
- [x] Kubernetes best practices followed

## Deployment

**Deployment Considerations**
- [x] No special deployment steps required
- [ ] CRD updates required (kubectl apply -f config/crd/bases/)
- [ ] Helm chart updates required
- [ ] RBAC changes required
- [ ] Dependencies need to be updated

## Additional Context

**Related Work**
- Complements PR #183 (WebSocket upload flow)
- Part of the multi-modal messaging feature set

## Reviewer Notes

**Areas of Focus**
- The `MediaChunkInfo` struct design in protocol.go
- Integration of `WriteMediaChunk` into the ResponseWriter interface
- Documentation clarity for client implementers

---

## Checklist

**Before Submitting**
- [x] I have signed my commits with `git commit -s`
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have followed the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes