### PR TITLE
feat(facade): add binary WebSocket frame support (#153)

### DIFF
--- a/internal/agent/echo_handler_test.go
+++ b/internal/agent/echo_handler_test.go
@@ -103,6 +103,14 @@ func (m *mockResponseWriter) WriteMediaChunk(_ *facade.MediaChunkInfo) error {
 	return m.err
 }
 
+func (m *mockResponseWriter) SupportsBinary() bool {
+	return false
+}
+
+func (m *mockResponseWriter) WriteBinaryMediaChunk(_ [facade.MediaIDSize]byte, _ uint32, _ bool, _ string, _ []byte) error {
+	return m.err
+}
+
 func TestNewEchoHandler(t *testing.T) {
 	handler := NewEchoHandler()
 	if handler == nil {

--- a/internal/facade/binary.go
+++ b/internal/facade/binary.go
@@ -1,0 +1,292 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+const (
+	// BinaryMagic is the magic bytes at the start of binary frames.
+	BinaryMagic = "OMNI"
+	// BinaryVersion is the current binary protocol version.
+	BinaryVersion = 1
+	// BinaryHeaderSize is the size of the binary frame header in bytes.
+	BinaryHeaderSize = 32
+	// MediaIDSize is the size of the media ID field in bytes.
+	MediaIDSize = 12
+)
+
+// Binary frame errors.
+var (
+	ErrInvalidMagic       = errors.New("invalid magic bytes")
+	ErrUnsupportedVersion = errors.New("unsupported binary protocol version")
+	ErrInvalidHeaderSize  = errors.New("invalid header size")
+	ErrMetadataOverflow   = errors.New("metadata length exceeds frame size")
+	ErrPayloadOverflow    = errors.New("payload length exceeds frame size")
+)
+
+// BinaryFlags represents the flags byte in binary frame headers.
+type BinaryFlags uint8
+
+const (
+	// FlagCompressed indicates the payload is compressed.
+	FlagCompressed BinaryFlags = 1 << iota
+	// FlagChunked indicates this is part of a chunked transfer.
+	FlagChunked
+	// FlagIsLast indicates this is the last chunk in a stream.
+	FlagIsLast
+)
+
+// IsCompressed returns true if the compressed flag is set.
+func (f BinaryFlags) IsCompressed() bool {
+	return f&FlagCompressed != 0
+}
+
+// IsChunked returns true if the chunked flag is set.
+func (f BinaryFlags) IsChunked() bool {
+	return f&FlagChunked != 0
+}
+
+// IsLast returns true if the is_last flag is set.
+func (f BinaryFlags) IsLast() bool {
+	return f&FlagIsLast != 0
+}
+
+// BinaryMessageType represents message types for binary frames.
+type BinaryMessageType uint16
+
+const (
+	// BinaryMessageTypeMediaChunk is for streaming media chunks.
+	BinaryMessageTypeMediaChunk BinaryMessageType = 1
+	// BinaryMessageTypeUpload is for binary upload data.
+	BinaryMessageTypeUpload BinaryMessageType = 2
+)
+
+// String returns a string representation of the binary message type.
+func (t BinaryMessageType) String() string {
+	switch t {
+	case BinaryMessageTypeMediaChunk:
+		return "media_chunk"
+	case BinaryMessageTypeUpload:
+		return "upload"
+	default:
+		return fmt.Sprintf("unknown(%d)", t)
+	}
+}
+
+// BinaryHeader represents the 32-byte header for binary WebSocket frames.
+type BinaryHeader struct {
+	Magic       [4]byte           // "OMNI"
+	Version     uint8             // Protocol version
+	Flags       BinaryFlags       // Bit flags
+	MessageType BinaryMessageType // Message type
+	MetadataLen uint32            // Length of JSON metadata
+	PayloadLen  uint32            // Length of binary payload
+	Sequence    uint32            // Sequence number
+	MediaID     [MediaIDSize]byte // Media stream identifier
+}
+
+// Validate checks if the header is valid.
+func (h *BinaryHeader) Validate() error {
+	if string(h.Magic[:]) != BinaryMagic {
+		return ErrInvalidMagic
+	}
+	if h.Version != BinaryVersion {
+		return fmt.Errorf("%w: got %d, expected %d", ErrUnsupportedVersion, h.Version, BinaryVersion)
+	}
+	return nil
+}
+
+// Encode serializes the header to bytes.
+func (h *BinaryHeader) Encode() []byte {
+	buf := make([]byte, BinaryHeaderSize)
+	copy(buf[0:4], h.Magic[:])
+	buf[4] = h.Version
+	buf[5] = byte(h.Flags)
+	binary.BigEndian.PutUint16(buf[6:8], uint16(h.MessageType))
+	binary.BigEndian.PutUint32(buf[8:12], h.MetadataLen)
+	binary.BigEndian.PutUint32(buf[12:16], h.PayloadLen)
+	binary.BigEndian.PutUint32(buf[16:20], h.Sequence)
+	copy(buf[20:32], h.MediaID[:])
+	return buf
+}
+
+// DecodeHeader parses bytes into a BinaryHeader.
+func DecodeHeader(data []byte) (*BinaryHeader, error) {
+	if len(data) < BinaryHeaderSize {
+		return nil, ErrInvalidHeaderSize
+	}
+
+	h := &BinaryHeader{
+		Version:     data[4],
+		Flags:       BinaryFlags(data[5]),
+		MessageType: BinaryMessageType(binary.BigEndian.Uint16(data[6:8])),
+		MetadataLen: binary.BigEndian.Uint32(data[8:12]),
+		PayloadLen:  binary.BigEndian.Uint32(data[12:16]),
+		Sequence:    binary.BigEndian.Uint32(data[16:20]),
+	}
+	copy(h.Magic[:], data[0:4])
+	copy(h.MediaID[:], data[20:32])
+
+	if err := h.Validate(); err != nil {
+		return nil, err
+	}
+
+	return h, nil
+}
+
+// BinaryFrame represents a complete binary WebSocket frame.
+type BinaryFrame struct {
+	Header   BinaryHeader
+	Metadata json.RawMessage // JSON metadata
+	Payload  []byte          // Binary payload
+}
+
+// BinaryMediaChunkMetadata is the JSON metadata for media chunk binary frames.
+type BinaryMediaChunkMetadata struct {
+	SessionID string `json:"session_id"`
+	MimeType  string `json:"mime_type"`
+}
+
+// Encode serializes a BinaryFrame to bytes.
+func (f *BinaryFrame) Encode() ([]byte, error) {
+	// Update lengths in header
+	f.Header.MetadataLen = uint32(len(f.Metadata))
+	f.Header.PayloadLen = uint32(len(f.Payload))
+
+	// Calculate total size
+	totalSize := BinaryHeaderSize + len(f.Metadata) + len(f.Payload)
+	buf := make([]byte, totalSize)
+
+	// Encode header
+	headerBytes := f.Header.Encode()
+	copy(buf[0:BinaryHeaderSize], headerBytes)
+
+	// Copy metadata
+	if len(f.Metadata) > 0 {
+		copy(buf[BinaryHeaderSize:BinaryHeaderSize+len(f.Metadata)], f.Metadata)
+	}
+
+	// Copy payload
+	if len(f.Payload) > 0 {
+		copy(buf[BinaryHeaderSize+len(f.Metadata):], f.Payload)
+	}
+
+	return buf, nil
+}
+
+// DecodeBinaryFrame parses bytes into a BinaryFrame.
+func DecodeBinaryFrame(data []byte) (*BinaryFrame, error) {
+	if len(data) < BinaryHeaderSize {
+		return nil, ErrInvalidHeaderSize
+	}
+
+	header, err := DecodeHeader(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// Validate lengths
+	expectedSize := BinaryHeaderSize + int(header.MetadataLen) + int(header.PayloadLen)
+	if len(data) < expectedSize {
+		if len(data) < BinaryHeaderSize+int(header.MetadataLen) {
+			return nil, ErrMetadataOverflow
+		}
+		return nil, ErrPayloadOverflow
+	}
+
+	frame := &BinaryFrame{
+		Header: *header,
+	}
+
+	// Extract metadata
+	metadataStart := BinaryHeaderSize
+	metadataEnd := metadataStart + int(header.MetadataLen)
+	if header.MetadataLen > 0 {
+		frame.Metadata = make(json.RawMessage, header.MetadataLen)
+		copy(frame.Metadata, data[metadataStart:metadataEnd])
+	}
+
+	// Extract payload
+	payloadStart := metadataEnd
+	payloadEnd := payloadStart + int(header.PayloadLen)
+	if header.PayloadLen > 0 {
+		frame.Payload = make([]byte, header.PayloadLen)
+		copy(frame.Payload, data[payloadStart:payloadEnd])
+	}
+
+	return frame, nil
+}
+
+// NewMediaChunkFrame creates a new binary frame for a media chunk.
+func NewMediaChunkFrame(sessionID string, mediaID [MediaIDSize]byte, sequence uint32, isLast bool, mimeType string, payload []byte) (*BinaryFrame, error) {
+	metadata := BinaryMediaChunkMetadata{
+		SessionID: sessionID,
+		MimeType:  mimeType,
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal metadata: %w", err)
+	}
+
+	flags := BinaryFlags(0)
+	if isLast {
+		flags |= FlagIsLast
+	}
+
+	return &BinaryFrame{
+		Header: BinaryHeader{
+			Magic:       [4]byte{'O', 'M', 'N', 'I'},
+			Version:     BinaryVersion,
+			Flags:       flags,
+			MessageType: BinaryMessageTypeMediaChunk,
+			MetadataLen: uint32(len(metadataBytes)),
+			PayloadLen:  uint32(len(payload)),
+			Sequence:    sequence,
+			MediaID:     mediaID,
+		},
+		Metadata: metadataBytes,
+		Payload:  payload,
+	}, nil
+}
+
+// MediaIDFromString converts a string to a MediaID.
+// If the string is longer than MediaIDSize, it is truncated.
+// If shorter, it is padded with zeros.
+func MediaIDFromString(s string) [MediaIDSize]byte {
+	var id [MediaIDSize]byte
+	copy(id[:], s)
+	return id
+}
+
+// MediaIDToString converts a MediaID to a string, trimming null bytes.
+func MediaIDToString(id [MediaIDSize]byte) string {
+	// Find the first null byte
+	n := 0
+	for i, b := range id {
+		if b == 0 {
+			n = i
+			break
+		}
+		n = i + 1
+	}
+	return string(id[:n])
+}

--- a/internal/facade/binary_test.go
+++ b/internal/facade/binary_test.go
@@ -1,0 +1,444 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBinaryHeaderEncode(t *testing.T) {
+	header := BinaryHeader{
+		Magic:       [4]byte{'O', 'M', 'N', 'I'},
+		Version:     BinaryVersion,
+		Flags:       FlagIsLast,
+		MessageType: BinaryMessageTypeMediaChunk,
+		MetadataLen: 42,
+		PayloadLen:  1024,
+		Sequence:    5,
+		MediaID:     [MediaIDSize]byte{'m', 'e', 'd', 'i', 'a', '-', '1', '2', '3', 0, 0, 0},
+	}
+
+	encoded := header.Encode()
+	assert.Equal(t, BinaryHeaderSize, len(encoded))
+
+	// Verify magic bytes
+	assert.Equal(t, []byte("OMNI"), encoded[0:4])
+
+	// Verify version
+	assert.Equal(t, byte(BinaryVersion), encoded[4])
+
+	// Verify flags
+	assert.Equal(t, byte(FlagIsLast), encoded[5])
+
+	// Verify message type (big-endian)
+	assert.Equal(t, byte(0), encoded[6])
+	assert.Equal(t, byte(1), encoded[7]) // BinaryMessageTypeMediaChunk = 1
+
+	// Verify metadata length (big-endian)
+	assert.Equal(t, byte(0), encoded[8])
+	assert.Equal(t, byte(0), encoded[9])
+	assert.Equal(t, byte(0), encoded[10])
+	assert.Equal(t, byte(42), encoded[11])
+
+	// Verify payload length (big-endian)
+	assert.Equal(t, byte(0), encoded[12])
+	assert.Equal(t, byte(0), encoded[13])
+	assert.Equal(t, byte(4), encoded[14]) // 1024 = 0x400
+	assert.Equal(t, byte(0), encoded[15])
+
+	// Verify sequence (big-endian)
+	assert.Equal(t, byte(0), encoded[16])
+	assert.Equal(t, byte(0), encoded[17])
+	assert.Equal(t, byte(0), encoded[18])
+	assert.Equal(t, byte(5), encoded[19])
+
+	// Verify media ID
+	assert.Equal(t, []byte("media-123\x00\x00\x00"), encoded[20:32])
+}
+
+func TestBinaryHeaderDecode(t *testing.T) {
+	header := BinaryHeader{
+		Magic:       [4]byte{'O', 'M', 'N', 'I'},
+		Version:     BinaryVersion,
+		Flags:       FlagChunked | FlagIsLast,
+		MessageType: BinaryMessageTypeMediaChunk,
+		MetadataLen: 100,
+		PayloadLen:  2048,
+		Sequence:    42,
+		MediaID:     [MediaIDSize]byte{'t', 'e', 's', 't', '-', 'i', 'd'},
+	}
+
+	encoded := header.Encode()
+	decoded, err := DecodeHeader(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, header.Magic, decoded.Magic)
+	assert.Equal(t, header.Version, decoded.Version)
+	assert.Equal(t, header.Flags, decoded.Flags)
+	assert.Equal(t, header.MessageType, decoded.MessageType)
+	assert.Equal(t, header.MetadataLen, decoded.MetadataLen)
+	assert.Equal(t, header.PayloadLen, decoded.PayloadLen)
+	assert.Equal(t, header.Sequence, decoded.Sequence)
+	assert.Equal(t, header.MediaID, decoded.MediaID)
+}
+
+func TestBinaryHeaderValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		header  BinaryHeader
+		wantErr error
+	}{
+		{
+			name: "valid header",
+			header: BinaryHeader{
+				Magic:   [4]byte{'O', 'M', 'N', 'I'},
+				Version: BinaryVersion,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "invalid magic",
+			header: BinaryHeader{
+				Magic:   [4]byte{'B', 'A', 'D', '!'},
+				Version: BinaryVersion,
+			},
+			wantErr: ErrInvalidMagic,
+		},
+		{
+			name: "unsupported version",
+			header: BinaryHeader{
+				Magic:   [4]byte{'O', 'M', 'N', 'I'},
+				Version: 99,
+			},
+			wantErr: ErrUnsupportedVersion,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.header.Validate()
+			if tt.wantErr != nil {
+				assert.ErrorIs(t, err, tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestInvalidMagicBytes(t *testing.T) {
+	data := make([]byte, BinaryHeaderSize)
+	copy(data[0:4], "BAD!")
+	data[4] = BinaryVersion
+
+	_, err := DecodeHeader(data)
+	assert.ErrorIs(t, err, ErrInvalidMagic)
+}
+
+func TestUnsupportedVersion(t *testing.T) {
+	data := make([]byte, BinaryHeaderSize)
+	copy(data[0:4], BinaryMagic)
+	data[4] = 99 // Unsupported version
+
+	_, err := DecodeHeader(data)
+	assert.ErrorIs(t, err, ErrUnsupportedVersion)
+}
+
+func TestBinaryFrameRoundTrip(t *testing.T) {
+	metadata := BinaryMediaChunkMetadata{
+		SessionID: "test-session-123",
+		MimeType:  "audio/mp3",
+	}
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	payload := []byte("test binary payload data")
+
+	frame := &BinaryFrame{
+		Header: BinaryHeader{
+			Magic:       [4]byte{'O', 'M', 'N', 'I'},
+			Version:     BinaryVersion,
+			Flags:       FlagIsLast,
+			MessageType: BinaryMessageTypeMediaChunk,
+			MetadataLen: uint32(len(metadataBytes)),
+			PayloadLen:  uint32(len(payload)),
+			Sequence:    1,
+			MediaID:     [MediaIDSize]byte{'m', 'e', 'd', 'i', 'a'},
+		},
+		Metadata: metadataBytes,
+		Payload:  payload,
+	}
+
+	encoded, err := frame.Encode()
+	require.NoError(t, err)
+
+	decoded, err := DecodeBinaryFrame(encoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, frame.Header.Magic, decoded.Header.Magic)
+	assert.Equal(t, frame.Header.Version, decoded.Header.Version)
+	assert.Equal(t, frame.Header.Flags, decoded.Header.Flags)
+	assert.Equal(t, frame.Header.MessageType, decoded.Header.MessageType)
+	assert.Equal(t, frame.Header.Sequence, decoded.Header.Sequence)
+	assert.Equal(t, frame.Header.MediaID, decoded.Header.MediaID)
+	assert.Equal(t, frame.Metadata, decoded.Metadata)
+	assert.Equal(t, frame.Payload, decoded.Payload)
+
+	// Verify metadata can be unmarshaled
+	var decodedMetadata BinaryMediaChunkMetadata
+	err = json.Unmarshal(decoded.Metadata, &decodedMetadata)
+	require.NoError(t, err)
+	assert.Equal(t, metadata.SessionID, decodedMetadata.SessionID)
+	assert.Equal(t, metadata.MimeType, decodedMetadata.MimeType)
+}
+
+func TestNewMediaChunkFrame(t *testing.T) {
+	mediaID := MediaIDFromString("audio-stream")
+	payload := []byte("chunk data here")
+
+	frame, err := NewMediaChunkFrame("session-123", mediaID, 5, true, "audio/wav", payload)
+	require.NoError(t, err)
+
+	assert.Equal(t, [4]byte{'O', 'M', 'N', 'I'}, frame.Header.Magic)
+	assert.Equal(t, uint8(BinaryVersion), frame.Header.Version)
+	assert.True(t, frame.Header.Flags.IsLast())
+	assert.False(t, frame.Header.Flags.IsChunked())
+	assert.False(t, frame.Header.Flags.IsCompressed())
+	assert.Equal(t, BinaryMessageTypeMediaChunk, frame.Header.MessageType)
+	assert.Equal(t, uint32(5), frame.Header.Sequence)
+	assert.Equal(t, mediaID, frame.Header.MediaID)
+	assert.Equal(t, payload, frame.Payload)
+
+	// Verify metadata
+	var metadata BinaryMediaChunkMetadata
+	err = json.Unmarshal(frame.Metadata, &metadata)
+	require.NoError(t, err)
+	assert.Equal(t, "session-123", metadata.SessionID)
+	assert.Equal(t, "audio/wav", metadata.MimeType)
+}
+
+func TestMediaIDFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected [MediaIDSize]byte
+	}{
+		{
+			name:     "short string",
+			input:    "test",
+			expected: [MediaIDSize]byte{'t', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:     "exact length",
+			input:    "123456789012",
+			expected: [MediaIDSize]byte{'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '1', '2'},
+		},
+		{
+			name:     "too long (truncated)",
+			input:    "123456789012345",
+			expected: [MediaIDSize]byte{'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '1', '2'},
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: [MediaIDSize]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MediaIDFromString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestMediaIDToString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    [MediaIDSize]byte
+		expected string
+	}{
+		{
+			name:     "with null bytes",
+			input:    [MediaIDSize]byte{'t', 'e', 's', 't', 0, 0, 0, 0, 0, 0, 0, 0},
+			expected: "test",
+		},
+		{
+			name:     "full length",
+			input:    [MediaIDSize]byte{'1', '2', '3', '4', '5', '6', '7', '8', '9', '0', '1', '2'},
+			expected: "123456789012",
+		},
+		{
+			name:     "empty",
+			input:    [MediaIDSize]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := MediaIDToString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestBinaryFlags(t *testing.T) {
+	tests := []struct {
+		name         string
+		flags        BinaryFlags
+		isCompressed bool
+		isChunked    bool
+		isLast       bool
+	}{
+		{
+			name:         "no flags",
+			flags:        0,
+			isCompressed: false,
+			isChunked:    false,
+			isLast:       false,
+		},
+		{
+			name:         "compressed only",
+			flags:        FlagCompressed,
+			isCompressed: true,
+			isChunked:    false,
+			isLast:       false,
+		},
+		{
+			name:         "chunked only",
+			flags:        FlagChunked,
+			isCompressed: false,
+			isChunked:    true,
+			isLast:       false,
+		},
+		{
+			name:         "is_last only",
+			flags:        FlagIsLast,
+			isCompressed: false,
+			isChunked:    false,
+			isLast:       true,
+		},
+		{
+			name:         "all flags",
+			flags:        FlagCompressed | FlagChunked | FlagIsLast,
+			isCompressed: true,
+			isChunked:    true,
+			isLast:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.isCompressed, tt.flags.IsCompressed())
+			assert.Equal(t, tt.isChunked, tt.flags.IsChunked())
+			assert.Equal(t, tt.isLast, tt.flags.IsLast())
+		})
+	}
+}
+
+func TestBinaryMessageTypeString(t *testing.T) {
+	tests := []struct {
+		msgType  BinaryMessageType
+		expected string
+	}{
+		{BinaryMessageTypeMediaChunk, "media_chunk"},
+		{BinaryMessageTypeUpload, "upload"},
+		{BinaryMessageType(99), "unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.msgType.String())
+		})
+	}
+}
+
+func TestDecodeHeaderTooShort(t *testing.T) {
+	data := make([]byte, BinaryHeaderSize-1)
+	_, err := DecodeHeader(data)
+	assert.ErrorIs(t, err, ErrInvalidHeaderSize)
+}
+
+func TestDecodeBinaryFrameTooShort(t *testing.T) {
+	data := make([]byte, BinaryHeaderSize-1)
+	_, err := DecodeBinaryFrame(data)
+	assert.ErrorIs(t, err, ErrInvalidHeaderSize)
+}
+
+func TestDecodeBinaryFrameMetadataOverflow(t *testing.T) {
+	header := BinaryHeader{
+		Magic:       [4]byte{'O', 'M', 'N', 'I'},
+		Version:     BinaryVersion,
+		MetadataLen: 1000, // Metadata length exceeds actual data
+		PayloadLen:  0,
+	}
+
+	data := header.Encode()
+	// Only add a few bytes of metadata, less than declared
+	data = append(data, []byte("short")...)
+
+	_, err := DecodeBinaryFrame(data)
+	assert.ErrorIs(t, err, ErrMetadataOverflow)
+}
+
+func TestDecodeBinaryFramePayloadOverflow(t *testing.T) {
+	header := BinaryHeader{
+		Magic:       [4]byte{'O', 'M', 'N', 'I'},
+		Version:     BinaryVersion,
+		MetadataLen: 5,
+		PayloadLen:  1000, // Payload length exceeds actual data
+	}
+
+	data := header.Encode()
+	// Add exact metadata but insufficient payload
+	data = append(data, []byte("meta!")...)
+	data = append(data, []byte("short")...)
+
+	_, err := DecodeBinaryFrame(data)
+	assert.ErrorIs(t, err, ErrPayloadOverflow)
+}
+
+func TestBinaryFrameEmptyMetadataAndPayload(t *testing.T) {
+	frame := &BinaryFrame{
+		Header: BinaryHeader{
+			Magic:       [4]byte{'O', 'M', 'N', 'I'},
+			Version:     BinaryVersion,
+			Flags:       0,
+			MessageType: BinaryMessageTypeMediaChunk,
+			MetadataLen: 0,
+			PayloadLen:  0,
+			Sequence:    0,
+		},
+		Metadata: nil,
+		Payload:  nil,
+	}
+
+	encoded, err := frame.Encode()
+	require.NoError(t, err)
+	assert.Equal(t, BinaryHeaderSize, len(encoded))
+
+	decoded, err := DecodeBinaryFrame(encoded)
+	require.NoError(t, err)
+	assert.Empty(t, decoded.Metadata)
+	assert.Empty(t, decoded.Payload)
+}

--- a/internal/facade/protocol.go
+++ b/internal/facade/protocol.go
@@ -207,6 +207,8 @@ type ServerMessage struct {
 	UploadComplete *UploadCompleteInfo `json:"upload_complete,omitempty"`
 	// MediaChunk contains streaming media chunk details (for media_chunk type).
 	MediaChunk *MediaChunkInfo `json:"media_chunk,omitempty"`
+	// Connected contains connection info (for connected type).
+	Connected *ConnectedInfo `json:"connected,omitempty"`
 	// Timestamp is when the message was created.
 	Timestamp time.Time `json:"timestamp"`
 }
@@ -290,6 +292,23 @@ type MediaChunkInfo struct {
 	MimeType string `json:"mime_type"`
 }
 
+// ConnectionCapabilities represents negotiated connection features.
+// Sent in the connected message to inform the client of available capabilities.
+type ConnectionCapabilities struct {
+	// BinaryFrames indicates whether the server supports binary WebSocket frames.
+	BinaryFrames bool `json:"binary_frames"`
+	// MaxPayloadSize is the maximum binary payload size in bytes.
+	MaxPayloadSize int `json:"max_payload_size,omitempty"`
+	// ProtocolVersion is the binary protocol version supported.
+	ProtocolVersion int `json:"protocol_version,omitempty"`
+}
+
+// ConnectedInfo contains additional information sent with the connected message.
+type ConnectedInfo struct {
+	// Capabilities describes the server's supported features.
+	Capabilities *ConnectionCapabilities `json:"capabilities,omitempty"`
+}
+
 // Error codes.
 const (
 	ErrorCodeInvalidMessage   = "INVALID_MESSAGE"
@@ -360,6 +379,18 @@ func NewConnectedMessage(sessionID string) *ServerMessage {
 	return &ServerMessage{
 		Type:      MessageTypeConnected,
 		SessionID: sessionID,
+		Timestamp: time.Now(),
+	}
+}
+
+// NewConnectedMessageWithCapabilities creates a new connected message with capabilities.
+func NewConnectedMessageWithCapabilities(sessionID string, capabilities *ConnectionCapabilities) *ServerMessage {
+	return &ServerMessage{
+		Type:      MessageTypeConnected,
+		SessionID: sessionID,
+		Connected: &ConnectedInfo{
+			Capabilities: capabilities,
+		},
 		Timestamp: time.Now(),
 	}
 }

--- a/test/integration/facade_runtime_test.go
+++ b/test/integration/facade_runtime_test.go
@@ -298,3 +298,11 @@ func (m *mockResponseWriter) WriteUploadComplete(_ *facade.UploadCompleteInfo) e
 func (m *mockResponseWriter) WriteMediaChunk(_ *facade.MediaChunkInfo) error {
 	return nil
 }
+
+func (m *mockResponseWriter) SupportsBinary() bool {
+	return false
+}
+
+func (m *mockResponseWriter) WriteBinaryMediaChunk(_ [facade.MediaIDSize]byte, _ uint32, _ bool, _ string, _ []byte) error {
+	return nil
+}


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Configuration/infrastructure change
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Adding or improving tests

**Component(s) Affected**
- [ ] Operator
- [ ] AgentRuntime Controller
- [ ] PromptPack Controller
- [ ] ToolRegistry Controller
- [x] WebSocket Facade
- [ ] Session Store
- [ ] Helm Chart
- [ ] CRD Definitions
- [ ] Examples
- [x] Documentation
- [ ] CI/CD
- [x] Other: Dashboard TypeScript types

## Description

**What does this PR do?**
Adds support for binary WebSocket frames to efficiently transfer large media without base64 encoding overhead (~33% size reduction). Binary frames use a 32-byte header followed by JSON metadata and raw binary payload.

**Why is this change needed?**
Base64 encoding increases data size by approximately 33%. For streaming audio/video responses, binary frames are more efficient and reduce bandwidth usage significantly.

Fixes #153

## Changes Made

**Code Changes**
- Add `internal/facade/binary.go` - Binary frame types, header encoding/decoding, helper functions
- Add `internal/facade/binary_test.go` - Comprehensive unit tests for binary encoding (98.8% coverage)
- Update `internal/facade/protocol.go` - Add `ConnectionCapabilities`, `ConnectedInfo`, `NewConnectedMessageWithCapabilities`
- Update `internal/facade/server.go` - Add `binaryCapable` field, binary message handling, `sendBinaryFrame`, extend `ResponseWriter` interface
- Update `internal/facade/server_test.go` - Add capability negotiation and binary frame tests
- Update `dashboard/src/types/websocket.ts` - Add TypeScript types and `decodeBinaryFrame` helper
- Update `docs/src/content/docs/reference/websocket-protocol.md` - Document binary frame format and usage

**Binary Frame Header (32 bytes)**
| Field | Offset | Size | Description |
|-------|--------|------|-------------|
| Magic | 0 | 4 | "OMNI" |
| Version | 4 | 1 | Protocol version (1) |
| Flags | 5 | 1 | compressed, chunked, is_last |
| MessageType | 6 | 2 | Message type (big-endian) |
| MetadataLen | 8 | 4 | JSON metadata length |
| PayloadLen | 12 | 4 | Binary payload length |
| Sequence | 16 | 4 | Sequence number |
| MediaID | 20 | 12 | Media stream identifier |

## Testing

**Test Coverage**
- [x] I have added unit tests for my changes
- [x] I have added integration tests for my changes
- [ ] I have tested with envtest
- [x] Existing tests pass with my changes
- [ ] I have tested this manually on a local K8s cluster

**Test Results**
- [x] All automated tests pass
- [x] Manual testing completed successfully
- [x] No regressions identified

Coverage on changed files:
- `binary.go`: 98.8%
- `protocol.go`: 100.0%
- `server.go`: 84.1%

## Documentation

**Documentation Updates**
- [x] I have updated relevant documentation
- [x] I have added/updated code comments
- [ ] I have updated CRD reference docs
- [ ] I have updated Helm chart documentation
- [ ] I have updated examples if needed
- [ ] No documentation changes needed

Updated `docs/src/content/docs/reference/websocket-protocol.md` with:
- `binary=true` query parameter
- Connected message capabilities
- Binary WebSocket Frames section with header layout, flags, message types, and JavaScript example

## Code Quality

**Code Review Checklist**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented where needed
- [x] No debug/temporary code included
- [x] Error handling is appropriate
- [x] Kubernetes best practices followed

## Deployment

**Deployment Considerations**
- [x] No special deployment steps required
- [ ] CRD updates required
- [ ] Helm chart updates required
- [ ] RBAC changes required
- [ ] Dependencies need to be updated

This is a backward-compatible change. Binary frames are opt-in via the `binary=true` query parameter. Existing clients continue to work without modification.

## Additional Context

**Backward Compatibility**
- Binary frames are opt-in via `?binary=true` query parameter
- JSON text frames remain the default
- `WriteBinaryMediaChunk` automatically falls back to base64 JSON if client doesn't support binary
- Existing clients work unchanged

---

## Checklist

**Before Submitting**
- [x] I have read the [Contributing Guidelines](./CONTRIBUTING.md)
- [x] I have followed the [Code of Conduct](./CODE_OF_CONDUCT.md)
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes