### PR TITLE
fix(ci): run E2E coverage server in production mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -453,8 +453,8 @@ jobs:
 
     - name: Run E2E tests with coverage
       run: |
-        # Start the server in background with demo mode
-        DEMO_MODE=true NEXT_PUBLIC_DEMO_MODE=true npm run start &
+        # Start the server in background with demo mode and production settings
+        NODE_ENV=production DEMO_MODE=true NEXT_PUBLIC_DEMO_MODE=true npm run start &
         # Wait for server to be ready
         npx wait-on http://localhost:3000 --timeout 60000
         # Run Playwright tests with coverage collection


### PR DESCRIPTION
## Summary
- Add `NODE_ENV=production` when starting the server for E2E coverage tests

## Problem
The E2E coverage server was running in development mode (turbopack/HMR), causing coverage output to contain bundled paths like `localhost-3000/_next/static/chunks/[turbopack]_browser_dev_hmr-client...` instead of source file paths. SonarCloud couldn't resolve these paths:
```
Could not resolve 157 file paths in [.../dashboard/coverage/lcov.info]
First unresolved path: localhost-3000/_next/static/chunks/[turbopack]_browser_dev_hmr-client_hmr-client_ts_956a0d3a._.js
```

## Solution
Set `NODE_ENV=production` when starting the server so it uses the production build with proper source maps.

## Test plan
- [ ] CI passes including SonarCloud Analysis
- [ ] E2E coverage paths are properly resolved