### PR TITLE
fix(ci): upgrade upload-artifact to v7 for compatibility with download-artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         fail-on-error: false
 
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: coverage-report
         path: coverage.out
@@ -382,7 +382,7 @@ jobs:
         go test -v ./internal/... -coverprofile=internal-coverage.out
 
     - name: Upload internal coverage
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: internal-coverage
         path: internal-coverage.out
@@ -445,7 +445,7 @@ jobs:
       working-directory: dashboard
 
     - name: Upload coverage
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       with:
         name: dashboard-coverage
         path: dashboard/coverage/lcov.info
@@ -521,7 +521,7 @@ jobs:
         fi
 
     - name: Upload E2E coverage
-      uses: actions/upload-artifact@v6
+      uses: actions/upload-artifact@v7
       if: success()
       with:
         name: dashboard-e2e-coverage


### PR DESCRIPTION
## Summary
- Upgrade all `upload-artifact` actions from v6 to v7 for compatibility with `download-artifact@v7`

## Problem
The SonarCloud job was failing to download coverage artifacts with:
```
Unable to download artifact(s): Artifact not found for name: coverage-report
Please ensure that your artifact is not expired and the artifact was uploaded using a compatible version of toolkit/upload-artifact.
```

This caused SonarCloud to report 0% coverage because:
1. Go unit tests uploaded `coverage-report` with `upload-artifact@v6`
2. SonarCloud job tried to download with `download-artifact@v7`
3. v6 and v7 use different backends and aren't compatible
4. Coverage files couldn't be found, resulting in the reported 40% coverage drop

## Test plan
- [ ] Verify CI pipeline passes
- [ ] Verify SonarCloud Analysis job successfully downloads coverage artifacts
- [ ] Verify coverage percentage is restored on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)