### PR TITLE
fix(dashboard): expose WebSocket proxy port and support gateway routing

### DIFF
--- a/charts/omnia/templates/dashboard/deployment.yaml
+++ b/charts/omnia/templates/dashboard/deployment.yaml
@@ -45,6 +45,9 @@ spec:
             - name: http
               containerPort: 3000
               protocol: TCP
+            - name: ws
+              containerPort: 3002
+              protocol: TCP
           envFrom:
             - configMapRef:
                 name: {{ include "omnia.dashboard.fullname" . }}

--- a/charts/omnia/templates/dashboard/httproute.yaml
+++ b/charts/omnia/templates/dashboard/httproute.yaml
@@ -15,6 +15,14 @@ spec:
     - name: {{ $gatewayName }}
       namespace: {{ .Release.Namespace }}
   rules:
+    # WebSocket route for agent connections (must be before catch-all)
+    - matches:
+        - path:
+            type: RegularExpression
+            value: /api/agents/[^/]+/[^/]+/ws
+      backendRefs:
+        - name: {{ include "omnia.dashboard.fullname" . }}
+          port: 3002
     # Dashboard routes at root path
     - matches:
         - path:

--- a/charts/omnia/templates/dashboard/service.yaml
+++ b/charts/omnia/templates/dashboard/service.yaml
@@ -12,6 +12,10 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: 3002
+      targetPort: ws
+      protocol: TCP
+      name: ws
   selector:
     {{- include "omnia.dashboard.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/dashboard/src/lib/data/live-service.ts
+++ b/dashboard/src/lib/data/live-service.ts
@@ -71,9 +71,10 @@ export class LiveAgentConnection implements AgentConnection {
         // Production: use configured proxy URL with full path
         wsUrl = `${wsProxyUrl}/api/agents/${this.namespace}/${this.agentName}/ws`;
       } else {
-        // Development: WebSocket proxy on port 3002
-        const wsHost = typeof globalThis !== "undefined" && globalThis.location ? globalThis.location.hostname : "localhost";
-        wsUrl = `${protocol}//${wsHost}:3002/api/agents/${this.namespace}/${this.agentName}/ws`;
+        // Use relative URL - works with gateway routing in production
+        // Falls back to localhost:3002 for SSR or when location is unavailable
+        const wsHost = typeof globalThis !== "undefined" && globalThis.location ? globalThis.location.host : "localhost:3002";
+        wsUrl = `${protocol}//${wsHost}/api/agents/${this.namespace}/${this.agentName}/ws`;
       }
 
       this.ws = new WebSocket(wsUrl);


### PR DESCRIPTION
## Pull Request Summary

**Type of Change**
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Configuration/infrastructure change
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Adding or improving tests

**Component(s) Affected**
- [ ] Operator
- [ ] AgentRuntime Controller
- [ ] PromptPack Controller
- [ ] ToolRegistry Controller
- [ ] WebSocket Facade
- [ ] Session Store
- [x] Helm Chart
- [ ] Examples
- [ ] Documentation
- [ ] CI/CD
- [x] Other: Dashboard frontend

## Description

**What does this PR do?**
Fixes WebSocket connections when accessing the dashboard through a gateway (e.g., Istio). The dashboard runs two servers (port 3000 for HTTP, port 3002 for WebSocket proxy) but only port 3000 was exposed.

**Why is this change needed?**
When accessing the dashboard through a gateway, WebSocket connections failed because:
1. Port 3002 wasn't exposed in the Kubernetes Service
2. No HTTPRoute existed for WebSocket traffic
3. The frontend used hardcoded `hostname:3002` instead of relative URLs

Fixes #221

## Changes Made

**Code Changes**
- `dashboard/src/lib/data/live-service.ts`: Changed fallback URL to use `location.host` (includes port) instead of hardcoded port 3002. This makes WebSocket connections go through the same gateway as HTTP.

**Helm Chart Changes**
- `templates/dashboard/deployment.yaml`: Added containerPort 3002 for WebSocket proxy
- `templates/dashboard/service.yaml`: Added port 3002 mapping to the ws target
- `templates/dashboard/httproute.yaml`: Added HTTPRoute rule for `/api/agents/{ns}/{name}/ws` to route WebSocket traffic to port 3002

## Testing

**Test Coverage**
- [x] Existing tests pass with my changes
- [ ] I have tested this manually on a local K8s cluster

**Test Results**
- [x] All automated tests pass
- [x] No regressions identified

## Documentation

**Documentation Updates**
- [x] No documentation changes needed

## Code Quality

**Code Review Checklist**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No debug/temporary code included

## Deployment

**Deployment Considerations**
- [ ] No special deployment steps required
- [x] Helm chart updates required

---

## Checklist

**Before Submitting**
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes