### PR TITLE
fix(dashboard): enable production source maps for E2E coverage

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -7,6 +7,11 @@ const nextConfig: NextConfig = {
 
   // Note: Grafana proxy is handled by /app/grafana/[...path]/route.ts
   // This allows us to add auth headers when proxying to Grafana
+
+  // Enable source maps in production for E2E code coverage collection.
+  // This allows monocart-reporter to map V8 coverage back to original source files.
+  // Source maps are only served when explicitly requested, so no security impact.
+  productionBrowserSourceMaps: true,
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- Enable `productionBrowserSourceMaps` in Next.js config so monocart-reporter can map V8 coverage back to original TypeScript source files
- Fixes SonarCloud Analysis failure where 157 file paths could not be resolved

## Problem
After merging #322, the SonarCloud Analysis failed because the E2E coverage lcov file contained bundled file paths like `localhost-3000/_next/static/chunks/...` instead of source file paths. SonarCloud couldn't resolve these paths.

## Solution
Enable production source maps in Next.js so that V8 coverage can be mapped back to original source files via source maps. The lcov output now contains proper paths like `app/src/app/agents/page.tsx` which the CI sed command converts to `dashboard/src/...` for SonarCloud.

## Test plan
- [x] Local E2E coverage test shows correct source paths in lcov output
- [ ] CI passes including SonarCloud Analysis