### PR TITLE
feat: add annotation-based provider binding for arena projects

### DIFF
--- a/ee/pkg/arena/binding/binding.go
+++ b/ee/pkg/arena/binding/binding.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+// Package binding provides annotation-based credential resolution for arena providers.
+// Arena projects imported from the dashboard contain binding annotations on provider YAML files
+// that link them to Provider CRDs. This package resolves those annotations against a registry
+// of available providers and injects credentials into the arena config.
+package binding
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/altairalabs/omnia/ee/pkg/arena/overrides"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	// AnnotationProviderName is the annotation key for the Provider CRD name.
+	AnnotationProviderName = "omnia.altairalabs.ai/provider-name"
+	// AnnotationProviderNamespace is the annotation key for the Provider CRD namespace.
+	AnnotationProviderNamespace = "omnia.altairalabs.ai/provider-namespace"
+)
+
+// ProviderBinding represents a binding between an arena provider YAML file
+// and a Provider CRD, extracted from annotations.
+type ProviderBinding struct {
+	// ProviderID is the arena provider ID (from spec.id in the YAML file).
+	ProviderID string
+	// SourceName is the Provider CRD name from the annotation.
+	SourceName string
+	// SourceNamespace is the Provider CRD namespace from the annotation.
+	SourceNamespace string
+}
+
+// ParseProviderAnnotations reads provider YAML files referenced by the config
+// and extracts binding annotations. Files that are unreadable or unparseable
+// are skipped gracefully.
+func ParseProviderAnnotations(cfg *config.Config, configPath string) ([]ProviderBinding, error) {
+	if len(cfg.Providers) == 0 {
+		return nil, nil
+	}
+
+	configDir := config.ResolveConfigDir(cfg, configPath)
+	bindings := make([]ProviderBinding, 0, len(cfg.Providers))
+
+	for _, ref := range cfg.Providers {
+		if ref.File == "" {
+			continue
+		}
+
+		filePath := filepath.Join(configDir, ref.File)
+		data, err := os.ReadFile(filePath)
+		if err != nil {
+			// Skip unreadable files gracefully
+			continue
+		}
+
+		var providerCfg config.ProviderConfig
+		if err := yaml.Unmarshal(data, &providerCfg); err != nil {
+			// Skip unparseable files
+			continue
+		}
+
+		name := providerCfg.Metadata.Annotations[AnnotationProviderName]
+		namespace := providerCfg.Metadata.Annotations[AnnotationProviderNamespace]
+		if name == "" || namespace == "" {
+			// No binding annotations present
+			continue
+		}
+
+		bindings = append(bindings, ProviderBinding{
+			ProviderID:      providerCfg.Spec.ID,
+			SourceName:      name,
+			SourceNamespace: namespace,
+		})
+	}
+
+	return bindings, nil
+}
+
+// ApplyBindings resolves binding annotations against the registry and injects
+// credentials into providers that don't already have them. Returns the number
+// of providers that were successfully bound.
+func ApplyBindings(
+	cfg *config.Config, bindings []ProviderBinding,
+	registry map[string]overrides.ProviderOverride, verbose bool,
+) int {
+	if len(bindings) == 0 || len(registry) == 0 {
+		return 0
+	}
+
+	boundCount := 0
+	for _, b := range bindings {
+		provider := cfg.LoadedProviders[b.ProviderID]
+		if provider == nil {
+			continue
+		}
+
+		if hasCredentials(provider) {
+			if verbose {
+				fmt.Printf("  Binding skip: %s already has credentials\n", b.ProviderID)
+			}
+			continue
+		}
+
+		key := b.SourceNamespace + "/" + b.SourceName
+		override, ok := registry[key]
+		if !ok {
+			if verbose {
+				fmt.Printf("  Binding miss: %s -> %s not found in registry\n", b.ProviderID, key)
+			}
+			continue
+		}
+
+		injectCredentials(provider, &override)
+		boundCount++
+		if verbose {
+			fmt.Printf("  Binding match: %s -> %s\n", b.ProviderID, key)
+		}
+	}
+
+	return boundCount
+}
+
+// ApplyNameMatching tries to match providers that still lack credentials by
+// comparing their provider ID against the "{namespace}-{name}" format used by
+// the dashboard's import converter. Returns the number of matched providers.
+func ApplyNameMatching(cfg *config.Config, registry map[string]overrides.ProviderOverride, verbose bool) int {
+	if len(registry) == 0 || len(cfg.LoadedProviders) == 0 {
+		return 0
+	}
+
+	matchedCount := 0
+	for id, provider := range cfg.LoadedProviders {
+		if hasCredentials(provider) {
+			continue
+		}
+		if !requiresCredentials(provider.Type) {
+			continue
+		}
+
+		// Try matching provider ID against "{namespace}-{name}" from registry keys
+		for key, override := range registry {
+			parts := strings.SplitN(key, "/", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			namespace, name := parts[0], parts[1]
+			expectedID := namespace + "-" + name
+			if id == expectedID {
+				injectCredentials(provider, &override)
+				matchedCount++
+				if verbose {
+					fmt.Printf("  Name match: %s -> %s\n", id, key)
+				}
+				break
+			}
+		}
+	}
+
+	return matchedCount
+}
+
+// hasCredentials checks whether a provider already has credentials configured.
+func hasCredentials(p *config.Provider) bool {
+	if p.Credential == nil {
+		return false
+	}
+	return p.Credential.APIKey != "" ||
+		p.Credential.CredentialEnv != "" ||
+		p.Credential.CredentialFile != ""
+}
+
+// requiresCredentials returns false for provider types that don't need credentials.
+func requiresCredentials(providerType string) bool {
+	switch providerType {
+	case "mock", "ollama":
+		return false
+	default:
+		return true
+	}
+}
+
+// injectCredentials copies credential and platform config from an override into a provider.
+func injectCredentials(provider *config.Provider, override *overrides.ProviderOverride) {
+	if override.SecretEnvVar != "" {
+		provider.Credential = &config.CredentialConfig{
+			CredentialEnv: override.SecretEnvVar,
+		}
+	} else if override.CredentialFile != "" {
+		provider.Credential = &config.CredentialConfig{
+			CredentialFile: override.CredentialFile,
+		}
+	}
+
+	// Inject platform config if the provider lacks it
+	if provider.Platform == nil && override.Platform != nil {
+		provider.Platform = &config.PlatformConfig{
+			Type:     override.Platform.Type,
+			Region:   override.Platform.Region,
+			Project:  override.Platform.Project,
+			Endpoint: override.Platform.Endpoint,
+		}
+	}
+}

--- a/ee/pkg/arena/binding/binding_test.go
+++ b/ee/pkg/arena/binding/binding_test.go
@@ -1,0 +1,637 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package binding
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/altairalabs/omnia/ee/pkg/arena/overrides"
+)
+
+func TestParseProviderAnnotations(t *testing.T) {
+	t.Run("with binding annotations", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Write a provider YAML with annotations
+		providerYAML := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: workspace-default-gpt4
+  annotations:
+    omnia.altairalabs.ai/provider-name: gpt4
+    omnia.altairalabs.ai/provider-namespace: workspace-default
+spec:
+  id: workspace-default-gpt4
+  type: openai
+  model: gpt-4o
+`
+		if err := os.WriteFile(filepath.Join(dir, "gpt4.provider.yaml"), []byte(providerYAML), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.Config{
+			Providers: []config.ProviderRef{
+				{File: "gpt4.provider.yaml"},
+			},
+		}
+
+		bindings, err := ParseProviderAnnotations(cfg, filepath.Join(dir, "config.arena.yaml"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(bindings) != 1 {
+			t.Fatalf("expected 1 binding, got %d", len(bindings))
+		}
+		if bindings[0].ProviderID != "workspace-default-gpt4" {
+			t.Errorf("expected provider ID workspace-default-gpt4, got %s", bindings[0].ProviderID)
+		}
+		if bindings[0].SourceName != "gpt4" {
+			t.Errorf("expected source name gpt4, got %s", bindings[0].SourceName)
+		}
+		if bindings[0].SourceNamespace != "workspace-default" {
+			t.Errorf("expected source namespace workspace-default, got %s", bindings[0].SourceNamespace)
+		}
+	})
+
+	t.Run("without annotations", func(t *testing.T) {
+		dir := t.TempDir()
+
+		providerYAML := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: local-provider
+spec:
+  id: local-provider
+  type: openai
+  model: gpt-4o
+`
+		if err := os.WriteFile(filepath.Join(dir, "local.provider.yaml"), []byte(providerYAML), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.Config{
+			Providers: []config.ProviderRef{
+				{File: "local.provider.yaml"},
+			},
+		}
+
+		bindings, err := ParseProviderAnnotations(cfg, filepath.Join(dir, "config.arena.yaml"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(bindings) != 0 {
+			t.Fatalf("expected 0 bindings, got %d", len(bindings))
+		}
+	})
+
+	t.Run("partial annotations", func(t *testing.T) {
+		dir := t.TempDir()
+
+		providerYAML := `apiVersion: promptkit.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: partial
+  annotations:
+    omnia.altairalabs.ai/provider-name: gpt4
+spec:
+  id: partial
+  type: openai
+`
+		if err := os.WriteFile(filepath.Join(dir, "partial.provider.yaml"), []byte(providerYAML), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.Config{
+			Providers: []config.ProviderRef{
+				{File: "partial.provider.yaml"},
+			},
+		}
+
+		bindings, err := ParseProviderAnnotations(cfg, filepath.Join(dir, "config.arena.yaml"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(bindings) != 0 {
+			t.Fatalf("expected 0 bindings (partial annotations should be skipped), got %d", len(bindings))
+		}
+	})
+
+	t.Run("invalid YAML", func(t *testing.T) {
+		dir := t.TempDir()
+
+		if err := os.WriteFile(filepath.Join(dir, "bad.provider.yaml"), []byte("not: valid: yaml: ["), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.Config{
+			Providers: []config.ProviderRef{
+				{File: "bad.provider.yaml"},
+			},
+		}
+
+		bindings, err := ParseProviderAnnotations(cfg, filepath.Join(dir, "config.arena.yaml"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(bindings) != 0 {
+			t.Fatalf("expected 0 bindings for invalid YAML, got %d", len(bindings))
+		}
+	})
+
+	t.Run("missing file", func(t *testing.T) {
+		dir := t.TempDir()
+
+		cfg := &config.Config{
+			Providers: []config.ProviderRef{
+				{File: "missing.provider.yaml"},
+			},
+		}
+
+		bindings, err := ParseProviderAnnotations(cfg, filepath.Join(dir, "config.arena.yaml"))
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if len(bindings) != 0 {
+			t.Fatalf("expected 0 bindings for missing file, got %d", len(bindings))
+		}
+	})
+
+	t.Run("empty providers", func(t *testing.T) {
+		cfg := &config.Config{}
+		bindings, err := ParseProviderAnnotations(cfg, "/some/path/config.yaml")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if bindings != nil {
+			t.Fatalf("expected nil bindings, got %v", bindings)
+		}
+	})
+}
+
+func TestApplyBindings(t *testing.T) {
+	t.Run("match found", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-gpt4": {
+					ID:   "workspace-default-gpt4",
+					Type: "openai",
+				},
+			},
+		}
+
+		bindings := []ProviderBinding{
+			{
+				ProviderID:      "workspace-default-gpt4",
+				SourceName:      "gpt4",
+				SourceNamespace: "workspace-default",
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/gpt4": {
+				ID:           "gpt4",
+				Type:         "openai",
+				SecretEnvVar: "OPENAI_API_KEY",
+			},
+		}
+
+		count := ApplyBindings(cfg, bindings, registry, false)
+		if count != 1 {
+			t.Fatalf("expected 1 binding applied, got %d", count)
+		}
+
+		p := cfg.LoadedProviders["workspace-default-gpt4"]
+		if p.Credential == nil {
+			t.Fatal("expected credential to be set")
+		}
+		if p.Credential.CredentialEnv != "OPENAI_API_KEY" {
+			t.Errorf("expected credential env OPENAI_API_KEY, got %s", p.Credential.CredentialEnv)
+		}
+	})
+
+	t.Run("already has credentials", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-gpt4": {
+					ID:   "workspace-default-gpt4",
+					Type: "openai",
+					Credential: &config.CredentialConfig{
+						CredentialEnv: "MY_CUSTOM_KEY",
+					},
+				},
+			},
+		}
+
+		bindings := []ProviderBinding{
+			{
+				ProviderID:      "workspace-default-gpt4",
+				SourceName:      "gpt4",
+				SourceNamespace: "workspace-default",
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/gpt4": {
+				ID:           "gpt4",
+				SecretEnvVar: "OPENAI_API_KEY",
+			},
+		}
+
+		count := ApplyBindings(cfg, bindings, registry, false)
+		if count != 0 {
+			t.Fatalf("expected 0 bindings (already has credentials), got %d", count)
+		}
+
+		// Verify original credential was preserved
+		p := cfg.LoadedProviders["workspace-default-gpt4"]
+		if p.Credential.CredentialEnv != "MY_CUSTOM_KEY" {
+			t.Errorf("expected credential env MY_CUSTOM_KEY preserved, got %s", p.Credential.CredentialEnv)
+		}
+	})
+
+	t.Run("key not found in registry", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-gpt4": {
+					ID:   "workspace-default-gpt4",
+					Type: "openai",
+				},
+			},
+		}
+
+		bindings := []ProviderBinding{
+			{
+				ProviderID:      "workspace-default-gpt4",
+				SourceName:      "gpt4",
+				SourceNamespace: "other-namespace",
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/gpt4": {
+				ID:           "gpt4",
+				SecretEnvVar: "OPENAI_API_KEY",
+			},
+		}
+
+		count := ApplyBindings(cfg, bindings, registry, false)
+		if count != 0 {
+			t.Fatalf("expected 0 bindings (key mismatch), got %d", count)
+		}
+	})
+
+	t.Run("empty bindings", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"test": {ID: "test", Type: "openai"},
+			},
+		}
+		registry := map[string]overrides.ProviderOverride{
+			"ns/test": {ID: "test", SecretEnvVar: "KEY"},
+		}
+
+		count := ApplyBindings(cfg, nil, registry, false)
+		if count != 0 {
+			t.Fatalf("expected 0 bindings for empty bindings, got %d", count)
+		}
+	})
+
+	t.Run("empty registry", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"test": {ID: "test", Type: "openai"},
+			},
+		}
+		bindings := []ProviderBinding{
+			{ProviderID: "test", SourceName: "test", SourceNamespace: "ns"},
+		}
+
+		count := ApplyBindings(cfg, bindings, nil, false)
+		if count != 0 {
+			t.Fatalf("expected 0 bindings for empty registry, got %d", count)
+		}
+	})
+
+	t.Run("platform injection", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-bedrock": {
+					ID:   "workspace-default-bedrock",
+					Type: "bedrock",
+				},
+			},
+		}
+
+		bindings := []ProviderBinding{
+			{
+				ProviderID:      "workspace-default-bedrock",
+				SourceName:      "bedrock",
+				SourceNamespace: "workspace-default",
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/bedrock": {
+				ID:           "bedrock",
+				Type:         "bedrock",
+				SecretEnvVar: "AWS_ACCESS_KEY_ID",
+				Platform: &overrides.PlatformOverride{
+					Type:   "aws",
+					Region: "us-west-2",
+				},
+			},
+		}
+
+		count := ApplyBindings(cfg, bindings, registry, false)
+		if count != 1 {
+			t.Fatalf("expected 1 binding, got %d", count)
+		}
+
+		p := cfg.LoadedProviders["workspace-default-bedrock"]
+		if p.Platform == nil {
+			t.Fatal("expected platform to be injected")
+		}
+		if p.Platform.Type != "aws" {
+			t.Errorf("expected platform type aws, got %s", p.Platform.Type)
+		}
+		if p.Platform.Region != "us-west-2" {
+			t.Errorf("expected region us-west-2, got %s", p.Platform.Region)
+		}
+	})
+
+	t.Run("credential file binding", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-vertex": {
+					ID:   "workspace-default-vertex",
+					Type: "vertex",
+				},
+			},
+		}
+
+		bindings := []ProviderBinding{
+			{
+				ProviderID:      "workspace-default-vertex",
+				SourceName:      "vertex",
+				SourceNamespace: "workspace-default",
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/vertex": {
+				ID:             "vertex",
+				Type:           "vertex",
+				CredentialFile: "/var/run/secrets/gcp/key.json",
+			},
+		}
+
+		count := ApplyBindings(cfg, bindings, registry, false)
+		if count != 1 {
+			t.Fatalf("expected 1 binding, got %d", count)
+		}
+
+		p := cfg.LoadedProviders["workspace-default-vertex"]
+		if p.Credential == nil {
+			t.Fatal("expected credential to be set")
+		}
+		if p.Credential.CredentialFile != "/var/run/secrets/gcp/key.json" {
+			t.Errorf("expected credential file path, got %s", p.Credential.CredentialFile)
+		}
+	})
+}
+
+func TestApplyNameMatching(t *testing.T) {
+	t.Run("match found", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-gpt4": {
+					ID:   "workspace-default-gpt4",
+					Type: "openai",
+				},
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/gpt4": {
+				ID:           "gpt4",
+				Type:         "openai",
+				SecretEnvVar: "OPENAI_API_KEY",
+			},
+		}
+
+		count := ApplyNameMatching(cfg, registry, false)
+		if count != 1 {
+			t.Fatalf("expected 1 match, got %d", count)
+		}
+
+		p := cfg.LoadedProviders["workspace-default-gpt4"]
+		if p.Credential == nil {
+			t.Fatal("expected credential to be set")
+		}
+		if p.Credential.CredentialEnv != "OPENAI_API_KEY" {
+			t.Errorf("expected OPENAI_API_KEY, got %s", p.Credential.CredentialEnv)
+		}
+	})
+
+	t.Run("no match", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"unrelated-provider": {
+					ID:   "unrelated-provider",
+					Type: "openai",
+				},
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/gpt4": {
+				ID:           "gpt4",
+				SecretEnvVar: "OPENAI_API_KEY",
+			},
+		}
+
+		count := ApplyNameMatching(cfg, registry, false)
+		if count != 0 {
+			t.Fatalf("expected 0 matches, got %d", count)
+		}
+	})
+
+	t.Run("skip mock and ollama", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-mock": {
+					ID:   "workspace-default-mock",
+					Type: "mock",
+				},
+				"workspace-default-ollama": {
+					ID:   "workspace-default-ollama",
+					Type: "ollama",
+				},
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/mock": {
+				ID:           "mock",
+				SecretEnvVar: "MOCK_KEY",
+			},
+			"workspace-default/ollama": {
+				ID:           "ollama",
+				SecretEnvVar: "OLLAMA_KEY",
+			},
+		}
+
+		count := ApplyNameMatching(cfg, registry, false)
+		if count != 0 {
+			t.Fatalf("expected 0 matches (mock/ollama should be skipped), got %d", count)
+		}
+	})
+
+	t.Run("skip already credentialed", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"workspace-default-gpt4": {
+					ID:   "workspace-default-gpt4",
+					Type: "openai",
+					Credential: &config.CredentialConfig{
+						CredentialEnv: "EXISTING_KEY",
+					},
+				},
+			},
+		}
+
+		registry := map[string]overrides.ProviderOverride{
+			"workspace-default/gpt4": {
+				ID:           "gpt4",
+				SecretEnvVar: "OPENAI_API_KEY",
+			},
+		}
+
+		count := ApplyNameMatching(cfg, registry, false)
+		if count != 0 {
+			t.Fatalf("expected 0 matches (already has credentials), got %d", count)
+		}
+	})
+
+	t.Run("empty registry", func(t *testing.T) {
+		cfg := &config.Config{
+			LoadedProviders: map[string]*config.Provider{
+				"test": {ID: "test", Type: "openai"},
+			},
+		}
+		count := ApplyNameMatching(cfg, nil, false)
+		if count != 0 {
+			t.Fatalf("expected 0 for empty registry, got %d", count)
+		}
+	})
+
+	t.Run("empty loaded providers", func(t *testing.T) {
+		cfg := &config.Config{}
+		registry := map[string]overrides.ProviderOverride{
+			"ns/test": {ID: "test", SecretEnvVar: "KEY"},
+		}
+		count := ApplyNameMatching(cfg, registry, false)
+		if count != 0 {
+			t.Fatalf("expected 0 for empty providers, got %d", count)
+		}
+	})
+}
+
+func TestHasCredentials(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *config.Provider
+		expected bool
+	}{
+		{
+			name:     "nil credential",
+			provider: &config.Provider{ID: "test"},
+			expected: false,
+		},
+		{
+			name: "empty credential",
+			provider: &config.Provider{
+				ID:         "test",
+				Credential: &config.CredentialConfig{},
+			},
+			expected: false,
+		},
+		{
+			name: "with API key",
+			provider: &config.Provider{
+				ID: "test",
+				Credential: &config.CredentialConfig{
+					APIKey: "sk-test",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "with credential env",
+			provider: &config.Provider{
+				ID: "test",
+				Credential: &config.CredentialConfig{
+					CredentialEnv: "OPENAI_API_KEY",
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "with credential file",
+			provider: &config.Provider{
+				ID: "test",
+				Credential: &config.CredentialConfig{
+					CredentialFile: "/path/to/key",
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := hasCredentials(tt.provider)
+			if result != tt.expected {
+				t.Errorf("hasCredentials() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRequiresCredentials(t *testing.T) {
+	tests := []struct {
+		providerType string
+		expected     bool
+	}{
+		{"openai", true},
+		{"claude", true},
+		{"bedrock", true},
+		{"mock", false},
+		{"ollama", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.providerType, func(t *testing.T) {
+			result := requiresCredentials(tt.providerType)
+			if result != tt.expected {
+				t.Errorf("requiresCredentials(%s) = %v, want %v", tt.providerType, result, tt.expected)
+			}
+		})
+	}
+}

--- a/ee/pkg/arena/overrides/types.go
+++ b/ee/pkg/arena/overrides/types.go
@@ -20,6 +20,12 @@ type OverrideConfig struct {
 	// Groups correspond to ArenaJob.spec.providerOverrides keys.
 	Providers map[string][]ProviderOverride `json:"providers,omitempty"`
 
+	// Bindings maps "{namespace}/{name}" to ProviderOverride for annotation-based
+	// credential resolution. The worker uses this registry to match arena provider
+	// YAML files (with binding annotations) to their corresponding Provider CRDs.
+	// Old workers without binding support ignore this field.
+	Bindings map[string]ProviderOverride `json:"bindings,omitempty"`
+
 	// Tools contains tool override configurations from ToolRegistry CRDs.
 	Tools []ToolOverride `json:"tools,omitempty"`
 }


### PR DESCRIPTION
## Summary

Closes #398

- Add annotation-based credential resolution so arena projects imported from the dashboard work without explicit `providerOverrides`
- Controller builds a binding registry from all namespace Provider CRDs and includes it in the override ConfigMap
- Worker parses `omnia.altairalabs.ai/provider-name` and `omnia.altairalabs.ai/provider-namespace` annotations from provider YAML files, resolves them against the registry, and falls back to name-based matching (`{namespace}-{name}` pattern) for unbound providers

### Fallback chain (applied in order)
1. Explicit `providerOverrides` (existing, highest priority)
2. Binding annotation → registry lookup
3. Name matching (provider ID matches `{namespace}-{name}`)
4. Existing credential config in provider YAML
5. Skip (mock, ollama)

### Files changed
- `ee/pkg/arena/overrides/types.go` — Add `Bindings` field to `OverrideConfig`
- `ee/pkg/arena/binding/binding.go` — New package with `ParseProviderAnnotations`, `ApplyBindings`, `ApplyNameMatching`
- `ee/pkg/arena/binding/binding_test.go` — 22 test cases (90.7% coverage)
- `ee/internal/controller/arenajob_controller.go` — Add `resolveBindingRegistry`, `deduplicateProviders`, integrate into `createWorkerJob`
- `ee/cmd/arena-worker/worker.go` — Add `applyProviderBindings`, integrate into `executeWorkItem`

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./ee/pkg/arena/binding/...` — 22/22 pass
- [x] `go test ./ee/pkg/arena/providers/...` — existing tests pass
- [x] `go test github.com/altairalabs/omnia/internal/controller` — existing tests pass
- [x] `go test github.com/altairalabs/omnia/ee/internal/controller` — 121/121 pass
- [x] Pre-commit checks pass (lint, vet, coverage ≥80%)