### PR TITLE
fix(ci): align artifact action versions and add ee/ to paths filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
               - 'config/**'
               - 'internal/**'
               - 'pkg/**'
+              - 'ee/**'
               - 'test/**'
               - 'hack/**'
               - 'dashboard/**'
@@ -56,6 +57,7 @@ jobs:
               - 'config/**'
               - 'internal/**'
               - 'pkg/**'
+              - 'ee/**'
               - 'test/**'
               - 'hack/**'
             dashboard:


### PR DESCRIPTION
## Summary
- Downgrade `download-artifact` from v7 to v6 to match `upload-artifact` v6
- Add `ee/**` to paths filter so Go tests run on EE code changes

## Problem
Recent dependabot updates bumped `upload-artifact` to v6 and `download-artifact` to v7 separately. This version mismatch caused artifacts uploaded with v6 to fail retrieval with v7, resulting in 0% coverage being reported to SonarCloud.

## Test plan
- CI pipeline should now correctly pass coverage artifacts between jobs
- SonarCloud should receive actual coverage data instead of 0%