### PR TITLE
chore: bump dashboard version to trigger full coverage rebuild

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashboard",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "node server.js",


### PR DESCRIPTION
## Summary
- Bump dashboard version to trigger both Go and Dashboard tests
- This will upload full coverage (Go + TypeScript) to SonarCloud

The previous PR (#337) only had Go changes, so only Go coverage (56%) was reported.
This PR triggers dashboard tests to include TypeScript coverage.

## Test plan
- [ ] Both Go and Dashboard tests run
- [ ] SonarCloud receives merged coverage from all sources
- [ ] Coverage percentage restored to expected levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)