### PR TITLE
ci: add .github/** to ci-skip paths for workflow-only PRs

### DIFF
--- a/.github/workflows/ci-skip.yml
+++ b/.github/workflows/ci-skip.yml
@@ -1,7 +1,7 @@
 name: CI
 
-# This workflow runs for PRs that only affect documentation.
-# It reports the same status checks as ci.yml so docs-only PRs can be merged.
+# This workflow runs for PRs that only affect documentation or CI workflows.
+# It reports the same status checks as ci.yml so these PRs can be merged.
 # ci.yml has path filters for code files; this workflow handles everything else.
 
 on:
@@ -12,9 +12,7 @@ on:
       - '*.md'
       - 'LICENSE'
       - '.gitignore'
-      - '.github/workflows/ci-skip.yml'
-      - '.github/workflows/ci-dependabot.yml'
-      - '.github/dependabot.yml'
+      - '.github/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Updates `ci-skip.yml` to trigger for any changes under `.github/`, not just specific files.

## Problem
Dependabot PRs that update GitHub Actions versions (e.g., #294, #295) only modify workflow files. These don't match `ci.yml`'s path filters, so required checks like SonarCloud never run and block merging.

## Solution
Use `.github/**` glob pattern in `ci-skip.yml` to match all GitHub configuration changes, providing skip checks for:
- Workflow file updates
- Dependabot config changes
- Any other `.github/` changes

## Test plan
- [ ] Verify Dependabot PRs #294 and #295 can now pass required checks
- [ ] Verify this PR's own checks pass (meta-test)