### PR TITLE
feat(arena): implement result aggregator for Arena jobs (#203)

### DIFF
--- a/pkg/arena/aggregator/aggregator.go
+++ b/pkg/arena/aggregator/aggregator.go
@@ -1,0 +1,270 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+	"github.com/altairalabs/omnia/pkg/arena/queue"
+)
+
+// Aggregator collects and summarizes results from Arena job executions.
+type Aggregator struct {
+	queue queue.WorkQueue
+}
+
+// New creates a new Aggregator with the given queue.
+func New(q queue.WorkQueue) *Aggregator {
+	return &Aggregator{
+		queue: q,
+	}
+}
+
+// Aggregate collects and summarizes results for a completed job.
+// It retrieves all completed and failed work items from the queue,
+// parses their results, and produces an aggregated summary.
+func (a *Aggregator) Aggregate(ctx context.Context, jobID string) (*AggregatedResult, error) {
+	// Get all completed items
+	completed, err := a.queue.GetCompletedItems(ctx, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get completed items: %w", err)
+	}
+
+	// Get all failed items
+	failed, err := a.queue.GetFailedItems(ctx, jobID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get failed items: %w", err)
+	}
+
+	// Parse results and aggregate
+	result := &AggregatedResult{
+		ByScenario: make(map[string]*ScenarioStats),
+		ByProvider: make(map[string]*ProviderStats),
+	}
+
+	// Track errors for grouping
+	errorCounts := make(map[string]*ErrorSummary)
+
+	// Process completed items
+	for _, item := range completed {
+		execResult, err := ParseExecutionResult(item)
+		if err != nil {
+			continue
+		}
+		a.aggregateResult(result, execResult, errorCounts)
+	}
+
+	// Process failed items
+	for _, item := range failed {
+		execResult, err := ParseExecutionResult(item)
+		if err != nil {
+			// Even if parsing fails, count the failure
+			result.TotalItems++
+			result.FailedItems++
+			a.trackError(errorCounts, item.Error, item.ID)
+			continue
+		}
+		a.aggregateResult(result, execResult, errorCounts)
+	}
+
+	// Calculate averages and rates
+	a.finalizeResult(result, errorCounts)
+
+	return result, nil
+}
+
+// aggregateResult adds a single execution result to the aggregated result.
+func (a *Aggregator) aggregateResult(
+	result *AggregatedResult, execResult *ExecutionResult, errorCounts map[string]*ErrorSummary,
+) {
+	result.TotalItems++
+	result.TotalDuration += execResult.Duration
+
+	// Track pass/fail
+	if execResult.Status == StatusPass {
+		result.PassedItems++
+	} else {
+		result.FailedItems++
+		if execResult.Error != "" {
+			a.trackError(errorCounts, execResult.Error, execResult.WorkItemID)
+		}
+	}
+
+	// Aggregate metrics
+	if execResult.Metrics != nil {
+		if tokens, ok := execResult.Metrics["tokens"]; ok {
+			result.TotalTokens += int64(tokens)
+		}
+		if cost, ok := execResult.Metrics["cost"]; ok {
+			result.TotalCost += cost
+		}
+	}
+
+	// Update scenario stats
+	if execResult.ScenarioID != "" {
+		stats := result.ByScenario[execResult.ScenarioID]
+		if stats == nil {
+			stats = &ScenarioStats{}
+			result.ByScenario[execResult.ScenarioID] = stats
+		}
+		a.updateScenarioStats(stats, execResult)
+	}
+
+	// Update provider stats
+	if execResult.ProviderID != "" {
+		stats := result.ByProvider[execResult.ProviderID]
+		if stats == nil {
+			stats = &ProviderStats{}
+			result.ByProvider[execResult.ProviderID] = stats
+		}
+		a.updateProviderStats(stats, execResult)
+	}
+}
+
+// updateScenarioStats updates statistics for a scenario.
+func (a *Aggregator) updateScenarioStats(stats *ScenarioStats, execResult *ExecutionResult) {
+	stats.Total++
+	stats.TotalDuration += execResult.Duration
+
+	if execResult.Status == StatusPass {
+		stats.Passed++
+	} else {
+		stats.Failed++
+	}
+
+	if execResult.Metrics != nil {
+		if tokens, ok := execResult.Metrics["tokens"]; ok {
+			stats.TotalTokens += int64(tokens)
+		}
+		if cost, ok := execResult.Metrics["cost"]; ok {
+			stats.TotalCost += cost
+		}
+	}
+}
+
+// updateProviderStats updates statistics for a provider.
+func (a *Aggregator) updateProviderStats(stats *ProviderStats, execResult *ExecutionResult) {
+	stats.Total++
+	stats.TotalDuration += execResult.Duration
+
+	if execResult.Status == StatusPass {
+		stats.Passed++
+	} else {
+		stats.Failed++
+	}
+
+	if execResult.Metrics != nil {
+		if tokens, ok := execResult.Metrics["tokens"]; ok {
+			stats.TotalTokens += int64(tokens)
+		}
+		if cost, ok := execResult.Metrics["cost"]; ok {
+			stats.TotalCost += cost
+		}
+	}
+}
+
+// trackError groups errors by message.
+func (a *Aggregator) trackError(errorCounts map[string]*ErrorSummary, errorMsg string, workItemID string) {
+	if errorMsg == "" {
+		errorMsg = "unknown error"
+	}
+
+	summary := errorCounts[errorMsg]
+	if summary == nil {
+		summary = &ErrorSummary{
+			Message:     errorMsg,
+			WorkItemIDs: []string{},
+		}
+		errorCounts[errorMsg] = summary
+	}
+	summary.Count++
+	summary.WorkItemIDs = append(summary.WorkItemIDs, workItemID)
+}
+
+// finalizeResult calculates averages and converts error map to slice.
+func (a *Aggregator) finalizeResult(result *AggregatedResult, errorCounts map[string]*ErrorSummary) {
+	// Calculate overall averages
+	if result.TotalItems > 0 {
+		result.PassRate = float64(result.PassedItems) / float64(result.TotalItems) * 100
+		result.AvgDuration = result.TotalDuration / time.Duration(result.TotalItems)
+	}
+
+	// Calculate scenario averages
+	for _, stats := range result.ByScenario {
+		if stats.Total > 0 {
+			stats.PassRate = float64(stats.Passed) / float64(stats.Total) * 100
+			stats.AvgDuration = stats.TotalDuration / time.Duration(stats.Total)
+		}
+	}
+
+	// Calculate provider averages
+	for _, stats := range result.ByProvider {
+		if stats.Total > 0 {
+			stats.PassRate = float64(stats.Passed) / float64(stats.Total) * 100
+			stats.AvgDuration = stats.TotalDuration / time.Duration(stats.Total)
+		}
+	}
+
+	// Convert error map to slice
+	result.Errors = make([]ErrorSummary, 0, len(errorCounts))
+	for _, summary := range errorCounts {
+		result.Errors = append(result.Errors, *summary)
+	}
+
+	// Clean up empty maps
+	if len(result.ByScenario) == 0 {
+		result.ByScenario = nil
+	}
+	if len(result.ByProvider) == 0 {
+		result.ByProvider = nil
+	}
+	if len(result.Errors) == 0 {
+		result.Errors = nil
+	}
+}
+
+// ToJobResult converts an AggregatedResult to the CRD JobResult format.
+// This is used to populate the ArenaJob.Status.Result field.
+func (a *Aggregator) ToJobResult(result *AggregatedResult) *omniav1alpha1.JobResult {
+	if result == nil {
+		return nil
+	}
+
+	summary := make(map[string]string)
+
+	// Add core metrics
+	summary["passRate"] = fmt.Sprintf("%.1f", result.PassRate)
+	summary["totalItems"] = fmt.Sprintf("%d", result.TotalItems)
+	summary["passedItems"] = fmt.Sprintf("%d", result.PassedItems)
+	summary["failedItems"] = fmt.Sprintf("%d", result.FailedItems)
+	summary["avgDurationMs"] = fmt.Sprintf("%d", result.AvgDuration.Milliseconds())
+
+	// Add optional metrics if present
+	if result.TotalTokens > 0 {
+		summary["totalTokens"] = fmt.Sprintf("%d", result.TotalTokens)
+	}
+	if result.TotalCost > 0 {
+		summary["totalCost"] = fmt.Sprintf("%.4f", result.TotalCost)
+	}
+
+	return &omniav1alpha1.JobResult{
+		Summary: summary,
+	}
+}

--- a/pkg/arena/aggregator/aggregator_test.go
+++ b/pkg/arena/aggregator/aggregator_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/omnia/pkg/arena/queue"
+)
+
+func TestAggregator_New(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	agg := New(q)
+
+	if agg == nil {
+		t.Fatal("New() returned nil")
+	}
+	if agg.queue != q {
+		t.Error("Aggregator queue not set correctly")
+	}
+}
+
+func TestAggregator_Aggregate_EmptyJob(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	agg := New(q)
+	ctx := context.Background()
+
+	// Push an item to create the job
+	_ = q.Push(ctx, "job-1", []queue.WorkItem{{ID: "item-1"}})
+
+	result, err := agg.Aggregate(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Aggregate() error = %v", err)
+	}
+
+	if result.TotalItems != 0 {
+		t.Errorf("TotalItems = %d, want 0", result.TotalItems)
+	}
+	if result.PassRate != 0 {
+		t.Errorf("PassRate = %f, want 0", result.PassRate)
+	}
+}
+
+func TestAggregator_Aggregate_AllPassed(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	agg := New(q)
+	ctx := context.Background()
+
+	// Push and complete items
+	items := []queue.WorkItem{
+		{ID: "item-1", ScenarioID: "scenario-1", ProviderID: "provider-1"},
+		{ID: "item-2", ScenarioID: "scenario-1", ProviderID: "provider-2"},
+		{ID: "item-3", ScenarioID: "scenario-2", ProviderID: "provider-1"},
+	}
+	_ = q.Push(ctx, "job-1", items)
+
+	// Pop and ack all items
+	for range 3 {
+		item, _ := q.Pop(ctx, "job-1")
+		result := []byte(`{"status": "pass", "durationMs": 100, "metrics": {"tokens": 50, "cost": 0.01}}`)
+		_ = q.Ack(ctx, "job-1", item.ID, result)
+	}
+
+	result, err := agg.Aggregate(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Aggregate() error = %v", err)
+	}
+
+	if result.TotalItems != 3 {
+		t.Errorf("TotalItems = %d, want 3", result.TotalItems)
+	}
+	if result.PassedItems != 3 {
+		t.Errorf("PassedItems = %d, want 3", result.PassedItems)
+	}
+	if result.FailedItems != 0 {
+		t.Errorf("FailedItems = %d, want 0", result.FailedItems)
+	}
+	if result.PassRate != 100 {
+		t.Errorf("PassRate = %f, want 100", result.PassRate)
+	}
+	if result.TotalTokens != 150 {
+		t.Errorf("TotalTokens = %d, want 150", result.TotalTokens)
+	}
+	if result.TotalCost != 0.03 {
+		t.Errorf("TotalCost = %f, want 0.03", result.TotalCost)
+	}
+}
+
+func TestAggregator_Aggregate_WithFailures(t *testing.T) {
+	q := queue.NewMemoryQueue(queue.Options{MaxRetries: 1})
+	agg := New(q)
+	ctx := context.Background()
+
+	// Push items
+	items := []queue.WorkItem{
+		{ID: "item-1", ScenarioID: "scenario-1", ProviderID: "provider-1"},
+		{ID: "item-2", ScenarioID: "scenario-1", ProviderID: "provider-1"},
+		{ID: "item-3", ScenarioID: "scenario-1", ProviderID: "provider-1"},
+		{ID: "item-4", ScenarioID: "scenario-1", ProviderID: "provider-1"},
+	}
+	_ = q.Push(ctx, "job-1", items)
+
+	// Complete 3, fail 1
+	for i := range 4 {
+		item, _ := q.Pop(ctx, "job-1")
+		if i == 2 {
+			_ = q.Nack(ctx, "job-1", item.ID, nil)
+		} else {
+			_ = q.Ack(ctx, "job-1", item.ID, []byte(`{"status": "pass"}`))
+		}
+	}
+
+	result, err := agg.Aggregate(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Aggregate() error = %v", err)
+	}
+
+	if result.TotalItems != 4 {
+		t.Errorf("TotalItems = %d, want 4", result.TotalItems)
+	}
+	if result.PassedItems != 3 {
+		t.Errorf("PassedItems = %d, want 3", result.PassedItems)
+	}
+	if result.FailedItems != 1 {
+		t.Errorf("FailedItems = %d, want 1", result.FailedItems)
+	}
+	if result.PassRate != 75 {
+		t.Errorf("PassRate = %f, want 75", result.PassRate)
+	}
+}
+
+func TestAggregator_Aggregate_ByScenario(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	agg := New(q)
+	ctx := context.Background()
+
+	// Push items with different scenarios
+	items := []queue.WorkItem{
+		{ID: "item-1", ScenarioID: "scenario-a"},
+		{ID: "item-2", ScenarioID: "scenario-a"},
+		{ID: "item-3", ScenarioID: "scenario-b"},
+	}
+	_ = q.Push(ctx, "job-1", items)
+
+	// Complete all
+	for range 3 {
+		item, _ := q.Pop(ctx, "job-1")
+		_ = q.Ack(ctx, "job-1", item.ID, []byte(`{"status": "pass"}`))
+	}
+
+	result, err := agg.Aggregate(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Aggregate() error = %v", err)
+	}
+
+	if len(result.ByScenario) != 2 {
+		t.Errorf("ByScenario count = %d, want 2", len(result.ByScenario))
+	}
+
+	scenarioA := result.ByScenario["scenario-a"]
+	if scenarioA == nil {
+		t.Fatal("scenario-a stats not found")
+	}
+	if scenarioA.Total != 2 {
+		t.Errorf("scenario-a Total = %d, want 2", scenarioA.Total)
+	}
+	if scenarioA.PassRate != 100 {
+		t.Errorf("scenario-a PassRate = %f, want 100", scenarioA.PassRate)
+	}
+
+	scenarioB := result.ByScenario["scenario-b"]
+	if scenarioB == nil {
+		t.Fatal("scenario-b stats not found")
+	}
+	if scenarioB.Total != 1 {
+		t.Errorf("scenario-b Total = %d, want 1", scenarioB.Total)
+	}
+}
+
+func TestAggregator_Aggregate_ByProvider(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	agg := New(q)
+	ctx := context.Background()
+
+	// Push items with different providers
+	items := []queue.WorkItem{
+		{ID: "item-1", ProviderID: "openai"},
+		{ID: "item-2", ProviderID: "anthropic"},
+		{ID: "item-3", ProviderID: "openai"},
+	}
+	_ = q.Push(ctx, "job-1", items)
+
+	// Complete all
+	for range 3 {
+		item, _ := q.Pop(ctx, "job-1")
+		_ = q.Ack(ctx, "job-1", item.ID, []byte(`{"status": "pass"}`))
+	}
+
+	result, err := agg.Aggregate(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Aggregate() error = %v", err)
+	}
+
+	if len(result.ByProvider) != 2 {
+		t.Errorf("ByProvider count = %d, want 2", len(result.ByProvider))
+	}
+
+	openai := result.ByProvider["openai"]
+	if openai == nil {
+		t.Fatal("openai stats not found")
+	}
+	if openai.Total != 2 {
+		t.Errorf("openai Total = %d, want 2", openai.Total)
+	}
+
+	anthropic := result.ByProvider["anthropic"]
+	if anthropic == nil {
+		t.Fatal("anthropic stats not found")
+	}
+	if anthropic.Total != 1 {
+		t.Errorf("anthropic Total = %d, want 1", anthropic.Total)
+	}
+}
+
+func TestAggregator_Aggregate_ErrorGrouping(t *testing.T) {
+	q := queue.NewMemoryQueue(queue.Options{MaxRetries: 1})
+	agg := New(q)
+	ctx := context.Background()
+
+	// Push items
+	items := []queue.WorkItem{
+		{ID: "item-1"},
+		{ID: "item-2"},
+		{ID: "item-3"},
+	}
+	_ = q.Push(ctx, "job-1", items)
+
+	// Fail all with same error
+	for range 3 {
+		item, _ := q.Pop(ctx, "job-1")
+		_ = q.Nack(ctx, "job-1", item.ID, &testError{msg: "connection timeout"})
+	}
+
+	result, err := agg.Aggregate(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Aggregate() error = %v", err)
+	}
+
+	if len(result.Errors) != 1 {
+		t.Errorf("Errors count = %d, want 1", len(result.Errors))
+	}
+	if result.Errors[0].Message != "connection timeout" {
+		t.Errorf("Error message = %s, want 'connection timeout'", result.Errors[0].Message)
+	}
+	if result.Errors[0].Count != 3 {
+		t.Errorf("Error count = %d, want 3", result.Errors[0].Count)
+	}
+	if len(result.Errors[0].WorkItemIDs) != 3 {
+		t.Errorf("WorkItemIDs count = %d, want 3", len(result.Errors[0].WorkItemIDs))
+	}
+}
+
+func TestAggregator_ToJobResult(t *testing.T) {
+	agg := &Aggregator{}
+
+	result := &AggregatedResult{
+		TotalItems:    100,
+		PassedItems:   85,
+		FailedItems:   15,
+		PassRate:      85.0,
+		TotalDuration: 100 * time.Second,
+		AvgDuration:   1 * time.Second,
+		TotalTokens:   50000,
+		TotalCost:     0.75,
+	}
+
+	jobResult := agg.ToJobResult(result)
+
+	if jobResult == nil {
+		t.Fatal("ToJobResult() returned nil")
+	}
+
+	tests := map[string]string{
+		"passRate":      "85.0",
+		"totalItems":    "100",
+		"passedItems":   "85",
+		"failedItems":   "15",
+		"avgDurationMs": "1000",
+		"totalTokens":   "50000",
+		"totalCost":     "0.7500",
+	}
+
+	for key, expected := range tests {
+		if jobResult.Summary[key] != expected {
+			t.Errorf("Summary[%s] = %s, want %s", key, jobResult.Summary[key], expected)
+		}
+	}
+}
+
+func TestAggregator_ToJobResult_Nil(t *testing.T) {
+	agg := &Aggregator{}
+
+	jobResult := agg.ToJobResult(nil)
+	if jobResult != nil {
+		t.Error("ToJobResult(nil) should return nil")
+	}
+}
+
+func TestAggregator_ToJobResult_NoOptionalMetrics(t *testing.T) {
+	agg := &Aggregator{}
+
+	result := &AggregatedResult{
+		TotalItems:  10,
+		PassedItems: 10,
+		PassRate:    100,
+		AvgDuration: 500 * time.Millisecond,
+	}
+
+	jobResult := agg.ToJobResult(result)
+
+	// Optional metrics should not be present
+	if _, ok := jobResult.Summary["totalTokens"]; ok {
+		t.Error("totalTokens should not be present when zero")
+	}
+	if _, ok := jobResult.Summary["totalCost"]; ok {
+		t.Error("totalCost should not be present when zero")
+	}
+}
+
+func TestAggregator_Aggregate_JobNotFound(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	agg := New(q)
+	ctx := context.Background()
+
+	_, err := agg.Aggregate(ctx, "nonexistent-job")
+	if err == nil {
+		t.Error("Aggregate() should return error for nonexistent job")
+	}
+}
+
+// testError is a simple error type for testing
+type testError struct {
+	msg string
+}
+
+func (e *testError) Error() string {
+	return e.msg
+}

--- a/pkg/arena/aggregator/parser.go
+++ b/pkg/arena/aggregator/parser.go
@@ -1,0 +1,295 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"errors"
+	"time"
+
+	"github.com/altairalabs/omnia/pkg/arena/queue"
+)
+
+// Common errors returned by parser functions.
+var (
+	// ErrNilWorkItem is returned when a nil work item is passed to a parser.
+	ErrNilWorkItem = errors.New("work item is nil")
+
+	// ErrEmptyResult is returned when the work item has no result data.
+	ErrEmptyResult = errors.New("work item has no result data")
+
+	// ErrInvalidFormat is returned when the result data cannot be parsed.
+	ErrInvalidFormat = errors.New("invalid result format")
+)
+
+// jsonResult represents the expected JSON structure from worker results.
+type jsonResult struct {
+	Status     string             `json:"status"`
+	Error      string             `json:"error,omitempty"`
+	DurationMs float64            `json:"durationMs,omitempty"`
+	Duration   string             `json:"duration,omitempty"`
+	Metrics    map[string]float64 `json:"metrics,omitempty"`
+	Assertions []struct {
+		Name    string `json:"name"`
+		Passed  bool   `json:"passed"`
+		Message string `json:"message,omitempty"`
+	} `json:"assertions,omitempty"`
+}
+
+// ParseExecutionResult parses a work item's result bytes into ExecutionResult.
+// It supports JSON format and falls back to inferring status from work item state.
+func ParseExecutionResult(item *queue.WorkItem) (*ExecutionResult, error) {
+	if item == nil {
+		return nil, ErrNilWorkItem
+	}
+
+	result := &ExecutionResult{
+		WorkItemID: item.ID,
+		ScenarioID: item.ScenarioID,
+		ProviderID: item.ProviderID,
+	}
+
+	// Calculate duration from work item timestamps
+	if item.StartedAt != nil && item.CompletedAt != nil {
+		result.Duration = item.CompletedAt.Sub(*item.StartedAt)
+	}
+
+	// If no result data, infer status from work item status
+	if len(item.Result) == 0 {
+		switch item.Status {
+		case queue.ItemStatusCompleted:
+			result.Status = StatusPass
+		case queue.ItemStatusFailed:
+			result.Status = StatusFail
+			result.Error = item.Error
+		default:
+			result.Status = StatusUnknown
+		}
+		return result, nil
+	}
+
+	// Try to parse as JSON
+	var jr jsonResult
+	if err := json.Unmarshal(item.Result, &jr); err != nil {
+		// If JSON parsing fails, still return a result based on item status
+		if item.Status == queue.ItemStatusCompleted {
+			result.Status = StatusPass
+		} else {
+			result.Status = StatusFail
+			result.Error = item.Error
+		}
+		return result, nil
+	}
+
+	// Populate from JSON result
+	if jr.Status != "" {
+		result.Status = jr.Status
+	} else if item.Status == queue.ItemStatusCompleted {
+		result.Status = StatusPass
+	} else {
+		result.Status = StatusFail
+	}
+
+	if jr.Error != "" {
+		result.Error = jr.Error
+	} else if item.Error != "" {
+		result.Error = item.Error
+	}
+
+	// Parse duration from JSON if not already set
+	if result.Duration == 0 {
+		if jr.DurationMs > 0 {
+			result.Duration = time.Duration(jr.DurationMs) * time.Millisecond
+		} else if jr.Duration != "" {
+			if d, err := time.ParseDuration(jr.Duration); err == nil {
+				result.Duration = d
+			}
+		}
+	}
+
+	// Copy metrics
+	if len(jr.Metrics) > 0 {
+		result.Metrics = make(map[string]float64, len(jr.Metrics))
+		for k, v := range jr.Metrics {
+			result.Metrics[k] = v
+		}
+	}
+
+	// Copy assertions
+	if len(jr.Assertions) > 0 {
+		result.Assertions = make([]AssertionResult, len(jr.Assertions))
+		for i, a := range jr.Assertions {
+			result.Assertions[i] = AssertionResult{
+				Name:    a.Name,
+				Passed:  a.Passed,
+				Message: a.Message,
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// JUnitTestSuites represents a collection of JUnit test suites.
+type JUnitTestSuites struct {
+	XMLName    xml.Name         `xml:"testsuites"`
+	TestSuites []JUnitTestSuite `xml:"testsuite"`
+}
+
+// JUnitTestSuite represents a single JUnit test suite.
+type JUnitTestSuite struct {
+	XMLName   xml.Name        `xml:"testsuite"`
+	Name      string          `xml:"name,attr"`
+	Tests     int             `xml:"tests,attr"`
+	Failures  int             `xml:"failures,attr"`
+	Errors    int             `xml:"errors,attr"`
+	Skipped   int             `xml:"skipped,attr"`
+	Time      float64         `xml:"time,attr"`
+	TestCases []JUnitTestCase `xml:"testcase"`
+}
+
+// JUnitTestCase represents a single JUnit test case.
+type JUnitTestCase struct {
+	XMLName   xml.Name      `xml:"testcase"`
+	Name      string        `xml:"name,attr"`
+	ClassName string        `xml:"classname,attr"`
+	Time      float64       `xml:"time,attr"`
+	Failure   *JUnitFailure `xml:"failure,omitempty"`
+	Error     *JUnitError   `xml:"error,omitempty"`
+	Skipped   *JUnitSkipped `xml:"skipped,omitempty"`
+}
+
+// JUnitFailure represents a test case failure.
+type JUnitFailure struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Content string `xml:",chardata"`
+}
+
+// JUnitError represents a test case error.
+type JUnitError struct {
+	Message string `xml:"message,attr"`
+	Type    string `xml:"type,attr"`
+	Content string `xml:",chardata"`
+}
+
+// JUnitSkipped represents a skipped test case.
+type JUnitSkipped struct {
+	Message string `xml:"message,attr"`
+}
+
+// ParseJUnitXML parses JUnit XML format into an ExecutionResult.
+// This is useful when outputFormats includes "junit".
+func ParseJUnitXML(data []byte) (*ExecutionResult, error) {
+	if len(data) == 0 {
+		return nil, ErrEmptyResult
+	}
+
+	// Try parsing as test suites first
+	var suites JUnitTestSuites
+	if err := xml.Unmarshal(data, &suites); err == nil && len(suites.TestSuites) > 0 {
+		return parseJUnitSuites(&suites)
+	}
+
+	// Try parsing as single test suite
+	var suite JUnitTestSuite
+	if err := xml.Unmarshal(data, &suite); err == nil && suite.Tests > 0 {
+		return parseJUnitSuite(&suite)
+	}
+
+	return nil, ErrInvalidFormat
+}
+
+// parseJUnitSuites converts multiple test suites into an ExecutionResult.
+func parseJUnitSuites(suites *JUnitTestSuites) (*ExecutionResult, error) {
+	result := &ExecutionResult{
+		Metrics:    make(map[string]float64),
+		Assertions: []AssertionResult{},
+	}
+
+	var totalTests, totalFailures, totalErrors int
+	var totalTime float64
+
+	for _, suite := range suites.TestSuites {
+		totalTests += suite.Tests
+		totalFailures += suite.Failures
+		totalErrors += suite.Errors
+		totalTime += suite.Time
+
+		for _, tc := range suite.TestCases {
+			assertion := AssertionResult{
+				Name:   tc.ClassName + "." + tc.Name,
+				Passed: tc.Failure == nil && tc.Error == nil,
+			}
+			if tc.Failure != nil {
+				assertion.Message = tc.Failure.Message
+			} else if tc.Error != nil {
+				assertion.Message = tc.Error.Message
+			}
+			result.Assertions = append(result.Assertions, assertion)
+		}
+	}
+
+	if totalFailures > 0 || totalErrors > 0 {
+		result.Status = StatusFail
+	} else {
+		result.Status = StatusPass
+	}
+
+	result.Duration = time.Duration(totalTime * float64(time.Second))
+	result.Metrics["tests"] = float64(totalTests)
+	result.Metrics["failures"] = float64(totalFailures)
+	result.Metrics["errors"] = float64(totalErrors)
+
+	return result, nil
+}
+
+// parseJUnitSuite converts a single test suite into an ExecutionResult.
+func parseJUnitSuite(suite *JUnitTestSuite) (*ExecutionResult, error) {
+	result := &ExecutionResult{
+		Metrics:    make(map[string]float64),
+		Assertions: make([]AssertionResult, 0, len(suite.TestCases)),
+	}
+
+	for _, tc := range suite.TestCases {
+		assertion := AssertionResult{
+			Name:   tc.ClassName + "." + tc.Name,
+			Passed: tc.Failure == nil && tc.Error == nil,
+		}
+		if tc.Failure != nil {
+			assertion.Message = tc.Failure.Message
+		} else if tc.Error != nil {
+			assertion.Message = tc.Error.Message
+		}
+		result.Assertions = append(result.Assertions, assertion)
+	}
+
+	if suite.Failures > 0 || suite.Errors > 0 {
+		result.Status = StatusFail
+	} else {
+		result.Status = StatusPass
+	}
+
+	result.Duration = time.Duration(suite.Time * float64(time.Second))
+	result.Metrics["tests"] = float64(suite.Tests)
+	result.Metrics["failures"] = float64(suite.Failures)
+	result.Metrics["errors"] = float64(suite.Errors)
+	result.Metrics["skipped"] = float64(suite.Skipped)
+
+	return result, nil
+}

--- a/pkg/arena/aggregator/parser_test.go
+++ b/pkg/arena/aggregator/parser_test.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aggregator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/altairalabs/omnia/pkg/arena/queue"
+)
+
+func TestParseExecutionResult_NilItem(t *testing.T) {
+	_, err := ParseExecutionResult(nil)
+	if err != ErrNilWorkItem {
+		t.Errorf("ParseExecutionResult(nil) error = %v, want %v", err, ErrNilWorkItem)
+	}
+}
+
+func TestParseExecutionResult_NoResult(t *testing.T) {
+	now := time.Now()
+	completed := now.Add(time.Second)
+
+	item := &queue.WorkItem{
+		ID:          "item-1",
+		ScenarioID:  "scenario-1",
+		ProviderID:  "provider-1",
+		Status:      queue.ItemStatusCompleted,
+		StartedAt:   &now,
+		CompletedAt: &completed,
+	}
+
+	result, err := ParseExecutionResult(item)
+	if err != nil {
+		t.Fatalf("ParseExecutionResult() error = %v", err)
+	}
+
+	if result.Status != StatusPass {
+		t.Errorf("Status = %s, want %s", result.Status, StatusPass)
+	}
+	if result.WorkItemID != "item-1" {
+		t.Errorf("WorkItemID = %s, want item-1", result.WorkItemID)
+	}
+	if result.ScenarioID != "scenario-1" {
+		t.Errorf("ScenarioID = %s, want scenario-1", result.ScenarioID)
+	}
+	if result.Duration != time.Second {
+		t.Errorf("Duration = %v, want 1s", result.Duration)
+	}
+}
+
+func TestParseExecutionResult_FailedItem(t *testing.T) {
+	item := &queue.WorkItem{
+		ID:     "item-1",
+		Status: queue.ItemStatusFailed,
+		Error:  "connection timeout",
+	}
+
+	result, err := ParseExecutionResult(item)
+	if err != nil {
+		t.Fatalf("ParseExecutionResult() error = %v", err)
+	}
+
+	if result.Status != StatusFail {
+		t.Errorf("Status = %s, want %s", result.Status, StatusFail)
+	}
+	if result.Error != "connection timeout" {
+		t.Errorf("Error = %s, want 'connection timeout'", result.Error)
+	}
+}
+
+func TestParseExecutionResult_JSONResult(t *testing.T) {
+	jsonData := []byte(`{
+		"status": "pass",
+		"durationMs": 1500,
+		"metrics": {
+			"tokens": 100,
+			"cost": 0.05,
+			"latency_ms": 250
+		},
+		"assertions": [
+			{"name": "check_output", "passed": true},
+			{"name": "check_format", "passed": false, "message": "invalid format"}
+		]
+	}`)
+
+	item := &queue.WorkItem{
+		ID:     "item-1",
+		Status: queue.ItemStatusCompleted,
+		Result: jsonData,
+	}
+
+	result, err := ParseExecutionResult(item)
+	if err != nil {
+		t.Fatalf("ParseExecutionResult() error = %v", err)
+	}
+
+	if result.Status != StatusPass {
+		t.Errorf("Status = %s, want %s", result.Status, StatusPass)
+	}
+	if result.Duration != 1500*time.Millisecond {
+		t.Errorf("Duration = %v, want 1.5s", result.Duration)
+	}
+	if result.Metrics["tokens"] != 100 {
+		t.Errorf("Metrics[tokens] = %v, want 100", result.Metrics["tokens"])
+	}
+	if result.Metrics["cost"] != 0.05 {
+		t.Errorf("Metrics[cost] = %v, want 0.05", result.Metrics["cost"])
+	}
+	if len(result.Assertions) != 2 {
+		t.Errorf("Assertions count = %d, want 2", len(result.Assertions))
+	}
+	if !result.Assertions[0].Passed {
+		t.Error("First assertion should have passed")
+	}
+	if result.Assertions[1].Passed {
+		t.Error("Second assertion should have failed")
+	}
+}
+
+func TestParseExecutionResult_JSONWithDurationString(t *testing.T) {
+	jsonData := []byte(`{
+		"status": "pass",
+		"duration": "2s"
+	}`)
+
+	item := &queue.WorkItem{
+		ID:     "item-1",
+		Status: queue.ItemStatusCompleted,
+		Result: jsonData,
+	}
+
+	result, err := ParseExecutionResult(item)
+	if err != nil {
+		t.Fatalf("ParseExecutionResult() error = %v", err)
+	}
+
+	if result.Duration != 2*time.Second {
+		t.Errorf("Duration = %v, want 2s", result.Duration)
+	}
+}
+
+func TestParseExecutionResult_InvalidJSON(t *testing.T) {
+	item := &queue.WorkItem{
+		ID:     "item-1",
+		Status: queue.ItemStatusCompleted,
+		Result: []byte("not valid json"),
+	}
+
+	result, err := ParseExecutionResult(item)
+	if err != nil {
+		t.Fatalf("ParseExecutionResult() error = %v", err)
+	}
+
+	// Should still return a result based on item status
+	if result.Status != StatusPass {
+		t.Errorf("Status = %s, want %s", result.Status, StatusPass)
+	}
+}
+
+func TestParseJUnitXML_Empty(t *testing.T) {
+	_, err := ParseJUnitXML(nil)
+	if err != ErrEmptyResult {
+		t.Errorf("ParseJUnitXML(nil) error = %v, want %v", err, ErrEmptyResult)
+	}
+
+	_, err = ParseJUnitXML([]byte{})
+	if err != ErrEmptyResult {
+		t.Errorf("ParseJUnitXML([]) error = %v, want %v", err, ErrEmptyResult)
+	}
+}
+
+func TestParseJUnitXML_SingleSuite(t *testing.T) {
+	xml := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestSuite" tests="3" failures="1" errors="0" skipped="0" time="1.5">
+    <testcase classname="TestClass" name="test1" time="0.5"/>
+    <testcase classname="TestClass" name="test2" time="0.5">
+        <failure message="assertion failed">Expected X, got Y</failure>
+    </testcase>
+    <testcase classname="TestClass" name="test3" time="0.5"/>
+</testsuite>`)
+
+	result, err := ParseJUnitXML(xml)
+	if err != nil {
+		t.Fatalf("ParseJUnitXML() error = %v", err)
+	}
+
+	if result.Status != StatusFail {
+		t.Errorf("Status = %s, want %s", result.Status, StatusFail)
+	}
+	if result.Metrics["tests"] != 3 {
+		t.Errorf("Metrics[tests] = %v, want 3", result.Metrics["tests"])
+	}
+	if result.Metrics["failures"] != 1 {
+		t.Errorf("Metrics[failures] = %v, want 1", result.Metrics["failures"])
+	}
+	if len(result.Assertions) != 3 {
+		t.Errorf("Assertions count = %d, want 3", len(result.Assertions))
+	}
+	if result.Duration != 1500*time.Millisecond {
+		t.Errorf("Duration = %v, want 1.5s", result.Duration)
+	}
+}
+
+func TestParseJUnitXML_TestSuites(t *testing.T) {
+	xml := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+    <testsuite name="Suite1" tests="2" failures="0" errors="0" time="1.0">
+        <testcase classname="Class1" name="test1" time="0.5"/>
+        <testcase classname="Class1" name="test2" time="0.5"/>
+    </testsuite>
+    <testsuite name="Suite2" tests="1" failures="0" errors="0" time="0.5">
+        <testcase classname="Class2" name="test3" time="0.5"/>
+    </testsuite>
+</testsuites>`)
+
+	result, err := ParseJUnitXML(xml)
+	if err != nil {
+		t.Fatalf("ParseJUnitXML() error = %v", err)
+	}
+
+	if result.Status != StatusPass {
+		t.Errorf("Status = %s, want %s", result.Status, StatusPass)
+	}
+	if result.Metrics["tests"] != 3 {
+		t.Errorf("Metrics[tests] = %v, want 3", result.Metrics["tests"])
+	}
+	if len(result.Assertions) != 3 {
+		t.Errorf("Assertions count = %d, want 3", len(result.Assertions))
+	}
+}
+
+func TestParseJUnitXML_WithErrors(t *testing.T) {
+	xml := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="TestSuite" tests="2" failures="0" errors="1" time="1.0">
+    <testcase classname="TestClass" name="test1" time="0.5"/>
+    <testcase classname="TestClass" name="test2" time="0.5">
+        <error message="runtime error" type="Exception">stack trace</error>
+    </testcase>
+</testsuite>`)
+
+	result, err := ParseJUnitXML(xml)
+	if err != nil {
+		t.Fatalf("ParseJUnitXML() error = %v", err)
+	}
+
+	if result.Status != StatusFail {
+		t.Errorf("Status = %s, want %s", result.Status, StatusFail)
+	}
+	if result.Metrics["errors"] != 1 {
+		t.Errorf("Metrics[errors] = %v, want 1", result.Metrics["errors"])
+	}
+
+	// Second assertion should have the error message
+	if result.Assertions[1].Passed {
+		t.Error("Second assertion should have failed")
+	}
+	if result.Assertions[1].Message != "runtime error" {
+		t.Errorf("Assertion message = %s, want 'runtime error'", result.Assertions[1].Message)
+	}
+}
+
+func TestParseJUnitXML_InvalidFormat(t *testing.T) {
+	_, err := ParseJUnitXML([]byte("not xml"))
+	if err != ErrInvalidFormat {
+		t.Errorf("ParseJUnitXML() error = %v, want %v", err, ErrInvalidFormat)
+	}
+
+	// Valid XML but not JUnit format
+	_, err = ParseJUnitXML([]byte("<root><child/></root>"))
+	if err != ErrInvalidFormat {
+		t.Errorf("ParseJUnitXML() error = %v, want %v", err, ErrInvalidFormat)
+	}
+}

--- a/pkg/arena/aggregator/types.go
+++ b/pkg/arena/aggregator/types.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package aggregator provides result aggregation for Arena jobs.
+// It collects results from completed work items, parses various output formats,
+// and produces aggregated metrics and summaries.
+package aggregator
+
+import "time"
+
+// Status constants for execution results.
+const (
+	// StatusPass indicates successful execution.
+	StatusPass = "pass"
+
+	// StatusFail indicates failed execution.
+	StatusFail = "fail"
+
+	// StatusUnknown indicates unknown execution status.
+	StatusUnknown = "unknown"
+)
+
+// ExecutionResult represents the result of executing a single work item.
+type ExecutionResult struct {
+	// WorkItemID is the unique identifier for the work item.
+	WorkItemID string `json:"workItemId"`
+
+	// ScenarioID identifies which scenario was executed.
+	ScenarioID string `json:"scenarioId"`
+
+	// ProviderID identifies which provider was used.
+	ProviderID string `json:"providerId"`
+
+	// Status indicates the execution outcome: "pass" or "fail".
+	Status string `json:"status"`
+
+	// Error contains the error message if execution failed.
+	Error string `json:"error,omitempty"`
+
+	// Duration is the execution time.
+	Duration time.Duration `json:"duration"`
+
+	// Metrics contains additional numeric metrics like latency_ms, tokens, cost.
+	Metrics map[string]float64 `json:"metrics,omitempty"`
+
+	// Assertions contains individual assertion results if applicable.
+	Assertions []AssertionResult `json:"assertions,omitempty"`
+}
+
+// AssertionResult represents the result of a single assertion.
+type AssertionResult struct {
+	// Name is the assertion identifier or description.
+	Name string `json:"name"`
+
+	// Passed indicates whether the assertion passed.
+	Passed bool `json:"passed"`
+
+	// Message contains additional details about the assertion result.
+	Message string `json:"message,omitempty"`
+}
+
+// ScenarioStats contains aggregated statistics for a single scenario.
+type ScenarioStats struct {
+	// Total is the total number of executions for this scenario.
+	Total int `json:"total"`
+
+	// Passed is the number of successful executions.
+	Passed int `json:"passed"`
+
+	// Failed is the number of failed executions.
+	Failed int `json:"failed"`
+
+	// PassRate is the success rate as a percentage (0-100).
+	PassRate float64 `json:"passRate"`
+
+	// TotalDuration is the sum of all execution durations.
+	TotalDuration time.Duration `json:"totalDuration"`
+
+	// AvgDuration is the average execution duration.
+	AvgDuration time.Duration `json:"avgDuration"`
+
+	// TotalTokens is the total token count if available.
+	TotalTokens int64 `json:"totalTokens,omitempty"`
+
+	// TotalCost is the total cost if available.
+	TotalCost float64 `json:"totalCost,omitempty"`
+}
+
+// ProviderStats contains aggregated statistics for a single provider.
+type ProviderStats struct {
+	// Total is the total number of executions for this provider.
+	Total int `json:"total"`
+
+	// Passed is the number of successful executions.
+	Passed int `json:"passed"`
+
+	// Failed is the number of failed executions.
+	Failed int `json:"failed"`
+
+	// PassRate is the success rate as a percentage (0-100).
+	PassRate float64 `json:"passRate"`
+
+	// TotalDuration is the sum of all execution durations.
+	TotalDuration time.Duration `json:"totalDuration"`
+
+	// AvgDuration is the average execution duration.
+	AvgDuration time.Duration `json:"avgDuration"`
+
+	// TotalTokens is the total token count if available.
+	TotalTokens int64 `json:"totalTokens,omitempty"`
+
+	// TotalCost is the total cost if available.
+	TotalCost float64 `json:"totalCost,omitempty"`
+}
+
+// ErrorSummary groups errors by message for reporting.
+type ErrorSummary struct {
+	// Message is the error message.
+	Message string `json:"message"`
+
+	// Count is the number of times this error occurred.
+	Count int `json:"count"`
+
+	// WorkItemIDs contains the IDs of work items that had this error.
+	WorkItemIDs []string `json:"workItemIds,omitempty"`
+}
+
+// AggregatedResult contains summary metrics for a completed job.
+type AggregatedResult struct {
+	// TotalItems is the total number of work items processed.
+	TotalItems int `json:"totalItems"`
+
+	// PassedItems is the number of items that passed.
+	PassedItems int `json:"passedItems"`
+
+	// FailedItems is the number of items that failed.
+	FailedItems int `json:"failedItems"`
+
+	// PassRate is the success rate as a percentage (0-100).
+	PassRate float64 `json:"passRate"`
+
+	// TotalDuration is the sum of all execution durations.
+	TotalDuration time.Duration `json:"totalDuration"`
+
+	// AvgDuration is the average execution duration.
+	AvgDuration time.Duration `json:"avgDuration"`
+
+	// TotalTokens is the total token count across all executions.
+	TotalTokens int64 `json:"totalTokens,omitempty"`
+
+	// TotalCost is the total cost across all executions.
+	TotalCost float64 `json:"totalCost,omitempty"`
+
+	// ByScenario contains per-scenario statistics.
+	ByScenario map[string]*ScenarioStats `json:"byScenario,omitempty"`
+
+	// ByProvider contains per-provider statistics.
+	ByProvider map[string]*ProviderStats `json:"byProvider,omitempty"`
+
+	// Errors contains grouped error summaries.
+	Errors []ErrorSummary `json:"errors,omitempty"`
+}

--- a/pkg/arena/queue/instrumented.go
+++ b/pkg/arena/queue/instrumented.go
@@ -127,5 +127,17 @@ func (q *InstrumentedQueue) Close() error {
 	return q.queue.Close()
 }
 
+// GetCompletedItems returns all completed work items for a job.
+// This is a read-only operation and does not record operation metrics.
+func (q *InstrumentedQueue) GetCompletedItems(ctx context.Context, jobID string) ([]*WorkItem, error) {
+	return q.queue.GetCompletedItems(ctx, jobID)
+}
+
+// GetFailedItems returns all failed work items for a job.
+// This is a read-only operation and does not record operation metrics.
+func (q *InstrumentedQueue) GetFailedItems(ctx context.Context, jobID string) ([]*WorkItem, error) {
+	return q.queue.GetFailedItems(ctx, jobID)
+}
+
 // Ensure InstrumentedQueue implements WorkQueue interface.
 var _ WorkQueue = (*InstrumentedQueue)(nil)

--- a/pkg/arena/queue/queue.go
+++ b/pkg/arena/queue/queue.go
@@ -167,6 +167,14 @@ type WorkQueue interface {
 	// Returns ErrJobNotFound if the job doesn't exist.
 	Progress(ctx context.Context, jobID string) (*JobProgress, error)
 
+	// GetCompletedItems returns all completed work items for a job.
+	// Returns ErrJobNotFound if the job doesn't exist.
+	GetCompletedItems(ctx context.Context, jobID string) ([]*WorkItem, error)
+
+	// GetFailedItems returns all failed work items for a job.
+	// Returns ErrJobNotFound if the job doesn't exist.
+	GetFailedItems(ctx context.Context, jobID string) ([]*WorkItem, error)
+
 	// Close releases any resources held by the queue.
 	// After Close is called, all other methods will return ErrQueueClosed.
 	Close() error

--- a/pkg/arena/queue/queue_test.go
+++ b/pkg/arena/queue/queue_test.go
@@ -252,6 +252,20 @@ func (m *mockQueue) Close() error {
 	return nil
 }
 
+func (m *mockQueue) GetCompletedItems(_ context.Context, _ string) ([]*WorkItem, error) {
+	if m.closed {
+		return nil, ErrQueueClosed
+	}
+	return nil, ErrJobNotFound
+}
+
+func (m *mockQueue) GetFailedItems(_ context.Context, _ string) ([]*WorkItem, error) {
+	if m.closed {
+		return nil, ErrQueueClosed
+	}
+	return nil, ErrJobNotFound
+}
+
 // Compile-time check that mockQueue implements WorkQueue.
 var _ WorkQueue = (*mockQueue)(nil)
 


### PR DESCRIPTION
## Summary

- Extend WorkQueue interface with `GetCompletedItems` and `GetFailedItems` methods
- Implement new methods in MemoryQueue, RedisQueue, and InstrumentedQueue
- Create aggregator package with result types, parsing utilities, and aggregation logic
- Integrate aggregator with ArenaJob controller to populate `Status.Result` on job completion
- Add status constants (`StatusPass`, `StatusFail`, `StatusUnknown`) for consistent result handling

## Test plan

- [x] Unit tests for aggregator package (93.6% coverage)
- [x] Unit tests for parser functions (87% coverage)
- [x] Unit tests for memory queue methods (99.4% coverage)
- [x] Integration tests for Redis queue methods (85.1% coverage)
- [x] Controller integration tests for aggregator
- [x] All pre-commit checks passing