### PR TITLE
feat: implement Redis hot cache provider (#362)

### DIFF
--- a/internal/session/providers/redis/benchmark_test.go
+++ b/internal/session/providers/redis/benchmark_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/altairalabs/omnia/internal/session"
+)
+
+func benchProvider(b *testing.B) *Provider {
+	b.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Cleanup(mr.Close)
+
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	b.Cleanup(func() { _ = client.Close() })
+
+	return NewFromClient(client, DefaultOptions())
+}
+
+func benchSession() *session.Session {
+	now := time.Now()
+	return &session.Session{
+		ID:                "bench-sess",
+		AgentName:         "bench-agent",
+		Namespace:         "bench-ns",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		Status:            session.SessionStatusActive,
+		WorkspaceName:     "bench-ws",
+		MessageCount:      42,
+		TotalInputTokens:  5000,
+		TotalOutputTokens: 8000,
+		Tags:              []string{"bench"},
+	}
+}
+
+func BenchmarkGetSession(b *testing.B) {
+	p := benchProvider(b)
+	ctx := context.Background()
+	s := benchSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	b.ResetTimer()
+	for b.Loop() {
+		_, _ = p.GetSession(ctx, s.ID)
+	}
+}
+
+func BenchmarkSetSession(b *testing.B) {
+	p := benchProvider(b)
+	ctx := context.Background()
+	s := benchSession()
+
+	b.Run("NoTTL", func(b *testing.B) {
+		for b.Loop() {
+			_ = p.SetSession(ctx, s, 0)
+		}
+	})
+
+	b.Run("WithTTL", func(b *testing.B) {
+		for b.Loop() {
+			_ = p.SetSession(ctx, s, time.Hour)
+		}
+	})
+}
+
+func BenchmarkAppendMessage(b *testing.B) {
+	p := benchProvider(b)
+	ctx := context.Background()
+	s := benchSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	msg := &session.Message{
+		ID:          "bench-msg",
+		Role:        session.RoleUser,
+		Content:     "benchmark message content that is reasonably sized for a typical user turn",
+		Timestamp:   time.Now(),
+		SequenceNum: 1,
+	}
+
+	b.ResetTimer()
+	for b.Loop() {
+		_ = p.AppendMessage(ctx, s.ID, msg)
+	}
+}
+
+func BenchmarkGetRecentMessages(b *testing.B) {
+	p := benchProvider(b)
+	ctx := context.Background()
+	s := benchSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	// Seed 200 messages.
+	for i := 1; i <= 200; i++ {
+		_ = p.AppendMessage(ctx, s.ID, &session.Message{
+			ID:          fmt.Sprintf("msg-%d", i),
+			Role:        session.RoleUser,
+			Content:     "benchmark message content that is reasonably sized for a typical user turn",
+			Timestamp:   time.Now(),
+			SequenceNum: int32(i),
+		})
+	}
+
+	for _, limit := range []int{10, 50, 200} {
+		b.Run(fmt.Sprintf("Limit_%d", limit), func(b *testing.B) {
+			for b.Loop() {
+				_, _ = p.GetRecentMessages(ctx, s.ID, limit)
+			}
+		})
+	}
+}

--- a/internal/session/providers/redis/config.go
+++ b/internal/session/providers/redis/config.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+const (
+	defaultKeyPrefix  = "hot:"
+	defaultMaxRetries = 3
+)
+
+// Config holds connection and behaviour settings for the Redis hot cache provider.
+type Config struct {
+	// Addrs lists Redis server addresses. A single address creates a standalone
+	// client; multiple addresses create a cluster client.
+	Addrs []string
+	// Password is used for Redis AUTH.
+	Password string
+	// DB selects the database number. Ignored in cluster mode.
+	DB int
+	// KeyPrefix is prepended to every key written by the provider.
+	// Default: "hot:".
+	KeyPrefix string
+	// MaxMessagesPerSession caps the message list length via LTRIM after each
+	// append. Zero means unlimited.
+	MaxMessagesPerSession int
+	// PoolSize overrides the go-redis default connection pool size.
+	// Zero uses the library default (10 * GOMAXPROCS).
+	PoolSize int
+	// MaxRetries is the maximum number of retries for a command. Default: 3.
+	MaxRetries int
+	// DialTimeout is the timeout for establishing new connections.
+	DialTimeout time.Duration
+	// ReadTimeout is the timeout for socket reads.
+	ReadTimeout time.Duration
+	// WriteTimeout is the timeout for socket writes.
+	WriteTimeout time.Duration
+	// TLS enables TLS when non-nil.
+	TLS *tls.Config
+}
+
+// DefaultConfig returns a Config with sensible defaults. Callers must still
+// set at least one address in Addrs.
+func DefaultConfig() Config {
+	return Config{
+		KeyPrefix:  defaultKeyPrefix,
+		MaxRetries: defaultMaxRetries,
+	}
+}
+
+// Options carries non-connection settings used by NewFromClient.
+type Options struct {
+	// KeyPrefix is prepended to every key. Default: "hot:".
+	KeyPrefix string
+	// MaxMessagesPerSession caps the message list length. Zero means unlimited.
+	MaxMessagesPerSession int
+}
+
+// DefaultOptions returns Options with sensible defaults.
+func DefaultOptions() Options {
+	return Options{
+		KeyPrefix: defaultKeyPrefix,
+	}
+}

--- a/internal/session/providers/redis/provider.go
+++ b/internal/session/providers/redis/provider.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/altairalabs/omnia/internal/session"
+	"github.com/altairalabs/omnia/internal/session/providers"
+)
+
+// Compile-time interface check.
+var _ providers.HotCacheProvider = (*Provider)(nil)
+
+// Provider implements providers.HotCacheProvider using Redis.
+type Provider struct {
+	client     goredis.UniversalClient
+	keyPrefix  string
+	maxMsgs    int
+	ownsClient bool
+}
+
+// New creates a Provider that owns the underlying Redis client. The client is
+// created from cfg and verified with a PING. Close will shut down the client.
+func New(cfg Config) (*Provider, error) {
+	if len(cfg.Addrs) == 0 {
+		return nil, fmt.Errorf("redis: at least one address is required")
+	}
+
+	prefix := cfg.KeyPrefix
+	if prefix == "" {
+		prefix = defaultKeyPrefix
+	}
+
+	opts := &goredis.UniversalOptions{
+		Addrs:        cfg.Addrs,
+		Password:     cfg.Password,
+		DB:           cfg.DB,
+		MaxRetries:   cfg.MaxRetries,
+		DialTimeout:  cfg.DialTimeout,
+		ReadTimeout:  cfg.ReadTimeout,
+		WriteTimeout: cfg.WriteTimeout,
+		TLSConfig:    cfg.TLS,
+	}
+	if cfg.PoolSize > 0 {
+		opts.PoolSize = cfg.PoolSize
+	}
+
+	client := goredis.NewUniversalClient(opts)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("redis: failed to connect: %w", err)
+	}
+
+	return &Provider{
+		client:     client,
+		keyPrefix:  prefix,
+		maxMsgs:    cfg.MaxMessagesPerSession,
+		ownsClient: true,
+	}, nil
+}
+
+// NewFromClient wraps an existing UniversalClient. Close is a no-op because
+// the caller retains ownership of the client.
+func NewFromClient(client goredis.UniversalClient, opts Options) *Provider {
+	prefix := opts.KeyPrefix
+	if prefix == "" {
+		prefix = defaultKeyPrefix
+	}
+	return &Provider{
+		client:     client,
+		keyPrefix:  prefix,
+		maxMsgs:    opts.MaxMessagesPerSession,
+		ownsClient: false,
+	}
+}
+
+// --- key helpers -----------------------------------------------------------
+
+func (p *Provider) sessionKey(id string) string {
+	return p.keyPrefix + "session:{" + id + "}"
+}
+
+func (p *Provider) messagesKey(id string) string {
+	return p.keyPrefix + "session:{" + id + "}:msgs"
+}
+
+// --- HotCacheProvider implementation ---------------------------------------
+
+func (p *Provider) GetSession(ctx context.Context, sessionID string) (*session.Session, error) {
+	data, err := p.client.Get(ctx, p.sessionKey(sessionID)).Bytes()
+	if err != nil {
+		if err == goredis.Nil {
+			return nil, session.ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("redis: get session: %w", err)
+	}
+
+	var s session.Session
+	if err := json.Unmarshal(data, &s); err != nil {
+		return nil, fmt.Errorf("redis: unmarshal session: %w", err)
+	}
+	return &s, nil
+}
+
+func (p *Provider) SetSession(ctx context.Context, s *session.Session, ttl time.Duration) error {
+	data, err := json.Marshal(s)
+	if err != nil {
+		return fmt.Errorf("redis: marshal session: %w", err)
+	}
+	if err := p.client.Set(ctx, p.sessionKey(s.ID), data, ttl).Err(); err != nil {
+		return fmt.Errorf("redis: set session: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) DeleteSession(ctx context.Context, sessionID string) error {
+	exists, err := p.client.Exists(ctx, p.sessionKey(sessionID)).Result()
+	if err != nil {
+		return fmt.Errorf("redis: check existence: %w", err)
+	}
+	if exists == 0 {
+		return session.ErrSessionNotFound
+	}
+
+	pipe := p.client.Pipeline()
+	pipe.Del(ctx, p.sessionKey(sessionID))
+	pipe.Del(ctx, p.messagesKey(sessionID))
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("redis: delete session: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) AppendMessage(ctx context.Context, sessionID string, msg *session.Message) error {
+	sessionKey := p.sessionKey(sessionID)
+	msgsKey := p.messagesKey(sessionID)
+
+	exists, err := p.client.Exists(ctx, sessionKey).Result()
+	if err != nil {
+		return fmt.Errorf("redis: check existence: %w", err)
+	}
+	if exists == 0 {
+		return session.ErrSessionNotFound
+	}
+
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("redis: marshal message: %w", err)
+	}
+
+	pipe := p.client.Pipeline()
+	pipe.RPush(ctx, msgsKey, data)
+
+	if p.maxMsgs > 0 {
+		pipe.LTrim(ctx, msgsKey, int64(-p.maxMsgs), -1)
+	}
+
+	// Sync messages key TTL with session key TTL.
+	ttlCmd := p.client.TTL(ctx, sessionKey)
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("redis: append message: %w", err)
+	}
+
+	// Apply TTL from session key to messages key.
+	ttl, err := ttlCmd.Result()
+	if err != nil {
+		return fmt.Errorf("redis: get session ttl: %w", err)
+	}
+
+	switch {
+	case ttl > 0:
+		if err := p.client.Expire(ctx, msgsKey, ttl).Err(); err != nil {
+			return fmt.Errorf("redis: sync messages ttl: %w", err)
+		}
+	case ttl == -1:
+		// Session has no expiry — make sure messages key also has no expiry.
+		if err := p.client.Persist(ctx, msgsKey).Err(); err != nil {
+			return fmt.Errorf("redis: persist messages key: %w", err)
+		}
+	}
+	// ttl == -2 means key doesn't exist; ignore (should not happen here).
+
+	return nil
+}
+
+func (p *Provider) GetRecentMessages(ctx context.Context, sessionID string, limit int) ([]*session.Message, error) {
+	exists, err := p.client.Exists(ctx, p.sessionKey(sessionID)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis: check existence: %w", err)
+	}
+	if exists == 0 {
+		return nil, session.ErrSessionNotFound
+	}
+
+	var start int64
+	if limit > 0 {
+		start = int64(-limit)
+	}
+
+	data, err := p.client.LRange(ctx, p.messagesKey(sessionID), start, -1).Result()
+	if err != nil {
+		return nil, fmt.Errorf("redis: lrange messages: %w", err)
+	}
+
+	msgs := make([]*session.Message, 0, len(data))
+	for _, d := range data {
+		var m session.Message
+		if err := json.Unmarshal([]byte(d), &m); err != nil {
+			return nil, fmt.Errorf("redis: unmarshal message: %w", err)
+		}
+		msgs = append(msgs, &m)
+	}
+	return msgs, nil
+}
+
+func (p *Provider) RefreshTTL(ctx context.Context, sessionID string, ttl time.Duration) error {
+	sessionKey := p.sessionKey(sessionID)
+	msgsKey := p.messagesKey(sessionID)
+
+	exists, err := p.client.Exists(ctx, sessionKey).Result()
+	if err != nil {
+		return fmt.Errorf("redis: check existence: %w", err)
+	}
+	if exists == 0 {
+		return session.ErrSessionNotFound
+	}
+
+	pipe := p.client.Pipeline()
+	if ttl > 0 {
+		pipe.Expire(ctx, sessionKey, ttl)
+		pipe.Expire(ctx, msgsKey, ttl)
+	} else {
+		pipe.Persist(ctx, sessionKey)
+		pipe.Persist(ctx, msgsKey)
+	}
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("redis: refresh ttl: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) Invalidate(ctx context.Context, sessionID string) error {
+	pipe := p.client.Pipeline()
+	pipe.Del(ctx, p.sessionKey(sessionID))
+	pipe.Del(ctx, p.messagesKey(sessionID))
+	if _, err := pipe.Exec(ctx); err != nil {
+		return fmt.Errorf("redis: invalidate: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) Ping(ctx context.Context) error {
+	return p.client.Ping(ctx).Err()
+}
+
+func (p *Provider) Close() error {
+	if p.ownsClient {
+		return p.client.Close()
+	}
+	return nil
+}

--- a/internal/session/providers/redis/provider_test.go
+++ b/internal/session/providers/redis/provider_test.go
@@ -1,0 +1,620 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/altairalabs/omnia/internal/session"
+	"github.com/altairalabs/omnia/internal/session/providers"
+)
+
+// Ensure Provider satisfies HotCacheProvider at test-compilation time.
+var _ providers.HotCacheProvider = (*Provider)(nil)
+
+func setupTestProvider(t *testing.T) (*Provider, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	p := NewFromClient(client, DefaultOptions())
+	return p, mr
+}
+
+func testSession() *session.Session {
+	now := time.Now().Truncate(time.Second)
+	return &session.Session{
+		ID:                "sess-1",
+		AgentName:         "agent-a",
+		Namespace:         "ns-1",
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		Status:            session.SessionStatusActive,
+		WorkspaceName:     "ws-1",
+		MessageCount:      5,
+		TotalInputTokens:  100,
+		TotalOutputTokens: 200,
+		Tags:              []string{"prod", "v2"},
+	}
+}
+
+func testMessage(id string, seq int32) *session.Message {
+	return &session.Message{
+		ID:          id,
+		Role:        session.RoleUser,
+		Content:     "hello " + id,
+		Timestamp:   time.Now().Truncate(time.Second),
+		SequenceNum: seq,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetSession / SetSession
+// ---------------------------------------------------------------------------
+
+func TestSetGetSession(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	if err := p.SetSession(ctx, s, 0); err != nil {
+		t.Fatalf("SetSession: %v", err)
+	}
+
+	got, err := p.GetSession(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.ID != s.ID {
+		t.Errorf("ID = %q, want %q", got.ID, s.ID)
+	}
+	if got.AgentName != s.AgentName {
+		t.Errorf("AgentName = %q, want %q", got.AgentName, s.AgentName)
+	}
+	if got.Namespace != s.Namespace {
+		t.Errorf("Namespace = %q, want %q", got.Namespace, s.Namespace)
+	}
+	if got.Status != s.Status {
+		t.Errorf("Status = %q, want %q", got.Status, s.Status)
+	}
+	if got.WorkspaceName != s.WorkspaceName {
+		t.Errorf("WorkspaceName = %q, want %q", got.WorkspaceName, s.WorkspaceName)
+	}
+	if got.MessageCount != s.MessageCount {
+		t.Errorf("MessageCount = %d, want %d", got.MessageCount, s.MessageCount)
+	}
+	if got.TotalInputTokens != s.TotalInputTokens {
+		t.Errorf("TotalInputTokens = %d, want %d", got.TotalInputTokens, s.TotalInputTokens)
+	}
+	if len(got.Tags) != len(s.Tags) {
+		t.Errorf("Tags len = %d, want %d", len(got.Tags), len(s.Tags))
+	}
+	if !got.CreatedAt.Equal(s.CreatedAt) {
+		t.Errorf("CreatedAt = %v, want %v", got.CreatedAt, s.CreatedAt)
+	}
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	_, err := p.GetSession(ctx, "nonexistent")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("error = %v, want %v", err, session.ErrSessionNotFound)
+	}
+}
+
+func TestSetSession_Upsert(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	if err := p.SetSession(ctx, s, 0); err != nil {
+		t.Fatalf("SetSession: %v", err)
+	}
+
+	s.AgentName = "agent-b"
+	s.Status = session.SessionStatusCompleted
+	if err := p.SetSession(ctx, s, 0); err != nil {
+		t.Fatalf("SetSession upsert: %v", err)
+	}
+
+	got, err := p.GetSession(ctx, s.ID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got.AgentName != "agent-b" {
+		t.Errorf("AgentName = %q, want %q", got.AgentName, "agent-b")
+	}
+	if got.Status != session.SessionStatusCompleted {
+		t.Errorf("Status = %q, want %q", got.Status, session.SessionStatusCompleted)
+	}
+}
+
+func TestSetSession_WithTTL(t *testing.T) {
+	p, mr := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	if err := p.SetSession(ctx, s, 10*time.Second); err != nil {
+		t.Fatalf("SetSession: %v", err)
+	}
+
+	// Should exist before TTL.
+	if _, err := p.GetSession(ctx, s.ID); err != nil {
+		t.Fatalf("GetSession before expiry: %v", err)
+	}
+
+	// Fast-forward past TTL.
+	mr.FastForward(11 * time.Second)
+
+	_, err := p.GetSession(ctx, s.ID)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("error after expiry = %v, want %v", err, session.ErrSessionNotFound)
+	}
+}
+
+func TestSetSession_ZeroTTL(t *testing.T) {
+	p, mr := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	if err := p.SetSession(ctx, s, 0); err != nil {
+		t.Fatalf("SetSession: %v", err)
+	}
+
+	// Should survive arbitrary time advance.
+	mr.FastForward(24 * time.Hour)
+
+	if _, err := p.GetSession(ctx, s.ID); err != nil {
+		t.Fatalf("GetSession after 24h: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DeleteSession
+// ---------------------------------------------------------------------------
+
+func TestDeleteSession(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+	_ = p.AppendMessage(ctx, s.ID, testMessage("m1", 1))
+
+	if err := p.DeleteSession(ctx, s.ID); err != nil {
+		t.Fatalf("DeleteSession: %v", err)
+	}
+
+	_, err := p.GetSession(ctx, s.ID)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("GetSession after delete = %v, want %v", err, session.ErrSessionNotFound)
+	}
+
+	// Messages should also be gone.
+	msgs, err := p.GetRecentMessages(ctx, s.ID, 0)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("GetRecentMessages after delete: err=%v, msgs=%d", err, len(msgs))
+	}
+}
+
+func TestDeleteSession_NotFound(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	err := p.DeleteSession(ctx, "nonexistent")
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("error = %v, want %v", err, session.ErrSessionNotFound)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AppendMessage / GetRecentMessages
+// ---------------------------------------------------------------------------
+
+func TestAppendMessage(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	msg := testMessage("m1", 1)
+	if err := p.AppendMessage(ctx, s.ID, msg); err != nil {
+		t.Fatalf("AppendMessage: %v", err)
+	}
+
+	msgs, err := p.GetRecentMessages(ctx, s.ID, 0)
+	if err != nil {
+		t.Fatalf("GetRecentMessages: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("count = %d, want 1", len(msgs))
+	}
+	if msgs[0].ID != "m1" {
+		t.Errorf("ID = %q, want %q", msgs[0].ID, "m1")
+	}
+	if msgs[0].Content != msg.Content {
+		t.Errorf("Content = %q, want %q", msgs[0].Content, msg.Content)
+	}
+}
+
+func TestAppendMessage_NotFound(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	err := p.AppendMessage(ctx, "nonexistent", testMessage("m1", 1))
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("error = %v, want %v", err, session.ErrSessionNotFound)
+	}
+}
+
+func TestGetRecentMessages_Limit(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	for i := 1; i <= 10; i++ {
+		_ = p.AppendMessage(ctx, s.ID, testMessage(fmt.Sprintf("m%d", i), int32(i)))
+	}
+
+	msgs, err := p.GetRecentMessages(ctx, s.ID, 3)
+	if err != nil {
+		t.Fatalf("GetRecentMessages: %v", err)
+	}
+	if len(msgs) != 3 {
+		t.Fatalf("count = %d, want 3", len(msgs))
+	}
+	// Should be the last 3 (chronological order).
+	if msgs[0].SequenceNum != 8 {
+		t.Errorf("first seq = %d, want 8", msgs[0].SequenceNum)
+	}
+	if msgs[2].SequenceNum != 10 {
+		t.Errorf("last seq = %d, want 10", msgs[2].SequenceNum)
+	}
+}
+
+func TestGetRecentMessages_All(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	for i := 1; i <= 5; i++ {
+		_ = p.AppendMessage(ctx, s.ID, testMessage(fmt.Sprintf("m%d", i), int32(i)))
+	}
+
+	msgs, err := p.GetRecentMessages(ctx, s.ID, 0)
+	if err != nil {
+		t.Fatalf("GetRecentMessages: %v", err)
+	}
+	if len(msgs) != 5 {
+		t.Errorf("count = %d, want 5", len(msgs))
+	}
+}
+
+func TestGetRecentMessages_NotFound(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	_, err := p.GetRecentMessages(ctx, "nonexistent", 10)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("error = %v, want %v", err, session.ErrSessionNotFound)
+	}
+}
+
+func TestGetRecentMessages_Empty(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	msgs, err := p.GetRecentMessages(ctx, s.ID, 0)
+	if err != nil {
+		t.Fatalf("GetRecentMessages: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("count = %d, want 0", len(msgs))
+	}
+}
+
+func TestMaxMessagesPerSession(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	p := NewFromClient(client, Options{
+		KeyPrefix:             defaultKeyPrefix,
+		MaxMessagesPerSession: 5,
+	})
+
+	ctx := context.Background()
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	for i := 1; i <= 10; i++ {
+		_ = p.AppendMessage(ctx, s.ID, testMessage(fmt.Sprintf("m%d", i), int32(i)))
+	}
+
+	msgs, err := p.GetRecentMessages(ctx, s.ID, 0)
+	if err != nil {
+		t.Fatalf("GetRecentMessages: %v", err)
+	}
+	if len(msgs) != 5 {
+		t.Fatalf("count = %d, want 5 (capped)", len(msgs))
+	}
+	// Should keep the most recent 5.
+	if msgs[0].SequenceNum != 6 {
+		t.Errorf("first seq = %d, want 6", msgs[0].SequenceNum)
+	}
+	if msgs[4].SequenceNum != 10 {
+		t.Errorf("last seq = %d, want 10", msgs[4].SequenceNum)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RefreshTTL
+// ---------------------------------------------------------------------------
+
+func TestRefreshTTL(t *testing.T) {
+	p, mr := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 10*time.Second)
+
+	if err := p.RefreshTTL(ctx, s.ID, 60*time.Second); err != nil {
+		t.Fatalf("RefreshTTL: %v", err)
+	}
+
+	// Should survive past original TTL.
+	mr.FastForward(15 * time.Second)
+
+	if _, err := p.GetSession(ctx, s.ID); err != nil {
+		t.Fatalf("GetSession after RefreshTTL: %v", err)
+	}
+}
+
+func TestRefreshTTL_RemoveExpiry(t *testing.T) {
+	p, mr := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 10*time.Second)
+
+	// Remove expiry.
+	if err := p.RefreshTTL(ctx, s.ID, 0); err != nil {
+		t.Fatalf("RefreshTTL(0): %v", err)
+	}
+
+	mr.FastForward(24 * time.Hour)
+
+	if _, err := p.GetSession(ctx, s.ID); err != nil {
+		t.Fatalf("GetSession after PERSIST: %v", err)
+	}
+}
+
+func TestRefreshTTL_NotFound(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	err := p.RefreshTTL(ctx, "nonexistent", time.Hour)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("error = %v, want %v", err, session.ErrSessionNotFound)
+	}
+}
+
+func TestRefreshTTL_BothKeys(t *testing.T) {
+	p, mr := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+	_ = p.AppendMessage(ctx, s.ID, testMessage("m1", 1))
+
+	// Set TTL on both keys.
+	if err := p.RefreshTTL(ctx, s.ID, 30*time.Second); err != nil {
+		t.Fatalf("RefreshTTL: %v", err)
+	}
+
+	mr.FastForward(31 * time.Second)
+
+	// Both session and messages should be gone.
+	_, err := p.GetSession(ctx, s.ID)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("session should be expired, got %v", err)
+	}
+
+	// Check messages key directly.
+	n, _ := p.client.Exists(ctx, p.messagesKey(s.ID)).Result()
+	if n != 0 {
+		t.Error("messages key should be expired")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Invalidate
+// ---------------------------------------------------------------------------
+
+func TestInvalidate(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+	_ = p.AppendMessage(ctx, s.ID, testMessage("m1", 1))
+
+	if err := p.Invalidate(ctx, s.ID); err != nil {
+		t.Fatalf("Invalidate: %v", err)
+	}
+
+	_, err := p.GetSession(ctx, s.ID)
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		t.Errorf("GetSession after Invalidate = %v, want %v", err, session.ErrSessionNotFound)
+	}
+}
+
+func TestInvalidate_Idempotent(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	ctx := context.Background()
+
+	// Should NOT error even if session doesn't exist.
+	if err := p.Invalidate(ctx, "nonexistent"); err != nil {
+		t.Errorf("Invalidate on nonexistent = %v, want nil", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ping / Close
+// ---------------------------------------------------------------------------
+
+func TestPing(t *testing.T) {
+	p, _ := setupTestProvider(t)
+	if err := p.Ping(context.Background()); err != nil {
+		t.Errorf("Ping: %v", err)
+	}
+}
+
+func TestClose_OwnsClient(t *testing.T) {
+	mr := miniredis.RunT(t)
+	p, err := New(Config{
+		Addrs:     []string{mr.Addr()},
+		KeyPrefix: defaultKeyPrefix,
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Client should be closed — Ping should fail.
+	if err := p.Ping(context.Background()); err == nil {
+		t.Error("Ping after Close should fail")
+	}
+}
+
+func TestClose_SharedClient(t *testing.T) {
+	p, _ := setupTestProvider(t)
+
+	// Close should be a no-op.
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	// Client should still be usable.
+	if err := p.Ping(context.Background()); err != nil {
+		t.Errorf("Ping after shared Close: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Key prefix
+// ---------------------------------------------------------------------------
+
+func TestKeyPrefix(t *testing.T) {
+	mr := miniredis.RunT(t)
+	client := goredis.NewClient(&goredis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = client.Close() })
+
+	p := NewFromClient(client, Options{KeyPrefix: "custom:"})
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 0)
+
+	// Verify the key in miniredis uses the custom prefix.
+	keys := mr.Keys()
+	if !slices.Contains(keys, "custom:session:{"+s.ID+"}") {
+		t.Errorf("expected key with custom prefix, got keys: %v", keys)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Config defaults
+// ---------------------------------------------------------------------------
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.KeyPrefix != defaultKeyPrefix {
+		t.Errorf("KeyPrefix = %q, want %q", cfg.KeyPrefix, defaultKeyPrefix)
+	}
+	if cfg.MaxRetries != defaultMaxRetries {
+		t.Errorf("MaxRetries = %d, want %d", cfg.MaxRetries, defaultMaxRetries)
+	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	if opts.KeyPrefix != defaultKeyPrefix {
+		t.Errorf("KeyPrefix = %q, want %q", opts.KeyPrefix, defaultKeyPrefix)
+	}
+	if opts.MaxMessagesPerSession != 0 {
+		t.Errorf("MaxMessagesPerSession = %d, want 0", opts.MaxMessagesPerSession)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// New — connection error
+// ---------------------------------------------------------------------------
+
+func TestNew_ConnectionError(t *testing.T) {
+	_, err := New(Config{
+		Addrs:     []string{"localhost:1"}, // unlikely to have a Redis here
+		KeyPrefix: defaultKeyPrefix,
+	})
+	if err == nil {
+		t.Fatal("New with invalid addr should fail")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AppendMessage syncs TTL to messages key
+// ---------------------------------------------------------------------------
+
+func TestAppendMessage_SyncsTTL(t *testing.T) {
+	p, mr := setupTestProvider(t)
+	ctx := context.Background()
+
+	s := testSession()
+	_ = p.SetSession(ctx, s, 30*time.Second)
+
+	_ = p.AppendMessage(ctx, s.ID, testMessage("m1", 1))
+
+	// Both keys should expire around the same time.
+	mr.FastForward(31 * time.Second)
+
+	n, _ := p.client.Exists(ctx, p.messagesKey(s.ID)).Result()
+	if n != 0 {
+		t.Error("messages key should have expired with session TTL")
+	}
+}


### PR DESCRIPTION
## Summary
- Implements `HotCacheProvider` interface with a Redis backend (`internal/session/providers/redis/`)
- Uses `go-redis/v9` `UniversalClient` to support both standalone and cluster modes
- Hash-tagged keys (`{id}`) ensure multi-key pipelines land on the same Redis Cluster slot
- `hot:` key prefix avoids collision with existing `session:` keys from `RedisStore`
- Automatic TTL synchronization between session and message keys on `AppendMessage`
- Two constructors: `New(Config)` (owns client) and `NewFromClient(client, Options)` (shared client)
- `LTRIM`-based message list capping via configurable `MaxMessagesPerSession`

## Files
| File | Purpose |
|------|---------|
| `config.go` | `Config` and `Options` types with defaults |
| `provider.go` | `Provider` struct implementing all `HotCacheProvider` methods |
| `provider_test.go` | 28 unit tests using `miniredis/v2` |
| `benchmark_test.go` | Benchmarks for `GetSession`, `SetSession`, `AppendMessage`, `GetRecentMessages` |

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/session/providers/redis/ -v -count=1` — 28/28 pass
- [x] `go test ./internal/session/providers/redis/ -bench=. -benchmem` — all benchmarks run
- [x] `go test ./internal/session/... -v -count=1` — full session package suite passes
- [x] Pre-commit hooks pass (lint, vet, coverage ≥80%)

Closes #362