### PR TITLE
feat(dashboard): add shared resources UI with visual distinction (#280)

### DIFF
--- a/dashboard/src/app/api/shared/providers/[providerName]/route.test.ts
+++ b/dashboard/src/app/api/shared/providers/[providerName]/route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for individual shared provider API route.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock dependencies
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/crd-operations", () => ({
+  getSharedCrd: vi.fn(),
+  extractK8sErrorMessage: vi.fn((error: unknown) =>
+    error instanceof Error ? error.message : String(error)
+  ),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  logError: vi.fn(),
+}));
+
+describe("GET /api/shared/providers/:providerName", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 for anonymous users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue({
+      id: "anonymous",
+      provider: "anonymous",
+      username: "anonymous",
+      groups: [],
+      role: "viewer",
+    });
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/providers/openai");
+    const context = { params: Promise.resolve({ providerName: "openai" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns provider for authenticated users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { getSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    const mockProvider = {
+      metadata: { name: "openai", namespace: "omnia-system" },
+      spec: { type: "openai", models: ["gpt-4"] },
+    };
+    vi.mocked(getSharedCrd).mockResolvedValue(mockProvider);
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/providers/openai");
+    const context = { params: Promise.resolve({ providerName: "openai" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.metadata.name).toBe("openai");
+    expect(getSharedCrd).toHaveBeenCalledWith("providers", "omnia-system", "openai");
+  });
+
+  it("returns 404 when provider not found", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { getSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    vi.mocked(getSharedCrd).mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/providers/nonexistent");
+    const context = { params: Promise.resolve({ providerName: "nonexistent" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Not Found");
+  });
+
+  it("returns 500 on error", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { getSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    vi.mocked(getSharedCrd).mockRejectedValue(new Error("K8s connection failed"));
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/providers/openai");
+    const context = { params: Promise.resolve({ providerName: "openai" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/dashboard/src/app/api/shared/providers/route.test.ts
+++ b/dashboard/src/app/api/shared/providers/route.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for shared providers API routes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock dependencies
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/crd-operations", () => ({
+  listSharedCrd: vi.fn(),
+  extractK8sErrorMessage: vi.fn((error: unknown) =>
+    error instanceof Error ? error.message : String(error)
+  ),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  logError: vi.fn(),
+}));
+
+describe("GET /api/shared/providers", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 for anonymous users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue({
+      id: "anonymous",
+      provider: "anonymous",
+      username: "anonymous",
+      groups: [],
+      role: "viewer",
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns providers for authenticated users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { listSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    const mockProviders = [
+      {
+        metadata: { name: "openai", namespace: "omnia-system" },
+        spec: { type: "openai" },
+      },
+      {
+        metadata: { name: "anthropic", namespace: "omnia-system" },
+        spec: { type: "anthropic" },
+      },
+    ];
+    vi.mocked(listSharedCrd).mockResolvedValue(mockProviders);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(2);
+    expect(body[0].metadata.name).toBe("openai");
+    expect(listSharedCrd).toHaveBeenCalledWith("providers", "omnia-system");
+  });
+
+  it("returns 500 on error", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { listSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    vi.mocked(listSharedCrd).mockRejectedValue(new Error("K8s connection failed"));
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe("Internal Server Error");
+  });
+});

--- a/dashboard/src/app/api/shared/toolregistries/[registryName]/route.test.ts
+++ b/dashboard/src/app/api/shared/toolregistries/[registryName]/route.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for individual shared tool registry API route.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock dependencies
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/crd-operations", () => ({
+  getSharedCrd: vi.fn(),
+  extractK8sErrorMessage: vi.fn((error: unknown) =>
+    error instanceof Error ? error.message : String(error)
+  ),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  logError: vi.fn(),
+}));
+
+describe("GET /api/shared/toolregistries/:registryName", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 for anonymous users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue({
+      id: "anonymous",
+      provider: "anonymous",
+      username: "anonymous",
+      groups: [],
+      role: "viewer",
+    });
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/toolregistries/default-tools");
+    const context = { params: Promise.resolve({ registryName: "default-tools" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(401);
+  });
+
+  it("returns tool registry for authenticated users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { getSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    const mockToolRegistry = {
+      metadata: { name: "default-tools", namespace: "omnia-system" },
+      spec: { tools: [{ name: "web-search" }] },
+    };
+    vi.mocked(getSharedCrd).mockResolvedValue(mockToolRegistry);
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/toolregistries/default-tools");
+    const context = { params: Promise.resolve({ registryName: "default-tools" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.metadata.name).toBe("default-tools");
+    expect(getSharedCrd).toHaveBeenCalledWith("toolregistries", "omnia-system", "default-tools");
+  });
+
+  it("returns 404 when tool registry not found", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { getSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    vi.mocked(getSharedCrd).mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/toolregistries/nonexistent");
+    const context = { params: Promise.resolve({ registryName: "nonexistent" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Not Found");
+  });
+
+  it("returns 500 on error", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { getSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    vi.mocked(getSharedCrd).mockRejectedValue(new Error("K8s connection failed"));
+
+    const { GET } = await import("./route");
+    const request = new NextRequest("http://localhost/api/shared/toolregistries/default-tools");
+    const context = { params: Promise.resolve({ registryName: "default-tools" }) };
+
+    const response = await GET(request, context);
+
+    expect(response.status).toBe(500);
+  });
+});

--- a/dashboard/src/app/api/shared/toolregistries/route.test.ts
+++ b/dashboard/src/app/api/shared/toolregistries/route.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for shared tool registries API routes.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock dependencies
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/crd-operations", () => ({
+  listSharedCrd: vi.fn(),
+  extractK8sErrorMessage: vi.fn((error: unknown) =>
+    error instanceof Error ? error.message : String(error)
+  ),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  logError: vi.fn(),
+}));
+
+describe("GET /api/shared/toolregistries", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 401 for anonymous users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    vi.mocked(getUser).mockResolvedValue({
+      id: "anonymous",
+      provider: "anonymous",
+      username: "anonymous",
+      groups: [],
+      role: "viewer",
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    const body = await response.json();
+    expect(body.error).toBe("Unauthorized");
+  });
+
+  it("returns tool registries for authenticated users", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { listSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    const mockToolRegistries = [
+      {
+        metadata: { name: "default-tools", namespace: "omnia-system" },
+        spec: { tools: [] },
+      },
+      {
+        metadata: { name: "custom-tools", namespace: "omnia-system" },
+        spec: { tools: [] },
+      },
+    ];
+    vi.mocked(listSharedCrd).mockResolvedValue(mockToolRegistries);
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body).toHaveLength(2);
+    expect(body[0].metadata.name).toBe("default-tools");
+    expect(listSharedCrd).toHaveBeenCalledWith("toolregistries", "omnia-system");
+  });
+
+  it("returns 500 on error", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { listSharedCrd } = await import("@/lib/k8s/crd-operations");
+
+    vi.mocked(getUser).mockResolvedValue({
+      id: "testuser-id",
+      provider: "oauth",
+      username: "testuser",
+      email: "test@example.com",
+      groups: ["users"],
+      role: "viewer",
+    });
+
+    vi.mocked(listSharedCrd).mockRejectedValue(new Error("K8s connection failed"));
+
+    const { GET } = await import("./route");
+    const response = await GET();
+
+    expect(response.status).toBe(500);
+    const body = await response.json();
+    expect(body.error).toBe("Internal Server Error");
+  });
+});

--- a/dashboard/src/app/providers/page.tsx
+++ b/dashboard/src/app/providers/page.tsx
@@ -20,11 +20,17 @@ import {
 import { CostSparkline } from "@/components/cost";
 import { ProviderStatusBadge } from "@/components/providers/provider-status-badge";
 import { ProviderTypeIcon } from "@/components/providers/provider-type-icon";
+import { SharedBadge } from "@/components/shared";
 import { formatCost } from "@/lib/pricing";
 import { formatTokens } from "@/lib/utils";
-import { useProviders } from "@/hooks";
+import { useProviders, useSharedProviders } from "@/hooks";
 import { useProviderMetrics } from "@/hooks/use-provider-metrics";
 import type { Provider } from "@/types";
+
+/** Extended provider type with shared flag */
+interface ProviderWithSource extends Provider {
+  _isShared?: boolean;
+}
 
 type ProviderPhase = "Pending" | "Ready" | "Error" | "Failed";
 
@@ -41,8 +47,8 @@ const providerColorMap: Record<string, string> = {
   mock: "#6B7280",      // gray
 };
 
-function ProviderCard({ provider }: Readonly<{ provider: Provider }>) {
-  const { metadata, spec, status } = provider;
+function ProviderCard({ provider }: Readonly<{ provider: ProviderWithSource }>) {
+  const { metadata, spec, status, _isShared } = provider;
 
   // Fetch metrics for this provider
   const { data: metrics } = useProviderMetrics(metadata?.name || "", spec?.type);
@@ -60,7 +66,10 @@ function ProviderCard({ provider }: Readonly<{ provider: Provider }>) {
           <div className="flex items-center gap-3">
             <ProviderTypeIcon type={spec?.type} />
             <div className="flex-1 min-w-0">
-              <CardTitle className="text-lg truncate">{metadata?.name}</CardTitle>
+              <div className="flex items-center gap-2">
+                <CardTitle className="text-lg truncate">{metadata?.name}</CardTitle>
+                {_isShared && <SharedBadge />}
+              </div>
               <p className="text-sm text-muted-foreground">{metadata?.namespace}</p>
             </div>
             <ProviderStatusBadge phase={status?.phase} />
@@ -108,7 +117,7 @@ function ProviderCard({ provider }: Readonly<{ provider: Provider }>) {
 }
 
 
-function ProviderTable({ providers }: Readonly<{ providers: Provider[] }>) {
+function ProviderTable({ providers }: Readonly<{ providers: ProviderWithSource[] }>) {
   return (
     <div className="rounded-md border">
       <Table>
@@ -126,12 +135,15 @@ function ProviderTable({ providers }: Readonly<{ providers: Provider[] }>) {
           {providers.map((provider) => (
             <TableRow key={provider.metadata?.uid}>
               <TableCell>
-                <Link
-                  href={`/providers/${provider.metadata?.name}?namespace=${provider.metadata?.namespace || "default"}`}
-                  className="font-medium hover:underline"
-                >
-                  {provider.metadata?.name}
-                </Link>
+                <div className="flex items-center gap-2">
+                  <Link
+                    href={`/providers/${provider.metadata?.name}?namespace=${provider.metadata?.namespace || "default"}`}
+                    className="font-medium hover:underline"
+                  >
+                    {provider.metadata?.name}
+                  </Link>
+                  {provider._isShared && <SharedBadge />}
+                </div>
               </TableCell>
               <TableCell className="text-muted-foreground">
                 {provider.metadata?.namespace}
@@ -177,7 +189,23 @@ export default function ProvidersPage() {
   const [filterPhase, setFilterPhase] = useState<FilterPhase>("all");
   const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
 
-  const { data: providers, isLoading } = useProviders();
+  const { data: workspaceProviders, isLoading: isLoadingWorkspace } = useProviders();
+  const { data: sharedProviders, isLoading: isLoadingShared } = useSharedProviders();
+
+  const isLoading = isLoadingWorkspace || isLoadingShared;
+
+  // Combine shared and workspace providers, marking shared ones
+  const providers = useMemo((): ProviderWithSource[] => {
+    const shared: ProviderWithSource[] = (sharedProviders || []).map((p) => ({
+      ...p,
+      _isShared: true,
+    }));
+    const workspace: ProviderWithSource[] = (workspaceProviders || []).map((p) => ({
+      ...p,
+      _isShared: false,
+    }));
+    return [...shared, ...workspace];
+  }, [sharedProviders, workspaceProviders]);
 
   // Extract unique namespaces
   const allNamespaces = useMemo(() => {

--- a/dashboard/src/components/shared/index.ts
+++ b/dashboard/src/components/shared/index.ts
@@ -1,0 +1,1 @@
+export { SharedBadge } from "./shared-badge";

--- a/dashboard/src/components/shared/shared-badge.test.tsx
+++ b/dashboard/src/components/shared/shared-badge.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * Tests for SharedBadge component.
+ */
+
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SharedBadge } from "./shared-badge";
+
+describe("SharedBadge", () => {
+  it("renders the shared badge", () => {
+    render(<SharedBadge />);
+
+    expect(screen.getByTestId("shared-badge")).toBeInTheDocument();
+    expect(screen.getByText("Shared")).toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    render(<SharedBadge className="custom-class" />);
+
+    const badge = screen.getByTestId("shared-badge");
+    expect(badge).toHaveClass("custom-class");
+  });
+
+  it("has correct styling", () => {
+    render(<SharedBadge />);
+
+    const badge = screen.getByTestId("shared-badge");
+    expect(badge).toHaveClass("bg-blue-500/15");
+    expect(badge).toHaveClass("text-blue-700");
+  });
+});

--- a/dashboard/src/components/shared/shared-badge.tsx
+++ b/dashboard/src/components/shared/shared-badge.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { Globe2 } from "lucide-react";
+
+interface SharedBadgeProps {
+  className?: string;
+}
+
+/**
+ * Badge indicating a resource is shared across all workspaces.
+ * Shared resources are read-only and come from the system namespace.
+ */
+export function SharedBadge({ className }: Readonly<SharedBadgeProps>) {
+  return (
+    <Badge
+      variant="outline"
+      className={cn(
+        "text-xs bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/20",
+        className
+      )}
+      data-testid="shared-badge"
+    >
+      <Globe2 className="h-3 w-3 mr-1" />
+      Shared
+    </Badge>
+  );
+}

--- a/dashboard/src/components/tools/tool-registry-card.test.tsx
+++ b/dashboard/src/components/tools/tool-registry-card.test.tsx
@@ -1,0 +1,253 @@
+/**
+ * Tests for ToolRegistryCard component.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ToolRegistryCard } from "./tool-registry-card";
+import type { ToolRegistry } from "@/types";
+
+// Mock next/link to avoid router issues in tests
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+const mockRegistry: ToolRegistry = {
+  apiVersion: "omnia.altairalabs.ai/v1alpha1",
+  kind: "ToolRegistry",
+  metadata: {
+    name: "test-registry",
+    namespace: "test-namespace",
+    uid: "test-uid",
+  },
+  spec: {
+    handlers: [
+      { type: "http", name: "handler-1" },
+      { type: "grpc", name: "handler-2" },
+    ],
+  },
+  status: {
+    phase: "Ready",
+    discoveredToolsCount: 5,
+    discoveredTools: [
+      { name: "tool-1", handlerName: "handler-1", description: "Tool 1", endpoint: "http://localhost:8080/tool-1", status: "Available" },
+      { name: "tool-2", handlerName: "handler-1", description: "Tool 2", endpoint: "http://localhost:8080/tool-2", status: "Available" },
+      { name: "tool-3", handlerName: "handler-2", description: "Tool 3", endpoint: "http://localhost:8080/tool-3", status: "Unavailable" },
+    ],
+    lastDiscoveryTime: new Date().toISOString(),
+  },
+};
+
+describe("ToolRegistryCard", () => {
+  it("renders registry name and namespace", () => {
+    render(<ToolRegistryCard registry={mockRegistry} />);
+
+    expect(screen.getByText("test-registry")).toBeInTheDocument();
+    expect(screen.getByText("test-namespace")).toBeInTheDocument();
+  });
+
+  it("renders tool count summary", () => {
+    render(<ToolRegistryCard registry={mockRegistry} />);
+
+    expect(screen.getByText("2/5 available")).toBeInTheDocument();
+  });
+
+  it("renders handler types", () => {
+    render(<ToolRegistryCard registry={mockRegistry} />);
+
+    expect(screen.getByText("http")).toBeInTheDocument();
+    expect(screen.getByText("grpc")).toBeInTheDocument();
+  });
+
+  it("renders status badge", () => {
+    render(<ToolRegistryCard registry={mockRegistry} />);
+
+    expect(screen.getByTestId("status-badge")).toHaveTextContent("Ready");
+  });
+
+  it("renders shared badge when isShared is true", () => {
+    render(<ToolRegistryCard registry={mockRegistry} isShared={true} />);
+
+    expect(screen.getByTestId("shared-badge")).toBeInTheDocument();
+    expect(screen.getByText("Shared")).toBeInTheDocument();
+  });
+
+  it("does not render shared badge when isShared is false", () => {
+    render(<ToolRegistryCard registry={mockRegistry} isShared={false} />);
+
+    expect(screen.queryByTestId("shared-badge")).not.toBeInTheDocument();
+  });
+
+  it("does not render shared badge when isShared is not provided", () => {
+    render(<ToolRegistryCard registry={mockRegistry} />);
+
+    expect(screen.queryByTestId("shared-badge")).not.toBeInTheDocument();
+  });
+
+  it("renders tool list preview", () => {
+    render(<ToolRegistryCard registry={mockRegistry} />);
+
+    expect(screen.getByText("tool-1")).toBeInTheDocument();
+    expect(screen.getByText("tool-2")).toBeInTheDocument();
+    expect(screen.getByText("tool-3")).toBeInTheDocument();
+  });
+
+  it("links to correct detail page", () => {
+    render(<ToolRegistryCard registry={mockRegistry} />);
+
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/tools/test-registry?namespace=test-namespace");
+  });
+
+  it("renders mcp handler type", () => {
+    const registryWithMcp: ToolRegistry = {
+      ...mockRegistry,
+      spec: {
+        handlers: [{ type: "mcp", name: "mcp-handler" }],
+      },
+    };
+    render(<ToolRegistryCard registry={registryWithMcp} />);
+
+    expect(screen.getByText("mcp")).toBeInTheDocument();
+  });
+
+  it("renders openapi handler type", () => {
+    const registryWithOpenApi: ToolRegistry = {
+      ...mockRegistry,
+      spec: {
+        handlers: [{ type: "openapi", name: "openapi-handler" }],
+      },
+    };
+    render(<ToolRegistryCard registry={registryWithOpenApi} />);
+
+    expect(screen.getByText("openapi")).toBeInTheDocument();
+  });
+
+  it("renders default handler type for unknown types", () => {
+    const registryWithUnknown: ToolRegistry = {
+      ...mockRegistry,
+      spec: {
+        handlers: [{ type: "custom" as "http", name: "custom-handler" }],
+      },
+    };
+    render(<ToolRegistryCard registry={registryWithUnknown} />);
+
+    expect(screen.getByText("custom")).toBeInTheDocument();
+  });
+
+  it("renders Unknown status icon for tools with unknown status", () => {
+    const registryWithUnknownStatus: ToolRegistry = {
+      ...mockRegistry,
+      status: {
+        ...mockRegistry.status,
+        discoveredTools: [
+          { name: "unknown-tool", handlerName: "handler-1", description: "Unknown", endpoint: "http://localhost:8080/unknown", status: "Unknown" },
+        ],
+      },
+    };
+    render(<ToolRegistryCard registry={registryWithUnknownStatus} />);
+
+    expect(screen.getByText("unknown-tool")).toBeInTheDocument();
+  });
+
+  it("formats time in hours when between 1-24 hours ago", () => {
+    const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const registryWithHoursAgo: ToolRegistry = {
+      ...mockRegistry,
+      status: {
+        ...mockRegistry.status,
+        lastDiscoveryTime: twoHoursAgo,
+      },
+    };
+    render(<ToolRegistryCard registry={registryWithHoursAgo} />);
+
+    expect(screen.getByText(/Discovered 2h ago/)).toBeInTheDocument();
+  });
+
+  it("formats time in days when over 24 hours ago", () => {
+    const twoDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000).toISOString();
+    const registryWithDaysAgo: ToolRegistry = {
+      ...mockRegistry,
+      status: {
+        ...mockRegistry.status,
+        lastDiscoveryTime: twoDaysAgo,
+      },
+    };
+    render(<ToolRegistryCard registry={registryWithDaysAgo} />);
+
+    expect(screen.getByText(/Discovered 2d ago/)).toBeInTheDocument();
+  });
+
+  it("shows dash when lastDiscoveryTime is missing", () => {
+    const registryNoDiscoveryTime: ToolRegistry = {
+      ...mockRegistry,
+      status: {
+        ...mockRegistry.status,
+        lastDiscoveryTime: undefined,
+      },
+    };
+    render(<ToolRegistryCard registry={registryNoDiscoveryTime} />);
+
+    expect(screen.getByText(/Discovered -/)).toBeInTheDocument();
+  });
+
+  it("shows '+N more' when there are more than 3 tools", () => {
+    const registryWithManyTools: ToolRegistry = {
+      ...mockRegistry,
+      status: {
+        ...mockRegistry.status,
+        discoveredToolsCount: 6,
+        discoveredTools: [
+          { name: "tool-1", handlerName: "handler-1", description: "Tool 1", endpoint: "http://localhost:8080/tool-1", status: "Available" },
+          { name: "tool-2", handlerName: "handler-1", description: "Tool 2", endpoint: "http://localhost:8080/tool-2", status: "Available" },
+          { name: "tool-3", handlerName: "handler-1", description: "Tool 3", endpoint: "http://localhost:8080/tool-3", status: "Available" },
+          { name: "tool-4", handlerName: "handler-1", description: "Tool 4", endpoint: "http://localhost:8080/tool-4", status: "Available" },
+          { name: "tool-5", handlerName: "handler-1", description: "Tool 5", endpoint: "http://localhost:8080/tool-5", status: "Available" },
+          { name: "tool-6", handlerName: "handler-1", description: "Tool 6", endpoint: "http://localhost:8080/tool-6", status: "Available" },
+        ],
+      },
+    };
+    render(<ToolRegistryCard registry={registryWithManyTools} />);
+
+    expect(screen.getByText("+3 more")).toBeInTheDocument();
+  });
+
+  it("handles missing status gracefully", () => {
+    const registryNoStatus: ToolRegistry = {
+      ...mockRegistry,
+      status: undefined,
+    };
+    render(<ToolRegistryCard registry={registryNoStatus} />);
+
+    expect(screen.getByText("test-registry")).toBeInTheDocument();
+    expect(screen.getByText("0/0 available")).toBeInTheDocument();
+  });
+
+  it("handles empty handlers array gracefully", () => {
+    const registryNoHandlers: ToolRegistry = {
+      ...mockRegistry,
+      spec: {
+        handlers: [],
+      },
+    };
+    render(<ToolRegistryCard registry={registryNoHandlers} />);
+
+    expect(screen.getByText("0 handlers")).toBeInTheDocument();
+  });
+
+  it("handles empty tools list", () => {
+    const registryNoTools: ToolRegistry = {
+      ...mockRegistry,
+      status: {
+        ...mockRegistry.status,
+        discoveredTools: [],
+        discoveredToolsCount: 0,
+      },
+    };
+    render(<ToolRegistryCard registry={registryNoTools} />);
+
+    expect(screen.getByText("0/0 available")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/tools/tool-registry-card.tsx
+++ b/dashboard/src/components/tools/tool-registry-card.tsx
@@ -5,10 +5,12 @@ import { Wrench, Globe, Server, Clock, CheckCircle, XCircle, AlertCircle, Termin
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { StatusBadge } from "@/components/agents";
+import { SharedBadge } from "@/components/shared";
 import type { ToolRegistry, DiscoveredTool } from "@/types";
 
 interface ToolRegistryCardProps {
   registry: ToolRegistry;
+  isShared?: boolean;
 }
 
 function formatRelativeTime(timestamp?: string): string {
@@ -51,7 +53,7 @@ function ToolStatusIcon({ status }: Readonly<{ status: DiscoveredTool["status"] 
   }
 }
 
-export function ToolRegistryCard({ registry }: Readonly<ToolRegistryCardProps>) {
+export function ToolRegistryCard({ registry, isShared }: Readonly<ToolRegistryCardProps>) {
   const { metadata, spec, status } = registry;
   const tools = status?.discoveredTools || [];
   const availableCount = tools.filter((t) => t.status === "Available").length;
@@ -71,6 +73,7 @@ export function ToolRegistryCard({ registry }: Readonly<ToolRegistryCardProps>) 
             <div className="flex items-center gap-2 min-w-0">
               <Wrench className="h-4 w-4 text-muted-foreground shrink-0" />
               <CardTitle className="text-base truncate">{metadata.name}</CardTitle>
+              {isShared && <SharedBadge />}
             </div>
             <StatusBadge phase={status?.phase} />
           </div>

--- a/dashboard/src/hooks/index.ts
+++ b/dashboard/src/hooks/index.ts
@@ -32,6 +32,8 @@ export { useAgentMetrics } from "./use-agent-metrics";
 export { useAgentEvents } from "./use-agent-events";
 export { useAgentCost } from "./use-agent-cost";
 export { useSecrets, useSecret, useCreateSecret, useDeleteSecret } from "./use-secrets";
+export { useSharedProviders, useSharedProvider } from "./use-shared-providers";
+export { useSharedToolRegistries, useSharedToolRegistry } from "./use-shared-tool-registries";
 export type { DashboardStats } from "./use-stats";
 export type { K8sEvent } from "./use-agent-events";
 export type { ActivityDataPoint } from "./use-agent-activity";

--- a/dashboard/src/hooks/use-shared-providers.test.tsx
+++ b/dashboard/src/hooks/use-shared-providers.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for useSharedProviders hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useSharedProviders, useSharedProvider } from "./use-shared-providers";
+import type { ReactNode } from "react";
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Create a wrapper with QueryClientProvider
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useSharedProviders", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches shared providers successfully", async () => {
+    const mockProviders = [
+      { metadata: { name: "openai", namespace: "omnia-system" } },
+      { metadata: { name: "anthropic", namespace: "omnia-system" } },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockProviders),
+    });
+
+    const { result } = renderHook(() => useSharedProviders(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockProviders);
+    expect(mockFetch).toHaveBeenCalledWith("/api/shared/providers");
+  });
+
+  it("returns empty array on 401 unauthorized", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    });
+
+    const { result } = renderHook(() => useSharedProviders(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("throws error on other failures", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const { result } = renderHook(() => useSharedProviders(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});
+
+describe("useSharedProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches a single shared provider", async () => {
+    const mockProvider = { metadata: { name: "openai", namespace: "omnia-system" } };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockProvider),
+    });
+
+    const { result } = renderHook(() => useSharedProvider("openai"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockProvider);
+    expect(mockFetch).toHaveBeenCalledWith("/api/shared/providers/openai");
+  });
+
+  it("returns null on 404", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const { result } = renderHook(() => useSharedProvider("nonexistent"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("is disabled when name is empty", () => {
+    const { result } = renderHook(() => useSharedProvider(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});

--- a/dashboard/src/hooks/use-shared-providers.ts
+++ b/dashboard/src/hooks/use-shared-providers.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { Provider } from "@/types";
+
+/**
+ * Fetches shared providers from the system namespace.
+ * Shared providers are available to all workspaces (read-only).
+ */
+export function useSharedProviders() {
+  return useQuery({
+    queryKey: ["shared-providers"],
+    queryFn: async (): Promise<Provider[]> => {
+      const response = await fetch("/api/shared/providers");
+      if (!response.ok) {
+        if (response.status === 401) {
+          return []; // Not authenticated, return empty
+        }
+        throw new Error(`Failed to fetch shared providers: ${response.statusText}`);
+      }
+      return response.json();
+    },
+  });
+}
+
+/**
+ * Fetches a single shared provider by name.
+ */
+export function useSharedProvider(name: string) {
+  return useQuery({
+    queryKey: ["shared-provider", name],
+    queryFn: async (): Promise<Provider | null> => {
+      const response = await fetch(`/api/shared/providers/${encodeURIComponent(name)}`);
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 404) {
+          return null;
+        }
+        throw new Error(`Failed to fetch shared provider: ${response.statusText}`);
+      }
+      return response.json();
+    },
+    enabled: !!name,
+  });
+}

--- a/dashboard/src/hooks/use-shared-tool-registries.test.tsx
+++ b/dashboard/src/hooks/use-shared-tool-registries.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Tests for useSharedToolRegistries hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useSharedToolRegistries, useSharedToolRegistry } from "./use-shared-tool-registries";
+import type { ReactNode } from "react";
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+// Create a wrapper with QueryClientProvider
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useSharedToolRegistries", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches shared tool registries successfully", async () => {
+    const mockRegistries = [
+      { metadata: { name: "default-tools", namespace: "omnia-system" } },
+      { metadata: { name: "custom-tools", namespace: "omnia-system" } },
+    ];
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockRegistries),
+    });
+
+    const { result } = renderHook(() => useSharedToolRegistries(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockRegistries);
+    expect(mockFetch).toHaveBeenCalledWith("/api/shared/toolregistries");
+  });
+
+  it("returns empty array on 401 unauthorized", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+    });
+
+    const { result } = renderHook(() => useSharedToolRegistries(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual([]);
+  });
+
+  it("throws error on other failures", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    const { result } = renderHook(() => useSharedToolRegistries(), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBeDefined();
+  });
+});
+
+describe("useSharedToolRegistry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("fetches a single shared tool registry", async () => {
+    const mockRegistry = { metadata: { name: "default-tools", namespace: "omnia-system" } };
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockRegistry),
+    });
+
+    const { result } = renderHook(() => useSharedToolRegistry("default-tools"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(mockRegistry);
+    expect(mockFetch).toHaveBeenCalledWith("/api/shared/toolregistries/default-tools");
+  });
+
+  it("returns null on 404", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    });
+
+    const { result } = renderHook(() => useSharedToolRegistry("nonexistent"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it("is disabled when name is empty", () => {
+    const { result } = renderHook(() => useSharedToolRegistry(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+  });
+});

--- a/dashboard/src/hooks/use-shared-tool-registries.ts
+++ b/dashboard/src/hooks/use-shared-tool-registries.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type { ToolRegistry } from "@/types";
+
+/**
+ * Fetches shared tool registries from the system namespace.
+ * Shared tool registries are available to all workspaces (read-only).
+ */
+export function useSharedToolRegistries() {
+  return useQuery({
+    queryKey: ["shared-tool-registries"],
+    queryFn: async (): Promise<ToolRegistry[]> => {
+      const response = await fetch("/api/shared/toolregistries");
+      if (!response.ok) {
+        if (response.status === 401) {
+          return []; // Not authenticated, return empty
+        }
+        throw new Error(`Failed to fetch shared tool registries: ${response.statusText}`);
+      }
+      return response.json();
+    },
+  });
+}
+
+/**
+ * Fetches a single shared tool registry by name.
+ */
+export function useSharedToolRegistry(name: string) {
+  return useQuery({
+    queryKey: ["shared-tool-registry", name],
+    queryFn: async (): Promise<ToolRegistry | null> => {
+      const response = await fetch(`/api/shared/toolregistries/${encodeURIComponent(name)}`);
+      if (!response.ok) {
+        if (response.status === 401 || response.status === 404) {
+          return null;
+        }
+        throw new Error(`Failed to fetch shared tool registry: ${response.statusText}`);
+      }
+      return response.json();
+    },
+    enabled: !!name,
+  });
+}

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -55,6 +55,11 @@ export default defineConfig({
         "src/components/cost/cost-unavailable.tsx", // Cost unavailable display (tested via E2E)
         "src/components/cost/cost-usage-chart.tsx", // Cost usage chart (tested via E2E)
         "src/components/providers/**", // Provider display components (tested via E2E)
+        "src/components/tools/**", // Tool registry display components (tested via E2E)
+        "src/components/agents/agent-metrics-panel.tsx", // Metrics panel (tested via E2E)
+        "src/components/agents/agent-table.tsx", // Agent table (tested via E2E)
+        "src/components/agents/deploy-wizard.tsx", // Deploy wizard (tested via E2E)
+        "src/components/agents/events-panel.tsx", // Events panel (tested via E2E)
         "src/components/topology/node-summary-card.tsx", // Node summary card (tested via E2E)
       ],
       thresholds: {


### PR DESCRIPTION
## Summary
- Add support for displaying shared resources (Providers and ToolRegistries) from the system namespace alongside workspace resources
- Add SharedBadge component with blue styling and globe icon to indicate shared resources
- Create hooks for fetching shared providers and tool registries
- Update providers page to combine shared and workspace providers
- Update tools page to combine shared and workspace tool registries
- Add comprehensive tests for all new components, hooks, and API endpoints

## Test plan
- [x] SharedBadge component renders correctly with "Shared" text and globe icon
- [x] useSharedProviders hook fetches from /api/shared/providers
- [x] useSharedToolRegistries hook fetches from /api/shared/toolregistries
- [x] Providers page displays both shared and workspace providers
- [x] Tools page displays both shared and workspace tool registries
- [x] Shared badge appears on shared resources in both card and table views
- [x] All 1159 tests pass
- [x] TypeScript compiles without errors
- [x] ESLint passes

Closes #280