### PR TITLE
chore: update copyright to restore SonarCloud coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
         fail-on-error: false
 
     - name: Upload coverage artifacts
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-report
         path: coverage.out
@@ -382,7 +382,7 @@ jobs:
         go test -v ./internal/... -coverprofile=internal-coverage.out
 
     - name: Upload internal coverage
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: internal-coverage
         path: internal-coverage.out
@@ -445,7 +445,7 @@ jobs:
       working-directory: dashboard
 
     - name: Upload coverage
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       with:
         name: dashboard-coverage
         path: dashboard/coverage/lcov.info
@@ -521,7 +521,7 @@ jobs:
         fi
 
     - name: Upload E2E coverage
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@v4
       if: success()
       with:
         name: dashboard-e2e-coverage
@@ -556,28 +556,28 @@ jobs:
         go-version-file: go.mod
 
     - name: Download unit test coverage
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v4
       continue-on-error: true
       with:
         name: coverage-report
         path: coverage-unit
 
     - name: Download internal/controller coverage
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v4
       continue-on-error: true
       with:
         name: internal-coverage
         path: coverage-internal
 
     - name: Download dashboard unit test coverage
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v4
       continue-on-error: true
       with:
         name: dashboard-coverage
         path: dashboard/coverage
 
     - name: Download dashboard E2E coverage
-      uses: actions/download-artifact@v7
+      uses: actions/download-artifact@v4
       continue-on-error: true
       with:
         name: dashboard-e2e-coverage

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025.
+Copyright 2025 Altaira Labs.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Fix artifact actions to use v4 (v7 doesn't exist, v6 was incompatible)
- Trivial copyright update to trigger full test suite

## Root cause
Previous CI runs had:
1. Artifact version mismatch - `upload-artifact@v6` / `download-artifact@v7` were incompatible
2. I incorrectly "fixed" this by changing to v7/v7 but upload-artifact@v7 doesn't exist
3. SonarCloud running for CI-only changes - fixed in #336

Now using v4/v4 which are the latest compatible versions.

## Test plan
- [ ] CI jobs resolve artifact actions successfully
- [ ] Go tests run and upload coverage artifacts
- [ ] SonarCloud downloads artifacts successfully  
- [ ] Coverage restored on main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)