### PR TITLE
feat(arena): add ConfigMap fetcher for Arena bundles (#195)

### DIFF
--- a/pkg/arena/fetcher/configmap.go
+++ b/pkg/arena/fetcher/configmap.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fetcher
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConfigMapFetcherConfig contains configuration for the ConfigMap fetcher.
+type ConfigMapFetcherConfig struct {
+	// Name is the ConfigMap name.
+	Name string
+
+	// Namespace is the ConfigMap namespace.
+	Namespace string
+
+	// Options contains common fetcher options.
+	Options Options
+}
+
+// ConfigMapFetcher implements the Fetcher interface for Kubernetes ConfigMaps.
+type ConfigMapFetcher struct {
+	config ConfigMapFetcherConfig
+	client client.Client
+}
+
+// NewConfigMapFetcher creates a new ConfigMap fetcher with the given configuration.
+func NewConfigMapFetcher(config ConfigMapFetcherConfig, k8sClient client.Client) *ConfigMapFetcher {
+	if config.Options.Timeout == 0 {
+		config.Options = DefaultOptions()
+	}
+	return &ConfigMapFetcher{
+		config: config,
+		client: k8sClient,
+	}
+}
+
+// Type returns the source type.
+func (f *ConfigMapFetcher) Type() string {
+	return "configmap"
+}
+
+// LatestRevision returns the resourceVersion of the ConfigMap.
+func (f *ConfigMapFetcher) LatestRevision(ctx context.Context) (string, error) {
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{
+		Name:      f.config.Name,
+		Namespace: f.config.Namespace,
+	}
+
+	if err := f.client.Get(ctx, key, cm); err != nil {
+		return "", fmt.Errorf("failed to get ConfigMap %s/%s: %w", f.config.Namespace, f.config.Name, err)
+	}
+
+	return cm.ResourceVersion, nil
+}
+
+// Fetch creates a tarball from the ConfigMap data.
+func (f *ConfigMapFetcher) Fetch(ctx context.Context, revision string) (*Artifact, error) {
+	cm := &corev1.ConfigMap{}
+	key := types.NamespacedName{
+		Name:      f.config.Name,
+		Namespace: f.config.Namespace,
+	}
+
+	if err := f.client.Get(ctx, key, cm); err != nil {
+		return nil, fmt.Errorf("failed to get ConfigMap %s/%s: %w", f.config.Namespace, f.config.Name, err)
+	}
+
+	// Verify revision matches if specified
+	if revision != "" && cm.ResourceVersion != revision {
+		return nil, fmt.Errorf("ConfigMap revision mismatch: expected %s, got %s", revision, cm.ResourceVersion)
+	}
+
+	// Create tarball from ConfigMap data
+	tarballPath, checksum, size, err := f.createTarball(cm)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create tarball: %w", err)
+	}
+
+	// Determine last modified time
+	lastModified := time.Now()
+	if cm.CreationTimestamp.After(time.Time{}) {
+		lastModified = cm.CreationTimestamp.Time
+	}
+
+	return &Artifact{
+		Path:         tarballPath,
+		Revision:     cm.ResourceVersion,
+		Checksum:     checksum,
+		Size:         size,
+		LastModified: lastModified,
+	}, nil
+}
+
+// createTarball creates a gzipped tarball from ConfigMap data.
+func (f *ConfigMapFetcher) createTarball(cm *corev1.ConfigMap) (string, string, int64, error) {
+	// Create temporary file for the tarball
+	tmpFile, err := os.CreateTemp(f.config.Options.WorkDir, "configmap-*.tar.gz")
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to create temp file: %w", err)
+	}
+
+	hash := sha256.New()
+	multiWriter := io.MultiWriter(tmpFile, hash)
+
+	gzipWriter := gzip.NewWriter(multiWriter)
+	tarWriter := tar.NewWriter(gzipWriter)
+
+	// Track if we've closed everything successfully
+	var closed bool
+	defer func() {
+		if !closed {
+			_ = tarWriter.Close()
+			_ = gzipWriter.Close()
+			_ = tmpFile.Close()
+		}
+	}()
+
+	// Sort keys for deterministic output
+	keys := make([]string, 0, len(cm.Data)+len(cm.BinaryData))
+	for k := range cm.Data {
+		keys = append(keys, k)
+	}
+	for k := range cm.BinaryData {
+		// Only add if not already in Data (Data takes precedence)
+		if _, exists := cm.Data[k]; !exists {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+
+	// Add each file to the tarball
+	for _, key := range keys {
+		var content []byte
+		if data, ok := cm.Data[key]; ok {
+			content = []byte(data)
+		} else if binData, ok := cm.BinaryData[key]; ok {
+			content = binData
+		}
+
+		header := &tar.Header{
+			Name:    key,
+			Mode:    0644,
+			Size:    int64(len(content)),
+			ModTime: cm.CreationTimestamp.Time,
+		}
+
+		if err := tarWriter.WriteHeader(header); err != nil {
+			return "", "", 0, fmt.Errorf("failed to write tar header for %s: %w", key, err)
+		}
+
+		if _, err := tarWriter.Write(content); err != nil {
+			return "", "", 0, fmt.Errorf("failed to write tar content for %s: %w", key, err)
+		}
+	}
+
+	// Close writers to flush
+	if err := tarWriter.Close(); err != nil {
+		return "", "", 0, fmt.Errorf("failed to close tar writer: %w", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		return "", "", 0, fmt.Errorf("failed to close gzip writer: %w", err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		return "", "", 0, fmt.Errorf("failed to close temp file: %w", err)
+	}
+	closed = true
+
+	// Get file size
+	stat, err := os.Stat(tmpFile.Name())
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to stat tarball: %w", err)
+	}
+
+	checksum := "sha256:" + hex.EncodeToString(hash.Sum(nil))
+	return tmpFile.Name(), checksum, stat.Size(), nil
+}
+
+// Ensure ConfigMapFetcher implements Fetcher interface.
+var _ Fetcher = (*ConfigMapFetcher)(nil)

--- a/pkg/arena/fetcher/configmap_test.go
+++ b/pkg/arena/fetcher/configmap_test.go
@@ -1,0 +1,383 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fetcher
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestNewConfigMapFetcher(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	tests := []struct {
+		name   string
+		config ConfigMapFetcherConfig
+	}{
+		{
+			name: "basic config",
+			config: ConfigMapFetcherConfig{
+				Name:      "my-config",
+				Namespace: "default",
+			},
+		},
+		{
+			name: "with custom timeout",
+			config: ConfigMapFetcherConfig{
+				Name:      "my-config",
+				Namespace: "default",
+				Options: Options{
+					Timeout: 120 * time.Second,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fetcher := NewConfigMapFetcher(tt.config, fakeClient)
+			assert.NotNil(t, fetcher)
+			assert.Equal(t, "configmap", fetcher.Type())
+		})
+	}
+}
+
+func TestConfigMapFetcher_Type(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "test",
+		Namespace: "default",
+	}, fakeClient)
+
+	assert.Equal(t, "configmap", fetcher.Type())
+}
+
+func TestConfigMapFetcher_LatestRevision(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-config",
+			Namespace:       "default",
+			ResourceVersion: "12345",
+		},
+		Data: map[string]string{
+			"config.yaml": "key: value",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cm).
+		Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "test-config",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	revision, err := fetcher.LatestRevision(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, "12345", revision)
+}
+
+func TestConfigMapFetcher_LatestRevision_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "nonexistent",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	_, err := fetcher.LatestRevision(ctx)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get ConfigMap")
+}
+
+func TestConfigMapFetcher_Fetch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-config",
+			Namespace:         "default",
+			ResourceVersion:   "12345",
+			CreationTimestamp: metav1.Now(),
+		},
+		Data: map[string]string{
+			"config.yaml": "key: value\n",
+			"prompt.txt":  "Hello, world!",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cm).
+		Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "test-config",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	artifact, err := fetcher.Fetch(ctx, "12345")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(artifact.Path) }()
+
+	assert.NotEmpty(t, artifact.Path)
+	assert.Equal(t, "12345", artifact.Revision)
+	assert.True(t, strings.HasPrefix(artifact.Checksum, "sha256:"))
+	assert.Greater(t, artifact.Size, int64(0))
+
+	// Verify tarball contents
+	verifyConfigMapTarball(t, artifact.Path, map[string]string{
+		"config.yaml": "key: value\n",
+		"prompt.txt":  "Hello, world!",
+	})
+}
+
+func TestConfigMapFetcher_Fetch_WithBinaryData(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	binaryContent := []byte{0x00, 0x01, 0x02, 0x03, 0xFF}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-config",
+			Namespace:         "default",
+			ResourceVersion:   "12345",
+			CreationTimestamp: metav1.Now(),
+		},
+		Data: map[string]string{
+			"config.yaml": "key: value",
+		},
+		BinaryData: map[string][]byte{
+			"binary.bin": binaryContent,
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cm).
+		Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "test-config",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	artifact, err := fetcher.Fetch(ctx, "")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(artifact.Path) }()
+
+	assert.NotEmpty(t, artifact.Path)
+
+	// Verify binary data is in tarball
+	contents := extractTarballContents(t, artifact.Path)
+	assert.Equal(t, binaryContent, contents["binary.bin"])
+}
+
+func TestConfigMapFetcher_Fetch_RevisionMismatch(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test-config",
+			Namespace:       "default",
+			ResourceVersion: "12345",
+		},
+		Data: map[string]string{
+			"config.yaml": "key: value",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cm).
+		Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "test-config",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	_, err := fetcher.Fetch(ctx, "99999")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "revision mismatch")
+}
+
+func TestConfigMapFetcher_Fetch_NotFound(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "nonexistent",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	_, err := fetcher.Fetch(ctx, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to get ConfigMap")
+}
+
+func TestConfigMapFetcher_Fetch_EmptyConfigMap(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "empty-config",
+			Namespace:         "default",
+			ResourceVersion:   "12345",
+			CreationTimestamp: metav1.Now(),
+		},
+		// No Data or BinaryData
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cm).
+		Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "empty-config",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	artifact, err := fetcher.Fetch(ctx, "")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(artifact.Path) }()
+
+	// Should create a valid (empty) tarball
+	assert.NotEmpty(t, artifact.Path)
+	assert.Equal(t, "12345", artifact.Revision)
+}
+
+func TestConfigMapFetcher_Fetch_DataPrecedenceOverBinary(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.AddToScheme(scheme)
+
+	// Same key in both Data and BinaryData - Data should take precedence
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "test-config",
+			Namespace:         "default",
+			ResourceVersion:   "12345",
+			CreationTimestamp: metav1.Now(),
+		},
+		Data: map[string]string{
+			"config.yaml": "from-data",
+		},
+		BinaryData: map[string][]byte{
+			"config.yaml": []byte("from-binary"),
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(cm).
+		Build()
+
+	fetcher := NewConfigMapFetcher(ConfigMapFetcherConfig{
+		Name:      "test-config",
+		Namespace: "default",
+	}, fakeClient)
+
+	ctx := context.Background()
+	artifact, err := fetcher.Fetch(ctx, "")
+	require.NoError(t, err)
+	defer func() { _ = os.Remove(artifact.Path) }()
+
+	// Data should take precedence
+	contents := extractTarballContents(t, artifact.Path)
+	assert.Equal(t, []byte("from-data"), contents["config.yaml"])
+}
+
+// Helper function to verify tarball contents
+func verifyConfigMapTarball(t *testing.T, tarballPath string, expected map[string]string) {
+	t.Helper()
+
+	contents := extractTarballContents(t, tarballPath)
+	for key, expectedValue := range expected {
+		actualValue, ok := contents[key]
+		assert.True(t, ok, "expected file %s not found in tarball", key)
+		assert.Equal(t, []byte(expectedValue), actualValue, "content mismatch for %s", key)
+	}
+}
+
+// Helper function to extract tarball contents
+func extractTarballContents(t *testing.T, tarballPath string) map[string][]byte {
+	t.Helper()
+
+	file, err := os.Open(tarballPath)
+	require.NoError(t, err)
+	defer func() { _ = file.Close() }()
+
+	gzipReader, err := gzip.NewReader(file)
+	require.NoError(t, err)
+	defer func() { _ = gzipReader.Close() }()
+
+	tarReader := tar.NewReader(gzipReader)
+	contents := make(map[string][]byte)
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+
+		data, err := io.ReadAll(tarReader)
+		require.NoError(t, err)
+		contents[header.Name] = data
+	}
+
+	return contents
+}


### PR DESCRIPTION
## Summary
- Implement ConfigMap fetcher that reads PromptKit bundles from Kubernetes ConfigMaps
- This completes the fetcher implementations (Git, OCI, ConfigMap)

## Features
- Read bundle content from ConfigMap `data` and `binaryData` fields
- Track ConfigMap `resourceVersion` as revision
- Create tarball from ConfigMap contents
- Support both single-file and multi-file bundles
- `data` takes precedence over `binaryData` for duplicate keys

## Use Case
Development and simple deployments where external Git/OCI dependencies are not needed.

## Test plan
- [x] Unit tests pass locally
- [x] Coverage at 83.1% (above 80% threshold)
- [ ] SonarCloud analysis passes