### PR TITLE
feat(arena): add ResultStorage interface for job results

### DIFF
--- a/pkg/arena/storage/memory.go
+++ b/pkg/arena/storage/memory.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/altairalabs/omnia/pkg/arena/aggregator"
+)
+
+// MemoryStorage implements ResultStorage using in-memory data structures.
+// It is suitable for development, testing, and single-node deployments.
+// Data is not persisted and will be lost when the process exits.
+type MemoryStorage struct {
+	mu      sync.RWMutex
+	closed  bool
+	results map[string]*storedResult
+}
+
+// storedResult wraps JobResults with storage metadata.
+type storedResult struct {
+	data      *JobResults
+	sizeBytes int64
+}
+
+// NewMemoryStorage creates a new in-memory result storage.
+func NewMemoryStorage() *MemoryStorage {
+	return &MemoryStorage{
+		results: make(map[string]*storedResult),
+	}
+}
+
+// Store persists job results to memory.
+func (s *MemoryStorage) Store(ctx context.Context, jobID string, results *JobResults) error {
+	if jobID == "" {
+		return ErrInvalidJobID
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return ErrStorageClosed
+	}
+
+	// Calculate approximate size by serializing to JSON
+	data, err := json.Marshal(results)
+	if err != nil {
+		return err
+	}
+
+	// Store a copy to prevent external modification
+	resultsCopy := *results
+	if results.Summary != nil {
+		summaryCopy := *results.Summary
+		resultsCopy.Summary = &summaryCopy
+	}
+	if results.Results != nil {
+		resultsCopy.Results = make([]aggregator.ExecutionResult, len(results.Results))
+		copy(resultsCopy.Results, results.Results)
+	}
+	if results.Metadata != nil {
+		resultsCopy.Metadata = make(map[string]string)
+		for k, v := range results.Metadata {
+			resultsCopy.Metadata[k] = v
+		}
+	}
+
+	s.results[jobID] = &storedResult{
+		data:      &resultsCopy,
+		sizeBytes: int64(len(data)),
+	}
+
+	return nil
+}
+
+// Get retrieves job results from memory.
+func (s *MemoryStorage) Get(ctx context.Context, jobID string) (*JobResults, error) {
+	if jobID == "" {
+		return nil, ErrInvalidJobID
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, ErrStorageClosed
+	}
+
+	stored, exists := s.results[jobID]
+	if !exists {
+		return nil, ErrResultNotFound
+	}
+
+	// Return a copy to prevent external modification
+	resultsCopy := *stored.data
+	if stored.data.Summary != nil {
+		summaryCopy := *stored.data.Summary
+		resultsCopy.Summary = &summaryCopy
+	}
+	if stored.data.Results != nil {
+		resultsCopy.Results = make([]aggregator.ExecutionResult, len(stored.data.Results))
+		copy(resultsCopy.Results, stored.data.Results)
+	}
+	if stored.data.Metadata != nil {
+		resultsCopy.Metadata = make(map[string]string)
+		for k, v := range stored.data.Metadata {
+			resultsCopy.Metadata[k] = v
+		}
+	}
+
+	return &resultsCopy, nil
+}
+
+// List returns job IDs that match the given prefix.
+func (s *MemoryStorage) List(ctx context.Context, prefix string) ([]string, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, ErrStorageClosed
+	}
+
+	var jobIDs []string
+	for jobID := range s.results {
+		if prefix == "" || strings.HasPrefix(jobID, prefix) {
+			jobIDs = append(jobIDs, jobID)
+		}
+	}
+
+	sort.Strings(jobIDs)
+	return jobIDs, nil
+}
+
+// Delete removes job results from memory.
+func (s *MemoryStorage) Delete(ctx context.Context, jobID string) error {
+	if jobID == "" {
+		return ErrInvalidJobID
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return ErrStorageClosed
+	}
+
+	if _, exists := s.results[jobID]; !exists {
+		return ErrResultNotFound
+	}
+
+	delete(s.results, jobID)
+	return nil
+}
+
+// Close releases resources and marks the storage as closed.
+func (s *MemoryStorage) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.closed = true
+	s.results = nil
+	return nil
+}
+
+// ListWithInfo returns result metadata for jobs matching the prefix.
+func (s *MemoryStorage) ListWithInfo(ctx context.Context, prefix string) ([]ResultInfo, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if s.closed {
+		return nil, ErrStorageClosed
+	}
+
+	var infos []ResultInfo
+	for jobID, stored := range s.results {
+		if prefix == "" || strings.HasPrefix(jobID, prefix) {
+			info := ResultInfo{
+				JobID:       jobID,
+				Namespace:   stored.data.Namespace,
+				CompletedAt: stored.data.CompletedAt,
+				SizeBytes:   stored.sizeBytes,
+			}
+			if stored.data.Summary != nil {
+				info.TotalItems = stored.data.Summary.TotalItems
+				info.PassedItems = stored.data.Summary.PassedItems
+				info.FailedItems = stored.data.Summary.FailedItems
+			}
+			infos = append(infos, info)
+		}
+	}
+
+	// Sort by job ID for consistent ordering
+	sort.Slice(infos, func(i, j int) bool {
+		return infos[i].JobID < infos[j].JobID
+	})
+
+	return infos, nil
+}
+
+// Ensure MemoryStorage implements both interfaces.
+var (
+	_ ResultStorage         = (*MemoryStorage)(nil)
+	_ ListableResultStorage = (*MemoryStorage)(nil)
+)

--- a/pkg/arena/storage/storage.go
+++ b/pkg/arena/storage/storage.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package storage provides interfaces and implementations for storing
+// Arena job results. It supports multiple backends including local filesystem
+// (PVC) and S3-compatible object storage.
+package storage
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/altairalabs/omnia/pkg/arena/aggregator"
+)
+
+// Common errors returned by storage implementations.
+var (
+	// ErrResultNotFound is returned when job results do not exist.
+	ErrResultNotFound = errors.New("result not found")
+
+	// ErrStorageClosed is returned when operations are attempted on a closed storage.
+	ErrStorageClosed = errors.New("storage closed")
+
+	// ErrInvalidJobID is returned when a job ID is empty or malformed.
+	ErrInvalidJobID = errors.New("invalid job ID")
+)
+
+// JobResults contains the complete results for an Arena job.
+type JobResults struct {
+	// JobID is the unique identifier for the job.
+	JobID string `json:"jobId"`
+
+	// Namespace is the Kubernetes namespace of the job.
+	Namespace string `json:"namespace,omitempty"`
+
+	// ConfigName is the name of the ArenaConfig used.
+	ConfigName string `json:"configName,omitempty"`
+
+	// StartedAt is when the job started executing.
+	StartedAt time.Time `json:"startedAt"`
+
+	// CompletedAt is when the job finished.
+	CompletedAt time.Time `json:"completedAt"`
+
+	// Summary contains aggregated metrics for the job.
+	Summary *aggregator.AggregatedResult `json:"summary"`
+
+	// Results contains individual execution results for each work item.
+	Results []aggregator.ExecutionResult `json:"results,omitempty"`
+
+	// Metadata contains additional key-value pairs.
+	Metadata map[string]string `json:"metadata,omitempty"`
+}
+
+// ResultStorage defines the interface for storing Arena job results.
+// Implementations must be safe for concurrent use.
+type ResultStorage interface {
+	// Store persists job results to storage.
+	// If results for the job already exist, they are overwritten.
+	// Returns ErrInvalidJobID if jobID is empty.
+	Store(ctx context.Context, jobID string, results *JobResults) error
+
+	// Get retrieves job results from storage.
+	// Returns ErrResultNotFound if no results exist for the job.
+	// Returns ErrInvalidJobID if jobID is empty.
+	Get(ctx context.Context, jobID string) (*JobResults, error)
+
+	// List returns job IDs that match the given prefix.
+	// If prefix is empty, all job IDs are returned.
+	// Results are returned in lexicographic order.
+	List(ctx context.Context, prefix string) ([]string, error)
+
+	// Delete removes job results from storage.
+	// Returns ErrResultNotFound if no results exist for the job.
+	// Returns ErrInvalidJobID if jobID is empty.
+	Delete(ctx context.Context, jobID string) error
+
+	// Close releases any resources held by the storage.
+	// After Close is called, all other methods return ErrStorageClosed.
+	Close() error
+}
+
+// ResultInfo contains metadata about stored results without the full result data.
+type ResultInfo struct {
+	// JobID is the unique identifier for the job.
+	JobID string `json:"jobId"`
+
+	// Namespace is the Kubernetes namespace of the job.
+	Namespace string `json:"namespace,omitempty"`
+
+	// CompletedAt is when the job finished.
+	CompletedAt time.Time `json:"completedAt"`
+
+	// TotalItems is the total number of work items.
+	TotalItems int `json:"totalItems"`
+
+	// PassedItems is the number of items that passed.
+	PassedItems int `json:"passedItems"`
+
+	// FailedItems is the number of items that failed.
+	FailedItems int `json:"failedItems"`
+
+	// SizeBytes is the size of the stored result data.
+	SizeBytes int64 `json:"sizeBytes,omitempty"`
+}
+
+// ListableResultStorage extends ResultStorage with the ability to list
+// results with metadata without loading full result data.
+type ListableResultStorage interface {
+	ResultStorage
+
+	// ListWithInfo returns result metadata for jobs matching the prefix.
+	// This is more efficient than calling Get for each job when only
+	// summary information is needed.
+	ListWithInfo(ctx context.Context, prefix string) ([]ResultInfo, error)
+}

--- a/pkg/arena/storage/storage_test.go
+++ b/pkg/arena/storage/storage_test.go
@@ -1,0 +1,345 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/omnia/pkg/arena/aggregator"
+)
+
+const testModified = "modified"
+
+func TestMemoryStorage_Store(t *testing.T) {
+	s := NewMemoryStorage()
+	defer func() { _ = s.Close() }()
+
+	results := &JobResults{
+		JobID:       "test-job-1",
+		Namespace:   "default",
+		ConfigName:  "test-config",
+		StartedAt:   time.Now().Add(-time.Minute),
+		CompletedAt: time.Now(),
+		Summary: &aggregator.AggregatedResult{
+			TotalItems:  10,
+			PassedItems: 8,
+			FailedItems: 2,
+			PassRate:    80.0,
+		},
+		Results: []aggregator.ExecutionResult{
+			{WorkItemID: "item-1", Status: "pass"},
+			{WorkItemID: "item-2", Status: "fail"},
+		},
+		Metadata: map[string]string{
+			"version": "1.0",
+		},
+	}
+
+	t.Run("stores results successfully", func(t *testing.T) {
+		err := s.Store(context.Background(), "test-job-1", results)
+		if err != nil {
+			t.Errorf("Store() error = %v", err)
+		}
+	})
+
+	t.Run("returns error for empty jobID", func(t *testing.T) {
+		err := s.Store(context.Background(), "", results)
+		if err != ErrInvalidJobID {
+			t.Errorf("Store() error = %v, want %v", err, ErrInvalidJobID)
+		}
+	})
+
+	t.Run("overwrites existing results", func(t *testing.T) {
+		newResults := &JobResults{
+			JobID:     "test-job-1",
+			Namespace: "updated",
+			Summary: &aggregator.AggregatedResult{
+				TotalItems:  20,
+				PassedItems: 20,
+				PassRate:    100.0,
+			},
+		}
+		err := s.Store(context.Background(), "test-job-1", newResults)
+		if err != nil {
+			t.Errorf("Store() error = %v", err)
+		}
+
+		got, err := s.Get(context.Background(), "test-job-1")
+		if err != nil {
+			t.Errorf("Get() error = %v", err)
+		}
+		if got.Namespace != "updated" {
+			t.Errorf("Namespace = %v, want updated", got.Namespace)
+		}
+		if got.Summary.TotalItems != 20 {
+			t.Errorf("TotalItems = %v, want 20", got.Summary.TotalItems)
+		}
+	})
+}
+
+func TestMemoryStorage_Get(t *testing.T) {
+	s := NewMemoryStorage()
+	defer func() { _ = s.Close() }()
+
+	results := &JobResults{
+		JobID:     "test-job-1",
+		Namespace: "default",
+		Summary: &aggregator.AggregatedResult{
+			TotalItems: 10,
+		},
+		Results: []aggregator.ExecutionResult{
+			{WorkItemID: "item-1"},
+		},
+		Metadata: map[string]string{
+			"key": "value",
+		},
+	}
+	_ = s.Store(context.Background(), "test-job-1", results)
+
+	t.Run("retrieves stored results", func(t *testing.T) {
+		got, err := s.Get(context.Background(), "test-job-1")
+		if err != nil {
+			t.Errorf("Get() error = %v", err)
+		}
+		if got.JobID != "test-job-1" {
+			t.Errorf("JobID = %v, want test-job-1", got.JobID)
+		}
+		if got.Summary.TotalItems != 10 {
+			t.Errorf("TotalItems = %v, want 10", got.Summary.TotalItems)
+		}
+	})
+
+	t.Run("returns copy not reference", func(t *testing.T) {
+		got, _ := s.Get(context.Background(), "test-job-1")
+		got.Namespace = testModified
+		got.Summary.TotalItems = 999
+		got.Results[0].WorkItemID = testModified
+		got.Metadata["key"] = testModified
+
+		original, _ := s.Get(context.Background(), "test-job-1")
+		if original.Namespace == testModified {
+			t.Error("Get() returned reference instead of copy")
+		}
+		if original.Summary.TotalItems == 999 {
+			t.Error("Get() returned reference to Summary")
+		}
+		if original.Results[0].WorkItemID == testModified {
+			t.Error("Get() returned reference to Results")
+		}
+		if original.Metadata["key"] == testModified {
+			t.Error("Get() returned reference to Metadata")
+		}
+	})
+
+	t.Run("returns error for non-existent job", func(t *testing.T) {
+		_, err := s.Get(context.Background(), "non-existent")
+		if err != ErrResultNotFound {
+			t.Errorf("Get() error = %v, want %v", err, ErrResultNotFound)
+		}
+	})
+
+	t.Run("returns error for empty jobID", func(t *testing.T) {
+		_, err := s.Get(context.Background(), "")
+		if err != ErrInvalidJobID {
+			t.Errorf("Get() error = %v, want %v", err, ErrInvalidJobID)
+		}
+	})
+}
+
+func TestMemoryStorage_List(t *testing.T) {
+	s := NewMemoryStorage()
+	defer func() { _ = s.Close() }()
+
+	// Store multiple results
+	for _, jobID := range []string{"job-a-1", "job-a-2", "job-b-1", "job-c-1"} {
+		_ = s.Store(context.Background(), jobID, &JobResults{JobID: jobID})
+	}
+
+	t.Run("lists all jobs with empty prefix", func(t *testing.T) {
+		jobs, err := s.List(context.Background(), "")
+		if err != nil {
+			t.Errorf("List() error = %v", err)
+		}
+		if len(jobs) != 4 {
+			t.Errorf("List() returned %d jobs, want 4", len(jobs))
+		}
+	})
+
+	t.Run("lists jobs with prefix", func(t *testing.T) {
+		jobs, err := s.List(context.Background(), "job-a")
+		if err != nil {
+			t.Errorf("List() error = %v", err)
+		}
+		if len(jobs) != 2 {
+			t.Errorf("List() returned %d jobs, want 2", len(jobs))
+		}
+	})
+
+	t.Run("returns sorted results", func(t *testing.T) {
+		jobs, _ := s.List(context.Background(), "")
+		for i := 1; i < len(jobs); i++ {
+			if jobs[i-1] > jobs[i] {
+				t.Errorf("List() not sorted: %v > %v", jobs[i-1], jobs[i])
+			}
+		}
+	})
+
+	t.Run("returns empty slice for no matches", func(t *testing.T) {
+		jobs, err := s.List(context.Background(), "no-match")
+		if err != nil {
+			t.Errorf("List() error = %v", err)
+		}
+		if len(jobs) != 0 {
+			t.Errorf("List() returned %d jobs, want 0", len(jobs))
+		}
+	})
+}
+
+func TestMemoryStorage_Delete(t *testing.T) {
+	s := NewMemoryStorage()
+	defer func() { _ = s.Close() }()
+
+	_ = s.Store(context.Background(), "test-job-1", &JobResults{JobID: "test-job-1"})
+
+	t.Run("deletes existing results", func(t *testing.T) {
+		err := s.Delete(context.Background(), "test-job-1")
+		if err != nil {
+			t.Errorf("Delete() error = %v", err)
+		}
+
+		_, err = s.Get(context.Background(), "test-job-1")
+		if err != ErrResultNotFound {
+			t.Errorf("Get() after Delete() error = %v, want %v", err, ErrResultNotFound)
+		}
+	})
+
+	t.Run("returns error for non-existent job", func(t *testing.T) {
+		err := s.Delete(context.Background(), "non-existent")
+		if err != ErrResultNotFound {
+			t.Errorf("Delete() error = %v, want %v", err, ErrResultNotFound)
+		}
+	})
+
+	t.Run("returns error for empty jobID", func(t *testing.T) {
+		err := s.Delete(context.Background(), "")
+		if err != ErrInvalidJobID {
+			t.Errorf("Delete() error = %v, want %v", err, ErrInvalidJobID)
+		}
+	})
+}
+
+func TestMemoryStorage_Close(t *testing.T) {
+	s := NewMemoryStorage()
+	_ = s.Store(context.Background(), "test-job-1", &JobResults{JobID: "test-job-1"})
+
+	err := s.Close()
+	if err != nil {
+		t.Errorf("Close() error = %v", err)
+	}
+
+	t.Run("Store returns error after close", func(t *testing.T) {
+		err := s.Store(context.Background(), "test", &JobResults{})
+		if err != ErrStorageClosed {
+			t.Errorf("Store() error = %v, want %v", err, ErrStorageClosed)
+		}
+	})
+
+	t.Run("Get returns error after close", func(t *testing.T) {
+		_, err := s.Get(context.Background(), "test-job-1")
+		if err != ErrStorageClosed {
+			t.Errorf("Get() error = %v, want %v", err, ErrStorageClosed)
+		}
+	})
+
+	t.Run("List returns error after close", func(t *testing.T) {
+		_, err := s.List(context.Background(), "")
+		if err != ErrStorageClosed {
+			t.Errorf("List() error = %v, want %v", err, ErrStorageClosed)
+		}
+	})
+
+	t.Run("Delete returns error after close", func(t *testing.T) {
+		err := s.Delete(context.Background(), "test-job-1")
+		if err != ErrStorageClosed {
+			t.Errorf("Delete() error = %v, want %v", err, ErrStorageClosed)
+		}
+	})
+}
+
+func TestMemoryStorage_ListWithInfo(t *testing.T) {
+	s := NewMemoryStorage()
+	defer func() { _ = s.Close() }()
+
+	now := time.Now()
+	results := []*JobResults{
+		{
+			JobID:       "job-1",
+			Namespace:   "ns-1",
+			CompletedAt: now,
+			Summary: &aggregator.AggregatedResult{
+				TotalItems:  10,
+				PassedItems: 8,
+				FailedItems: 2,
+			},
+		},
+		{
+			JobID:       "job-2",
+			Namespace:   "ns-2",
+			CompletedAt: now.Add(-time.Hour),
+			Summary: &aggregator.AggregatedResult{
+				TotalItems:  5,
+				PassedItems: 5,
+				FailedItems: 0,
+			},
+		},
+	}
+	for _, r := range results {
+		_ = s.Store(context.Background(), r.JobID, r)
+	}
+
+	t.Run("lists with metadata", func(t *testing.T) {
+		infos, err := s.ListWithInfo(context.Background(), "")
+		if err != nil {
+			t.Errorf("ListWithInfo() error = %v", err)
+		}
+		if len(infos) != 2 {
+			t.Errorf("ListWithInfo() returned %d infos, want 2", len(infos))
+		}
+
+		// Check first result (sorted by job ID, so job-1 first)
+		if infos[0].JobID != "job-1" {
+			t.Errorf("infos[0].JobID = %v, want job-1", infos[0].JobID)
+		}
+		if infos[0].TotalItems != 10 {
+			t.Errorf("infos[0].TotalItems = %v, want 10", infos[0].TotalItems)
+		}
+		if infos[0].PassedItems != 8 {
+			t.Errorf("infos[0].PassedItems = %v, want 8", infos[0].PassedItems)
+		}
+	})
+
+	t.Run("includes size information", func(t *testing.T) {
+		infos, _ := s.ListWithInfo(context.Background(), "")
+		for _, info := range infos {
+			if info.SizeBytes <= 0 {
+				t.Errorf("info.SizeBytes = %v, want > 0", info.SizeBytes)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Add `ResultStorage` interface for storing Arena job results
- Add `ListableResultStorage` extended interface for efficient metadata listings
- Add `JobResults` type containing aggregated results and metadata
- Add `MemoryStorage` in-memory implementation for testing/development

## Test plan
- [x] Unit tests for all MemoryStorage methods
- [x] Tests for error conditions (invalid jobID, not found, closed)
- [x] Tests for copy semantics (Store/Get return copies, not references)
- [x] Coverage: 97.6%

Closes #206