### PR TITLE
feat(dashboard): add workspace ServiceAccount token management (#277)

### DIFF
--- a/dashboard/src/lib/k8s/token-cache.test.ts
+++ b/dashboard/src/lib/k8s/token-cache.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  getCachedToken,
+  setCachedToken,
+  invalidateWorkspaceTokens,
+  invalidateToken,
+  clearTokenCache,
+  getTokenCacheStats,
+  pruneExpiredTokens,
+} from "./token-cache";
+
+describe("token-cache", () => {
+  const mockToken = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.test-token";
+
+  beforeEach(() => {
+    clearTokenCache();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("getCachedToken", () => {
+    it("should return null for uncached entries", () => {
+      const result = getCachedToken("my-workspace", "editor");
+      expect(result).toBeNull();
+    });
+
+    it("should return cached token after set", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000; // 1 hour
+      setCachedToken("my-workspace", "editor", mockToken, expiresAt);
+
+      const result = getCachedToken("my-workspace", "editor");
+      expect(result).toBe(mockToken);
+    });
+
+    it("should return null for expired entries", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000; // 1 hour
+      setCachedToken("my-workspace", "editor", mockToken, expiresAt);
+
+      // Advance time past expiry
+      vi.advanceTimersByTime(60 * 60 * 1000 + 1000);
+
+      const result = getCachedToken("my-workspace", "editor");
+      expect(result).toBeNull();
+    });
+
+    it("should return null for entries expiring within safety margin", () => {
+      const expiresAt = Date.now() + 4 * 60 * 1000; // 4 minutes (within 5 min margin)
+      setCachedToken("my-workspace", "editor", mockToken, expiresAt);
+
+      const result = getCachedToken("my-workspace", "editor");
+      expect(result).toBeNull();
+    });
+
+    it("should return valid entry just outside safety margin", () => {
+      const expiresAt = Date.now() + 6 * 60 * 1000; // 6 minutes (outside 5 min margin)
+      setCachedToken("my-workspace", "editor", mockToken, expiresAt);
+
+      const result = getCachedToken("my-workspace", "editor");
+      expect(result).toBe(mockToken);
+    });
+
+    it("should use default TTL when expiresAt not provided", () => {
+      setCachedToken("my-workspace", "editor", mockToken);
+
+      // Should be valid immediately
+      expect(getCachedToken("my-workspace", "editor")).toBe(mockToken);
+
+      // Advance time to 40 minutes (should still be valid with 50 min TTL - 5 min margin = 45 min effective)
+      vi.advanceTimersByTime(40 * 60 * 1000);
+      expect(getCachedToken("my-workspace", "editor")).toBe(mockToken);
+
+      // Advance another 6 minutes (now at 46 min, past 45 min effective TTL)
+      vi.advanceTimersByTime(6 * 60 * 1000);
+      expect(getCachedToken("my-workspace", "editor")).toBeNull();
+    });
+  });
+
+  describe("setCachedToken", () => {
+    it("should store tokens by workspace and role", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+
+      setCachedToken("workspace-a", "owner", "token-a-owner", expiresAt);
+      setCachedToken("workspace-a", "editor", "token-a-editor", expiresAt);
+      setCachedToken("workspace-b", "viewer", "token-b-viewer", expiresAt);
+
+      expect(getCachedToken("workspace-a", "owner")).toBe("token-a-owner");
+      expect(getCachedToken("workspace-a", "editor")).toBe("token-a-editor");
+      expect(getCachedToken("workspace-b", "viewer")).toBe("token-b-viewer");
+    });
+
+    it("should update existing entry", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+
+      setCachedToken("my-workspace", "editor", "old-token", expiresAt);
+      setCachedToken("my-workspace", "editor", "new-token", expiresAt);
+
+      const result = getCachedToken("my-workspace", "editor");
+      expect(result).toBe("new-token");
+    });
+
+    it("should evict oldest entries when at capacity", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+
+      // Fill cache to capacity (100 entries)
+      for (let i = 0; i < 100; i++) {
+        setCachedToken(`workspace-${i}`, "editor", `token-${i}`, expiresAt);
+      }
+
+      // Verify first entry exists
+      expect(getCachedToken("workspace-0", "editor")).toBe("token-0");
+
+      // Add one more entry
+      setCachedToken("workspace-new", "editor", "new-token", expiresAt);
+
+      // First entry should be evicted (but we accessed it above so it moved to end)
+      // The second entry (workspace-1) should be evicted instead
+      expect(getCachedToken("workspace-1", "editor")).toBeNull();
+
+      // New entry should exist
+      expect(getCachedToken("workspace-new", "editor")).toBe("new-token");
+    });
+  });
+
+  describe("invalidateWorkspaceTokens", () => {
+    it("should remove all tokens for a workspace", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+
+      setCachedToken("my-workspace", "owner", "token-owner", expiresAt);
+      setCachedToken("my-workspace", "editor", "token-editor", expiresAt);
+      setCachedToken("my-workspace", "viewer", "token-viewer", expiresAt);
+      setCachedToken("other-workspace", "editor", "other-token", expiresAt);
+
+      invalidateWorkspaceTokens("my-workspace");
+
+      expect(getCachedToken("my-workspace", "owner")).toBeNull();
+      expect(getCachedToken("my-workspace", "editor")).toBeNull();
+      expect(getCachedToken("my-workspace", "viewer")).toBeNull();
+      expect(getCachedToken("other-workspace", "editor")).toBe("other-token");
+    });
+  });
+
+  describe("invalidateToken", () => {
+    it("should remove specific token", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+
+      setCachedToken("my-workspace", "owner", "token-owner", expiresAt);
+      setCachedToken("my-workspace", "editor", "token-editor", expiresAt);
+
+      invalidateToken("my-workspace", "editor");
+
+      expect(getCachedToken("my-workspace", "owner")).toBe("token-owner");
+      expect(getCachedToken("my-workspace", "editor")).toBeNull();
+    });
+  });
+
+  describe("clearTokenCache", () => {
+    it("should remove all entries", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+
+      setCachedToken("workspace-a", "editor", "token-a", expiresAt);
+      setCachedToken("workspace-b", "editor", "token-b", expiresAt);
+
+      clearTokenCache();
+
+      expect(getCachedToken("workspace-a", "editor")).toBeNull();
+      expect(getCachedToken("workspace-b", "editor")).toBeNull();
+      expect(getTokenCacheStats().size).toBe(0);
+    });
+  });
+
+  describe("getTokenCacheStats", () => {
+    it("should return correct stats", () => {
+      const expiresAt = Date.now() + 60 * 60 * 1000;
+
+      setCachedToken("workspace-a", "editor", "token-a", expiresAt);
+      setCachedToken("workspace-b", "editor", "token-b", expiresAt);
+
+      const stats = getTokenCacheStats();
+
+      expect(stats.size).toBe(2);
+      expect(stats.maxSize).toBe(100);
+      expect(stats.defaultTtlMs).toBe(50 * 60 * 1000);
+    });
+  });
+
+  describe("pruneExpiredTokens", () => {
+    it("should remove expired entries", () => {
+      const shortExpiry = Date.now() + 10 * 60 * 1000; // 10 minutes
+      const longExpiry = Date.now() + 60 * 60 * 1000; // 1 hour
+
+      setCachedToken("workspace-short", "editor", "short-token", shortExpiry);
+      setCachedToken("workspace-long", "editor", "long-token", longExpiry);
+
+      // Advance time past short expiry but not long expiry
+      vi.advanceTimersByTime(15 * 60 * 1000);
+
+      const removed = pruneExpiredTokens();
+
+      expect(removed).toBe(1);
+      expect(getCachedToken("workspace-short", "editor")).toBeNull();
+      expect(getCachedToken("workspace-long", "editor")).toBe("long-token");
+    });
+  });
+});

--- a/dashboard/src/lib/k8s/token-cache.ts
+++ b/dashboard/src/lib/k8s/token-cache.ts
@@ -1,0 +1,191 @@
+/**
+ * LRU cache for workspace ServiceAccount tokens.
+ *
+ * Caches SA tokens to avoid repeated TokenRequest API calls.
+ * Uses a simple LRU eviction strategy with TTL-based expiration.
+ *
+ * Tokens are cached with a 50-minute TTL (before 1hr token expiry)
+ * to ensure they're refreshed before expiration.
+ */
+
+import type { WorkspaceRole } from "@/types/workspace";
+
+/** Cache entry with expiration timestamp */
+interface TokenCacheEntry {
+  token: string;
+  expiresAt: number;
+}
+
+/** Time-to-live for cache entries (50 minutes - before 1hr token expiry) */
+const DEFAULT_TTL_MS = 50 * 60 * 1000;
+
+/** Maximum number of entries before LRU eviction */
+const MAX_ENTRIES = 100;
+
+/** Safety margin before token expiry (5 minutes) */
+const EXPIRY_MARGIN_MS = 5 * 60 * 1000;
+
+/**
+ * The token cache.
+ * Uses a Map which maintains insertion order for LRU eviction.
+ * Key format: "workspace:role"
+ */
+const cache = new Map<string, TokenCacheEntry>();
+
+/**
+ * Generate a cache key from workspace name and role.
+ */
+function getCacheKey(workspace: string, role: WorkspaceRole): string {
+  return `${workspace}:${role}`;
+}
+
+/**
+ * Check if a cache entry has expired or is about to expire.
+ * We consider a token expired if it will expire within the safety margin.
+ */
+function isExpiredOrExpiring(entry: TokenCacheEntry): boolean {
+  return Date.now() + EXPIRY_MARGIN_MS >= entry.expiresAt;
+}
+
+/**
+ * Get cached token if available and not expired/expiring.
+ *
+ * @param workspace - Workspace name
+ * @param role - Workspace role (owner, editor, viewer)
+ * @returns Cached token or null if not cached/expired
+ */
+export function getCachedToken(
+  workspace: string,
+  role: WorkspaceRole
+): string | null {
+  const key = getCacheKey(workspace, role);
+  const entry = cache.get(key);
+
+  if (!entry) {
+    return null;
+  }
+
+  if (isExpiredOrExpiring(entry)) {
+    // Remove expired/expiring entry
+    cache.delete(key);
+    return null;
+  }
+
+  // Move to end for LRU (delete and re-add)
+  cache.delete(key);
+  cache.set(key, entry);
+
+  return entry.token;
+}
+
+/**
+ * Store a token in the cache.
+ *
+ * @param workspace - Workspace name
+ * @param role - Workspace role (owner, editor, viewer)
+ * @param token - The SA token to cache
+ * @param expiresAt - Token expiration timestamp (ms since epoch), or undefined to use default TTL
+ */
+export function setCachedToken(
+  workspace: string,
+  role: WorkspaceRole,
+  token: string,
+  expiresAt?: number
+): void {
+  const key = getCacheKey(workspace, role);
+
+  // If key exists, delete it first to update its position
+  cache.delete(key);
+
+  // Evict oldest entries if at capacity
+  while (cache.size >= MAX_ENTRIES) {
+    // Map.keys().next() gives the oldest entry (first inserted)
+    const oldestKey = cache.keys().next().value;
+    if (oldestKey) {
+      cache.delete(oldestKey);
+    }
+  }
+
+  cache.set(key, {
+    token,
+    expiresAt: expiresAt ?? Date.now() + DEFAULT_TTL_MS,
+  });
+}
+
+/**
+ * Invalidate all cached tokens for a specific workspace.
+ * Call this when workspace is deleted or SAs are regenerated.
+ *
+ * @param workspace - Workspace name to invalidate
+ */
+export function invalidateWorkspaceTokens(workspace: string): void {
+  const prefix = `${workspace}:`;
+  const keysToDelete: string[] = [];
+
+  for (const key of cache.keys()) {
+    if (key.startsWith(prefix)) {
+      keysToDelete.push(key);
+    }
+  }
+
+  for (const key of keysToDelete) {
+    cache.delete(key);
+  }
+}
+
+/**
+ * Invalidate a specific token (e.g., on auth error).
+ *
+ * @param workspace - Workspace name
+ * @param role - Workspace role
+ */
+export function invalidateToken(workspace: string, role: WorkspaceRole): void {
+  const key = getCacheKey(workspace, role);
+  cache.delete(key);
+}
+
+/**
+ * Clear all cached tokens.
+ */
+export function clearTokenCache(): void {
+  cache.clear();
+}
+
+/**
+ * Get cache statistics for monitoring.
+ *
+ * @returns Cache size and configuration
+ */
+export function getTokenCacheStats(): {
+  size: number;
+  maxSize: number;
+  defaultTtlMs: number;
+} {
+  return {
+    size: cache.size,
+    maxSize: MAX_ENTRIES,
+    defaultTtlMs: DEFAULT_TTL_MS,
+  };
+}
+
+/**
+ * Remove all expired entries from the cache.
+ * Can be called periodically to clean up stale entries.
+ *
+ * @returns Number of entries removed
+ */
+export function pruneExpiredTokens(): number {
+  const keysToDelete: string[] = [];
+
+  for (const [key, entry] of cache.entries()) {
+    if (isExpiredOrExpiring(entry)) {
+      keysToDelete.push(key);
+    }
+  }
+
+  for (const key of keysToDelete) {
+    cache.delete(key);
+  }
+
+  return keysToDelete.length;
+}

--- a/dashboard/src/lib/k8s/token-fetcher.test.ts
+++ b/dashboard/src/lib/k8s/token-fetcher.test.ts
@@ -1,0 +1,253 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Store mock functions
+const mockCreateNamespacedServiceAccountToken = vi.fn();
+
+// Mock the kubernetes client-node module
+vi.mock("@kubernetes/client-node", () => {
+  class MockKubeConfig {
+    loadFromCluster() {
+      throw new Error("Not in cluster");
+    }
+    loadFromDefault() {
+      // no-op
+    }
+    makeApiClient() {
+      return {
+        createNamespacedServiceAccountToken: mockCreateNamespacedServiceAccountToken,
+      };
+    }
+  }
+
+  return {
+    KubeConfig: MockKubeConfig,
+    CoreV1Api: vi.fn(),
+  };
+});
+
+// Mock the token-cache module
+vi.mock("./token-cache", () => ({
+  getCachedToken: vi.fn(),
+  setCachedToken: vi.fn(),
+  invalidateToken: vi.fn(),
+}));
+
+// Import mocked modules
+import { getCachedToken, setCachedToken, invalidateToken } from "./token-cache";
+
+// Import after mocking - use dynamic import to reset module state
+let tokenFetcherModule: typeof import("./token-fetcher");
+
+describe("token-fetcher", () => {
+  const originalEnv = process.env;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+
+    // Reset environment
+    process.env = { ...originalEnv };
+    delete process.env.OMNIA_K8S_DEV_MODE;
+    delete process.env.OMNIA_K8S_DEV_TOKEN;
+
+    tokenFetcherModule = await import("./token-fetcher");
+    tokenFetcherModule.resetKubeConfig();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.clearAllMocks();
+  });
+
+  describe("getServiceAccountName", () => {
+    it("should generate correct SA name for owner", () => {
+      const name = tokenFetcherModule.getServiceAccountName("my-workspace", "owner");
+      expect(name).toBe("workspace-my-workspace-owner-sa");
+    });
+
+    it("should generate correct SA name for editor", () => {
+      const name = tokenFetcherModule.getServiceAccountName("my-workspace", "editor");
+      expect(name).toBe("workspace-my-workspace-editor-sa");
+    });
+
+    it("should generate correct SA name for viewer", () => {
+      const name = tokenFetcherModule.getServiceAccountName("my-workspace", "viewer");
+      expect(name).toBe("workspace-my-workspace-viewer-sa");
+    });
+  });
+
+  describe("fetchServiceAccountToken", () => {
+    it("should fetch token from K8s API", async () => {
+      const mockToken = "mock-jwt-token";
+      const mockExpiration = new Date(Date.now() + 3600000).toISOString();
+
+      mockCreateNamespacedServiceAccountToken.mockResolvedValue({
+        status: {
+          token: mockToken,
+          expirationTimestamp: mockExpiration,
+        },
+      });
+
+      const result = await tokenFetcherModule.fetchServiceAccountToken(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+
+      expect(mockCreateNamespacedServiceAccountToken).toHaveBeenCalledWith({
+        name: "workspace-my-workspace-editor-sa",
+        namespace: "my-namespace",
+        body: {
+          apiVersion: "authentication.k8s.io/v1",
+          kind: "TokenRequest",
+          spec: {
+            audiences: [],
+            expirationSeconds: 3600,
+          },
+        },
+      });
+
+      expect(result.token).toBe(mockToken);
+      expect(result.expiresAt).toBe(new Date(mockExpiration).getTime());
+    });
+
+    it("should throw error when token not in response", async () => {
+      mockCreateNamespacedServiceAccountToken.mockResolvedValue({
+        status: {},
+      });
+
+      await expect(
+        tokenFetcherModule.fetchServiceAccountToken(
+          "my-workspace",
+          "my-namespace",
+          "editor"
+        )
+      ).rejects.toThrow("TokenRequest response did not contain a token");
+    });
+
+    it("should wrap K8s API errors with context", async () => {
+      mockCreateNamespacedServiceAccountToken.mockRejectedValue(
+        new Error("Forbidden")
+      );
+
+      await expect(
+        tokenFetcherModule.fetchServiceAccountToken(
+          "my-workspace",
+          "my-namespace",
+          "editor"
+        )
+      ).rejects.toThrow(
+        "Failed to fetch token for SA workspace-my-workspace-editor-sa in namespace my-namespace: Forbidden"
+      );
+    });
+
+    it("should use dev token in dev mode", async () => {
+      process.env.OMNIA_K8S_DEV_MODE = "true";
+      process.env.OMNIA_K8S_DEV_TOKEN = "dev-token-123";
+
+      // Re-import to pick up env changes
+      vi.resetModules();
+      tokenFetcherModule = await import("./token-fetcher");
+
+      const result = await tokenFetcherModule.fetchServiceAccountToken(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+
+      expect(result.token).toBe("dev-token-123");
+      expect(mockCreateNamespacedServiceAccountToken).not.toHaveBeenCalled();
+    });
+
+    it("should throw error in dev mode when token not set", async () => {
+      process.env.OMNIA_K8S_DEV_MODE = "true";
+      delete process.env.OMNIA_K8S_DEV_TOKEN;
+
+      // Re-import to pick up env changes
+      vi.resetModules();
+      tokenFetcherModule = await import("./token-fetcher");
+
+      await expect(
+        tokenFetcherModule.fetchServiceAccountToken(
+          "my-workspace",
+          "my-namespace",
+          "editor"
+        )
+      ).rejects.toThrow(
+        "OMNIA_K8S_DEV_MODE is enabled but OMNIA_K8S_DEV_TOKEN is not set"
+      );
+    });
+  });
+
+  describe("getWorkspaceToken", () => {
+    it("should return cached token if available", async () => {
+      vi.mocked(getCachedToken).mockReturnValue("cached-token");
+
+      const result = await tokenFetcherModule.getWorkspaceToken(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+
+      expect(result).toBe("cached-token");
+      expect(mockCreateNamespacedServiceAccountToken).not.toHaveBeenCalled();
+    });
+
+    it("should fetch and cache token if not cached", async () => {
+      vi.mocked(getCachedToken).mockReturnValue(null);
+
+      const mockToken = "new-token";
+      const mockExpiration = new Date(Date.now() + 3600000).toISOString();
+
+      mockCreateNamespacedServiceAccountToken.mockResolvedValue({
+        status: {
+          token: mockToken,
+          expirationTimestamp: mockExpiration,
+        },
+      });
+
+      const result = await tokenFetcherModule.getWorkspaceToken(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+
+      expect(result).toBe(mockToken);
+      expect(setCachedToken).toHaveBeenCalledWith(
+        "my-workspace",
+        "editor",
+        mockToken,
+        expect.any(Number)
+      );
+    });
+  });
+
+  describe("refreshWorkspaceToken", () => {
+    it("should invalidate cache and fetch new token", async () => {
+      const mockToken = "refreshed-token";
+      const mockExpiration = new Date(Date.now() + 3600000).toISOString();
+
+      mockCreateNamespacedServiceAccountToken.mockResolvedValue({
+        status: {
+          token: mockToken,
+          expirationTimestamp: mockExpiration,
+        },
+      });
+
+      const result = await tokenFetcherModule.refreshWorkspaceToken(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+
+      expect(invalidateToken).toHaveBeenCalledWith("my-workspace", "editor");
+      expect(result).toBe(mockToken);
+      expect(setCachedToken).toHaveBeenCalledWith(
+        "my-workspace",
+        "editor",
+        mockToken,
+        expect.any(Number)
+      );
+    });
+  });
+});

--- a/dashboard/src/lib/k8s/token-fetcher.ts
+++ b/dashboard/src/lib/k8s/token-fetcher.ts
@@ -1,0 +1,203 @@
+/**
+ * TokenRequest API client for fetching workspace ServiceAccount tokens.
+ *
+ * Uses the Kubernetes TokenRequest API to get short-lived tokens for
+ * workspace ServiceAccounts. Tokens are valid for 1 hour by default.
+ *
+ * Environment variables for dev mode:
+ * - OMNIA_K8S_DEV_MODE=true - Use static token instead of TokenRequest
+ * - OMNIA_K8S_DEV_TOKEN - Token to use in dev mode
+ */
+
+import * as k8s from "@kubernetes/client-node";
+import type { WorkspaceRole } from "@/types/workspace";
+import {
+  getCachedToken,
+  setCachedToken,
+  invalidateToken,
+} from "./token-cache";
+
+/** Token expiration time in seconds (1 hour) */
+const TOKEN_EXPIRATION_SECONDS = 3600;
+
+/** Singleton KubeConfig */
+let kubeConfig: k8s.KubeConfig | null = null;
+
+/**
+ * Get or create the KubeConfig.
+ */
+function getKubeConfig(): k8s.KubeConfig {
+  if (!kubeConfig) {
+    kubeConfig = new k8s.KubeConfig();
+    try {
+      // Try in-cluster config first (when running in K8s)
+      kubeConfig.loadFromCluster();
+    } catch {
+      // Fall back to default kubeconfig for local development
+      kubeConfig.loadFromDefault();
+    }
+  }
+  return kubeConfig;
+}
+
+/**
+ * Get the ServiceAccount name for a workspace and role.
+ *
+ * @param workspaceName - Name of the workspace
+ * @param role - Workspace role
+ * @returns ServiceAccount name
+ */
+export function getServiceAccountName(
+  workspaceName: string,
+  role: WorkspaceRole
+): string {
+  return `workspace-${workspaceName}-${role}-sa`;
+}
+
+/**
+ * Fetch a token for a workspace ServiceAccount using the TokenRequest API.
+ *
+ * This makes a request to the K8s API to get a short-lived token for the
+ * specified ServiceAccount. The token can then be used to make K8s API
+ * calls with the permissions of that ServiceAccount.
+ *
+ * @param workspaceName - Name of the workspace
+ * @param namespace - Namespace where the SA resides (usually same as workspace)
+ * @param role - Workspace role (owner, editor, viewer)
+ * @returns Token string and expiration timestamp
+ */
+export async function fetchServiceAccountToken(
+  workspaceName: string,
+  namespace: string,
+  role: WorkspaceRole
+): Promise<{ token: string; expiresAt: number }> {
+  // Check for dev mode
+  if (process.env.OMNIA_K8S_DEV_MODE === "true") {
+    const devToken = process.env.OMNIA_K8S_DEV_TOKEN;
+    if (!devToken) {
+      throw new Error(
+        "OMNIA_K8S_DEV_MODE is enabled but OMNIA_K8S_DEV_TOKEN is not set"
+      );
+    }
+    // Return dev token with 1 hour expiry
+    return {
+      token: devToken,
+      expiresAt: Date.now() + TOKEN_EXPIRATION_SECONDS * 1000,
+    };
+  }
+
+  const kc = getKubeConfig();
+  const coreApi = kc.makeApiClient(k8s.CoreV1Api);
+  const saName = getServiceAccountName(workspaceName, role);
+
+  // Create TokenRequest body
+  const tokenRequest: k8s.AuthenticationV1TokenRequest = {
+    apiVersion: "authentication.k8s.io/v1",
+    kind: "TokenRequest",
+    spec: {
+      audiences: [], // Empty means token is valid for default API server audience
+      expirationSeconds: TOKEN_EXPIRATION_SECONDS,
+    },
+  };
+
+  try {
+    const response = await coreApi.createNamespacedServiceAccountToken({
+      name: saName,
+      namespace,
+      body: tokenRequest,
+    });
+
+    const token = response.status?.token;
+    if (!token) {
+      throw new Error("TokenRequest response did not contain a token");
+    }
+
+    // Calculate expiration time from response or use default
+    const expirationTimestamp = response.status?.expirationTimestamp;
+    const expiresAt = expirationTimestamp
+      ? new Date(expirationTimestamp).getTime()
+      : Date.now() + TOKEN_EXPIRATION_SECONDS * 1000;
+
+    return { token, expiresAt };
+  } catch (error) {
+    // Wrap K8s API errors with more context
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to fetch token for SA ${saName} in namespace ${namespace}: ${message}`
+    );
+  }
+}
+
+/**
+ * Get a token for a workspace ServiceAccount, using cache when available.
+ *
+ * This is the main entry point for getting workspace tokens. It checks the
+ * cache first and only fetches a new token if needed.
+ *
+ * @param workspaceName - Name of the workspace
+ * @param namespace - Namespace where the SA resides
+ * @param role - Workspace role (owner, editor, viewer)
+ * @returns Token string
+ */
+export async function getWorkspaceToken(
+  workspaceName: string,
+  namespace: string,
+  role: WorkspaceRole
+): Promise<string> {
+  // Check cache first
+  const cachedToken = getCachedToken(workspaceName, role);
+  if (cachedToken) {
+    return cachedToken;
+  }
+
+  // Fetch new token
+  const { token, expiresAt } = await fetchServiceAccountToken(
+    workspaceName,
+    namespace,
+    role
+  );
+
+  // Cache the token
+  setCachedToken(workspaceName, role, token, expiresAt);
+
+  return token;
+}
+
+/**
+ * Refresh a token for a workspace ServiceAccount.
+ *
+ * Forces a new token fetch even if a cached token exists.
+ * Use this when a cached token has been rejected (e.g., 401 error).
+ *
+ * @param workspaceName - Name of the workspace
+ * @param namespace - Namespace where the SA resides
+ * @param role - Workspace role (owner, editor, viewer)
+ * @returns New token string
+ */
+export async function refreshWorkspaceToken(
+  workspaceName: string,
+  namespace: string,
+  role: WorkspaceRole
+): Promise<string> {
+  // Invalidate cached token
+  invalidateToken(workspaceName, role);
+
+  // Fetch new token
+  const { token, expiresAt } = await fetchServiceAccountToken(
+    workspaceName,
+    namespace,
+    role
+  );
+
+  // Cache the new token
+  setCachedToken(workspaceName, role, token, expiresAt);
+
+  return token;
+}
+
+/**
+ * Reset the KubeConfig (for testing purposes).
+ */
+export function resetKubeConfig(): void {
+  kubeConfig = null;
+}

--- a/dashboard/src/lib/k8s/workspace-k8s-client-factory.test.ts
+++ b/dashboard/src/lib/k8s/workspace-k8s-client-factory.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock the token-fetcher module
+vi.mock("./token-fetcher", () => ({
+  getWorkspaceToken: vi.fn(),
+  refreshWorkspaceToken: vi.fn(),
+}));
+
+// Mock API classes
+class MockCoreV1Api {
+  listNamespacedPod = vi.fn();
+}
+
+class MockCustomObjectsApi {
+  listNamespacedCustomObject = vi.fn();
+}
+
+class MockAppsV1Api {
+  listNamespacedDeployment = vi.fn();
+}
+
+// Mock the kubernetes client-node module
+vi.mock("@kubernetes/client-node", () => {
+  class MockKubeConfig {
+    private clusters: Array<{ name: string; server: string; caData?: string }> = [];
+    private currentCluster: { name: string; server: string; caData?: string } | null = null;
+
+    loadFromCluster() {
+      throw new Error("Not in cluster");
+    }
+    loadFromDefault() {
+      this.clusters = [
+        {
+          name: "default-cluster",
+          server: "https://kubernetes.default.svc",
+          caData: "base64-ca-data",
+        },
+      ];
+      this.currentCluster = this.clusters[0];
+    }
+    loadFromOptions(_options: unknown) {
+      // Config loaded
+    }
+    getCurrentCluster() {
+      return this.currentCluster;
+    }
+    makeApiClient(ApiClass: new () => object) {
+      return new ApiClass();
+    }
+  }
+
+  return {
+    KubeConfig: MockKubeConfig,
+    CoreV1Api: MockCoreV1Api,
+    CustomObjectsApi: MockCustomObjectsApi,
+    AppsV1Api: MockAppsV1Api,
+  };
+});
+
+import { getWorkspaceToken, refreshWorkspaceToken } from "./token-fetcher";
+
+// Import after mocking
+let factoryModule: typeof import("./workspace-k8s-client-factory");
+
+describe("workspace-k8s-client-factory", () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    factoryModule = await import("./workspace-k8s-client-factory");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getWorkspaceKubeConfig", () => {
+    it("should create a KubeConfig with workspace token", async () => {
+      vi.mocked(getWorkspaceToken).mockResolvedValue("test-token");
+
+      const kc = await factoryModule.getWorkspaceKubeConfig({
+        workspace: "my-workspace",
+        namespace: "my-namespace",
+        role: "editor",
+      });
+
+      expect(getWorkspaceToken).toHaveBeenCalledWith(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+      expect(kc).toBeDefined();
+    });
+  });
+
+  describe("getWorkspaceCustomObjectsApi", () => {
+    it("should create a CustomObjectsApi client", async () => {
+      vi.mocked(getWorkspaceToken).mockResolvedValue("test-token");
+
+      const api = await factoryModule.getWorkspaceCustomObjectsApi({
+        workspace: "my-workspace",
+        namespace: "my-namespace",
+        role: "viewer",
+      });
+
+      expect(api).toBeDefined();
+      expect(getWorkspaceToken).toHaveBeenCalledWith(
+        "my-workspace",
+        "my-namespace",
+        "viewer"
+      );
+    });
+  });
+
+  describe("getWorkspaceCoreApi", () => {
+    it("should create a CoreV1Api client", async () => {
+      vi.mocked(getWorkspaceToken).mockResolvedValue("test-token");
+
+      const api = await factoryModule.getWorkspaceCoreApi({
+        workspace: "my-workspace",
+        namespace: "my-namespace",
+        role: "owner",
+      });
+
+      expect(api).toBeDefined();
+      expect(getWorkspaceToken).toHaveBeenCalledWith(
+        "my-workspace",
+        "my-namespace",
+        "owner"
+      );
+    });
+  });
+
+  describe("getWorkspaceAppsApi", () => {
+    it("should create an AppsV1Api client", async () => {
+      vi.mocked(getWorkspaceToken).mockResolvedValue("test-token");
+
+      const api = await factoryModule.getWorkspaceAppsApi({
+        workspace: "my-workspace",
+        namespace: "my-namespace",
+        role: "editor",
+      });
+
+      expect(api).toBeDefined();
+      expect(getWorkspaceToken).toHaveBeenCalledWith(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+    });
+  });
+
+  describe("withTokenRefresh", () => {
+    it("should return result on successful call", async () => {
+      const mockFn = vi.fn().mockResolvedValue("success");
+
+      const result = await factoryModule.withTokenRefresh(
+        {
+          workspace: "my-workspace",
+          namespace: "my-namespace",
+          role: "editor",
+        },
+        mockFn
+      );
+
+      expect(result).toBe("success");
+      expect(mockFn).toHaveBeenCalledTimes(1);
+      expect(refreshWorkspaceToken).not.toHaveBeenCalled();
+    });
+
+    it("should refresh token and retry on 401 error", async () => {
+      vi.mocked(refreshWorkspaceToken).mockResolvedValue("new-token");
+
+      const authError = { statusCode: 401 };
+      const mockFn = vi
+        .fn()
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce("success after refresh");
+
+      const result = await factoryModule.withTokenRefresh(
+        {
+          workspace: "my-workspace",
+          namespace: "my-namespace",
+          role: "editor",
+        },
+        mockFn
+      );
+
+      expect(result).toBe("success after refresh");
+      expect(mockFn).toHaveBeenCalledTimes(2);
+      expect(refreshWorkspaceToken).toHaveBeenCalledWith(
+        "my-workspace",
+        "my-namespace",
+        "editor"
+      );
+    });
+
+    it("should refresh token on response.statusCode 401", async () => {
+      vi.mocked(refreshWorkspaceToken).mockResolvedValue("new-token");
+
+      const authError = { response: { statusCode: 401 } };
+      const mockFn = vi
+        .fn()
+        .mockRejectedValueOnce(authError)
+        .mockResolvedValueOnce("success");
+
+      const result = await factoryModule.withTokenRefresh(
+        {
+          workspace: "my-workspace",
+          namespace: "my-namespace",
+          role: "editor",
+        },
+        mockFn
+      );
+
+      expect(result).toBe("success");
+      expect(refreshWorkspaceToken).toHaveBeenCalled();
+    });
+
+    it("should throw non-auth errors", async () => {
+      const otherError = new Error("Not found");
+      const mockFn = vi.fn().mockRejectedValue(otherError);
+
+      await expect(
+        factoryModule.withTokenRefresh(
+          {
+            workspace: "my-workspace",
+            namespace: "my-namespace",
+            role: "editor",
+          },
+          mockFn
+        )
+      ).rejects.toThrow("Not found");
+
+      expect(refreshWorkspaceToken).not.toHaveBeenCalled();
+    });
+
+    it("should throw 403 errors without refresh", async () => {
+      const forbiddenError = { statusCode: 403 };
+      const mockFn = vi.fn().mockRejectedValue(forbiddenError);
+
+      await expect(
+        factoryModule.withTokenRefresh(
+          {
+            workspace: "my-workspace",
+            namespace: "my-namespace",
+            role: "editor",
+          },
+          mockFn
+        )
+      ).rejects.toEqual(forbiddenError);
+
+      expect(refreshWorkspaceToken).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/dashboard/src/lib/k8s/workspace-k8s-client-factory.ts
+++ b/dashboard/src/lib/k8s/workspace-k8s-client-factory.ts
@@ -1,0 +1,206 @@
+/**
+ * Workspace-scoped Kubernetes client factory.
+ *
+ * Creates K8s API clients that use workspace ServiceAccount tokens
+ * for authentication. This enables workspace-scoped permissions for
+ * all K8s API calls.
+ *
+ * Usage:
+ * ```typescript
+ * const client = await getWorkspaceCustomObjectsApi("my-workspace", "editor");
+ * const agents = await client.listNamespacedCustomObject({...});
+ * ```
+ */
+
+import * as k8s from "@kubernetes/client-node";
+import type { WorkspaceRole } from "@/types/workspace";
+import { getWorkspaceToken, refreshWorkspaceToken } from "./token-fetcher";
+
+/**
+ * Options for creating workspace K8s clients.
+ */
+export interface WorkspaceClientOptions {
+  /** Workspace name */
+  workspace: string;
+  /** Namespace where workspace resources reside */
+  namespace: string;
+  /** User's role in the workspace */
+  role: WorkspaceRole;
+}
+
+/**
+ * Create a KubeConfig configured with a workspace ServiceAccount token.
+ *
+ * @param options - Workspace client options
+ * @returns Configured KubeConfig
+ */
+export async function getWorkspaceKubeConfig(
+  options: WorkspaceClientOptions
+): Promise<k8s.KubeConfig> {
+  const { workspace, namespace, role } = options;
+
+  // Get the token for this workspace/role
+  const token = await getWorkspaceToken(workspace, namespace, role);
+
+  // Create a new KubeConfig with the token
+  const kc = new k8s.KubeConfig();
+
+  // First load the base config to get cluster info
+  try {
+    kc.loadFromCluster();
+  } catch {
+    kc.loadFromDefault();
+  }
+
+  // Get the current cluster info
+  const currentCluster = kc.getCurrentCluster();
+  if (!currentCluster) {
+    throw new Error("No cluster found in kubeconfig");
+  }
+
+  // Create a new config with the workspace SA token
+  const clusterName = currentCluster.name;
+  const userName = `workspace-${workspace}-${role}`;
+  const contextName = `${userName}-context`;
+
+  // Build the config object
+  const configObj = {
+    clusters: [
+      {
+        name: clusterName,
+        cluster: {
+          server: currentCluster.server,
+          "certificate-authority-data": currentCluster.caData,
+          "certificate-authority": currentCluster.caFile,
+          "insecure-skip-tls-verify": currentCluster.skipTLSVerify,
+        },
+      },
+    ],
+    users: [
+      {
+        name: userName,
+        user: {
+          token,
+        },
+      },
+    ],
+    contexts: [
+      {
+        name: contextName,
+        context: {
+          cluster: clusterName,
+          user: userName,
+          namespace,
+        },
+      },
+    ],
+    "current-context": contextName,
+  };
+
+  // Load the new config
+  const newKc = new k8s.KubeConfig();
+  newKc.loadFromOptions(configObj);
+
+  return newKc;
+}
+
+/**
+ * Create a CustomObjectsApi client for a workspace.
+ *
+ * Use this for working with Omnia CRDs (AgentRuntimes, PromptPacks, etc.)
+ *
+ * @param options - Workspace client options
+ * @returns CustomObjectsApi client
+ */
+export async function getWorkspaceCustomObjectsApi(
+  options: WorkspaceClientOptions
+): Promise<k8s.CustomObjectsApi> {
+  const kc = await getWorkspaceKubeConfig(options);
+  return kc.makeApiClient(k8s.CustomObjectsApi);
+}
+
+/**
+ * Create a CoreV1Api client for a workspace.
+ *
+ * Use this for working with core K8s resources (ConfigMaps, Secrets, Pods, etc.)
+ *
+ * @param options - Workspace client options
+ * @returns CoreV1Api client
+ */
+export async function getWorkspaceCoreApi(
+  options: WorkspaceClientOptions
+): Promise<k8s.CoreV1Api> {
+  const kc = await getWorkspaceKubeConfig(options);
+  return kc.makeApiClient(k8s.CoreV1Api);
+}
+
+/**
+ * Create an AppsV1Api client for a workspace.
+ *
+ * Use this for working with apps resources (Deployments, ReplicaSets, etc.)
+ *
+ * @param options - Workspace client options
+ * @returns AppsV1Api client
+ */
+export async function getWorkspaceAppsApi(
+  options: WorkspaceClientOptions
+): Promise<k8s.AppsV1Api> {
+  const kc = await getWorkspaceKubeConfig(options);
+  return kc.makeApiClient(k8s.AppsV1Api);
+}
+
+/**
+ * Wrapper that handles token refresh on auth errors.
+ *
+ * If a K8s API call fails with a 401 error, this will refresh the token
+ * and retry the call once.
+ *
+ * @param options - Workspace client options
+ * @param fn - Function that makes the K8s API call
+ * @returns Result of the API call
+ */
+export async function withTokenRefresh<T>(
+  options: WorkspaceClientOptions,
+  fn: () => Promise<T>
+): Promise<T> {
+  try {
+    return await fn();
+  } catch (error) {
+    // Check if it's an auth error
+    if (isAuthError(error)) {
+      // Refresh the token
+      await refreshWorkspaceToken(
+        options.workspace,
+        options.namespace,
+        options.role
+      );
+      // Retry the call
+      return await fn();
+    }
+    throw error;
+  }
+}
+
+/**
+ * Check if an error is an authentication error (401).
+ */
+function isAuthError(error: unknown): boolean {
+  if (typeof error === "object" && error !== null) {
+    // Check for statusCode property
+    if ("statusCode" in error && (error as { statusCode?: number }).statusCode === 401) {
+      return true;
+    }
+    // Check for response.statusCode
+    if (
+      "response" in error &&
+      typeof (error as { response: unknown }).response === "object" &&
+      (error as { response: unknown }).response !== null
+    ) {
+      const response = (error as { response: { statusCode?: number } }).response;
+      if (response?.statusCode === 401) {
+        return true;
+      }
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- Add LRU token cache (`token-cache.ts`) with 50-minute TTL and 5-minute safety margin for early refresh
- Add TokenRequest API client (`token-fetcher.ts`) for fetching short-lived SA tokens with dev mode support
- Add workspace-scoped K8s client factory (`workspace-k8s-client-factory.ts`) for creating CustomObjectsApi, CoreV1Api, and AppsV1Api clients

## Key Features
- **Token caching**: LRU cache with max 100 entries, automatic eviction of oldest entries
- **Dev mode**: Support for `OMNIA_K8S_DEV_MODE` and `OMNIA_K8S_DEV_TOKEN` environment variables for local development
- **Automatic refresh**: `withTokenRefresh` wrapper automatically refreshes tokens on 401 errors

## Test plan
- [x] All 72 k8s lib tests pass
- [x] 100% coverage on token-cache.ts and token-fetcher.ts
- [x] 97.2% coverage on workspace-k8s-client-factory.ts
- [x] Pre-commit checks pass (ESLint, TypeScript, tests)

Closes #277