### PR TITLE
feat: SessionRetentionPolicy controller with events, ConfigMap, finalizer, and metrics (#360)

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	"github.com/altairalabs/omnia/internal/controller"
 	"github.com/altairalabs/omnia/internal/schema"
+	"github.com/altairalabs/omnia/pkg/metrics"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -214,10 +215,15 @@ func main() {
 		setupLog.Error(err, errUnableToCreateController, logKeyController, "Workspace")
 		os.Exit(1)
 	}
+	retentionMetrics := metrics.NewRetentionMetrics()
+	retentionMetrics.Initialize()
+
 	if err := (&controller.SessionRetentionPolicyReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: mgr.GetEventRecorderFor("sessionretentionpolicy-controller"),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Recorder:  mgr.GetEventRecorderFor("sessionretentionpolicy-controller"),
+		Namespace: os.Getenv("POD_NAMESPACE"),
+		Metrics:   retentionMetrics,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, errUnableToCreateController, logKeyController, "SessionRetentionPolicy")
 		os.Exit(1)

--- a/pkg/metrics/retention.go
+++ b/pkg/metrics/retention.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// RetentionMetrics holds Prometheus metrics for retention policy reconciliation.
+type RetentionMetrics struct {
+	// ReconcileErrorsTotal counts reconcile errors by policy name and error type.
+	ReconcileErrorsTotal *prometheus.CounterVec
+	// ActivePolicies is the current count of Active retention policies.
+	ActivePolicies prometheus.Gauge
+	// WorkspaceOverrides tracks the number of workspace overrides per policy.
+	WorkspaceOverrides *prometheus.GaugeVec
+	// ConfigMapSyncErrors counts ConfigMap sync failures by policy name.
+	ConfigMapSyncErrors *prometheus.CounterVec
+}
+
+// NewRetentionMetrics creates and registers all Prometheus metrics for retention policy reconciliation.
+func NewRetentionMetrics() *RetentionMetrics {
+	return &RetentionMetrics{
+		ReconcileErrorsTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "omnia_retention_reconcile_errors_total",
+			Help: "Total number of retention policy reconcile errors",
+		}, []string{"policy_name", "error_type"}),
+
+		ActivePolicies: promauto.NewGauge(prometheus.GaugeOpts{
+			Name: "omnia_retention_active_policies",
+			Help: "Current number of active retention policies",
+		}),
+
+		WorkspaceOverrides: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "omnia_retention_workspace_overrides",
+			Help: "Number of workspace overrides per retention policy",
+		}, []string{"policy_name"}),
+
+		ConfigMapSyncErrors: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "omnia_retention_configmap_sync_errors_total",
+			Help: "Total number of ConfigMap sync errors for retention policies",
+		}, []string{"policy_name"}),
+	}
+}
+
+// Initialize pre-registers retention metrics so they appear in /metrics output at startup.
+func (m *RetentionMetrics) Initialize() {
+	m.ActivePolicies.Set(0)
+}
+
+// RecordReconcileError increments the reconcile error counter.
+func (m *RetentionMetrics) RecordReconcileError(policyName, errorType string) {
+	m.ReconcileErrorsTotal.WithLabelValues(policyName, errorType).Inc()
+}
+
+// RecordConfigMapSyncError increments the ConfigMap sync error counter.
+func (m *RetentionMetrics) RecordConfigMapSyncError(policyName string) {
+	m.ConfigMapSyncErrors.WithLabelValues(policyName).Inc()
+}
+
+// SetWorkspaceOverrides sets the workspace override count for a policy.
+func (m *RetentionMetrics) SetWorkspaceOverrides(policyName string, count int) {
+	m.WorkspaceOverrides.WithLabelValues(policyName).Set(float64(count))
+}
+
+// newRetentionMetricsWithRegistry creates retention metrics with a custom registry for testing.
+func newRetentionMetricsWithRegistry(reg *prometheus.Registry) *RetentionMetrics {
+	reconcileErrorsTotal := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "omnia_retention_reconcile_errors_total",
+		Help: "Total number of retention policy reconcile errors",
+	}, []string{"policy_name", "error_type"})
+
+	activePolicies := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "omnia_retention_active_policies",
+		Help: "Current number of active retention policies",
+	})
+
+	workspaceOverrides := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "omnia_retention_workspace_overrides",
+		Help: "Number of workspace overrides per retention policy",
+	}, []string{"policy_name"})
+
+	configMapSyncErrors := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "omnia_retention_configmap_sync_errors_total",
+		Help: "Total number of ConfigMap sync errors for retention policies",
+	}, []string{"policy_name"})
+
+	reg.MustRegister(reconcileErrorsTotal, activePolicies, workspaceOverrides, configMapSyncErrors)
+
+	return &RetentionMetrics{
+		ReconcileErrorsTotal: reconcileErrorsTotal,
+		ActivePolicies:       activePolicies,
+		WorkspaceOverrides:   workspaceOverrides,
+		ConfigMapSyncErrors:  configMapSyncErrors,
+	}
+}

--- a/pkg/metrics/retention_test.go
+++ b/pkg/metrics/retention_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+func TestNewRetentionMetrics(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRetentionMetricsWithRegistry(reg)
+	if m == nil {
+		t.Fatal("NewRetentionMetrics returned nil")
+	}
+	if m.ReconcileErrorsTotal == nil {
+		t.Error("ReconcileErrorsTotal is nil")
+	}
+	if m.ActivePolicies == nil {
+		t.Error("ActivePolicies is nil")
+	}
+	if m.WorkspaceOverrides == nil {
+		t.Error("WorkspaceOverrides is nil")
+	}
+	if m.ConfigMapSyncErrors == nil {
+		t.Error("ConfigMapSyncErrors is nil")
+	}
+}
+
+func TestNewRetentionMetrics_Promauto(t *testing.T) {
+	m := NewRetentionMetrics()
+	if m == nil {
+		t.Fatal("NewRetentionMetrics returned nil")
+	}
+	if m.ReconcileErrorsTotal == nil {
+		t.Error("ReconcileErrorsTotal is nil")
+	}
+	if m.ActivePolicies == nil {
+		t.Error("ActivePolicies is nil")
+	}
+	if m.WorkspaceOverrides == nil {
+		t.Error("WorkspaceOverrides is nil")
+	}
+	if m.ConfigMapSyncErrors == nil {
+		t.Error("ConfigMapSyncErrors is nil")
+	}
+}
+
+func TestRetentionMetrics_Initialize(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRetentionMetricsWithRegistry(reg)
+	m.Initialize()
+
+	// Verify ActivePolicies gauge is 0 after initialize
+	var metric dto.Metric
+	if err := m.ActivePolicies.Write(&metric); err != nil {
+		t.Fatalf("Failed to write metric: %v", err)
+	}
+	if metric.GetGauge().GetValue() != 0 {
+		t.Errorf("Expected ActivePolicies to be 0, got %v", metric.GetGauge().GetValue())
+	}
+}
+
+func TestRetentionMetrics_RecordReconcileError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRetentionMetricsWithRegistry(reg)
+
+	m.RecordReconcileError("test-policy", "validation")
+	m.RecordReconcileError("test-policy", "validation")
+
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	found := false
+	for _, mf := range metrics {
+		if mf.GetName() == "omnia_retention_reconcile_errors_total" {
+			found = true
+			for _, m := range mf.GetMetric() {
+				if m.GetCounter().GetValue() != 2 {
+					t.Errorf("Expected counter value 2, got %v", m.GetCounter().GetValue())
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("omnia_retention_reconcile_errors_total metric not found")
+	}
+}
+
+func TestRetentionMetrics_RecordConfigMapSyncError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRetentionMetricsWithRegistry(reg)
+
+	m.RecordConfigMapSyncError("test-policy")
+
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	found := false
+	for _, mf := range metrics {
+		if mf.GetName() == "omnia_retention_configmap_sync_errors_total" {
+			found = true
+			for _, m := range mf.GetMetric() {
+				if m.GetCounter().GetValue() != 1 {
+					t.Errorf("Expected counter value 1, got %v", m.GetCounter().GetValue())
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("omnia_retention_configmap_sync_errors_total metric not found")
+	}
+}
+
+func TestRetentionMetrics_SetWorkspaceOverrides(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newRetentionMetricsWithRegistry(reg)
+
+	m.SetWorkspaceOverrides("test-policy", 5)
+
+	metrics, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("Failed to gather metrics: %v", err)
+	}
+
+	found := false
+	for _, mf := range metrics {
+		if mf.GetName() == "omnia_retention_workspace_overrides" {
+			found = true
+			for _, m := range mf.GetMetric() {
+				if m.GetGauge().GetValue() != 5 {
+					t.Errorf("Expected gauge value 5, got %v", m.GetGauge().GetValue())
+				}
+			}
+		}
+	}
+	if !found {
+		t.Error("omnia_retention_workspace_overrides metric not found")
+	}
+}


### PR DESCRIPTION
## Summary
- **SessionRetentionPolicy CRD** (#359): Cluster-scoped CRD defining retention rules for session history across hot/warm/cold storage tiers, with per-workspace overrides
- **Controller enhancements** (#360): Production-readiness features including Kubernetes events, ConfigMap projection, finalizer-based cleanup, Ready summary condition, and Prometheus metrics
- **Error path coverage**: Comprehensive tests for API server errors, status update failures, and workspace resolution errors

## Changes
- `api/v1alpha1/sessionretentionpolicy_types.go` — CRD types (HotCache, WarmStore, ColdArchive, per-workspace overrides)
- `internal/controller/sessionretentionpolicy_controller.go` — Reconciler with validation, workspace resolution, event emission, ConfigMap sync, finalizer, Ready condition, and metrics
- `pkg/metrics/retention.go` — Prometheus metrics (reconcile errors, active policies, workspace overrides, ConfigMap sync errors)
- `cmd/main.go` — Wire Namespace (POD_NAMESPACE), Recorder, and RetentionMetrics to reconciler
- `charts/omnia/` — Helm chart CRDs, default retention policy, ClusterRole permissions
- `dashboard/src/types/generated/` — Auto-generated TypeScript types

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./api/v1alpha1/ -run SessionRetentionPolicy` — 8 tests pass
- [x] `go test ./internal/controller/ --ginkgo.focus=SessionRetentionPolicy` — 30 tests pass (81.3% coverage)
- [x] `go test ./pkg/metrics/ -run Retention` — 6 tests pass (100% coverage)
- [x] `cd dashboard && npx next build` passes
- [x] Pre-commit hooks pass (formatting, vet, lint, coverage ≥80%)