### PR TITLE
feat(arena): add WorkQueue interface for job distribution

### DIFF
--- a/pkg/arena/queue/queue.go
+++ b/pkg/arena/queue/queue.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package queue provides interfaces and implementations for distributing
+// Arena work items across multiple workers.
+package queue
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+// Common errors returned by WorkQueue implementations.
+var (
+	// ErrQueueEmpty is returned when Pop is called on an empty queue.
+	ErrQueueEmpty = errors.New("queue is empty")
+
+	// ErrItemNotFound is returned when an item cannot be found for Ack/Nack.
+	ErrItemNotFound = errors.New("work item not found")
+
+	// ErrQueueClosed is returned when operations are attempted on a closed queue.
+	ErrQueueClosed = errors.New("queue is closed")
+
+	// ErrJobNotFound is returned when a job cannot be found.
+	ErrJobNotFound = errors.New("job not found")
+)
+
+// ItemStatus represents the status of a work item.
+type ItemStatus string
+
+const (
+	// ItemStatusPending indicates the item is waiting to be processed.
+	ItemStatusPending ItemStatus = "pending"
+
+	// ItemStatusProcessing indicates the item is currently being processed.
+	ItemStatusProcessing ItemStatus = "processing"
+
+	// ItemStatusCompleted indicates the item was processed successfully.
+	ItemStatusCompleted ItemStatus = "completed"
+
+	// ItemStatusFailed indicates the item processing failed.
+	ItemStatusFailed ItemStatus = "failed"
+)
+
+// WorkItem represents a unit of work to be processed by an Arena worker.
+type WorkItem struct {
+	// ID is the unique identifier for this work item.
+	ID string `json:"id"`
+
+	// JobID is the ID of the parent ArenaJob.
+	JobID string `json:"jobId"`
+
+	// ScenarioID identifies which scenario from the bundle to execute.
+	ScenarioID string `json:"scenarioId"`
+
+	// ProviderID identifies which provider to use for this scenario.
+	ProviderID string `json:"providerId"`
+
+	// BundleURL is the URL to fetch the PromptKit bundle from.
+	BundleURL string `json:"bundleUrl"`
+
+	// Config contains the scenario configuration as JSON.
+	Config []byte `json:"config,omitempty"`
+
+	// Status is the current status of the work item.
+	Status ItemStatus `json:"status"`
+
+	// Attempt tracks the current attempt number (1-based).
+	Attempt int `json:"attempt"`
+
+	// MaxAttempts is the maximum number of retry attempts.
+	MaxAttempts int `json:"maxAttempts"`
+
+	// CreatedAt is when the work item was created.
+	CreatedAt time.Time `json:"createdAt"`
+
+	// StartedAt is when the work item started processing.
+	StartedAt *time.Time `json:"startedAt,omitempty"`
+
+	// CompletedAt is when the work item finished (success or failure).
+	CompletedAt *time.Time `json:"completedAt,omitempty"`
+
+	// Error contains the error message if the item failed.
+	Error string `json:"error,omitempty"`
+
+	// Result contains the execution result as JSON.
+	Result []byte `json:"result,omitempty"`
+}
+
+// JobProgress represents the progress of an Arena job's work items.
+type JobProgress struct {
+	// JobID is the ID of the ArenaJob.
+	JobID string `json:"jobId"`
+
+	// Total is the total number of work items.
+	Total int `json:"total"`
+
+	// Pending is the number of items waiting to be processed.
+	Pending int `json:"pending"`
+
+	// Processing is the number of items currently being processed.
+	Processing int `json:"processing"`
+
+	// Completed is the number of items that completed successfully.
+	Completed int `json:"completed"`
+
+	// Failed is the number of items that failed.
+	Failed int `json:"failed"`
+
+	// StartedAt is when the first item started processing.
+	StartedAt *time.Time `json:"startedAt,omitempty"`
+
+	// CompletedAt is when all items finished processing.
+	CompletedAt *time.Time `json:"completedAt,omitempty"`
+}
+
+// IsComplete returns true if all work items have been processed.
+func (p *JobProgress) IsComplete() bool {
+	return p.Pending == 0 && p.Processing == 0
+}
+
+// SuccessRate returns the success rate as a percentage (0-100).
+func (p *JobProgress) SuccessRate() float64 {
+	finished := p.Completed + p.Failed
+	if finished == 0 {
+		return 0
+	}
+	return float64(p.Completed) / float64(finished) * 100
+}
+
+// WorkQueue defines the interface for distributing work items to Arena workers.
+type WorkQueue interface {
+	// Push adds work items to the queue for the specified job.
+	// Items are added in the order provided and will be processed FIFO.
+	Push(ctx context.Context, jobID string, items []WorkItem) error
+
+	// Pop retrieves the next available work item for the specified job.
+	// The item is marked as processing and must be acknowledged or rejected.
+	// Returns ErrQueueEmpty if no items are available.
+	Pop(ctx context.Context, jobID string) (*WorkItem, error)
+
+	// Ack acknowledges successful processing of a work item.
+	// The item is marked as completed and removed from the processing set.
+	// The result parameter contains the execution result as JSON.
+	Ack(ctx context.Context, jobID string, itemID string, result []byte) error
+
+	// Nack indicates that processing of a work item failed.
+	// If retries remain, the item is requeued; otherwise, it's marked as failed.
+	// The error parameter contains the failure reason.
+	Nack(ctx context.Context, jobID string, itemID string, err error) error
+
+	// Progress returns the current progress for the specified job.
+	// Returns ErrJobNotFound if the job doesn't exist.
+	Progress(ctx context.Context, jobID string) (*JobProgress, error)
+
+	// Close releases any resources held by the queue.
+	// After Close is called, all other methods will return ErrQueueClosed.
+	Close() error
+}
+
+// Options contains configuration options for WorkQueue implementations.
+type Options struct {
+	// VisibilityTimeout is how long an item remains invisible after Pop.
+	// If not acknowledged within this time, the item becomes visible again.
+	// Default: 5 minutes.
+	VisibilityTimeout time.Duration
+
+	// MaxRetries is the maximum number of times an item can be retried.
+	// Default: 3.
+	MaxRetries int
+}
+
+// DefaultOptions returns the default queue options.
+func DefaultOptions() Options {
+	return Options{
+		VisibilityTimeout: 5 * time.Minute,
+		MaxRetries:        3,
+	}
+}

--- a/pkg/arena/queue/queue_test.go
+++ b/pkg/arena/queue/queue_test.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestWorkItemSerialization(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	item := WorkItem{
+		ID:          "item-1",
+		JobID:       "job-1",
+		ScenarioID:  "scenario-1",
+		ProviderID:  "provider-1",
+		BundleURL:   "http://example.com/bundle.tar.gz",
+		Config:      []byte(`{"key":"value"}`),
+		Status:      ItemStatusPending,
+		Attempt:     1,
+		MaxAttempts: 3,
+		CreatedAt:   now,
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("failed to marshal WorkItem: %v", err)
+	}
+
+	var decoded WorkItem
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("failed to unmarshal WorkItem: %v", err)
+	}
+
+	if decoded.ID != item.ID {
+		t.Errorf("ID mismatch: got %s, want %s", decoded.ID, item.ID)
+	}
+	if decoded.JobID != item.JobID {
+		t.Errorf("JobID mismatch: got %s, want %s", decoded.JobID, item.JobID)
+	}
+	if decoded.ScenarioID != item.ScenarioID {
+		t.Errorf("ScenarioID mismatch: got %s, want %s", decoded.ScenarioID, item.ScenarioID)
+	}
+	if decoded.Status != item.Status {
+		t.Errorf("Status mismatch: got %s, want %s", decoded.Status, item.Status)
+	}
+}
+
+func TestJobProgressIsComplete(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress JobProgress
+		want     bool
+	}{
+		{
+			name: "all completed",
+			progress: JobProgress{
+				Total:      10,
+				Pending:    0,
+				Processing: 0,
+				Completed:  8,
+				Failed:     2,
+			},
+			want: true,
+		},
+		{
+			name: "still pending",
+			progress: JobProgress{
+				Total:      10,
+				Pending:    5,
+				Processing: 0,
+				Completed:  5,
+				Failed:     0,
+			},
+			want: false,
+		},
+		{
+			name: "still processing",
+			progress: JobProgress{
+				Total:      10,
+				Pending:    0,
+				Processing: 2,
+				Completed:  8,
+				Failed:     0,
+			},
+			want: false,
+		},
+		{
+			name: "empty job",
+			progress: JobProgress{
+				Total:      0,
+				Pending:    0,
+				Processing: 0,
+				Completed:  0,
+				Failed:     0,
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.progress.IsComplete(); got != tt.want {
+				t.Errorf("IsComplete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestJobProgressSuccessRate(t *testing.T) {
+	tests := []struct {
+		name     string
+		progress JobProgress
+		want     float64
+	}{
+		{
+			name: "all successful",
+			progress: JobProgress{
+				Completed: 10,
+				Failed:    0,
+			},
+			want: 100.0,
+		},
+		{
+			name: "all failed",
+			progress: JobProgress{
+				Completed: 0,
+				Failed:    10,
+			},
+			want: 0.0,
+		},
+		{
+			name: "50% success",
+			progress: JobProgress{
+				Completed: 5,
+				Failed:    5,
+			},
+			want: 50.0,
+		},
+		{
+			name: "no finished items",
+			progress: JobProgress{
+				Completed: 0,
+				Failed:    0,
+			},
+			want: 0.0,
+		},
+		{
+			name: "80% success",
+			progress: JobProgress{
+				Completed: 8,
+				Failed:    2,
+			},
+			want: 80.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.progress.SuccessRate(); got != tt.want {
+				t.Errorf("SuccessRate() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+
+	if opts.VisibilityTimeout != 5*time.Minute {
+		t.Errorf("VisibilityTimeout = %v, want %v", opts.VisibilityTimeout, 5*time.Minute)
+	}
+	if opts.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want %d", opts.MaxRetries, 3)
+	}
+}
+
+func TestItemStatusConstants(t *testing.T) {
+	// Verify status constants have expected values
+	if ItemStatusPending != "pending" {
+		t.Errorf("ItemStatusPending = %s, want pending", ItemStatusPending)
+	}
+	if ItemStatusProcessing != "processing" {
+		t.Errorf("ItemStatusProcessing = %s, want processing", ItemStatusProcessing)
+	}
+	if ItemStatusCompleted != "completed" {
+		t.Errorf("ItemStatusCompleted = %s, want completed", ItemStatusCompleted)
+	}
+	if ItemStatusFailed != "failed" {
+		t.Errorf("ItemStatusFailed = %s, want failed", ItemStatusFailed)
+	}
+}
+
+// mockQueue is a minimal implementation to verify interface compliance.
+type mockQueue struct {
+	closed bool
+}
+
+func (m *mockQueue) Push(_ context.Context, _ string, _ []WorkItem) error {
+	if m.closed {
+		return ErrQueueClosed
+	}
+	return nil
+}
+
+func (m *mockQueue) Pop(_ context.Context, _ string) (*WorkItem, error) {
+	if m.closed {
+		return nil, ErrQueueClosed
+	}
+	return nil, ErrQueueEmpty
+}
+
+func (m *mockQueue) Ack(_ context.Context, _, _ string, _ []byte) error {
+	if m.closed {
+		return ErrQueueClosed
+	}
+	return nil
+}
+
+func (m *mockQueue) Nack(_ context.Context, _, _ string, _ error) error {
+	if m.closed {
+		return ErrQueueClosed
+	}
+	return nil
+}
+
+func (m *mockQueue) Progress(_ context.Context, _ string) (*JobProgress, error) {
+	if m.closed {
+		return nil, ErrQueueClosed
+	}
+	return nil, ErrJobNotFound
+}
+
+func (m *mockQueue) Close() error {
+	m.closed = true
+	return nil
+}
+
+// Compile-time check that mockQueue implements WorkQueue.
+var _ WorkQueue = (*mockQueue)(nil)
+
+func TestMockQueueImplementsInterface(t *testing.T) {
+	var q WorkQueue = &mockQueue{}
+	ctx := context.Background()
+
+	// Test basic operations
+	if err := q.Push(ctx, "job-1", nil); err != nil {
+		t.Errorf("Push() error = %v", err)
+	}
+
+	if _, err := q.Pop(ctx, "job-1"); err != ErrQueueEmpty {
+		t.Errorf("Pop() error = %v, want ErrQueueEmpty", err)
+	}
+
+	if _, err := q.Progress(ctx, "job-1"); err != ErrJobNotFound {
+		t.Errorf("Progress() error = %v, want ErrJobNotFound", err)
+	}
+
+	// Test after close
+	if err := q.Close(); err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+
+	if err := q.Push(ctx, "job-1", nil); err != ErrQueueClosed {
+		t.Errorf("Push() after close error = %v, want ErrQueueClosed", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Define the `WorkQueue` interface with `Push`, `Pop`, `Ack`, `Nack`, `Progress`, and `Close` methods
- Add `WorkItem` struct with status tracking, retry support, and JSON serialization
- Add `JobProgress` struct with helper methods (`IsComplete`, `SuccessRate`)
- Define common error types (`ErrQueueEmpty`, `ErrItemNotFound`, `ErrQueueClosed`, `ErrJobNotFound`)
- Add configurable options (`VisibilityTimeout`, `MaxRetries`)

## Test plan
- [x] Unit tests pass with 100% coverage on new code
- [x] Mock implementation verifies interface compliance
- [x] JSON serialization/deserialization tested

Closes #198