### PR TITLE
feat(arena): add ArenaConfig controller for configuration validation

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,6 +72,7 @@ rules:
   - omnia.altairalabs.ai
   resources:
   - agentruntimes
+  - arenaconfigs
   - arenasources
   - promptpacks
   - providers
@@ -88,6 +89,7 @@ rules:
   - omnia.altairalabs.ai
   resources:
   - agentruntimes/finalizers
+  - arenaconfigs/finalizers
   - arenasources/finalizers
   - promptpacks/finalizers
   - providers/finalizers
@@ -98,6 +100,7 @@ rules:
   - omnia.altairalabs.ai
   resources:
   - agentruntimes/status
+  - arenaconfigs/status
   - arenasources/status
   - promptpacks/status
   - providers/status

--- a/internal/controller/arenaconfig_controller.go
+++ b/internal/controller/arenaconfig_controller.go
@@ -1,0 +1,387 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// ArenaConfig condition types
+const (
+	ArenaConfigConditionTypeReady          = "Ready"
+	ArenaConfigConditionTypeSourceResolved = "SourceResolved"
+	ArenaConfigConditionTypeProvidersValid = "ProvidersValid"
+	ArenaConfigConditionTypeToolRegsValid  = "ToolRegistriesValid"
+)
+
+// Event reasons for ArenaConfig
+const (
+	ArenaConfigEventReasonValidationStarted   = "ValidationStarted"
+	ArenaConfigEventReasonValidationSucceeded = "ValidationSucceeded"
+	ArenaConfigEventReasonValidationFailed    = "ValidationFailed"
+	ArenaConfigEventReasonSourceResolved      = "SourceResolved"
+	ArenaConfigEventReasonSourceNotReady      = "SourceNotReady"
+	ArenaConfigEventReasonProviderNotFound    = "ProviderNotFound"
+	ArenaConfigEventReasonProviderNotReady    = "ProviderNotReady"
+	ArenaConfigEventReasonToolRegNotFound     = "ToolRegistryNotFound"
+)
+
+// ArenaConfigReconciler reconciles an ArenaConfig object
+type ArenaConfigReconciler struct {
+	client.Client
+	Scheme   *runtime.Scheme
+	Recorder record.EventRecorder
+}
+
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=arenaconfigs,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=arenaconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=arenaconfigs/finalizers,verbs=update
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=arenasources,verbs=get;list;watch
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=providers,verbs=get;list;watch
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=toolregistries,verbs=get;list;watch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *ArenaConfigReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.V(1).Info("reconciling ArenaConfig", "name", req.Name, "namespace", req.Namespace)
+
+	// Fetch the ArenaConfig instance
+	config := &omniav1alpha1.ArenaConfig{}
+	if err := r.Get(ctx, req.NamespacedName, config); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("ArenaConfig resource not found, ignoring")
+			return ctrl.Result{}, nil
+		}
+		log.Error(err, "Failed to get ArenaConfig")
+		return ctrl.Result{}, err
+	}
+
+	// Initialize status if needed
+	if config.Status.Phase == "" {
+		config.Status.Phase = omniav1alpha1.ArenaConfigPhasePending
+	}
+
+	// Update observed generation
+	config.Status.ObservedGeneration = config.Generation
+
+	// Check if suspended
+	if config.Spec.Suspend {
+		log.Info("ArenaConfig is suspended, skipping validation")
+		r.setCondition(config, ArenaConfigConditionTypeReady, metav1.ConditionFalse,
+			"Suspended", "ArenaConfig validation is suspended")
+		if err := r.Status().Update(ctx, config); err != nil {
+			log.Error(err, "Failed to update status")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if r.Recorder != nil {
+		r.Recorder.Event(config, corev1.EventTypeNormal, ArenaConfigEventReasonValidationStarted, "Started validating configuration")
+	}
+
+	// Resolve ArenaSource
+	source, err := r.resolveSource(ctx, config)
+	if err != nil {
+		log.Error(err, "Failed to resolve ArenaSource")
+		r.handleValidationError(ctx, config, ArenaConfigConditionTypeSourceResolved, err)
+		return ctrl.Result{}, nil
+	}
+
+	// Check if source is ready
+	if source.Status.Phase != omniav1alpha1.ArenaSourcePhaseReady {
+		log.Info("ArenaSource is not ready", "source", config.Spec.SourceRef.Name, "phase", source.Status.Phase)
+		r.setCondition(config, ArenaConfigConditionTypeSourceResolved, metav1.ConditionFalse,
+			"SourceNotReady", fmt.Sprintf("ArenaSource %s is not ready (phase: %s)", config.Spec.SourceRef.Name, source.Status.Phase))
+		config.Status.Phase = omniav1alpha1.ArenaConfigPhasePending
+		if r.Recorder != nil {
+			r.Recorder.Event(config, corev1.EventTypeWarning, ArenaConfigEventReasonSourceNotReady,
+				fmt.Sprintf("ArenaSource %s is not ready", config.Spec.SourceRef.Name))
+		}
+		if err := r.Status().Update(ctx, config); err != nil {
+			log.Error(err, "Failed to update status")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
+	// Update resolved source info
+	config.Status.ResolvedSource = &omniav1alpha1.ResolvedSource{
+		Revision: source.Status.Artifact.Revision,
+		URL:      source.Status.Artifact.URL,
+	}
+	r.setCondition(config, ArenaConfigConditionTypeSourceResolved, metav1.ConditionTrue,
+		"SourceResolved", fmt.Sprintf("ArenaSource %s resolved at revision %s", config.Spec.SourceRef.Name, source.Status.Artifact.Revision))
+
+	// Resolve Providers
+	resolvedProviders, err := r.resolveProviders(ctx, config)
+	if err != nil {
+		log.Error(err, "Failed to resolve Providers")
+		r.handleValidationError(ctx, config, ArenaConfigConditionTypeProvidersValid, err)
+		return ctrl.Result{}, nil
+	}
+	config.Status.ResolvedProviders = resolvedProviders
+	r.setCondition(config, ArenaConfigConditionTypeProvidersValid, metav1.ConditionTrue,
+		"ProvidersValid", fmt.Sprintf("All %d providers validated", len(resolvedProviders)))
+
+	// Resolve ToolRegistries (if specified)
+	if len(config.Spec.ToolRegistries) > 0 {
+		if err := r.resolveToolRegistries(ctx, config); err != nil {
+			log.Error(err, "Failed to resolve ToolRegistries")
+			r.handleValidationError(ctx, config, ArenaConfigConditionTypeToolRegsValid, err)
+			return ctrl.Result{}, nil
+		}
+		r.setCondition(config, ArenaConfigConditionTypeToolRegsValid, metav1.ConditionTrue,
+			"ToolRegistriesValid", fmt.Sprintf("All %d tool registries validated", len(config.Spec.ToolRegistries)))
+	}
+
+	// All validations passed - set Ready
+	config.Status.Phase = omniav1alpha1.ArenaConfigPhaseReady
+	now := metav1.Now()
+	config.Status.LastValidatedAt = &now
+	r.setCondition(config, ArenaConfigConditionTypeReady, metav1.ConditionTrue,
+		"Ready", "ArenaConfig is valid and ready for jobs")
+
+	if r.Recorder != nil {
+		r.Recorder.Event(config, corev1.EventTypeNormal, ArenaConfigEventReasonValidationSucceeded,
+			fmt.Sprintf("Configuration validated with %d providers", len(resolvedProviders)))
+	}
+
+	if err := r.Status().Update(ctx, config); err != nil {
+		log.Error(err, "Failed to update status")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("Successfully reconciled ArenaConfig", "providers", len(resolvedProviders))
+	return ctrl.Result{}, nil
+}
+
+// resolveSource fetches and validates the referenced ArenaSource.
+func (r *ArenaConfigReconciler) resolveSource(ctx context.Context, config *omniav1alpha1.ArenaConfig) (*omniav1alpha1.ArenaSource, error) {
+	source := &omniav1alpha1.ArenaSource{}
+	if err := r.Get(ctx, types.NamespacedName{
+		Name:      config.Spec.SourceRef.Name,
+		Namespace: config.Namespace,
+	}, source); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil, fmt.Errorf("ArenaSource %s not found", config.Spec.SourceRef.Name)
+		}
+		return nil, fmt.Errorf("failed to get ArenaSource %s: %w", config.Spec.SourceRef.Name, err)
+	}
+
+	// Verify source has an artifact
+	if source.Status.Artifact == nil {
+		return nil, fmt.Errorf("ArenaSource %s has no artifact", config.Spec.SourceRef.Name)
+	}
+
+	return source, nil
+}
+
+// resolveProviders fetches and validates all referenced Provider CRDs.
+func (r *ArenaConfigReconciler) resolveProviders(ctx context.Context, config *omniav1alpha1.ArenaConfig) ([]string, error) {
+	if len(config.Spec.Providers) == 0 {
+		return nil, fmt.Errorf("at least one provider is required")
+	}
+
+	var resolvedProviders []string
+
+	for _, provRef := range config.Spec.Providers {
+		namespace := provRef.Namespace
+		if namespace == "" {
+			namespace = config.Namespace
+		}
+
+		provider := &omniav1alpha1.Provider{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      provRef.Name,
+			Namespace: namespace,
+		}, provider); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil, fmt.Errorf("provider %s/%s not found", namespace, provRef.Name)
+			}
+			return nil, fmt.Errorf("failed to get provider %s/%s: %w", namespace, provRef.Name, err)
+		}
+
+		// Check if provider is ready
+		if provider.Status.Phase != omniav1alpha1.ProviderPhaseReady && provider.Status.Phase != "" {
+			return nil, fmt.Errorf("provider %s/%s is not ready (phase: %s)", namespace, provRef.Name, provider.Status.Phase)
+		}
+
+		// Add to resolved list with full reference
+		if namespace == config.Namespace {
+			resolvedProviders = append(resolvedProviders, provRef.Name)
+		} else {
+			resolvedProviders = append(resolvedProviders, fmt.Sprintf("%s/%s", namespace, provRef.Name))
+		}
+	}
+
+	return resolvedProviders, nil
+}
+
+// resolveToolRegistries fetches and validates all referenced ToolRegistry CRDs.
+func (r *ArenaConfigReconciler) resolveToolRegistries(ctx context.Context, config *omniav1alpha1.ArenaConfig) error {
+	for _, regRef := range config.Spec.ToolRegistries {
+		namespace := regRef.Namespace
+		if namespace == "" {
+			namespace = config.Namespace
+		}
+
+		registry := &omniav1alpha1.ToolRegistry{}
+		if err := r.Get(ctx, types.NamespacedName{
+			Name:      regRef.Name,
+			Namespace: namespace,
+		}, registry); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("ToolRegistry %s/%s not found", namespace, regRef.Name)
+			}
+			return fmt.Errorf("failed to get ToolRegistry %s/%s: %w", namespace, regRef.Name, err)
+		}
+
+		// Check if registry is ready (has at least one tool or is in ready state)
+		if registry.Status.Phase != omniav1alpha1.ToolRegistryPhaseReady && registry.Status.Phase != "" {
+			return fmt.Errorf("ToolRegistry %s/%s is not ready (phase: %s)", namespace, regRef.Name, registry.Status.Phase)
+		}
+	}
+
+	return nil
+}
+
+// handleValidationError handles errors during validation.
+func (r *ArenaConfigReconciler) handleValidationError(ctx context.Context, config *omniav1alpha1.ArenaConfig, conditionType string, err error) {
+	log := logf.FromContext(ctx)
+
+	config.Status.Phase = omniav1alpha1.ArenaConfigPhaseInvalid
+	r.setCondition(config, conditionType, metav1.ConditionFalse, "ValidationFailed", err.Error())
+	r.setCondition(config, ArenaConfigConditionTypeReady, metav1.ConditionFalse,
+		"ValidationFailed", err.Error())
+
+	if r.Recorder != nil {
+		r.Recorder.Event(config, corev1.EventTypeWarning, ArenaConfigEventReasonValidationFailed, err.Error())
+	}
+
+	if statusErr := r.Status().Update(ctx, config); statusErr != nil {
+		log.Error(statusErr, "Failed to update status after validation error")
+	}
+}
+
+// setCondition sets a condition on the ArenaConfig status.
+func (r *ArenaConfigReconciler) setCondition(config *omniav1alpha1.ArenaConfig, conditionType string, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(&config.Status.Conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: config.Generation,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	})
+}
+
+// findArenaConfigsForSource maps ArenaSource changes to ArenaConfig reconcile requests.
+func (r *ArenaConfigReconciler) findArenaConfigsForSource(ctx context.Context, obj client.Object) []ctrl.Request {
+	source, ok := obj.(*omniav1alpha1.ArenaSource)
+	if !ok {
+		return nil
+	}
+
+	// Find all ArenaConfigs in the same namespace that reference this source
+	configList := &omniav1alpha1.ArenaConfigList{}
+	if err := r.List(ctx, configList, client.InNamespace(source.Namespace)); err != nil {
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for _, config := range configList.Items {
+		if config.Spec.SourceRef.Name == source.Name {
+			requests = append(requests, ctrl.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      config.Name,
+					Namespace: config.Namespace,
+				},
+			})
+		}
+	}
+
+	return requests
+}
+
+// findArenaConfigsForProvider maps Provider changes to ArenaConfig reconcile requests.
+func (r *ArenaConfigReconciler) findArenaConfigsForProvider(ctx context.Context, obj client.Object) []ctrl.Request {
+	provider, ok := obj.(*omniav1alpha1.Provider)
+	if !ok {
+		return nil
+	}
+
+	// Find all ArenaConfigs that reference this provider
+	configList := &omniav1alpha1.ArenaConfigList{}
+	if err := r.List(ctx, configList); err != nil {
+		return nil
+	}
+
+	var requests []ctrl.Request
+	for _, config := range configList.Items {
+		for _, provRef := range config.Spec.Providers {
+			namespace := provRef.Namespace
+			if namespace == "" {
+				namespace = config.Namespace
+			}
+			if provRef.Name == provider.Name && namespace == provider.Namespace {
+				requests = append(requests, ctrl.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      config.Name,
+						Namespace: config.Namespace,
+					},
+				})
+				break
+			}
+		}
+	}
+
+	return requests
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *ArenaConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&omniav1alpha1.ArenaConfig{}).
+		Watches(
+			&omniav1alpha1.ArenaSource{},
+			handler.EnqueueRequestsFromMapFunc(r.findArenaConfigsForSource),
+		).
+		Watches(
+			&omniav1alpha1.Provider{},
+			handler.EnqueueRequestsFromMapFunc(r.findArenaConfigsForProvider),
+		).
+		Named("arenaconfig").
+		Complete(r)
+}

--- a/internal/controller/arenaconfig_controller_test.go
+++ b/internal/controller/arenaconfig_controller_test.go
@@ -1,0 +1,1158 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+var _ = Describe("ArenaConfig Controller", func() {
+	const (
+		arenaConfigName      = "test-arenaconfig"
+		arenaConfigNamespace = "default"
+		arenaSourceName      = "test-source"
+		providerName         = "test-provider"
+		toolRegistryName     = "test-toolregistry"
+	)
+
+	ctx := context.Background()
+
+	Context("When reconciling a non-existent ArenaConfig", func() {
+		It("should return without error", func() {
+			By("reconciling a non-existent ArenaConfig")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "nonexistent-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When reconciling a suspended ArenaConfig", func() {
+		var arenaConfig *omniav1alpha1.ArenaConfig
+
+		BeforeEach(func() {
+			By("creating the suspended ArenaConfig")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "suspended-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: arenaSourceName,
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: providerName},
+					},
+					Suspend: true,
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up the ArenaConfig")
+			resource := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "suspended-config",
+				Namespace: arenaConfigNamespace,
+			}, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("should skip validation and set condition", func() {
+			By("reconciling the suspended ArenaConfig")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "suspended-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "suspended-config",
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			By("checking the Ready condition")
+			condition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal("Suspended"))
+		})
+	})
+
+	Context("When reconciling an ArenaConfig with missing ArenaSource", func() {
+		var arenaConfig *omniav1alpha1.ArenaConfig
+
+		BeforeEach(func() {
+			By("creating the ArenaConfig with missing source")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "missing-source-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: "nonexistent-source",
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: providerName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up the ArenaConfig")
+			resource := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "missing-source-config",
+				Namespace: arenaConfigNamespace,
+			}, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+		})
+
+		It("should set Invalid phase and SourceResolved condition to false", func() {
+			By("reconciling the ArenaConfig")
+			fakeRecorder := record.NewFakeRecorder(10)
+			reconciler := &ArenaConfigReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: fakeRecorder,
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "missing-source-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "missing-source-config",
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			Expect(updatedConfig.Status.Phase).To(Equal(omniav1alpha1.ArenaConfigPhaseInvalid))
+
+			By("checking the SourceResolved condition")
+			condition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeSourceResolved)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		})
+	})
+
+	Context("When reconciling an ArenaConfig with ready ArenaSource but no providers", func() {
+		var (
+			arenaConfig *omniav1alpha1.ArenaConfig
+			arenaSource *omniav1alpha1.ArenaSource
+		)
+
+		BeforeEach(func() {
+			By("creating the ArenaSource")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ready-source",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+
+			// Update source status to Ready
+			arenaSource.Status.Phase = omniav1alpha1.ArenaSourcePhaseReady
+			arenaSource.Status.Artifact = &omniav1alpha1.Artifact{
+				Revision:       "v1.0.0",
+				URL:            "http://localhost:8080/artifacts/test.tar.gz",
+				LastUpdateTime: metav1.Now(),
+			}
+			Expect(k8sClient.Status().Update(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaConfig without providers")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "no-providers-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: "ready-source",
+					},
+					// No providers specified
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			resource := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "no-providers-config",
+				Namespace: arenaConfigNamespace,
+			}, resource)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "ready-source",
+				Namespace: arenaConfigNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+		})
+
+		It("should set Invalid phase due to no providers", func() {
+			By("reconciling the ArenaConfig")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "no-providers-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "no-providers-config",
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			Expect(updatedConfig.Status.Phase).To(Equal(omniav1alpha1.ArenaConfigPhaseInvalid))
+		})
+	})
+
+	Context("When reconciling a fully valid ArenaConfig", func() {
+		var (
+			arenaConfig *omniav1alpha1.ArenaConfig
+			arenaSource *omniav1alpha1.ArenaSource
+			provider    *omniav1alpha1.Provider
+			secret      *corev1.Secret
+		)
+
+		BeforeEach(func() {
+			By("creating the secret for provider")
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "provider-secret",
+					Namespace: arenaConfigNamespace,
+				},
+				Data: map[string][]byte{
+					"api-key": []byte("test-api-key"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+
+			By("creating the Provider")
+			provider = &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      providerName,
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type: omniav1alpha1.ProviderTypeClaude,
+					SecretRef: &omniav1alpha1.SecretKeyRef{
+						Name: "provider-secret",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+
+			// Update provider status to Ready
+			provider.Status.Phase = omniav1alpha1.ProviderPhaseReady
+			Expect(k8sClient.Status().Update(ctx, provider)).To(Succeed())
+
+			By("creating the ArenaSource")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      arenaSourceName,
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+
+			// Update source status to Ready with artifact
+			arenaSource.Status.Phase = omniav1alpha1.ArenaSourcePhaseReady
+			arenaSource.Status.Artifact = &omniav1alpha1.Artifact{
+				Revision:       "v1.0.0",
+				URL:            "http://localhost:8080/artifacts/test.tar.gz",
+				LastUpdateTime: metav1.Now(),
+			}
+			Expect(k8sClient.Status().Update(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaConfig")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      arenaConfigName,
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: arenaSourceName,
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: providerName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			config := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      arenaConfigName,
+				Namespace: arenaConfigNamespace,
+			}, config)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      arenaSourceName,
+				Namespace: arenaConfigNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+
+			prov := &omniav1alpha1.Provider{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      providerName,
+				Namespace: arenaConfigNamespace,
+			}, prov)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, prov)).To(Succeed())
+			}
+
+			s := &corev1.Secret{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "provider-secret",
+				Namespace: arenaConfigNamespace,
+			}, s)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, s)).To(Succeed())
+			}
+		})
+
+		It("should set Ready phase and resolve all references", func() {
+			By("reconciling the ArenaConfig")
+			fakeRecorder := record.NewFakeRecorder(10)
+			reconciler := &ArenaConfigReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: fakeRecorder,
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      arenaConfigName,
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      arenaConfigName,
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			Expect(updatedConfig.Status.Phase).To(Equal(omniav1alpha1.ArenaConfigPhaseReady))
+			Expect(updatedConfig.Status.ResolvedSource).NotTo(BeNil())
+			Expect(updatedConfig.Status.ResolvedSource.Revision).To(Equal("v1.0.0"))
+			Expect(updatedConfig.Status.ResolvedProviders).To(HaveLen(1))
+			Expect(updatedConfig.Status.ResolvedProviders[0]).To(Equal(providerName))
+			Expect(updatedConfig.Status.LastValidatedAt).NotTo(BeNil())
+
+			By("checking the Ready condition")
+			readyCondition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeReady)
+			Expect(readyCondition).NotTo(BeNil())
+			Expect(readyCondition.Status).To(Equal(metav1.ConditionTrue))
+
+			By("checking the SourceResolved condition")
+			sourceCondition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeSourceResolved)
+			Expect(sourceCondition).NotTo(BeNil())
+			Expect(sourceCondition.Status).To(Equal(metav1.ConditionTrue))
+
+			By("checking the ProvidersValid condition")
+			providerCondition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeProvidersValid)
+			Expect(providerCondition).NotTo(BeNil())
+			Expect(providerCondition.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("When ArenaSource is not ready", func() {
+		var (
+			arenaConfig *omniav1alpha1.ArenaConfig
+			arenaSource *omniav1alpha1.ArenaSource
+		)
+
+		BeforeEach(func() {
+			By("creating the ArenaSource in Pending state")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pending-source",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+
+			// Set source to Pending (not Ready)
+			arenaSource.Status.Phase = omniav1alpha1.ArenaSourcePhasePending
+			arenaSource.Status.Artifact = &omniav1alpha1.Artifact{
+				Revision:       "v1.0.0",
+				URL:            "http://localhost:8080/artifacts/test.tar.gz",
+				LastUpdateTime: metav1.Now(),
+			}
+			Expect(k8sClient.Status().Update(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaConfig")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "pending-source-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: "pending-source",
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: providerName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			config := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "pending-source-config",
+				Namespace: arenaConfigNamespace,
+			}, config)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "pending-source",
+				Namespace: arenaConfigNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+		})
+
+		It("should set Pending phase and wait for source", func() {
+			By("reconciling the ArenaConfig")
+			fakeRecorder := record.NewFakeRecorder(10)
+			reconciler := &ArenaConfigReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: fakeRecorder,
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "pending-source-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "pending-source-config",
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			Expect(updatedConfig.Status.Phase).To(Equal(omniav1alpha1.ArenaConfigPhasePending))
+
+			By("checking the SourceResolved condition")
+			condition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeSourceResolved)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal("SourceNotReady"))
+		})
+	})
+
+	Context("When Provider is not found", func() {
+		var (
+			arenaConfig *omniav1alpha1.ArenaConfig
+			arenaSource *omniav1alpha1.ArenaSource
+		)
+
+		BeforeEach(func() {
+			By("creating the ArenaSource")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "valid-source-2",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+
+			arenaSource.Status.Phase = omniav1alpha1.ArenaSourcePhaseReady
+			arenaSource.Status.Artifact = &omniav1alpha1.Artifact{
+				Revision:       "v1.0.0",
+				URL:            "http://localhost:8080/artifacts/test.tar.gz",
+				LastUpdateTime: metav1.Now(),
+			}
+			Expect(k8sClient.Status().Update(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaConfig with missing provider")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "missing-provider-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: "valid-source-2",
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: "nonexistent-provider"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			config := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "missing-provider-config",
+				Namespace: arenaConfigNamespace,
+			}, config)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "valid-source-2",
+				Namespace: arenaConfigNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+		})
+
+		It("should set Invalid phase with provider error", func() {
+			By("reconciling the ArenaConfig")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "missing-provider-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "missing-provider-config",
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			Expect(updatedConfig.Status.Phase).To(Equal(omniav1alpha1.ArenaConfigPhaseInvalid))
+
+			By("checking the ProvidersValid condition")
+			condition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeProvidersValid)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		})
+	})
+
+	Context("When testing setCondition helper", func() {
+		It("should set a condition on the ArenaConfig", func() {
+			config := &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-condition-config",
+					Namespace:  arenaConfigNamespace,
+					Generation: 1,
+				},
+			}
+
+			reconciler := &ArenaConfigReconciler{}
+			reconciler.setCondition(config, ArenaConfigConditionTypeReady, metav1.ConditionTrue, "TestReason", "Test message")
+
+			condition := meta.FindStatusCondition(config.Status.Conditions, ArenaConfigConditionTypeReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal("TestReason"))
+			Expect(condition.Message).To(Equal("Test message"))
+			Expect(condition.ObservedGeneration).To(Equal(int64(1)))
+		})
+	})
+
+	Context("When testing findArenaConfigsForSource", func() {
+		var (
+			arenaConfig *omniav1alpha1.ArenaConfig
+			arenaSource *omniav1alpha1.ArenaSource
+		)
+
+		BeforeEach(func() {
+			By("creating the ArenaSource")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "watch-test-source",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaConfig that references the source")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "watch-test-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: "watch-test-source",
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: providerName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			config := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "watch-test-config",
+				Namespace: arenaConfigNamespace,
+			}, config)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "watch-test-source",
+				Namespace: arenaConfigNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+		})
+
+		It("should return reconcile requests for ArenaConfigs referencing the source", func() {
+			By("calling findArenaConfigsForSource")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			requests := reconciler.findArenaConfigsForSource(ctx, arenaSource)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("watch-test-config"))
+			Expect(requests[0].Namespace).To(Equal(arenaConfigNamespace))
+		})
+	})
+
+	Context("When testing SetupWithManager", func() {
+		It("should return error with nil manager", func() {
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			err := reconciler.SetupWithManager(nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Context("When testing findArenaConfigsForProvider", func() {
+		var (
+			arenaConfig *omniav1alpha1.ArenaConfig
+			provider    *omniav1alpha1.Provider
+		)
+
+		BeforeEach(func() {
+			By("creating the Provider")
+			provider = &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "watch-provider",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type: omniav1alpha1.ProviderTypeClaude,
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+
+			By("creating the ArenaConfig that references the provider")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "provider-watch-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: arenaSourceName,
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: "watch-provider"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			config := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "provider-watch-config",
+				Namespace: arenaConfigNamespace,
+			}, config)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			prov := &omniav1alpha1.Provider{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "watch-provider",
+				Namespace: arenaConfigNamespace,
+			}, prov)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, prov)).To(Succeed())
+			}
+		})
+
+		It("should return reconcile requests for ArenaConfigs referencing the provider", func() {
+			By("calling findArenaConfigsForProvider")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			requests := reconciler.findArenaConfigsForProvider(ctx, provider)
+			Expect(requests).To(HaveLen(1))
+			Expect(requests[0].Name).To(Equal("provider-watch-config"))
+			Expect(requests[0].Namespace).To(Equal(arenaConfigNamespace))
+		})
+
+		It("should return nil for non-Provider objects", func() {
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			requests := reconciler.findArenaConfigsForProvider(ctx, &corev1.Secret{})
+			Expect(requests).To(BeNil())
+		})
+	})
+
+	Context("When reconciling an ArenaConfig with ToolRegistries", func() {
+		var (
+			arenaConfig  *omniav1alpha1.ArenaConfig
+			arenaSource  *omniav1alpha1.ArenaSource
+			provider     *omniav1alpha1.Provider
+			toolRegistry *omniav1alpha1.ToolRegistry
+		)
+
+		BeforeEach(func() {
+			By("creating the Provider")
+			provider = &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "toolreg-provider",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type: omniav1alpha1.ProviderTypeClaude,
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+			provider.Status.Phase = omniav1alpha1.ProviderPhaseReady
+			Expect(k8sClient.Status().Update(ctx, provider)).To(Succeed())
+
+			By("creating the ToolRegistry")
+			sseEndpoint := "http://localhost:8080/sse"
+			toolRegistry = &omniav1alpha1.ToolRegistry{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      toolRegistryName,
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ToolRegistrySpec{
+					Handlers: []omniav1alpha1.HandlerDefinition{
+						{
+							Name: "test-handler",
+							Type: omniav1alpha1.HandlerTypeMCP,
+							MCPConfig: &omniav1alpha1.MCPConfig{
+								Transport: omniav1alpha1.MCPTransportSSE,
+								Endpoint:  &sseEndpoint,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, toolRegistry)).To(Succeed())
+			toolRegistry.Status.Phase = omniav1alpha1.ToolRegistryPhaseReady
+			Expect(k8sClient.Status().Update(ctx, toolRegistry)).To(Succeed())
+
+			By("creating the ArenaSource")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "toolreg-source",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+			arenaSource.Status.Phase = omniav1alpha1.ArenaSourcePhaseReady
+			arenaSource.Status.Artifact = &omniav1alpha1.Artifact{
+				Revision:       "v1.0.0",
+				URL:            "http://localhost:8080/artifacts/test.tar.gz",
+				LastUpdateTime: metav1.Now(),
+			}
+			Expect(k8sClient.Status().Update(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaConfig with ToolRegistry")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "toolreg-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: "toolreg-source",
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: "toolreg-provider"},
+					},
+					ToolRegistries: []omniav1alpha1.NamespacedObjectReference{
+						{Name: toolRegistryName},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			config := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-config",
+				Namespace: arenaConfigNamespace,
+			}, config)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-source",
+				Namespace: arenaConfigNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+
+			prov := &omniav1alpha1.Provider{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-provider",
+				Namespace: arenaConfigNamespace,
+			}, prov)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, prov)).To(Succeed())
+			}
+
+			registry := &omniav1alpha1.ToolRegistry{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      toolRegistryName,
+				Namespace: arenaConfigNamespace,
+			}, registry)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, registry)).To(Succeed())
+			}
+		})
+
+		It("should set Ready phase with valid ToolRegistry", func() {
+			By("reconciling the ArenaConfig")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "toolreg-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-config",
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			Expect(updatedConfig.Status.Phase).To(Equal(omniav1alpha1.ArenaConfigPhaseReady))
+
+			By("checking the ToolRegistriesValid condition")
+			condition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeToolRegsValid)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		})
+	})
+
+	Context("When ToolRegistry is not found", func() {
+		var (
+			arenaConfig *omniav1alpha1.ArenaConfig
+			arenaSource *omniav1alpha1.ArenaSource
+			provider    *omniav1alpha1.Provider
+		)
+
+		BeforeEach(func() {
+			By("creating the Provider")
+			provider = &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "toolreg-missing-provider",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type: omniav1alpha1.ProviderTypeClaude,
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+			provider.Status.Phase = omniav1alpha1.ProviderPhaseReady
+			Expect(k8sClient.Status().Update(ctx, provider)).To(Succeed())
+
+			By("creating the ArenaSource")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "toolreg-missing-source",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+			arenaSource.Status.Phase = omniav1alpha1.ArenaSourcePhaseReady
+			arenaSource.Status.Artifact = &omniav1alpha1.Artifact{
+				Revision:       "v1.0.0",
+				URL:            "http://localhost:8080/artifacts/test.tar.gz",
+				LastUpdateTime: metav1.Now(),
+			}
+			Expect(k8sClient.Status().Update(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaConfig with missing ToolRegistry")
+			arenaConfig = &omniav1alpha1.ArenaConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "toolreg-missing-config",
+					Namespace: arenaConfigNamespace,
+				},
+				Spec: omniav1alpha1.ArenaConfigSpec{
+					SourceRef: omniav1alpha1.LocalObjectReference{
+						Name: "toolreg-missing-source",
+					},
+					Providers: []omniav1alpha1.NamespacedObjectReference{
+						{Name: "toolreg-missing-provider"},
+					},
+					ToolRegistries: []omniav1alpha1.NamespacedObjectReference{
+						{Name: "nonexistent-registry"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaConfig)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			config := &omniav1alpha1.ArenaConfig{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-missing-config",
+				Namespace: arenaConfigNamespace,
+			}, config)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, config)).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-missing-source",
+				Namespace: arenaConfigNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+
+			prov := &omniav1alpha1.Provider{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-missing-provider",
+				Namespace: arenaConfigNamespace,
+			}, prov)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, prov)).To(Succeed())
+			}
+		})
+
+		It("should set Invalid phase with ToolRegistry error", func() {
+			By("reconciling the ArenaConfig")
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "toolreg-missing-config",
+					Namespace: arenaConfigNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the updated status")
+			updatedConfig := &omniav1alpha1.ArenaConfig{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "toolreg-missing-config",
+				Namespace: arenaConfigNamespace,
+			}, updatedConfig)).To(Succeed())
+
+			Expect(updatedConfig.Status.Phase).To(Equal(omniav1alpha1.ArenaConfigPhaseInvalid))
+
+			By("checking the ToolRegistriesValid condition")
+			condition := meta.FindStatusCondition(updatedConfig.Status.Conditions, ArenaConfigConditionTypeToolRegsValid)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+		})
+	})
+
+	Context("When findArenaConfigsForSource receives non-ArenaSource object", func() {
+		It("should return nil", func() {
+			reconciler := &ArenaConfigReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			requests := reconciler.findArenaConfigsForSource(ctx, &corev1.Secret{})
+			Expect(requests).To(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- Implements ArenaConfig controller that validates references to ArenaSource, Provider, and ToolRegistry resources
- Resolves and validates ArenaSource references (must be Ready with artifact)
- Validates Provider references (checks existence and Ready phase)
- Validates ToolRegistry references when specified
- Sets appropriate status conditions (Ready, SourceResolved, ProvidersValid, ToolRegistriesValid)
- Watches ArenaSource and Provider changes to re-reconcile dependent configs
- Supports suspension via spec.suspend field

## Test plan
- [x] Unit tests cover all controller functions with 86.9% coverage
- [x] Pre-commit checks pass (formatting, linting, tests)
- [ ] Deploy to test cluster and verify ArenaConfig reconciliation

Closes #197