### PR TITLE
fix(ee): migrate webhooks for controller-runtime v0.23.1

### DIFF
--- a/ee/internal/webhook/arenajob_webhook_test.go
+++ b/ee/internal/webhook/arenajob_webhook_test.go
@@ -1,0 +1,210 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/license"
+)
+
+func TestArenaJobValidatorValidateCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		job         *omniav1alpha1.ArenaJob
+		expectError bool
+	}{
+		{
+			name: "valid evaluation job",
+			job: &omniav1alpha1.ArenaJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+				Spec: omniav1alpha1.ArenaJobSpec{
+					Type: omniav1alpha1.ArenaJobTypeEvaluation,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid loadtest job",
+			job: &omniav1alpha1.ArenaJob{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+				Spec: omniav1alpha1.ArenaJobSpec{
+					Type: omniav1alpha1.ArenaJobTypeLoadTest,
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	validator := &ArenaJobValidator{LicenseValidator: nil}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validator.ValidateCreate(context.Background(), tt.job)
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestArenaJobValidatorValidateUpdate(t *testing.T) {
+	validator := &ArenaJobValidator{LicenseValidator: nil}
+
+	oldJob := &omniav1alpha1.ArenaJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaJobSpec{
+			Type: omniav1alpha1.ArenaJobTypeEvaluation,
+		},
+	}
+	newJob := &omniav1alpha1.ArenaJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaJobSpec{
+			Type: omniav1alpha1.ArenaJobTypeLoadTest,
+		},
+	}
+
+	_, err := validator.ValidateUpdate(context.Background(), oldJob, newJob)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestArenaJobValidatorValidateDelete(t *testing.T) {
+	validator := &ArenaJobValidator{LicenseValidator: nil}
+
+	job := &omniav1alpha1.ArenaJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaJobSpec{
+			Type: omniav1alpha1.ArenaJobTypeEvaluation,
+		},
+	}
+
+	_, err := validator.ValidateDelete(context.Background(), job)
+	if err != nil {
+		t.Errorf("unexpected error on delete: %v", err)
+	}
+}
+
+func TestArenaJobValidateLicenseNoValidator(t *testing.T) {
+	validator := &ArenaJobValidator{LicenseValidator: nil}
+
+	job := &omniav1alpha1.ArenaJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaJobSpec{
+			Type: omniav1alpha1.ArenaJobTypeEvaluation,
+		},
+	}
+
+	warnings, err := validator.validateLicense(context.Background(), job)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestArenaJobValidateLicenseDevMode(t *testing.T) {
+	licenseValidator, err := license.NewValidator(nil, license.WithDevMode())
+	if err != nil {
+		t.Fatalf("failed to create license validator: %v", err)
+	}
+
+	validator := &ArenaJobValidator{LicenseValidator: licenseValidator}
+
+	job := &omniav1alpha1.ArenaJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaJobSpec{
+			Type:    omniav1alpha1.ArenaJobTypeLoadTest,
+			Workers: &omniav1alpha1.WorkerConfig{Replicas: 5},
+			Schedule: &omniav1alpha1.ScheduleConfig{
+				Cron: "0 2 * * * * *",
+			},
+		},
+	}
+
+	warnings, err := validator.validateLicense(context.Background(), job)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestArenaJobValidateLicenseDefaultJobType(t *testing.T) {
+	licenseValidator, err := license.NewValidator(nil, license.WithDevMode())
+	if err != nil {
+		t.Fatalf("failed to create license validator: %v", err)
+	}
+
+	validator := &ArenaJobValidator{LicenseValidator: licenseValidator}
+
+	// Empty type defaults to "evaluation"
+	job := &omniav1alpha1.ArenaJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Spec:       omniav1alpha1.ArenaJobSpec{},
+	}
+
+	warnings, err := validator.validateLicense(context.Background(), job)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestArenaJobValidateLicenseOpenCoreRestriction(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	licenseValidator, err := license.NewValidator(fakeClient)
+	if err != nil {
+		t.Fatalf("failed to create license validator: %v", err)
+	}
+
+	validator := &ArenaJobValidator{LicenseValidator: licenseValidator}
+
+	// Scheduled jobs should be restricted on open-core
+	job := &omniav1alpha1.ArenaJob{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-job", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaJobSpec{
+			Type: omniav1alpha1.ArenaJobTypeEvaluation,
+			Schedule: &omniav1alpha1.ScheduleConfig{
+				Cron: "0 2 * * * * *",
+			},
+		},
+	}
+
+	warnings, err := validator.validateLicense(context.Background(), job)
+	if err == nil {
+		t.Error("expected error for scheduled job on open-core license")
+	}
+	if len(warnings) == 0 {
+		t.Error("expected warnings with upgrade message")
+	}
+}

--- a/ee/internal/webhook/arenasource_webhook_test.go
+++ b/ee/internal/webhook/arenasource_webhook_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/license"
+)
+
+func TestArenaSourceValidatorValidateCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		source      *omniav1alpha1.ArenaSource
+		expectError bool
+	}{
+		{
+			name: "valid git source",
+			source: &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type: omniav1alpha1.ArenaSourceTypeGit,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid oci source",
+			source: &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type: omniav1alpha1.ArenaSourceTypeOCI,
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "valid configmap source",
+			source: &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type: omniav1alpha1.ArenaSourceTypeConfigMap,
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	validator := &ArenaSourceValidator{LicenseValidator: nil}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := validator.ValidateCreate(context.Background(), tt.source)
+			if tt.expectError && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tt.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestArenaSourceValidatorValidateUpdate(t *testing.T) {
+	validator := &ArenaSourceValidator{LicenseValidator: nil}
+
+	oldSource := &omniav1alpha1.ArenaSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaSourceSpec{
+			Type: omniav1alpha1.ArenaSourceTypeGit,
+		},
+	}
+	newSource := &omniav1alpha1.ArenaSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaSourceSpec{
+			Type: omniav1alpha1.ArenaSourceTypeOCI,
+		},
+	}
+
+	_, err := validator.ValidateUpdate(context.Background(), oldSource, newSource)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestArenaSourceValidatorValidateDelete(t *testing.T) {
+	validator := &ArenaSourceValidator{LicenseValidator: nil}
+
+	source := &omniav1alpha1.ArenaSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaSourceSpec{
+			Type: omniav1alpha1.ArenaSourceTypeGit,
+		},
+	}
+
+	_, err := validator.ValidateDelete(context.Background(), source)
+	if err != nil {
+		t.Errorf("unexpected error on delete: %v", err)
+	}
+}
+
+func TestArenaSourceValidateLicenseNoValidator(t *testing.T) {
+	validator := &ArenaSourceValidator{LicenseValidator: nil}
+
+	source := &omniav1alpha1.ArenaSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaSourceSpec{
+			Type: omniav1alpha1.ArenaSourceTypeGit,
+		},
+	}
+
+	warnings, err := validator.validateLicense(context.Background(), source)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestArenaSourceValidateLicenseDevMode(t *testing.T) {
+	licenseValidator, err := license.NewValidator(nil, license.WithDevMode())
+	if err != nil {
+		t.Fatalf("failed to create license validator: %v", err)
+	}
+
+	validator := &ArenaSourceValidator{LicenseValidator: licenseValidator}
+
+	source := &omniav1alpha1.ArenaSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaSourceSpec{
+			Type: omniav1alpha1.ArenaSourceTypeOCI,
+		},
+	}
+
+	warnings, err := validator.validateLicense(context.Background(), source)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+}
+
+func TestArenaSourceValidateLicenseOpenCoreRestriction(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("failed to add scheme: %v", err)
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
+
+	licenseValidator, err := license.NewValidator(fakeClient)
+	if err != nil {
+		t.Fatalf("failed to create license validator: %v", err)
+	}
+
+	validator := &ArenaSourceValidator{LicenseValidator: licenseValidator}
+
+	// OCI source should be restricted on open-core
+	source := &omniav1alpha1.ArenaSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
+		Spec: omniav1alpha1.ArenaSourceSpec{
+			Type: omniav1alpha1.ArenaSourceTypeOCI,
+		},
+	}
+
+	warnings, err := validator.validateLicense(context.Background(), source)
+	if err == nil {
+		t.Error("expected error for OCI source on open-core license")
+	}
+	if len(warnings) == 0 {
+		t.Error("expected warnings with upgrade message")
+	}
+}

--- a/ee/internal/webhook/arenatemplatesource_webhook_test.go
+++ b/ee/internal/webhook/arenatemplatesource_webhook_test.go
@@ -277,34 +277,6 @@ func TestValidateLicenseNoValidator(t *testing.T) {
 	}
 }
 
-func TestValidateCreateWrongType(t *testing.T) {
-	validator := &ArenaTemplateSourceValidator{LicenseValidator: nil}
-
-	// Pass wrong type to ValidateCreate
-	_, err := validator.ValidateCreate(context.Background(), &omniav1alpha1.ArenaSource{})
-	if err == nil {
-		t.Error("expected error for wrong type")
-	}
-}
-
-func TestValidateUpdateWrongType(t *testing.T) {
-	validator := &ArenaTemplateSourceValidator{LicenseValidator: nil}
-
-	validSource := &omniav1alpha1.ArenaTemplateSource{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-source", Namespace: "default"},
-		Spec: omniav1alpha1.ArenaTemplateSourceSpec{
-			Type: omniav1alpha1.ArenaTemplateSourceTypeGit,
-			Git:  &omniav1alpha1.GitSource{URL: "https://github.com/test/repo"},
-		},
-	}
-
-	// Pass wrong type as newObj to ValidateUpdate
-	_, err := validator.ValidateUpdate(context.Background(), validSource, &omniav1alpha1.ArenaSource{})
-	if err == nil {
-		t.Error("expected error for wrong type")
-	}
-}
-
 func TestValidateLicenseWithDevModeValidator(t *testing.T) {
 	// Create a dev mode validator which allows all features
 	licenseValidator, err := license.NewValidator(nil, license.WithDevMode())


### PR DESCRIPTION
## Summary
- Migrates all 3 arena webhooks from deprecated `CustomValidator` (`runtime.Object`) to the generic `Validator[T]` interface introduced in controller-runtime v0.23.1
- Fixes build failure caused by `NewWebhookManagedBy` API change (now requires API type as second argument, `.For()` removed)
- Removes unnecessary runtime type assertions since the compiler enforces types
- Adds unit tests for `ArenaJob` and `ArenaSource` webhooks (previously 0% coverage)

## Test plan
- [x] All 24 webhook unit tests pass locally
- [x] Pre-commit checks pass (lint, vet, build, coverage all green)
- [x] Coverage: arenajob 90.5%, arenasource 86.7%, arenatemplatesource 92.9%
- [ ] CI pipeline passes