### PR TITLE
fix(ci): only run SonarCloud when testable code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -535,11 +535,12 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     needs: [changes, test, lint, envtest, dashboard, dashboard-e2e]
-    # Skip for dependabot (no secrets) or non-code changes
+    # Only run when actual testable code changed (Go or Dashboard)
+    # Skip for dependabot (no secrets) or CI-only changes that don't produce coverage
     # Use always() to run even if optional jobs were skipped
     if: |
       always() &&
-      needs.changes.outputs.code == 'true' &&
+      (needs.changes.outputs.go == 'true' || needs.changes.outputs.dashboard == 'true') &&
       github.actor != 'dependabot[bot]' &&
       !contains(needs.*.result, 'failure')
 
@@ -643,6 +644,6 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     needs: changes
-    if: needs.changes.outputs.code != 'true' || github.actor == 'dependabot[bot]'
+    if: (needs.changes.outputs.go != 'true' && needs.changes.outputs.dashboard != 'true') || github.actor == 'dependabot[bot]'
     steps:
-      - run: echo "Skipped - no code changes or dependabot PR"
+      - run: echo "Skipped - no testable code changes or dependabot PR"


### PR DESCRIPTION
## Summary
- Fix SonarCloud condition to only run when Go or Dashboard code changes
- Previous condition used `code == 'true'` which includes workflow file changes
- New condition uses `(go == 'true' || dashboard == 'true')` for actual testable code

## Problem
When only CI workflow files changed:
1. `paths-filter` set `code=true` (because `.github/workflows/ci.yml` is in code filter)
2. But `go=false` and `dashboard=false` (no actual source code changes)
3. Test jobs skipped (no Go/Dashboard changes)
4. SonarCloud ran (because `code=true`)
5. No coverage artifacts exist → "artifact not found" errors
6. SonarCloud reports 0% coverage

## Solution
Change SonarCloud condition from:
```yaml
needs.changes.outputs.code == 'true'
```
to:
```yaml
(needs.changes.outputs.go == 'true' || needs.changes.outputs.dashboard == 'true')
```

This ensures SonarCloud only runs when tests actually ran and produced coverage artifacts.

## Test plan
- [ ] CI-only changes should skip SonarCloud (this PR)
- [ ] Go code changes should run SonarCloud with coverage
- [ ] Dashboard code changes should run SonarCloud with coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)