### PR TITLE
feat(facade): add media upload/download Prometheus metrics (#158)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -106,7 +106,7 @@ func main() {
 		defer mediaCleanup()
 	}
 	if mediaStorage != nil {
-		mediaHandler := media.NewHandler(mediaStorage, log)
+		mediaHandler := media.NewHandler(mediaStorage, log, media.WithHandlerMetrics(metrics))
 		mediaHandler.RegisterRoutes(mux)
 		log.Info("media storage enabled", "type", cfg.MediaStorageType, "path", cfg.MediaStoragePath)
 	}

--- a/internal/agent/metrics.go
+++ b/internal/agent/metrics.go
@@ -49,6 +49,28 @@ type Metrics struct {
 
 	// MessagesSent is the total number of messages sent.
 	MessagesSent prometheus.Counter
+
+	// Media metrics
+	// UploadsTotal is the total number of upload attempts.
+	UploadsTotal *prometheus.CounterVec
+
+	// UploadBytesTotal is the total bytes uploaded.
+	UploadBytesTotal prometheus.Counter
+
+	// UploadDuration is the histogram of upload durations.
+	UploadDuration prometheus.Histogram
+
+	// DownloadsTotal is the total number of download attempts.
+	DownloadsTotal *prometheus.CounterVec
+
+	// DownloadBytesTotal is the total bytes downloaded.
+	DownloadBytesTotal prometheus.Counter
+
+	// MediaChunksTotal is the total number of media chunks sent.
+	MediaChunksTotal *prometheus.CounterVec
+
+	// MediaChunkBytesTotal is the total bytes sent as media chunks.
+	MediaChunkBytesTotal prometheus.Counter
 }
 
 // NewMetrics creates and registers all Prometheus metrics.
@@ -107,6 +129,50 @@ func NewMetrics(agentName, namespace string) *Metrics {
 			Help:        "Total number of WebSocket messages sent",
 			ConstLabels: labels,
 		}),
+
+		// Media metrics
+		UploadsTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name:        "omnia_facade_uploads_total",
+			Help:        "Total number of media upload attempts",
+			ConstLabels: labels,
+		}, []string{"status"}), // status: success, failed
+
+		UploadBytesTotal: promauto.NewCounter(prometheus.CounterOpts{
+			Name:        "omnia_facade_upload_bytes_total",
+			Help:        "Total bytes uploaded",
+			ConstLabels: labels,
+		}),
+
+		UploadDuration: promauto.NewHistogram(prometheus.HistogramOpts{
+			Name:        "omnia_facade_upload_duration_seconds",
+			Help:        "Upload duration in seconds",
+			ConstLabels: labels,
+			Buckets:     []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60, 120},
+		}),
+
+		DownloadsTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name:        "omnia_facade_downloads_total",
+			Help:        "Total number of media download attempts",
+			ConstLabels: labels,
+		}, []string{"status"}), // status: success, failed
+
+		DownloadBytesTotal: promauto.NewCounter(prometheus.CounterOpts{
+			Name:        "omnia_facade_download_bytes_total",
+			Help:        "Total bytes downloaded",
+			ConstLabels: labels,
+		}),
+
+		MediaChunksTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name:        "omnia_facade_media_chunks_total",
+			Help:        "Total number of media chunks sent",
+			ConstLabels: labels,
+		}, []string{"type"}), // type: json, binary
+
+		MediaChunkBytesTotal: promauto.NewCounter(prometheus.CounterOpts{
+			Name:        "omnia_facade_media_chunk_bytes_total",
+			Help:        "Total bytes sent as media chunks",
+			ConstLabels: labels,
+		}),
 	}
 }
 
@@ -151,4 +217,47 @@ func (m *Metrics) MessageReceived() {
 // MessageSent records a sent message.
 func (m *Metrics) MessageSent() {
 	m.MessagesSent.Inc()
+}
+
+// UploadStarted records the start of a media upload.
+func (m *Metrics) UploadStarted() {
+	// No-op: we track uploads in UploadCompleted/UploadFailed
+}
+
+// UploadCompleted records a successful media upload.
+func (m *Metrics) UploadCompleted(bytes int64, durationSeconds float64) {
+	m.UploadsTotal.WithLabelValues("success").Inc()
+	m.UploadBytesTotal.Add(float64(bytes))
+	m.UploadDuration.Observe(durationSeconds)
+}
+
+// UploadFailed records a failed media upload.
+func (m *Metrics) UploadFailed() {
+	m.UploadsTotal.WithLabelValues("failed").Inc()
+}
+
+// DownloadStarted records the start of a media download.
+func (m *Metrics) DownloadStarted() {
+	// No-op: we track downloads in DownloadCompleted/DownloadFailed
+}
+
+// DownloadCompleted records a successful media download.
+func (m *Metrics) DownloadCompleted(bytes int64) {
+	m.DownloadsTotal.WithLabelValues("success").Inc()
+	m.DownloadBytesTotal.Add(float64(bytes))
+}
+
+// DownloadFailed records a failed media download.
+func (m *Metrics) DownloadFailed() {
+	m.DownloadsTotal.WithLabelValues("failed").Inc()
+}
+
+// MediaChunkSent records a media chunk sent to the client.
+func (m *Metrics) MediaChunkSent(isBinary bool, bytes int) {
+	chunkType := "json"
+	if isBinary {
+		chunkType = "binary"
+	}
+	m.MediaChunksTotal.WithLabelValues(chunkType).Inc()
+	m.MediaChunkBytesTotal.Add(float64(bytes))
 }

--- a/internal/facade/metrics.go
+++ b/internal/facade/metrics.go
@@ -35,6 +35,22 @@ type ServerMetrics interface {
 	MessageReceived()
 	// MessageSent records a sent message.
 	MessageSent()
+
+	// Media metrics
+	// UploadStarted records the start of a media upload.
+	UploadStarted()
+	// UploadCompleted records a successful media upload with size and duration.
+	UploadCompleted(bytes int64, durationSeconds float64)
+	// UploadFailed records a failed media upload.
+	UploadFailed()
+	// DownloadStarted records the start of a media download.
+	DownloadStarted()
+	// DownloadCompleted records a successful media download with size.
+	DownloadCompleted(bytes int64)
+	// DownloadFailed records a failed media download.
+	DownloadFailed()
+	// MediaChunkSent records a media chunk sent to the client.
+	MediaChunkSent(isBinary bool, bytes int)
 }
 
 // NoOpMetrics is a no-op implementation of ServerMetrics for when metrics are disabled.
@@ -64,3 +80,24 @@ func (n *NoOpMetrics) MessageReceived() { /* no-op: null object pattern */ }
 
 // MessageSent is a no-op - metrics are disabled.
 func (n *NoOpMetrics) MessageSent() { /* no-op: null object pattern */ }
+
+// UploadStarted is a no-op - metrics are disabled.
+func (n *NoOpMetrics) UploadStarted() { /* no-op: null object pattern */ }
+
+// UploadCompleted is a no-op - metrics are disabled.
+func (n *NoOpMetrics) UploadCompleted(int64, float64) { /* no-op: null object pattern */ }
+
+// UploadFailed is a no-op - metrics are disabled.
+func (n *NoOpMetrics) UploadFailed() { /* no-op: null object pattern */ }
+
+// DownloadStarted is a no-op - metrics are disabled.
+func (n *NoOpMetrics) DownloadStarted() { /* no-op: null object pattern */ }
+
+// DownloadCompleted is a no-op - metrics are disabled.
+func (n *NoOpMetrics) DownloadCompleted(int64) { /* no-op: null object pattern */ }
+
+// DownloadFailed is a no-op - metrics are disabled.
+func (n *NoOpMetrics) DownloadFailed() { /* no-op: null object pattern */ }
+
+// MediaChunkSent is a no-op - metrics are disabled.
+func (n *NoOpMetrics) MediaChunkSent(bool, int) { /* no-op: null object pattern */ }

--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -679,7 +679,11 @@ func (w *connResponseWriter) WriteUploadComplete(uploadComplete *UploadCompleteI
 }
 
 func (w *connResponseWriter) WriteMediaChunk(mediaChunk *MediaChunkInfo) error {
-	return w.server.sendMessage(w.conn, NewMediaChunkMessage(w.sessionID, mediaChunk))
+	err := w.server.sendMessage(w.conn, NewMediaChunkMessage(w.sessionID, mediaChunk))
+	if err == nil {
+		w.server.metrics.MediaChunkSent(false, len(mediaChunk.Data))
+	}
+	return err
 }
 
 func (w *connResponseWriter) SupportsBinary() bool {
@@ -703,5 +707,9 @@ func (w *connResponseWriter) WriteBinaryMediaChunk(mediaID [MediaIDSize]byte, se
 		return err
 	}
 
-	return w.server.sendBinaryFrame(w.conn, frame)
+	err = w.server.sendBinaryFrame(w.conn, frame)
+	if err == nil {
+		w.server.metrics.MediaChunkSent(true, len(payload))
+	}
+	return err
 }


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration/infrastructure change
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Adding or improving tests

**Component(s) Affected**
- [ ] Operator
- [ ] AgentRuntime Controller
- [ ] PromptPack Controller
- [ ] ToolRegistry Controller
- [x] WebSocket Facade
- [ ] Session Store
- [ ] Helm Chart
- [ ] CRD Definitions
- [ ] Examples
- [ ] Documentation
- [ ] CI/CD
- [ ] Other: ___________

## Description

**What does this PR do?**
Adds Prometheus metrics to track media upload and download operations in the WebSocket facade, enabling observability of media usage patterns.

**Why is this change needed?**
Media operations need monitoring to identify slow uploads, track storage consumption, and observe usage patterns for capacity planning.

Fixes #158

## Changes Made

**Code Changes**
- Extended `ServerMetrics` interface with media-related methods
- Added Prometheus metrics to `agent.Metrics`:
  - `omnia_facade_uploads_total` (counter with status label)
  - `omnia_facade_upload_bytes_total` (counter)
  - `omnia_facade_upload_duration_seconds` (histogram)
  - `omnia_facade_downloads_total` (counter with status label)
  - `omnia_facade_download_bytes_total` (counter)
  - `omnia_facade_media_chunks_total` (counter with type label)
  - `omnia_facade_media_chunk_bytes_total` (counter)
- Added `HandlerMetrics` interface to media handler with optional injection
- Instrumented `handleUpload` and `handleDownload` in media handler
- Added media chunk tracking to `WriteMediaChunk` and `WriteBinaryMediaChunk`

All metrics include `agent` and `namespace` labels for filtering.

## Testing

**Test Coverage**
- [x] I have added unit tests for my changes
- [ ] I have added integration tests for my changes
- [ ] I have tested with envtest
- [x] Existing tests pass with my changes
- [ ] I have tested this manually on a local K8s cluster

**Test Results**
- [x] All automated tests pass
- [x] Manual testing completed successfully
- [x] No regressions identified

Coverage on changed files:
- `internal/agent/metrics.go`: 92%
- `internal/facade/server.go`: 84.5%
- `internal/media/handler.go`: 89.4%

## Documentation

**Documentation Updates**
- [ ] I have updated relevant documentation
- [x] I have added/updated code comments
- [ ] I have updated CRD reference docs
- [ ] I have updated Helm chart documentation
- [ ] I have updated examples if needed
- [x] No documentation changes needed

## Code Quality

**Code Review Checklist**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Code is well-commented where needed
- [x] No debug/temporary code included
- [x] Error handling is appropriate
- [x] Kubernetes best practices followed

## Deployment

**Deployment Considerations**
- [x] No special deployment steps required
- [ ] CRD updates required
- [ ] Helm chart updates required
- [ ] RBAC changes required
- [ ] Dependencies need to be updated

## Checklist

**Before Submitting**
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or my feature works
- [x] New and existing unit tests pass locally with my changes