### PR TITLE
feat(dashboard): add workspace switcher UI (#285)

### DIFF
--- a/dashboard/src/components/layout/header.test.tsx
+++ b/dashboard/src/components/layout/header.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * Tests for header component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { Header } from "./header";
+
+// Mock next-themes
+const mockSetTheme = vi.fn();
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: "light",
+    setTheme: mockSetTheme,
+  }),
+}));
+
+// Mock the UserMenu
+vi.mock("./user-menu", () => ({
+  UserMenu: () => <div data-testid="user-menu">UserMenu</div>,
+}));
+
+// Mock the WorkspaceSwitcher
+vi.mock("@/components/workspace-switcher", () => ({
+  WorkspaceSwitcher: () => <div data-testid="workspace-switcher">WorkspaceSwitcher</div>,
+}));
+
+describe("Header", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders title", () => {
+    render(<Header title="Test Title" />);
+
+    expect(screen.getByText("Test Title")).toBeInTheDocument();
+  });
+
+  it("renders description when provided", () => {
+    render(<Header title="Title" description="Test description" />);
+
+    expect(screen.getByText("Test description")).toBeInTheDocument();
+  });
+
+  it("does not render description when not provided", () => {
+    render(<Header title="Title" />);
+
+    const description = screen.queryByText("Test description");
+    expect(description).not.toBeInTheDocument();
+  });
+
+  it("renders children when provided", () => {
+    render(
+      <Header title="Title">
+        <button>Custom Button</button>
+      </Header>
+    );
+
+    expect(screen.getByText("Custom Button")).toBeInTheDocument();
+  });
+
+  it("renders UserMenu component", () => {
+    render(<Header title="Title" />);
+
+    expect(screen.getByTestId("user-menu")).toBeInTheDocument();
+  });
+
+  it("renders WorkspaceSwitcher component", () => {
+    render(<Header title="Title" />);
+
+    expect(screen.getByTestId("workspace-switcher")).toBeInTheDocument();
+  });
+
+  it("renders theme toggle button", () => {
+    render(<Header title="Title" />);
+
+    expect(screen.getByTestId("theme-toggle")).toBeInTheDocument();
+  });
+
+  it("toggles theme when theme button is clicked", () => {
+    render(<Header title="Title" />);
+
+    const themeToggle = screen.getByTestId("theme-toggle");
+    fireEvent.click(themeToggle);
+
+    expect(mockSetTheme).toHaveBeenCalledWith("dark");
+  });
+
+  it("renders refresh button", () => {
+    render(<Header title="Title" />);
+
+    // Find the refresh button by looking for the RefreshCw icon's parent button
+    const buttons = screen.getAllByRole("button");
+    // Should have theme toggle, refresh button
+    expect(buttons.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("accepts ReactNode as title", () => {
+    render(
+      <Header title={<span data-testid="custom-title">Custom Title</span>} />
+    );
+
+    expect(screen.getByTestId("custom-title")).toBeInTheDocument();
+  });
+
+  it("accepts ReactNode as description", () => {
+    render(
+      <Header
+        title="Title"
+        description={<span data-testid="custom-description">Custom Desc</span>}
+      />
+    );
+
+    expect(screen.getByTestId("custom-description")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/layout/header.tsx
+++ b/dashboard/src/components/layout/header.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { RefreshCw, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { UserMenu } from "./user-menu";
+import { WorkspaceSwitcher } from "@/components/workspace-switcher";
 
 interface HeaderProps {
   title: React.ReactNode;
@@ -23,6 +24,7 @@ export function Header({ title, description, children }: Readonly<HeaderProps>) 
         )}
       </div>
       <div className="flex items-center gap-3">
+        <WorkspaceSwitcher />
         {children}
         <Button variant="ghost" size="icon">
           <RefreshCw className="h-4 w-4" />

--- a/dashboard/src/components/providers.test.tsx
+++ b/dashboard/src/components/providers.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * Tests for providers component.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Providers } from "./providers";
+
+// Mock the dependencies
+vi.mock("@/lib/data", () => ({
+  DataServiceProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="data-service-provider">{children}</div>
+  ),
+}));
+
+vi.mock("@/contexts/workspace-context", () => ({
+  WorkspaceProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="workspace-provider">{children}</div>
+  ),
+}));
+
+vi.mock("next-themes", () => ({
+  ThemeProvider: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="theme-provider">{children}</div>
+  ),
+}));
+
+describe("Providers", () => {
+  it("renders children wrapped in all providers", () => {
+    render(
+      <Providers>
+        <div data-testid="child">Child content</div>
+      </Providers>
+    );
+
+    expect(screen.getByTestId("child")).toBeInTheDocument();
+    expect(screen.getByText("Child content")).toBeInTheDocument();
+  });
+
+  it("includes ThemeProvider", () => {
+    render(
+      <Providers>
+        <span>Content</span>
+      </Providers>
+    );
+
+    expect(screen.getByTestId("theme-provider")).toBeInTheDocument();
+  });
+
+  it("includes WorkspaceProvider", () => {
+    render(
+      <Providers>
+        <span>Content</span>
+      </Providers>
+    );
+
+    expect(screen.getByTestId("workspace-provider")).toBeInTheDocument();
+  });
+
+  it("includes DataServiceProvider", () => {
+    render(
+      <Providers>
+        <span>Content</span>
+      </Providers>
+    );
+
+    expect(screen.getByTestId("data-service-provider")).toBeInTheDocument();
+  });
+
+  it("nests providers in correct order", () => {
+    render(
+      <Providers>
+        <span data-testid="content">Content</span>
+      </Providers>
+    );
+
+    // Check that providers are nested correctly
+    const themeProvider = screen.getByTestId("theme-provider");
+    const workspaceProvider = screen.getByTestId("workspace-provider");
+    const dataServiceProvider = screen.getByTestId("data-service-provider");
+    const content = screen.getByTestId("content");
+
+    // ThemeProvider should contain WorkspaceProvider
+    expect(themeProvider).toContainElement(workspaceProvider);
+    // WorkspaceProvider should contain DataServiceProvider
+    expect(workspaceProvider).toContainElement(dataServiceProvider);
+    // DataServiceProvider should contain the content
+    expect(dataServiceProvider).toContainElement(content);
+  });
+});

--- a/dashboard/src/components/providers.tsx
+++ b/dashboard/src/components/providers.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ThemeProvider } from "next-themes";
 import { useState } from "react";
 import { DataServiceProvider } from "@/lib/data";
+import { WorkspaceProvider } from "@/contexts/workspace-context";
 
 export function Providers({ children }: Readonly<{ children: React.ReactNode }>) {
   const [queryClient] = useState(
@@ -26,9 +27,11 @@ export function Providers({ children }: Readonly<{ children: React.ReactNode }>)
         enableSystem
         disableTransitionOnChange
       >
-        <DataServiceProvider>
-          {children}
-        </DataServiceProvider>
+        <WorkspaceProvider>
+          <DataServiceProvider>
+            {children}
+          </DataServiceProvider>
+        </WorkspaceProvider>
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/dashboard/src/components/workspace-switcher.test.tsx
+++ b/dashboard/src/components/workspace-switcher.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * Tests for workspace-switcher component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { WorkspaceSwitcher } from "./workspace-switcher";
+import type { WorkspaceListItem } from "@/hooks/use-workspaces";
+
+// Mock the workspace context
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: vi.fn(),
+}));
+
+import { useWorkspace } from "@/contexts/workspace-context";
+
+const mockWorkspaces: WorkspaceListItem[] = [
+  {
+    name: "dev-workspace",
+    displayName: "Development",
+    description: "Development environment",
+    environment: "development",
+    namespace: "ns-dev",
+    role: "owner",
+    permissions: { read: true, write: true, delete: true, manageMembers: true },
+  },
+  {
+    name: "staging-workspace",
+    displayName: "Staging",
+    environment: "staging",
+    namespace: "ns-staging",
+    role: "editor",
+    permissions: { read: true, write: true, delete: false, manageMembers: false },
+  },
+  {
+    name: "prod-workspace",
+    displayName: "Production",
+    description: "Production environment",
+    environment: "production",
+    namespace: "ns-prod",
+    role: "viewer",
+    permissions: { read: true, write: false, delete: false, manageMembers: false },
+  },
+];
+
+describe("WorkspaceSwitcher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading state", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: [],
+      currentWorkspace: null,
+      setCurrentWorkspace: vi.fn(),
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("renders error state", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: [],
+      currentWorkspace: null,
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: new Error("Failed to load"),
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    expect(screen.getByText("Error loading workspaces")).toBeInTheDocument();
+  });
+
+  it("renders no workspaces state", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: [],
+      currentWorkspace: null,
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    expect(screen.getByText("No workspaces")).toBeInTheDocument();
+  });
+
+  it("renders current workspace with role badge", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: mockWorkspaces,
+      currentWorkspace: mockWorkspaces[0],
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    expect(screen.getByText("Development")).toBeInTheDocument();
+    expect(screen.getByText("owner")).toBeInTheDocument();
+  });
+
+  it("shows placeholder when no workspace is selected", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: mockWorkspaces,
+      currentWorkspace: null,
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    expect(screen.getByText("Select workspace")).toBeInTheDocument();
+  });
+
+  it("renders dropdown trigger as button", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: mockWorkspaces,
+      currentWorkspace: mockWorkspaces[0],
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-haspopup", "menu");
+  });
+
+  it("shows different role badges correctly", () => {
+    // Test editor role
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: mockWorkspaces,
+      currentWorkspace: mockWorkspaces[1], // Staging with editor role
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    const { rerender } = render(<WorkspaceSwitcher />);
+    expect(screen.getByText("editor")).toBeInTheDocument();
+    expect(screen.getByText("Staging")).toBeInTheDocument();
+
+    // Test viewer role
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: mockWorkspaces,
+      currentWorkspace: mockWorkspaces[2], // Production with viewer role
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    rerender(<WorkspaceSwitcher />);
+    expect(screen.getByText("viewer")).toBeInTheDocument();
+    expect(screen.getByText("Production")).toBeInTheDocument();
+  });
+
+  it("disabled buttons in loading state", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: [],
+      currentWorkspace: null,
+      setCurrentWorkspace: vi.fn(),
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+  });
+
+  it("disabled buttons in error state", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: [],
+      currentWorkspace: null,
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: new Error("Failed"),
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+  });
+
+  it("disabled buttons when no workspaces", () => {
+    vi.mocked(useWorkspace).mockReturnValue({
+      workspaces: [],
+      currentWorkspace: null,
+      setCurrentWorkspace: vi.fn(),
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+
+    render(<WorkspaceSwitcher />);
+
+    const button = screen.getByRole("button");
+    expect(button).toBeDisabled();
+  });
+});

--- a/dashboard/src/components/workspace-switcher.tsx
+++ b/dashboard/src/components/workspace-switcher.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+/**
+ * Workspace switcher dropdown component.
+ *
+ * Displays the current workspace and allows users to switch between
+ * workspaces they have access to. Shows the user's role in each workspace.
+ */
+
+import { Check, ChevronsUpDown, Building2, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Badge } from "@/components/ui/badge";
+import { useWorkspace } from "@/contexts/workspace-context";
+import type { WorkspaceRole } from "@/types/workspace";
+import { cn } from "@/lib/utils";
+
+/**
+ * Get badge variant based on workspace role.
+ */
+function getRoleBadgeVariant(role: WorkspaceRole): "default" | "secondary" | "outline" {
+  switch (role) {
+    case "owner":
+      return "default";
+    case "editor":
+      return "secondary";
+    default:
+      return "outline";
+  }
+}
+
+/**
+ * Get environment badge color.
+ */
+function getEnvironmentColor(environment: string): string {
+  switch (environment) {
+    case "production":
+      return "text-red-600 bg-red-50 border-red-200 dark:text-red-400 dark:bg-red-950 dark:border-red-800";
+    case "staging":
+      return "text-yellow-600 bg-yellow-50 border-yellow-200 dark:text-yellow-400 dark:bg-yellow-950 dark:border-yellow-800";
+    default:
+      return "text-blue-600 bg-blue-50 border-blue-200 dark:text-blue-400 dark:bg-blue-950 dark:border-blue-800";
+  }
+}
+
+/**
+ * Workspace switcher component.
+ * Shows current workspace and dropdown to switch between workspaces.
+ */
+export function WorkspaceSwitcher() {
+  const { workspaces, currentWorkspace, setCurrentWorkspace, isLoading, error } = useWorkspace();
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Button variant="outline" disabled className="w-[200px] justify-between">
+        <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+        <span>Loading...</span>
+      </Button>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Button variant="outline" disabled className="w-[200px] justify-between text-destructive">
+        <Building2 className="mr-2 h-4 w-4" />
+        <span>Error loading workspaces</span>
+      </Button>
+    );
+  }
+
+  // No workspaces available
+  if (workspaces.length === 0) {
+    return (
+      <Button variant="outline" disabled className="w-[200px] justify-between">
+        <Building2 className="mr-2 h-4 w-4" />
+        <span>No workspaces</span>
+      </Button>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" className="w-[250px] justify-between">
+          <div className="flex items-center gap-2 truncate">
+            <Building2 className="h-4 w-4 shrink-0" />
+            <span className="truncate">
+              {currentWorkspace?.displayName || "Select workspace"}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            {currentWorkspace && (
+              <Badge variant={getRoleBadgeVariant(currentWorkspace.role)} className="text-xs">
+                {currentWorkspace.role}
+              </Badge>
+            )}
+            <ChevronsUpDown className="h-4 w-4 opacity-50" />
+          </div>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-[250px]" align="start">
+        <DropdownMenuLabel>Workspaces</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {workspaces.map((workspace) => (
+          <DropdownMenuItem
+            key={workspace.name}
+            onClick={() => setCurrentWorkspace(workspace.name)}
+            className="flex items-center justify-between cursor-pointer"
+          >
+            <div className="flex items-center gap-2 min-w-0">
+              <Check
+                className={cn(
+                  "h-4 w-4 shrink-0",
+                  currentWorkspace?.name === workspace.name ? "opacity-100" : "opacity-0"
+                )}
+              />
+              <div className="flex flex-col min-w-0">
+                <span className="truncate font-medium">{workspace.displayName}</span>
+                {workspace.description && (
+                  <span className="text-xs text-muted-foreground truncate">
+                    {workspace.description}
+                  </span>
+                )}
+              </div>
+            </div>
+            <div className="flex items-center gap-2 shrink-0 ml-2">
+              <Badge
+                variant="outline"
+                className={cn("text-xs", getEnvironmentColor(workspace.environment))}
+              >
+                {workspace.environment.slice(0, 3)}
+              </Badge>
+              <Badge variant={getRoleBadgeVariant(workspace.role)} className="text-xs">
+                {workspace.role}
+              </Badge>
+            </div>
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/dashboard/src/contexts/workspace-context.test.tsx
+++ b/dashboard/src/contexts/workspace-context.test.tsx
@@ -1,0 +1,306 @@
+/**
+ * Tests for workspace-context.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { WorkspaceProvider, useWorkspace } from "./workspace-context";
+
+// Mock the useWorkspaces hook
+vi.mock("@/hooks/use-workspaces", () => ({
+  useWorkspaces: vi.fn(),
+}));
+
+import { useWorkspaces, type WorkspaceListItem } from "@/hooks/use-workspaces";
+
+const mockWorkspaces: WorkspaceListItem[] = [
+  {
+    name: "workspace-1",
+    displayName: "Workspace One",
+    environment: "development",
+    namespace: "ns-1",
+    role: "owner",
+    permissions: { read: true, write: true, delete: true, manageMembers: true },
+  },
+  {
+    name: "workspace-2",
+    displayName: "Workspace Two",
+    environment: "production",
+    namespace: "ns-2",
+    role: "viewer",
+    permissions: { read: true, write: false, delete: false, manageMembers: false },
+  },
+];
+
+function TestConsumer() {
+  const { workspaces, currentWorkspace, setCurrentWorkspace, isLoading, error } = useWorkspace();
+
+  return (
+    <div>
+      <div data-testid="loading">{isLoading ? "loading" : "loaded"}</div>
+      <div data-testid="error">{error ? error.message : "no-error"}</div>
+      <div data-testid="workspaces-count">{workspaces.length}</div>
+      <div data-testid="current-workspace">{currentWorkspace?.name || "none"}</div>
+      <button onClick={() => setCurrentWorkspace("workspace-2")}>Switch</button>
+      <button onClick={() => setCurrentWorkspace(null)}>Clear</button>
+    </div>
+  );
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("WorkspaceContext", () => {
+  const mockLocalStorage: Record<string, string> = {};
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Mock localStorage
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: vi.fn((key: string) => mockLocalStorage[key] || null),
+        setItem: vi.fn((key: string, value: string) => {
+          mockLocalStorage[key] = value;
+        }),
+        removeItem: vi.fn((key: string) => {
+          delete mockLocalStorage[key];
+        }),
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    for (const key in mockLocalStorage) {
+      delete mockLocalStorage[key];
+    }
+  });
+
+  it("provides workspaces data from useWorkspaces hook", async () => {
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: mockWorkspaces,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("workspaces-count").textContent).toBe("2");
+    });
+  });
+
+  it("shows loading state", () => {
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId("loading").textContent).toBe("loading");
+  });
+
+  it("shows error state", () => {
+    const mockError = new Error("Failed to fetch");
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: mockError,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    expect(screen.getByTestId("error").textContent).toBe("Failed to fetch");
+  });
+
+  it("auto-selects first workspace when none selected", async () => {
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: mockWorkspaces,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-workspace").textContent).toBe("workspace-1");
+    });
+  });
+
+  it("allows switching workspaces", async () => {
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: mockWorkspaces,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-workspace").textContent).toBe("workspace-1");
+    });
+
+    act(() => {
+      screen.getByText("Switch").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-workspace").textContent).toBe("workspace-2");
+    });
+  });
+
+  it("persists workspace selection to localStorage", async () => {
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: mockWorkspaces,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-workspace").textContent).toBe("workspace-1");
+    });
+
+    act(() => {
+      screen.getByText("Switch").click();
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.setItem).toHaveBeenCalledWith(
+        "omnia-selected-workspace",
+        "workspace-2"
+      );
+    });
+  });
+
+  it("clears workspace selection from localStorage", async () => {
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: mockWorkspaces,
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-workspace").textContent).toBe("workspace-1");
+    });
+
+    act(() => {
+      screen.getByText("Clear").click();
+    });
+
+    await waitFor(() => {
+      expect(window.localStorage.removeItem).toHaveBeenCalledWith(
+        "omnia-selected-workspace"
+      );
+    });
+  });
+
+  it("throws error when useWorkspace is used outside provider", () => {
+    // Suppress console.error for this test
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(() => {
+      render(<TestConsumer />);
+    }).toThrow("useWorkspace must be used within a WorkspaceProvider");
+
+    consoleSpy.mockRestore();
+  });
+
+  it("returns null for currentWorkspace when no workspaces exist", async () => {
+    vi.mocked(useWorkspaces).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useWorkspaces>);
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <WorkspaceProvider>
+          <TestConsumer />
+        </WorkspaceProvider>
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("current-workspace").textContent).toBe("none");
+    });
+  });
+});

--- a/dashboard/src/contexts/workspace-context.tsx
+++ b/dashboard/src/contexts/workspace-context.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/**
+ * Workspace context for managing current workspace selection.
+ *
+ * Usage:
+ *   import { useWorkspace, WorkspaceProvider } from "@/contexts/workspace-context";
+ *
+ *   function MyComponent() {
+ *     const { currentWorkspace, setCurrentWorkspace, workspaces } = useWorkspace();
+ *     ...
+ *   }
+ */
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useMemo,
+  useCallback,
+  type ReactNode,
+} from "react";
+import { useWorkspaces, type WorkspaceListItem } from "@/hooks/use-workspaces";
+
+const STORAGE_KEY = "omnia-selected-workspace";
+
+/**
+ * Get the stored workspace name from localStorage.
+ * Only called on the client.
+ */
+function getStoredWorkspaceName(): string | null {
+  if (typeof window === "undefined") return null;
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+interface WorkspaceContextValue {
+  /** List of workspaces the user has access to */
+  workspaces: WorkspaceListItem[];
+  /** Currently selected workspace */
+  currentWorkspace: WorkspaceListItem | null;
+  /** Set the current workspace by name */
+  setCurrentWorkspace: (workspaceName: string | null) => void;
+  /** Whether workspaces are loading */
+  isLoading: boolean;
+  /** Error if workspace fetch failed */
+  error: Error | null;
+  /** Refetch workspaces */
+  refetch: () => void;
+}
+
+const WorkspaceContext = createContext<WorkspaceContextValue | null>(null);
+
+interface WorkspaceProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * Workspace provider - manages workspace selection state.
+ * Persists the selected workspace to localStorage.
+ */
+export function WorkspaceProvider({ children }: Readonly<WorkspaceProviderProps>) {
+  const { data: workspaces = [], isLoading, error, refetch } = useWorkspaces();
+  // Initialize state with stored value (lazy initializer runs once on mount)
+  const [selectedWorkspaceName, setSelectedWorkspaceName] = useState<string | null>(
+    () => getStoredWorkspaceName()
+  );
+
+  // Compute the effective selected workspace name, defaulting to first workspace
+  // if no selection or the selected workspace doesn't exist
+  const effectiveWorkspaceName = useMemo(() => {
+    if (isLoading || workspaces.length === 0) return null;
+
+    // If we have a selection and it exists in the workspace list, use it
+    if (selectedWorkspaceName) {
+      const exists = workspaces.some(ws => ws.name === selectedWorkspaceName);
+      if (exists) return selectedWorkspaceName;
+    }
+
+    // Default to first workspace and persist it
+    const firstWorkspace = workspaces[0].name;
+    if (typeof window !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, firstWorkspace);
+    }
+    return firstWorkspace;
+  }, [selectedWorkspaceName, workspaces, isLoading]);
+
+  // Find the current workspace object
+  const currentWorkspace = useMemo(() => {
+    if (!effectiveWorkspaceName || workspaces.length === 0) return null;
+    return workspaces.find(ws => ws.name === effectiveWorkspaceName) || null;
+  }, [effectiveWorkspaceName, workspaces]);
+
+  const setCurrentWorkspace = useCallback((workspaceName: string | null) => {
+    setSelectedWorkspaceName(workspaceName);
+    if (typeof window !== "undefined") {
+      if (workspaceName) {
+        localStorage.setItem(STORAGE_KEY, workspaceName);
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+  }, []);
+
+  const value = useMemo<WorkspaceContextValue>(
+    () => ({
+      workspaces,
+      currentWorkspace,
+      setCurrentWorkspace,
+      isLoading,
+      error: error as Error | null,
+      refetch,
+    }),
+    [workspaces, currentWorkspace, setCurrentWorkspace, isLoading, error, refetch]
+  );
+
+  return (
+    <WorkspaceContext.Provider value={value}>
+      {children}
+    </WorkspaceContext.Provider>
+  );
+}
+
+/**
+ * Hook to access workspace context.
+ */
+export function useWorkspace(): WorkspaceContextValue {
+  const context = useContext(WorkspaceContext);
+  if (!context) {
+    throw new Error("useWorkspace must be used within a WorkspaceProvider");
+  }
+  return context;
+}

--- a/dashboard/src/hooks/use-workspaces.test.tsx
+++ b/dashboard/src/hooks/use-workspaces.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * Tests for use-workspaces hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useWorkspaces, type WorkspaceListItem } from "./use-workspaces";
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockWorkspaces: WorkspaceListItem[] = [
+  {
+    name: "workspace-1",
+    displayName: "Workspace One",
+    description: "First workspace",
+    environment: "development",
+    namespace: "ns-1",
+    role: "owner",
+    permissions: { read: true, write: true, delete: true, manageMembers: true },
+    createdAt: "2024-01-15T10:00:00Z",
+  },
+  {
+    name: "workspace-2",
+    displayName: "Workspace Two",
+    environment: "production",
+    namespace: "ns-2",
+    role: "viewer",
+    permissions: { read: true, write: false, delete: false, manageMembers: false },
+  },
+];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("useWorkspaces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("fetches workspaces successfully", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ workspaces: mockWorkspaces, count: 2 }),
+    });
+
+    const { result } = renderHook(() => useWorkspaces(), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual(mockWorkspaces);
+    expect(result.current.error).toBeNull();
+    expect(mockFetch).toHaveBeenCalledWith("/api/workspaces");
+  });
+
+  it("handles fetch error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ message: "Unauthorized" }),
+    });
+
+    const { result } = renderHook(() => useWorkspaces(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeTruthy();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it("handles JSON parse error", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      json: async () => {
+        throw new Error("Invalid JSON");
+      },
+    });
+
+    const { result } = renderHook(() => useWorkspaces(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it("filters by minRole when provided", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ workspaces: [mockWorkspaces[0]], count: 1 }),
+    });
+
+    const { result } = renderHook(() => useWorkspaces({ minRole: "editor" }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith("/api/workspaces?minRole=editor");
+  });
+
+  it("respects enabled option", async () => {
+    const { result } = renderHook(() => useWorkspaces({ enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    // Should not fetch when disabled
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it("returns empty array when no workspaces", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ workspaces: [], count: 0 }),
+    });
+
+    const { result } = renderHook(() => useWorkspaces(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/dashboard/src/hooks/use-workspaces.ts
+++ b/dashboard/src/hooks/use-workspaces.ts
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * Hook for fetching user's accessible workspaces.
+ * Uses React Query for caching and automatic refetching.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import type { WorkspaceRole, WorkspacePermissions } from "@/types/workspace";
+
+/**
+ * Workspace item returned from the API.
+ */
+export interface WorkspaceListItem {
+  name: string;
+  displayName: string;
+  description?: string;
+  environment: "development" | "staging" | "production";
+  namespace: string;
+  role: WorkspaceRole;
+  permissions: WorkspacePermissions;
+  createdAt?: string;
+}
+
+/**
+ * Response from /api/workspaces endpoint.
+ */
+interface WorkspacesResponse {
+  workspaces: WorkspaceListItem[];
+  count: number;
+}
+
+/**
+ * Options for fetching workspaces.
+ */
+interface UseWorkspacesOptions {
+  /** Minimum role required (filters workspaces) */
+  minRole?: WorkspaceRole;
+  /** Whether to enable the query */
+  enabled?: boolean;
+}
+
+/**
+ * Fetch workspaces from the API.
+ */
+async function fetchWorkspaces(minRole?: WorkspaceRole): Promise<WorkspaceListItem[]> {
+  const url = minRole ? `/api/workspaces?minRole=${minRole}` : "/api/workspaces";
+  const response = await fetch(url);
+
+  if (!response.ok) {
+    const error = await response.json().catch(() => ({ message: "Failed to fetch workspaces" }));
+    throw new Error(error.message || "Failed to fetch workspaces");
+  }
+
+  const data: WorkspacesResponse = await response.json();
+  return data.workspaces;
+}
+
+/**
+ * Hook to fetch workspaces the current user has access to.
+ *
+ * @example
+ * ```tsx
+ * function MyComponent() {
+ *   const { data: workspaces, isLoading, error } = useWorkspaces();
+ *
+ *   if (isLoading) return <Spinner />;
+ *   if (error) return <ErrorMessage error={error} />;
+ *
+ *   return (
+ *     <ul>
+ *       {workspaces?.map(ws => (
+ *         <li key={ws.name}>{ws.displayName} ({ws.role})</li>
+ *       ))}
+ *     </ul>
+ *   );
+ * }
+ * ```
+ */
+export function useWorkspaces(options: UseWorkspacesOptions = {}) {
+  const { minRole, enabled = true } = options;
+
+  return useQuery({
+    queryKey: ["workspaces", minRole],
+    queryFn: () => fetchWorkspaces(minRole),
+    staleTime: 60000, // Cache for 1 minute
+    enabled,
+  });
+}


### PR DESCRIPTION
## Summary
- Add workspace switcher component in the dashboard header
- Create WorkspaceContext for managing workspace selection state
- Create useWorkspaces hook for fetching accessible workspaces from `/api/workspaces`
- Persist workspace selection to localStorage
- Display user's role (owner/editor/viewer) and environment (dev/staging/prod) badges

## Test plan
- [x] Unit tests for WorkspaceSwitcher component (10 tests)
- [x] Unit tests for WorkspaceContext (9 tests)
- [x] Unit tests for useWorkspaces hook (6 tests)
- [x] Unit tests for Header component (11 tests)
- [x] Unit tests for Providers component (5 tests)
- [ ] Manual testing with running dashboard

Closes #285