### PR TITLE
docs: add hyperscaler provider guides and update Provider reference

### DIFF
--- a/docs/src/content/docs/how-to/configure-azure-ai-provider.md
+++ b/docs/src/content/docs/how-to/configure-azure-ai-provider.md
@@ -1,0 +1,232 @@
+---
+title: "Configure Azure AI Provider"
+description: "Set up Omnia to use Azure AI (Azure OpenAI) via Azure AD Workload Identity or service principal"
+sidebar:
+  order: 18
+---
+
+This guide covers how to configure an Omnia Provider to use Azure AI Services (Azure OpenAI) for LLM access. Azure AI providers support two authentication methods: **Azure AD Workload Identity** for production use, and **service principals** for simpler setups.
+
+## Prerequisites
+
+- An AKS cluster with OIDC issuer enabled
+- An Azure AI (Azure OpenAI) resource deployed
+- `az` CLI installed and authenticated
+- Omnia operator installed in the cluster
+
+## Option 1: Workload Identity — Recommended
+
+Azure AD Workload Identity lets Kubernetes pods authenticate as a managed identity without storing credentials. This is the recommended approach for production.
+
+### 1. Create a managed identity
+
+```bash
+az identity create \
+  --name omnia-azure-ai \
+  --resource-group my-resource-group \
+  --location eastus
+```
+
+Note the `clientId` from the output — you'll need it later.
+
+### 2. Assign the Cognitive Services role
+
+```bash
+az role assignment create \
+  --assignee <managed-identity-client-id> \
+  --role "Cognitive Services OpenAI User" \
+  --scope /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.CognitiveServices/accounts/<resource-name>
+```
+
+### 3. Establish a federated credential
+
+Get the OIDC issuer URL from your AKS cluster:
+
+```bash
+az aks show \
+  --name my-cluster \
+  --resource-group my-resource-group \
+  --query "oidcIssuerProfile.issuerUrl" -o tsv
+```
+
+Create the federated credential:
+
+```bash
+az identity federated-credential create \
+  --name omnia-federated \
+  --identity-name omnia-azure-ai \
+  --resource-group my-resource-group \
+  --issuer <oidc-issuer-url> \
+  --subject system:serviceaccount:agents:omnia-agent \
+  --audiences api://AzureADTokenExchange
+```
+
+### 4. Annotate the service account
+
+Configure the service account via Helm values:
+
+```yaml
+# values.yaml
+serviceAccount:
+  labels:
+    azure.workload.identity/use: "true"
+  annotations:
+    azure.workload.identity/client-id: <managed-identity-client-id>
+```
+
+### 5. Create the Provider
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: azure-openai
+  namespace: agents
+spec:
+  type: azure-ai
+  model: gpt-4o
+
+  platform:
+    type: azure
+    region: eastus
+    endpoint: https://my-resource.openai.azure.com
+
+  auth:
+    type: workloadIdentity
+
+  capabilities:
+    - text
+    - streaming
+    - tools
+    - json
+```
+
+### 6. Verify
+
+```bash
+kubectl get provider azure-openai -n agents -o wide
+kubectl get provider azure-openai -n agents -o jsonpath='{.status.conditions}' | jq .
+```
+
+Both the `AuthConfigured` and `Ready` conditions should be `True`.
+
+## Option 2: Service Principal
+
+For development or environments without Workload Identity, you can use service principal credentials.
+
+### 1. Create a service principal
+
+```bash
+az ad sp create-for-rbac \
+  --name omnia-azure-ai-sp \
+  --role "Cognitive Services OpenAI User" \
+  --scopes /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.CognitiveServices/accounts/<resource-name>
+```
+
+### 2. Create a Secret
+
+```bash
+kubectl create secret generic azure-credentials \
+  --namespace agents \
+  --from-literal=AZURE_CLIENT_ID=<app-id> \
+  --from-literal=AZURE_CLIENT_SECRET=<password> \
+  --from-literal=AZURE_TENANT_ID=<tenant-id>
+```
+
+### 3. Create the Provider
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: azure-openai
+  namespace: agents
+spec:
+  type: azure-ai
+  model: gpt-4o
+
+  platform:
+    type: azure
+    region: eastus
+    endpoint: https://my-resource.openai.azure.com
+
+  auth:
+    type: servicePrincipal
+    credentialsSecretRef:
+      name: azure-credentials
+
+  capabilities:
+    - text
+    - streaming
+    - tools
+    - json
+```
+
+## Using with AgentRuntime
+
+Reference the Provider from an AgentRuntime:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: my-agent
+  namespace: agents
+spec:
+  promptPackRef:
+    name: my-prompts
+  providerRef:
+    name: azure-openai
+  facade:
+    type: websocket
+    port: 8080
+```
+
+## Troubleshooting
+
+### Endpoint URL format
+
+The `platform.endpoint` must be the full Azure OpenAI resource URL, including `https://` and the `.openai.azure.com` suffix:
+
+```
+https://my-resource.openai.azure.com
+```
+
+Do not include a trailing slash or API version path.
+
+### Identity not federated
+
+If using workload identity and the Provider shows `AuthConfigured: False`, verify the federated credential exists:
+
+```bash
+az identity federated-credential list \
+  --identity-name omnia-azure-ai \
+  --resource-group my-resource-group
+```
+
+Ensure the `subject` matches `system:serviceaccount:<namespace>:<service-account-name>`.
+
+### Role assignment missing
+
+Verify the managed identity or service principal has the correct role:
+
+```bash
+az role assignment list \
+  --assignee <client-id> \
+  --scope /subscriptions/<subscription-id>/resourceGroups/<resource-group>/providers/Microsoft.CognitiveServices/accounts/<resource-name>
+```
+
+### Checking Provider conditions
+
+```bash
+kubectl describe provider azure-openai -n agents
+```
+
+Look at the `Conditions` section for `AuthConfigured`, `CredentialConfigured`, and `Ready`.
+
+## Related Resources
+
+- [Provider CRD Reference](/reference/provider/)
+- [Configure AWS Bedrock Provider](/how-to/configure-bedrock-provider/)
+- [Configure GCP Vertex AI Provider](/how-to/configure-vertex-provider/)
+- [Migrate Provider Credentials](/how-to/migrate-provider-credentials/)

--- a/docs/src/content/docs/how-to/configure-bedrock-provider.md
+++ b/docs/src/content/docs/how-to/configure-bedrock-provider.md
@@ -1,0 +1,207 @@
+---
+title: "Configure AWS Bedrock Provider"
+description: "Set up Omnia to use AWS Bedrock for LLM access via IRSA or access keys"
+sidebar:
+  order: 16
+---
+
+This guide covers how to configure an Omnia Provider to use AWS Bedrock for LLM access. Bedrock providers support two authentication methods: **workload identity (IRSA)** for production use, and **access keys** for simpler setups.
+
+## Prerequisites
+
+- An EKS cluster with the OIDC provider enabled
+- AWS Bedrock model access enabled in your target region ([enable model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html))
+- `eksctl` and `aws` CLI installed
+- Omnia operator installed in the cluster
+
+## Option 1: Workload Identity (IRSA) — Recommended
+
+IAM Roles for Service Accounts (IRSA) lets pods assume an IAM role without static credentials. This is the recommended approach for production.
+
+### 1. Create an IAM policy
+
+Create a policy that grants access to Bedrock model invocation:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "bedrock:InvokeModel",
+        "bedrock:InvokeModelWithResponseStream"
+      ],
+      "Resource": "*"
+    }
+  ]
+}
+```
+
+Save this as `bedrock-policy.json` and create the policy:
+
+```bash
+aws iam create-policy \
+  --policy-name OmniaBedrock \
+  --policy-document file://bedrock-policy.json
+```
+
+### 2. Create an IAM role with OIDC trust
+
+Use `eksctl` to create a role bound to the Omnia service account:
+
+```bash
+eksctl create iamserviceaccount \
+  --name omnia-agent \
+  --namespace agents \
+  --cluster my-cluster \
+  --role-name omnia-bedrock-role \
+  --attach-policy-arn arn:aws:iam::123456789012:policy/OmniaBedrock \
+  --approve
+```
+
+Alternatively, annotate the service account via Helm values:
+
+```yaml
+# values.yaml
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/omnia-bedrock-role
+```
+
+### 3. Create the Provider
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: bedrock-claude
+  namespace: agents
+spec:
+  type: bedrock
+  model: anthropic.claude-3-5-sonnet-20241022-v2:0
+
+  platform:
+    type: aws
+    region: us-east-1
+
+  auth:
+    type: workloadIdentity
+    roleArn: arn:aws:iam::123456789012:role/omnia-bedrock-role
+
+  capabilities:
+    - text
+    - streaming
+    - vision
+    - tools
+```
+
+### 4. Verify
+
+```bash
+kubectl get provider bedrock-claude -n agents -o wide
+kubectl get provider bedrock-claude -n agents -o jsonpath='{.status.conditions}' | jq .
+```
+
+Both the `AuthConfigured` and `Ready` conditions should be `True`.
+
+## Option 2: Access Key
+
+For development or environments without IRSA, you can use static AWS credentials.
+
+### 1. Create a Secret
+
+```bash
+kubectl create secret generic aws-credentials \
+  --namespace agents \
+  --from-literal=AWS_ACCESS_KEY_ID=AKIA... \
+  --from-literal=AWS_SECRET_ACCESS_KEY=...
+```
+
+### 2. Create the Provider
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: bedrock-claude
+  namespace: agents
+spec:
+  type: bedrock
+  model: anthropic.claude-3-5-sonnet-20241022-v2:0
+
+  platform:
+    type: aws
+    region: us-east-1
+
+  auth:
+    type: accessKey
+    credentialsSecretRef:
+      name: aws-credentials
+
+  capabilities:
+    - text
+    - streaming
+    - vision
+    - tools
+```
+
+## Using with AgentRuntime
+
+Reference the Provider from an AgentRuntime:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: my-agent
+  namespace: agents
+spec:
+  promptPackRef:
+    name: my-prompts
+  providerRef:
+    name: bedrock-claude
+  facade:
+    type: websocket
+    port: 8080
+```
+
+## Troubleshooting
+
+### Model access not enabled
+
+If the Provider shows an error, verify that model access is enabled in the target region:
+
+```bash
+aws bedrock list-foundation-models --region us-east-1 \
+  --query "modelSummaries[?modelId=='anthropic.claude-3-5-sonnet-20241022-v2:0']"
+```
+
+### Region mismatch
+
+Ensure the `platform.region` in the Provider spec matches the region where you enabled Bedrock model access. Bedrock model availability varies by region.
+
+### IRSA annotation missing
+
+If using workload identity, verify the service account has the correct annotation:
+
+```bash
+kubectl get sa omnia-agent -n agents -o jsonpath='{.metadata.annotations}'
+```
+
+Look for `eks.amazonaws.com/role-arn` pointing to the correct role.
+
+### Checking Provider conditions
+
+```bash
+kubectl describe provider bedrock-claude -n agents
+```
+
+Look at the `Conditions` section for `AuthConfigured`, `CredentialConfigured`, and `Ready`.
+
+## Related Resources
+
+- [Provider CRD Reference](/reference/provider/)
+- [Configure GCP Vertex AI Provider](/how-to/configure-vertex-provider/)
+- [Configure Azure AI Provider](/how-to/configure-azure-ai-provider/)
+- [Migrate Provider Credentials](/how-to/migrate-provider-credentials/)

--- a/docs/src/content/docs/how-to/configure-vertex-provider.md
+++ b/docs/src/content/docs/how-to/configure-vertex-provider.md
@@ -1,0 +1,209 @@
+---
+title: "Configure GCP Vertex AI Provider"
+description: "Set up Omnia to use Google Vertex AI via GKE Workload Identity or service account key"
+sidebar:
+  order: 17
+---
+
+This guide covers how to configure an Omnia Provider to use Google Vertex AI for LLM access. Vertex AI providers support two authentication methods: **GKE Workload Identity** for production use, and **service account keys** for simpler setups.
+
+## Prerequisites
+
+- A GKE cluster with Workload Identity enabled
+- Vertex AI API enabled in your GCP project (`gcloud services enable aiplatform.googleapis.com`)
+- `gcloud` CLI installed and authenticated
+- Omnia operator installed in the cluster
+
+## Option 1: Workload Identity — Recommended
+
+GKE Workload Identity lets Kubernetes service accounts act as GCP service accounts without exporting keys. This is the recommended approach for production.
+
+### 1. Create a GCP service account
+
+```bash
+gcloud iam service-accounts create omnia-vertex \
+  --display-name="Omnia Vertex AI" \
+  --project=my-gcp-project
+```
+
+### 2. Grant the Vertex AI user role
+
+```bash
+gcloud projects add-iam-policy-binding my-gcp-project \
+  --member="serviceAccount:omnia-vertex@my-gcp-project.iam.gserviceaccount.com" \
+  --role="roles/aiplatform.user"
+```
+
+### 3. Bind the Kubernetes service account to the GCP service account
+
+```bash
+gcloud iam service-accounts add-iam-policy-binding \
+  omnia-vertex@my-gcp-project.iam.gserviceaccount.com \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:my-gcp-project.svc.id.goog[agents/omnia-agent]"
+```
+
+Annotate the Kubernetes service account via Helm values:
+
+```yaml
+# values.yaml
+serviceAccount:
+  annotations:
+    iam.gke.io/gcp-service-account: omnia-vertex@my-gcp-project.iam.gserviceaccount.com
+```
+
+### 4. Create the Provider
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: vertex-gemini
+  namespace: agents
+spec:
+  type: vertex
+  model: gemini-1.5-pro
+
+  platform:
+    type: gcp
+    region: us-central1
+    project: my-gcp-project
+
+  auth:
+    type: workloadIdentity
+    serviceAccountEmail: omnia-vertex@my-gcp-project.iam.gserviceaccount.com
+
+  capabilities:
+    - text
+    - streaming
+    - vision
+    - tools
+    - json
+```
+
+### 5. Verify
+
+```bash
+kubectl get provider vertex-gemini -n agents -o wide
+kubectl get provider vertex-gemini -n agents -o jsonpath='{.status.conditions}' | jq .
+```
+
+Both the `AuthConfigured` and `Ready` conditions should be `True`.
+
+## Option 2: Service Account Key
+
+For development or environments without GKE Workload Identity, you can use a service account JSON key.
+
+### 1. Create and download a key
+
+```bash
+gcloud iam service-accounts keys create key.json \
+  --iam-account=omnia-vertex@my-gcp-project.iam.gserviceaccount.com
+```
+
+### 2. Create a Secret
+
+```bash
+kubectl create secret generic gcp-credentials \
+  --namespace agents \
+  --from-file=credentials.json=key.json
+```
+
+### 3. Create the Provider
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: vertex-gemini
+  namespace: agents
+spec:
+  type: vertex
+  model: gemini-1.5-pro
+
+  platform:
+    type: gcp
+    region: us-central1
+    project: my-gcp-project
+
+  auth:
+    type: serviceAccount
+    credentialsSecretRef:
+      name: gcp-credentials
+
+  capabilities:
+    - text
+    - streaming
+    - vision
+    - tools
+    - json
+```
+
+## Using with AgentRuntime
+
+Reference the Provider from an AgentRuntime:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: my-agent
+  namespace: agents
+spec:
+  promptPackRef:
+    name: my-prompts
+  providerRef:
+    name: vertex-gemini
+  facade:
+    type: websocket
+    port: 8080
+```
+
+## Troubleshooting
+
+### Vertex AI API not enabled
+
+Ensure the API is enabled in your project:
+
+```bash
+gcloud services list --enabled --project=my-gcp-project \
+  --filter="config.name:aiplatform.googleapis.com"
+```
+
+If missing, enable it:
+
+```bash
+gcloud services enable aiplatform.googleapis.com --project=my-gcp-project
+```
+
+### Project mismatch
+
+The `platform.project` field must match the GCP project where Vertex AI is enabled. Verify the project ID:
+
+```bash
+gcloud config get-value project
+```
+
+### IAM binding not propagated
+
+Workload Identity bindings can take a few minutes to propagate. If the Provider shows `AuthConfigured: False`, wait 2-3 minutes and check again. You can also verify the binding:
+
+```bash
+gcloud iam service-accounts get-iam-policy \
+  omnia-vertex@my-gcp-project.iam.gserviceaccount.com
+```
+
+### Checking Provider conditions
+
+```bash
+kubectl describe provider vertex-gemini -n agents
+```
+
+Look at the `Conditions` section for `AuthConfigured`, `CredentialConfigured`, and `Ready`.
+
+## Related Resources
+
+- [Provider CRD Reference](/reference/provider/)
+- [Configure AWS Bedrock Provider](/how-to/configure-bedrock-provider/)
+- [Configure Azure AI Provider](/how-to/configure-azure-ai-provider/)
+- [Migrate Provider Credentials](/how-to/migrate-provider-credentials/)

--- a/docs/src/content/docs/how-to/migrate-provider-credentials.md
+++ b/docs/src/content/docs/how-to/migrate-provider-credentials.md
@@ -1,0 +1,153 @@
+---
+title: "Migrate Provider Credentials"
+description: "Migrate from legacy secretRef to the unified credential configuration"
+sidebar:
+  order: 19
+---
+
+This guide walks you through migrating Provider resources from the legacy top-level `secretRef` field to the newer `credential` configuration. The `credential` field provides a unified API with support for Kubernetes Secrets, environment variables, and file-based credentials.
+
+## Why Migrate
+
+- **Unified API** — The `credential` field supports multiple credential strategies (`secretRef`, `envVar`, `filePath`) under a single field, replacing the top-level `secretRef` which only supports Kubernetes Secrets.
+- **Future-proof** — The top-level `secretRef` is deprecated and may be removed in a future release.
+- **Consistency** — New features like hyperscaler authentication (`platform` + `auth`) are built around the modern credential model.
+
+Both `secretRef` and `credential.secretRef` continue to work, so migration can be done at your own pace.
+
+## Before You Begin
+
+List all Providers in your cluster:
+
+```bash
+kubectl get providers -A
+```
+
+## Step 1: Identify Providers Using Legacy secretRef
+
+Find Providers that use the top-level `secretRef`:
+
+```bash
+kubectl get providers -A -o json | \
+  jq -r '.items[] | select(.spec.secretRef != null) | "\(.metadata.namespace)/\(.metadata.name)"'
+```
+
+## Step 2: Update the Provider Spec
+
+Move `secretRef` under the `credential` field. The structure is identical — only the nesting changes.
+
+**Before:**
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: claude-production
+  namespace: agents
+spec:
+  type: claude
+  model: claude-sonnet-4-20250514
+  secretRef:
+    name: anthropic-credentials
+  defaults:
+    temperature: "0.7"
+```
+
+**After:**
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: claude-production
+  namespace: agents
+spec:
+  type: claude
+  model: claude-sonnet-4-20250514
+  credential:
+    secretRef:
+      name: anthropic-credentials
+  defaults:
+    temperature: "0.7"
+```
+
+The only change is replacing the top-level `secretRef` with `credential.secretRef`. The Secret itself does not need to change.
+
+> **Important**: Do not set both `secretRef` and `credential` on the same Provider. CEL validation will reject the resource.
+
+## Step 3: Apply and Verify
+
+Apply the updated Provider:
+
+```bash
+kubectl apply -f provider.yaml
+```
+
+Verify the Provider is healthy:
+
+```bash
+kubectl get provider claude-production -n agents -o wide
+```
+
+Check conditions:
+
+```bash
+kubectl get provider claude-production -n agents \
+  -o jsonpath='{.status.conditions}' | jq .
+```
+
+The `CredentialConfigured` condition should be `True` with reason `SecretRef`.
+
+## Batch Migration
+
+For clusters with many Providers, you can use a script to update them all:
+
+```bash
+#!/bin/bash
+# migrate-providers.sh — Migrate all Providers from secretRef to credential.secretRef
+
+for provider in $(kubectl get providers -A -o json | \
+  jq -r '.items[] | select(.spec.secretRef != null) | "\(.metadata.namespace)/\(.metadata.name)"'); do
+
+  NAMESPACE=$(echo "$provider" | cut -d/ -f1)
+  NAME=$(echo "$provider" | cut -d/ -f2)
+
+  echo "Migrating $NAMESPACE/$NAME..."
+
+  # Get current secretRef values
+  SECRET_NAME=$(kubectl get provider "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.secretRef.name}')
+  SECRET_KEY=$(kubectl get provider "$NAME" -n "$NAMESPACE" -o jsonpath='{.spec.secretRef.key}')
+
+  # Build the patch
+  if [ -n "$SECRET_KEY" ]; then
+    PATCH="{\"spec\":{\"secretRef\":null,\"credential\":{\"secretRef\":{\"name\":\"$SECRET_NAME\",\"key\":\"$SECRET_KEY\"}}}}"
+  else
+    PATCH="{\"spec\":{\"secretRef\":null,\"credential\":{\"secretRef\":{\"name\":\"$SECRET_NAME\"}}}}"
+  fi
+
+  kubectl patch provider "$NAME" -n "$NAMESPACE" --type=merge -p "$PATCH"
+done
+
+echo "Migration complete. Verifying..."
+kubectl get providers -A -o wide
+```
+
+## Rollback
+
+If you need to revert, restore the original `secretRef` field and remove `credential`:
+
+```yaml
+spec:
+  secretRef:
+    name: anthropic-credentials
+  # Remove the credential field entirely
+```
+
+Both formats are supported, so rollback is safe. The only constraint is that you cannot have both `secretRef` and `credential` set at the same time.
+
+## Related Resources
+
+- [Provider CRD Reference](/reference/provider/)
+- [Configure AWS Bedrock Provider](/how-to/configure-bedrock-provider/)
+- [Configure GCP Vertex AI Provider](/how-to/configure-vertex-provider/)
+- [Configure Azure AI Provider](/how-to/configure-azure-ai-provider/)


### PR DESCRIPTION
## Summary

- **Updated Provider CRD reference** (`docs/src/content/docs/reference/provider.md`): added `bedrock`/`vertex`/`azure-ai` types, new `platform` and `auth` sections, `contextWindow`/`truncationStrategy` in defaults, `AuthConfigured` condition, deprecation notice on top-level `secretRef`, and cross-links to new guides
- **Created 3 hyperscaler how-to guides** for AWS Bedrock, GCP Vertex AI, and Azure AI — each covering workload identity (recommended) and static credential options with full CLI setup steps and troubleshooting
- **Created credential migration guide** with before/after YAML, batch migration script, and rollback instructions

Closes #397

## Test plan

- [x] `cd docs && npm run build` — all 46 pages build without errors
- [ ] Verify sidebar shows new guides in the How-To section
- [ ] Verify cross-reference links resolve correctly between Provider reference and all 4 new guides