### PR TITLE
feat(helm): add Redis subchart with Grafana integration

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -46,7 +46,7 @@ PROMPTKIT_PATH = os.getenv('PROMPTKIT_PATH', '../PromptKit')
 ENABLE_FULL_STACK = os.getenv('ENABLE_FULL_STACK', '').lower() in ('true', '1', 'yes') or False
 
 # Allow deployment to local clusters only (safety check)
-allow_k8s_contexts(['kind-omnia-dev', 'docker-desktop', 'minikube', 'kind-kind'])
+allow_k8s_contexts(['kind-omnia-dev', 'docker-desktop', 'minikube', 'kind-kind', 'orbstack'])
 
 # Suppress warnings for images passed as CLI args to operator (not in K8s manifests)
 update_settings(suppress_unused_image_warnings=['omnia-facade-dev', 'omnia-runtime-dev'])
@@ -64,6 +64,9 @@ if ENABLE_OBSERVABILITY or ENABLE_FULL_STACK:
 
 if ENABLE_FULL_STACK:
     helm_repo('istio', 'https://istio-release.storage.googleapis.com/charts')
+
+# Bitnami charts for Redis
+helm_repo('bitnami', 'https://charts.bitnami.com/bitnami')
 
 # ============================================================================
 # Full Stack Mode - Istio Installation via Helm
@@ -414,6 +417,17 @@ if ENABLE_OBSERVABILITY:
             '4318:4318',   # OTLP HTTP
         ],
     )
+
+# ============================================================================
+# Redis for Arena Queue (Bitnami)
+# ============================================================================
+
+# Redis master (Bitnami standalone mode)
+k8s_resource(
+    'omnia-redis-master',
+    labels=['redis'],
+    port_forwards=['6379:6379'],  # Redis port for local debugging
+)
 
 # ============================================================================
 # Full Stack Mode Resources (Istio, Tempo, Loki, Alloy)

--- a/charts/omnia/Chart.yaml
+++ b/charts/omnia/Chart.yaml
@@ -52,6 +52,10 @@ dependencies:
     version: "~2.16"
     repository: https://kedacore.github.io/charts
     condition: keda.enabled
+  - name: redis
+    version: "~21.0"
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
 
 # NOTE: Istio should be installed separately before deploying Omnia.
 # See: https://istio.io/latest/docs/setup/install/helm/

--- a/charts/omnia/templates/grafana-redis-dashboard.yaml
+++ b/charts/omnia/templates/grafana-redis-dashboard.yaml
@@ -1,0 +1,540 @@
+{{- if and .Values.grafana.enabled .Values.redis.enabled }}
+---
+# Redis monitoring dashboard for Grafana
+# Auto-configured when both grafana.enabled and redis.enabled are true
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "omnia.fullname" . }}-grafana-redis-dashboard
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "omnia.labels" . | nindent 4 }}
+    grafana_dashboard: "1"
+data:
+  redis-overview.json: |
+    {
+      "annotations": {
+        "list": []
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "redis-datasource",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "command": "info",
+              "datasource": {
+                "type": "redis-datasource",
+                "uid": "${datasource}"
+              },
+              "query": "",
+              "refId": "A",
+              "section": "clients",
+              "type": "command"
+            }
+          ],
+          "title": "Connected Clients",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": ["connected_clients"]
+                }
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "redis-datasource",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 6,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "command": "info",
+              "datasource": {
+                "type": "redis-datasource",
+                "uid": "${datasource}"
+              },
+              "query": "",
+              "refId": "A",
+              "section": "memory",
+              "type": "command"
+            }
+          ],
+          "title": "Used Memory",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": ["used_memory"]
+                }
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "redis-datasource",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 12,
+            "y": 0
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "command": "dbsize",
+              "datasource": {
+                "type": "redis-datasource",
+                "uid": "${datasource}"
+              },
+              "query": "",
+              "refId": "A",
+              "type": "command"
+            }
+          ],
+          "title": "Total Keys",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "redis-datasource",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 0
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": ["lastNotNull"],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "command": "info",
+              "datasource": {
+                "type": "redis-datasource",
+                "uid": "${datasource}"
+              },
+              "query": "",
+              "refId": "A",
+              "section": "server",
+              "type": "command"
+            }
+          ],
+          "title": "Uptime",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": ["uptime_in_seconds"]
+                }
+              }
+            }
+          ],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "redis-datasource",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "ops"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 4
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "command": "info",
+              "datasource": {
+                "type": "redis-datasource",
+                "uid": "${datasource}"
+              },
+              "query": "",
+              "refId": "A",
+              "section": "stats",
+              "streaming": true,
+              "streamingInterval": 1000,
+              "type": "command"
+            }
+          ],
+          "title": "Commands/sec",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": ["Time", "instantaneous_ops_per_sec"]
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "redis-datasource",
+            "uid": "${datasource}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 4
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "command": "info",
+              "datasource": {
+                "type": "redis-datasource",
+                "uid": "${datasource}"
+              },
+              "query": "",
+              "refId": "A",
+              "section": "memory",
+              "streaming": true,
+              "streamingInterval": 1000,
+              "type": "command"
+            }
+          ],
+          "title": "Memory Usage",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": ["Time", "used_memory", "used_memory_rss"]
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        }
+      ],
+      "refresh": "5s",
+      "schemaVersion": 38,
+      "tags": ["redis", "arena"],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Redis",
+              "value": "Redis"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "redis-datasource",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          }
+        ]
+      },
+      "time": {
+        "from": "now-5m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "",
+      "title": "Redis Overview",
+      "uid": "redis-overview",
+      "version": 1,
+      "weekStart": ""
+    }
+{{- end }}

--- a/charts/omnia/templates/grafana-redis-datasource.yaml
+++ b/charts/omnia/templates/grafana-redis-datasource.yaml
@@ -1,0 +1,34 @@
+{{- if and .Values.grafana.enabled .Values.redis.enabled }}
+---
+# Redis datasource for Grafana
+# Auto-configured when both grafana.enabled and redis.enabled are true
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "omnia.fullname" . }}-grafana-redis-datasource
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "omnia.labels" . | nindent 4 }}
+    grafana_datasource: "1"
+data:
+  redis-datasource.yaml: |
+    apiVersion: 1
+    datasources:
+      - name: Redis
+        type: redis-datasource
+        access: proxy
+        url: redis://{{ include "omnia.fullname" . }}-redis-master:6379
+        isDefault: false
+        editable: true
+        jsonData:
+          client: standalone
+          {{- if .Values.redis.auth.enabled }}
+          acl: true
+          {{- else }}
+          acl: false
+          {{- end }}
+        {{- if .Values.redis.auth.enabled }}
+        secureJsonData:
+          password: $REDIS_PASSWORD
+        {{- end }}
+{{- end }}

--- a/charts/omnia/values-dev.yaml
+++ b/charts/omnia/values-dev.yaml
@@ -76,3 +76,31 @@ gateway:
 
 internalGateway:
   enabled: false
+
+# Enable Redis for Arena queue development (Bitnami Redis)
+redis:
+  enabled: true
+  architecture: standalone
+  image:
+    tag: latest  # Use latest for dev to avoid version mismatch issues
+  auth:
+    enabled: false  # No auth for dev
+  master:
+    persistence:
+      enabled: false  # No persistence for dev
+    resources:
+      limits:
+        cpu: 100m
+        memory: 128Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+# Arena queue configuration
+arena:
+  queue:
+    type: redis
+    redis:
+      # Auto-configured to use the Bitnami Redis subchart
+      host: "omnia-redis-master"
+      port: 6379

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -392,6 +392,37 @@ arena:
       # -- Volume size
       size: 10Gi
 
+  # Work queue configuration for job distribution
+  queue:
+    # -- Queue backend type: memory (dev) or redis (prod)
+    type: memory
+
+    # Redis configuration (when type: redis)
+    # Uses the Bitnami Redis subchart when redis.enabled=true
+    # Or connect to external Redis via arena.queue.external
+    redis:
+      # -- Redis host (auto-configured when redis.enabled=true)
+      host: ""
+      # -- Redis port
+      port: 6379
+
+    # External Redis configuration (BYOD - Bring Your Own Database)
+    external:
+      # -- External Redis URL (e.g., redis://host:6379, rediss://host:6379 for TLS)
+      # Supports: ElastiCache, Memorystore, Azure Cache, or any Redis 6+
+      url: ""
+      # -- Reference to existing secret containing Redis URL
+      # Secret must have a key specified by urlKey
+      secretRef:
+        name: ""
+        key: "redis-url"
+      # -- Redis password (if not using URL with password)
+      password: ""
+      # -- Reference to existing secret containing Redis password
+      passwordSecretRef:
+        name: ""
+        key: "redis-password"
+
 # Facade container configuration (used by AgentRuntime)
 facade:
   image:
@@ -539,6 +570,10 @@ grafana:
     # Allow embedding in iframes
     security:
       allow_embedding: true
+  # -- Grafana plugins to install
+  # Redis plugin provides Redis datasource for monitoring and visualization
+  plugins:
+    - redis-datasource
   # Sidecar configuration for auto-loading dashboards/datasources
   sidecar:
     dashboards:
@@ -891,6 +926,42 @@ keda:
     # -- Prometheus server address for KEDA triggers
     # This is the default when using the Prometheus subchart
     serverAddress: "http://omnia-prometheus-server.omnia-system.svc.cluster.local"
+
+# ============================================================================
+# Redis (Bitnami)
+# Optional Redis deployment for Arena queue, sessions, caching, etc.
+# See: https://github.com/bitnami/charts/tree/main/bitnami/redis
+# ============================================================================
+
+redis:
+  # -- Enable Redis subchart (Bitnami Redis)
+  # Use this for development or when you want a managed Redis instance
+  enabled: false
+
+  # -- Subchart values for Bitnami Redis
+  # See: https://github.com/bitnami/charts/tree/main/bitnami/redis
+  # Architecture: standalone (1 master) or replication (master + replicas)
+  architecture: standalone
+
+  auth:
+    # -- Disable auth for development (enable and set password for production)
+    enabled: false
+
+  master:
+    persistence:
+      # -- Disable persistence for development
+      enabled: false
+    resources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+
+  replica:
+    # -- Number of replicas (only used when architecture: replication)
+    replicaCount: 0
 
 # ============================================================================
 # Demo Mode (Separate Chart)


### PR DESCRIPTION
## Summary

- Add Bitnami Redis as optional Helm subchart dependency for Arena queue
- Auto-configure Grafana with Redis datasource and dashboard when both enabled
- Add OrbStack to allowed Tilt contexts for local development

## Changes

### Helm Chart
- **Chart.yaml**: Add `redis` subchart (Bitnami) with condition `redis.enabled`
- **values.yaml**: Add Redis configuration options and `redis-datasource` plugin to Grafana
- **values-dev.yaml**: Enable Redis with dev-friendly defaults (no auth, no persistence)

### New Templates
- **grafana-redis-datasource.yaml**: Auto-configures Redis datasource when `redis.enabled` and `grafana.enabled`
- **grafana-redis-dashboard.yaml**: Redis Overview dashboard with:
  - Connected clients
  - Memory usage (stat + time series)
  - Total keys
  - Uptime
  - Commands per second

### Tiltfile
- Add `orbstack` to allowed k8s contexts
- Add `bitnami` helm repo for Redis chart

### Documentation
- Update `helm-values.md` with Redis configuration and Grafana integration docs

## Test plan

- [x] Helm lint passes
- [x] Tilt deploys Redis successfully
- [x] Grafana loads Redis plugin
- [x] Redis datasource auto-configured
- [x] Redis Overview dashboard displays metrics
- [ ] CI passes