### PR TITLE
fix(ci): handle [project] prefix in E2E coverage paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,8 @@ jobs:
       if: success()
       run: |
         if [ -f dashboard/e2e-coverage/coverage/lcov.info ]; then
-          # lcov.info has paths like "app/src/..." but SonarCloud needs "dashboard/src/..."
+          # lcov.info has paths like "[project]/src/..." or "app/src/..." but SonarCloud needs "dashboard/src/..."
+          sed -i 's|^SF:\[project\]/src/|SF:dashboard/src/|g' dashboard/e2e-coverage/coverage/lcov.info
           sed -i 's|^SF:app/src/|SF:dashboard/src/|g' dashboard/e2e-coverage/coverage/lcov.info
           sed -i 's|^SF:src/|SF:dashboard/src/|g' dashboard/e2e-coverage/coverage/lcov.info
           echo "Fixed E2E lcov.info paths:"


### PR DESCRIPTION
## Summary
- Add sed command to convert `[project]/src/` paths to `dashboard/src/` for SonarCloud

## Problem
After fixing production mode (#325), the E2E coverage paths now have a `[project]` prefix:
```
Could not resolve 141 file paths
First unresolved path: [project]/src/app/agents/[name]/page.tsx
```

## Solution
Add sed replacement for `[project]/src/` -> `dashboard/src/` in the E2E coverage path fix step.

## Test plan
- [ ] CI passes including SonarCloud Analysis