### PR TITLE
feat: implement Postgres warm store provider (#363)

### DIFF
--- a/hack/pre-commit
+++ b/hack/pre-commit
@@ -484,7 +484,7 @@ if [ -f coverage.out ]; then
         fi
 
         # Skip Postgres session store (requires real Postgres via testcontainers, tested in integration)
-        if [[ "$file" == "internal/session/postgres/migrator.go" ]]; then
+        if [[ "$file" == "internal/session/postgres/migrator.go" ]] || [[ "$file" == internal/session/providers/postgres/*.go ]]; then
             continue
         fi
 

--- a/internal/session/providers/postgres/config.go
+++ b/internal/session/providers/postgres/config.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgres
+
+import (
+	"crypto/tls"
+	"time"
+)
+
+// Config holds connection and pool settings for the PostgreSQL warm store provider.
+type Config struct {
+	// ConnString is the PostgreSQL connection URI (e.g. "postgres://user:pass@host:5432/db").
+	ConnString string
+	// MaxConns is the maximum number of connections in the pool. Default: 10.
+	MaxConns int32
+	// MinConns is the minimum number of idle connections maintained. Default: 2.
+	MinConns int32
+	// MaxConnLifetime is the maximum lifetime of a connection. Default: 1h.
+	MaxConnLifetime time.Duration
+	// MaxConnIdleTime is the maximum time a connection can be idle. Default: 30m.
+	MaxConnIdleTime time.Duration
+	// HealthCheckPeriod is the interval between health checks on idle connections. Default: 1m.
+	HealthCheckPeriod time.Duration
+	// TLS enables TLS when non-nil.
+	TLS *tls.Config
+}
+
+// DefaultConfig returns a Config with sensible pool defaults. Callers must
+// still set ConnString.
+func DefaultConfig() Config {
+	return Config{
+		MaxConns:          10,
+		MinConns:          2,
+		MaxConnLifetime:   time.Hour,
+		MaxConnIdleTime:   30 * time.Minute,
+		HealthCheckPeriod: time.Minute,
+	}
+}

--- a/internal/session/providers/postgres/provider.go
+++ b/internal/session/providers/postgres/provider.go
@@ -1,0 +1,792 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/altairalabs/omnia/internal/session"
+	"github.com/altairalabs/omnia/internal/session/providers"
+)
+
+// Compile-time interface check.
+var _ providers.WarmStoreProvider = (*Provider)(nil)
+
+// Provider implements providers.WarmStoreProvider using PostgreSQL.
+type Provider struct {
+	pool     *pgxpool.Pool
+	ownsPool bool
+}
+
+// New creates a Provider that owns the underlying connection pool. The pool is
+// created from cfg and verified with a PING. Close will shut down the pool.
+func New(cfg Config) (*Provider, error) {
+	if cfg.ConnString == "" {
+		return nil, fmt.Errorf("postgres: connection string is required")
+	}
+
+	poolCfg, err := pgxpool.ParseConfig(cfg.ConnString)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: parsing connection string: %w", err)
+	}
+
+	poolCfg.MaxConns = cfg.MaxConns
+	poolCfg.MinConns = cfg.MinConns
+	poolCfg.MaxConnLifetime = cfg.MaxConnLifetime
+	poolCfg.MaxConnIdleTime = cfg.MaxConnIdleTime
+	poolCfg.HealthCheckPeriod = cfg.HealthCheckPeriod
+	if cfg.TLS != nil {
+		poolCfg.ConnConfig.TLSConfig = cfg.TLS
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolCfg)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: creating pool: %w", err)
+	}
+
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("postgres: ping failed: %w", err)
+	}
+
+	return &Provider{pool: pool, ownsPool: true}, nil
+}
+
+// NewFromPool wraps an existing connection pool. Close is a no-op because the
+// caller retains ownership of the pool.
+func NewFromPool(pool *pgxpool.Pool) *Provider {
+	return &Provider{pool: pool, ownsPool: false}
+}
+
+// --- nullable helpers -------------------------------------------------------
+
+func nullTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+func timeOrZero(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+func nullString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+func stringOrEmpty(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func nullInt32(v int32) *int32 {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}
+
+func marshalJSONB(m map[string]string) []byte {
+	if m == nil {
+		return []byte("{}")
+	}
+	b, _ := json.Marshal(m)
+	return b
+}
+
+func unmarshalJSONB(data []byte) map[string]string {
+	if len(data) == 0 {
+		return nil
+	}
+	var m map[string]string
+	if json.Unmarshal(data, &m) != nil || len(m) == 0 {
+		return nil
+	}
+	return m
+}
+
+// --- row scanners -----------------------------------------------------------
+
+// sessionColumns is the SELECT column list for sessions (no trailing comma).
+const sessionColumns = `id, agent_name, namespace, workspace_name, status,
+	created_at, updated_at, expires_at, ended_at,
+	message_count, tool_call_count, total_input_tokens, total_output_tokens,
+	estimated_cost_usd, tags, state, last_message_preview`
+
+// populateSession fills nullable fields on a scanned session.
+func populateSession(s *session.Session, workspaceName, lastMsgPreview *string, expiresAt, endedAt *time.Time, stateJSON []byte) {
+	s.WorkspaceName = stringOrEmpty(workspaceName)
+	s.ExpiresAt = timeOrZero(expiresAt)
+	s.EndedAt = timeOrZero(endedAt)
+	s.State = unmarshalJSONB(stateJSON)
+	s.LastMessagePreview = stringOrEmpty(lastMsgPreview)
+	if s.Tags == nil {
+		s.Tags = []string{}
+	}
+}
+
+func scanSession(row pgx.Row) (*session.Session, error) {
+	var s session.Session
+	var workspaceName, lastMsgPreview *string
+	var expiresAt, endedAt *time.Time
+	var stateJSON []byte
+
+	err := row.Scan(
+		&s.ID, &s.AgentName, &s.Namespace, &workspaceName, &s.Status,
+		&s.CreatedAt, &s.UpdatedAt, &expiresAt, &endedAt,
+		&s.MessageCount, &s.ToolCallCount, &s.TotalInputTokens, &s.TotalOutputTokens,
+		&s.EstimatedCostUSD, &s.Tags, &stateJSON, &lastMsgPreview,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, session.ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("postgres: scan session: %w", err)
+	}
+
+	populateSession(&s, workspaceName, lastMsgPreview, expiresAt, endedAt, stateJSON)
+	return &s, nil
+}
+
+func scanSessionWithCount(row pgx.Row) (*session.Session, int64, error) {
+	var s session.Session
+	var workspaceName, lastMsgPreview *string
+	var expiresAt, endedAt *time.Time
+	var stateJSON []byte
+	var totalCount int64
+
+	err := row.Scan(
+		&s.ID, &s.AgentName, &s.Namespace, &workspaceName, &s.Status,
+		&s.CreatedAt, &s.UpdatedAt, &expiresAt, &endedAt,
+		&s.MessageCount, &s.ToolCallCount, &s.TotalInputTokens, &s.TotalOutputTokens,
+		&s.EstimatedCostUSD, &s.Tags, &stateJSON, &lastMsgPreview,
+		&totalCount,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("postgres: scan session: %w", err)
+	}
+
+	populateSession(&s, workspaceName, lastMsgPreview, expiresAt, endedAt, stateJSON)
+	return &s, totalCount, nil
+}
+
+func scanMessage(row pgx.Row) (*session.Message, error) {
+	var m session.Message
+	var toolCallID *string
+	var inputTokens, outputTokens *int32
+	var metadataJSON []byte
+
+	err := row.Scan(
+		&m.ID, &m.Role, &m.Content, &m.Timestamp,
+		&inputTokens, &outputTokens,
+		&toolCallID, &metadataJSON, &m.SequenceNum,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: scan message: %w", err)
+	}
+
+	m.ToolCallID = stringOrEmpty(toolCallID)
+	m.Metadata = unmarshalJSONB(metadataJSON)
+	if inputTokens != nil {
+		m.InputTokens = *inputTokens
+	}
+	if outputTokens != nil {
+		m.OutputTokens = *outputTokens
+	}
+	return &m, nil
+}
+
+// --- query builder ----------------------------------------------------------
+
+type queryBuilder struct {
+	clauses []string
+	args    []any
+}
+
+func (qb *queryBuilder) add(clause string, arg any) {
+	qb.args = append(qb.args, arg)
+	qb.clauses = append(qb.clauses, strings.ReplaceAll(clause, "$?", "$"+strconv.Itoa(len(qb.args))))
+}
+
+func (qb *queryBuilder) where() string {
+	if len(qb.clauses) == 0 {
+		return ""
+	}
+	return " AND " + strings.Join(qb.clauses, " AND ")
+}
+
+// appendPagination adds LIMIT and OFFSET clauses to the query when non-zero.
+func (qb *queryBuilder) appendPagination(query string, limit, offset int) string {
+	if limit > 0 {
+		qb.args = append(qb.args, limit)
+		query += " LIMIT $" + strconv.Itoa(len(qb.args))
+	}
+	if offset > 0 {
+		qb.args = append(qb.args, offset)
+		query += " OFFSET $" + strconv.Itoa(len(qb.args))
+	}
+	return query
+}
+
+// --- helper: begin transaction ----------------------------------------------
+
+func (p *Provider) beginTx(ctx context.Context) (pgx.Tx, error) {
+	tx, err := p.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: begin tx: %w", err)
+	}
+	return tx, nil
+}
+
+// --- helper: session exists check -------------------------------------------
+
+func (p *Provider) sessionExists(ctx context.Context, sessionID string) error {
+	var exists bool
+	err := p.pool.QueryRow(ctx, "SELECT EXISTS(SELECT 1 FROM sessions WHERE id=$1)", sessionID).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("postgres: check session: %w", err)
+	}
+	if !exists {
+		return session.ErrSessionNotFound
+	}
+	return nil
+}
+
+// --- helper: collect session page -------------------------------------------
+
+func collectSessionPage(rows pgx.Rows, offset int) (*providers.SessionPage, error) {
+	defer rows.Close()
+
+	var sessions []*session.Session
+	var totalCount int64
+
+	for rows.Next() {
+		s, cnt, err := scanSessionWithCount(rows)
+		if err != nil {
+			return nil, err
+		}
+		totalCount = cnt
+		sessions = append(sessions, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate sessions: %w", err)
+	}
+	if sessions == nil {
+		sessions = []*session.Session{}
+	}
+
+	return &providers.SessionPage{
+		Sessions:   sessions,
+		TotalCount: totalCount,
+		HasMore:    int64(offset)+int64(len(sessions)) < totalCount,
+	}, nil
+}
+
+// --- helper: collect session list -------------------------------------------
+
+func collectSessions(rows pgx.Rows) ([]*session.Session, error) {
+	defer rows.Close()
+
+	var sessions []*session.Session
+	for rows.Next() {
+		s, err := scanSession(rows)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate sessions: %w", err)
+	}
+	if sessions == nil {
+		sessions = []*session.Session{}
+	}
+	return sessions, nil
+}
+
+// --- helper: delete child rows in transaction -------------------------------
+
+// childTables lists tables with session_id FK in reverse dependency order.
+var childTables = []string{"message_artifacts", "tool_calls", "messages"}
+
+func deleteChildRows(ctx context.Context, tx pgx.Tx, sessionIDClause string, args ...any) error {
+	for _, table := range childTables {
+		if _, err := tx.Exec(ctx, "DELETE FROM "+table+" WHERE "+sessionIDClause, args...); err != nil {
+			return fmt.Errorf("postgres: delete %s: %w", table, err)
+		}
+	}
+	return nil
+}
+
+// --- WarmStoreProvider implementation ---------------------------------------
+
+func (p *Provider) CreateSession(ctx context.Context, s *session.Session) error {
+	query := `INSERT INTO sessions (
+		id, agent_name, namespace, workspace_name, status,
+		created_at, updated_at, expires_at, ended_at,
+		message_count, tool_call_count, total_input_tokens, total_output_tokens,
+		estimated_cost_usd, tags, state, last_message_preview
+	) SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17
+	WHERE NOT EXISTS (SELECT 1 FROM sessions WHERE id=$1)`
+
+	tags := s.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+
+	res, err := p.pool.Exec(ctx, query,
+		s.ID, s.AgentName, s.Namespace, nullString(s.WorkspaceName), s.Status,
+		s.CreatedAt, s.UpdatedAt, nullTime(s.ExpiresAt), nullTime(s.EndedAt),
+		s.MessageCount, s.ToolCallCount, s.TotalInputTokens, s.TotalOutputTokens,
+		s.EstimatedCostUSD, tags, marshalJSONB(s.State), nullString(s.LastMessagePreview),
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: create session: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return fmt.Errorf("postgres: create session: duplicate session ID %s", s.ID)
+	}
+	return nil
+}
+
+func (p *Provider) GetSession(ctx context.Context, sessionID string) (*session.Session, error) {
+	query := `SELECT ` + sessionColumns + ` FROM sessions WHERE id=$1 LIMIT 1`
+	return scanSession(p.pool.QueryRow(ctx, query, sessionID))
+}
+
+func (p *Provider) UpdateSession(ctx context.Context, s *session.Session) error {
+	query := `UPDATE sessions SET
+		agent_name=$2, namespace=$3, workspace_name=$4, status=$5,
+		updated_at=$6, expires_at=$7, ended_at=$8,
+		message_count=$9, tool_call_count=$10, total_input_tokens=$11, total_output_tokens=$12,
+		estimated_cost_usd=$13, tags=$14, state=$15, last_message_preview=$16
+	WHERE id=$1`
+
+	tags := s.Tags
+	if tags == nil {
+		tags = []string{}
+	}
+
+	res, err := p.pool.Exec(ctx, query,
+		s.ID, s.AgentName, s.Namespace, nullString(s.WorkspaceName), s.Status,
+		s.UpdatedAt, nullTime(s.ExpiresAt), nullTime(s.EndedAt),
+		s.MessageCount, s.ToolCallCount, s.TotalInputTokens, s.TotalOutputTokens,
+		s.EstimatedCostUSD, tags, marshalJSONB(s.State), nullString(s.LastMessagePreview),
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: update session: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return session.ErrSessionNotFound
+	}
+	return nil
+}
+
+func (p *Provider) DeleteSession(ctx context.Context, sessionID string) error {
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := deleteChildRows(ctx, tx, "session_id=$1", sessionID); err != nil {
+		return err
+	}
+
+	res, err := tx.Exec(ctx, "DELETE FROM sessions WHERE id=$1", sessionID)
+	if err != nil {
+		return fmt.Errorf("postgres: delete session: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		return session.ErrSessionNotFound
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (p *Provider) AppendMessage(ctx context.Context, sessionID string, msg *session.Message) error {
+	if err := p.sessionExists(ctx, sessionID); err != nil {
+		return err
+	}
+
+	query := `INSERT INTO messages (id, session_id, role, content, timestamp, input_tokens, output_tokens, tool_call_id, metadata, sequence_num)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`
+
+	_, err := p.pool.Exec(ctx, query,
+		msg.ID, sessionID, msg.Role, msg.Content, msg.Timestamp,
+		nullInt32(msg.InputTokens), nullInt32(msg.OutputTokens),
+		nullString(msg.ToolCallID), marshalJSONB(msg.Metadata), msg.SequenceNum,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: append message: %w", err)
+	}
+	return nil
+}
+
+func (p *Provider) GetMessages(ctx context.Context, sessionID string, opts providers.MessageQueryOpts) ([]*session.Message, error) {
+	if err := p.sessionExists(ctx, sessionID); err != nil {
+		return nil, err
+	}
+
+	qb := &queryBuilder{}
+	qb.add("session_id=$?", sessionID)
+
+	if opts.AfterSeq > 0 {
+		qb.add("sequence_num > $?", opts.AfterSeq)
+	}
+	if opts.BeforeSeq > 0 {
+		qb.add("sequence_num < $?", opts.BeforeSeq)
+	}
+	if len(opts.Roles) > 0 {
+		qb.add("role = ANY($?)", opts.Roles)
+	}
+
+	sort := "ASC"
+	if opts.SortOrder == providers.SortDesc {
+		sort = "DESC"
+	}
+
+	query := `SELECT id, role, content, timestamp, input_tokens, output_tokens, tool_call_id, metadata, sequence_num
+		FROM messages WHERE 1=1` + qb.where() + ` ORDER BY sequence_num ` + sort
+	query = qb.appendPagination(query, opts.Limit, opts.Offset)
+
+	rows, err := p.pool.Query(ctx, query, qb.args...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: get messages: %w", err)
+	}
+	defer rows.Close()
+
+	var msgs []*session.Message
+	for rows.Next() {
+		m, err := scanMessage(rows)
+		if err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate messages: %w", err)
+	}
+	if msgs == nil {
+		msgs = []*session.Message{}
+	}
+	return msgs, nil
+}
+
+func (p *Provider) ListSessions(ctx context.Context, opts providers.SessionListOpts) (*providers.SessionPage, error) {
+	qb := &queryBuilder{}
+	p.applySessionFilters(qb, opts)
+
+	sort := "DESC"
+	if opts.SortOrder == providers.SortAsc {
+		sort = "ASC"
+	}
+
+	query := `SELECT ` + sessionColumns + `, count(*) OVER() FROM sessions WHERE 1=1` + qb.where() +
+		` ORDER BY created_at ` + sort
+	query = qb.appendPagination(query, opts.Limit, opts.Offset)
+
+	rows, err := p.pool.Query(ctx, query, qb.args...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list sessions: %w", err)
+	}
+	return collectSessionPage(rows, opts.Offset)
+}
+
+func (p *Provider) SearchSessions(ctx context.Context, query string, opts providers.SessionListOpts) (*providers.SessionPage, error) {
+	qb := &queryBuilder{}
+
+	// CTE to find session IDs matching the FTS query.
+	qb.add("search_vector @@ plainto_tsquery('english', $?)", query)
+	cteClauses := qb.where()
+
+	// Continue accumulating args for session filters.
+	sessionQB := &queryBuilder{args: qb.args}
+	p.applySessionFilters(sessionQB, opts)
+
+	sort := "DESC"
+	if opts.SortOrder == providers.SortAsc {
+		sort = "ASC"
+	}
+
+	sql := `WITH matching AS (
+		SELECT DISTINCT session_id FROM messages WHERE 1=1` + cteClauses + `
+	) SELECT ` + sessionColumns + `, count(*) OVER()
+	FROM sessions s JOIN matching ms ON ms.session_id = s.id
+	WHERE 1=1` + sessionQB.where() +
+		` ORDER BY s.created_at ` + sort
+	sql = sessionQB.appendPagination(sql, opts.Limit, opts.Offset)
+
+	rows, err := p.pool.Query(ctx, sql, sessionQB.args...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: search sessions: %w", err)
+	}
+	return collectSessionPage(rows, opts.Offset)
+}
+
+func (p *Provider) applySessionFilters(qb *queryBuilder, opts providers.SessionListOpts) {
+	if opts.AgentName != "" {
+		qb.add("agent_name=$?", opts.AgentName)
+	}
+	if opts.Namespace != "" {
+		qb.add("namespace=$?", opts.Namespace)
+	}
+	if opts.WorkspaceName != "" {
+		qb.add("workspace_name=$?", opts.WorkspaceName)
+	}
+	if opts.Status != "" {
+		qb.add("status=$?", string(opts.Status))
+	}
+	if len(opts.Tags) > 0 {
+		qb.add("tags @> $?", opts.Tags)
+	}
+	if !opts.CreatedAfter.IsZero() {
+		qb.add("created_at >= $?", opts.CreatedAfter)
+	}
+	if !opts.CreatedBefore.IsZero() {
+		qb.add("created_at < $?", opts.CreatedBefore)
+	}
+}
+
+// --- Partition management ---------------------------------------------------
+
+var partitionTables = []string{"sessions", "messages", "tool_calls", "message_artifacts"}
+
+func (p *Provider) CreatePartition(ctx context.Context, date time.Time) error {
+	// Align to ISO week boundary (Monday).
+	isoYear, isoWeek := date.ISOWeek()
+	weekStart := isoWeekStart(isoYear, isoWeek)
+	weekEnd := weekStart.AddDate(0, 0, 7)
+
+	var totalCreated int
+	for _, table := range partitionTables {
+		var created int
+		err := p.pool.QueryRow(ctx,
+			"SELECT create_weekly_partitions($1, $2::DATE, $3::DATE)",
+			table, weekStart, weekEnd,
+		).Scan(&created)
+		if err != nil {
+			return fmt.Errorf("postgres: create partition for %s: %w", table, err)
+		}
+		totalCreated += created
+	}
+
+	if totalCreated == 0 {
+		return providers.ErrPartitionExists
+	}
+	return nil
+}
+
+func (p *Provider) DropPartition(ctx context.Context, date time.Time) error {
+	isoYear, isoWeek := date.ISOWeek()
+	suffix := fmt.Sprintf("w%04d_%02d", isoYear, isoWeek)
+
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Check that the sessions partition exists.
+	var exists bool
+	err = tx.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE c.relname = $1 AND n.nspname = current_schema()
+	)`, "sessions_"+suffix).Scan(&exists)
+	if err != nil {
+		return fmt.Errorf("postgres: check partition: %w", err)
+	}
+	if !exists {
+		return providers.ErrPartitionNotFound
+	}
+
+	// Drop all 4 table partitions in reverse dependency order.
+	for _, table := range []string{"message_artifacts", "tool_calls", "messages", "sessions"} {
+		name := pgx.Identifier{table + "_" + suffix}.Sanitize()
+		_, err := tx.Exec(ctx, "DROP TABLE IF EXISTS "+name)
+		if err != nil {
+			return fmt.Errorf("postgres: drop partition %s: %w", name, err)
+		}
+	}
+
+	return tx.Commit(ctx)
+}
+
+// partBoundRe matches partition range expressions like:
+// FOR VALUES FROM ('2025-01-06 00:00:00+00') TO ('2025-01-13 00:00:00+00')
+var partBoundRe = regexp.MustCompile(`FROM \('([^']+)'\) TO \('([^']+)'\)`)
+
+// partitionDateLayouts lists time formats used by pg_get_expr for partition bounds.
+var partitionDateLayouts = []string{
+	"2006-01-02 15:04:05-07",
+	"2006-01-02 15:04:05+00",
+}
+
+// parsePartitionDate tries each known layout to parse a partition bound timestamp.
+func parsePartitionDate(s string) (time.Time, bool) {
+	for _, layout := range partitionDateLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func (p *Provider) ListPartitions(ctx context.Context) ([]providers.PartitionInfo, error) {
+	query := `SELECT c.relname,
+		pg_get_expr(c.relpartbound, c.oid),
+		pg_table_size(c.oid),
+		pg_stat_get_live_tuples(c.oid)
+	FROM pg_class c
+	JOIN pg_inherits i ON i.inhrelid = c.oid
+	JOIN pg_class parent ON parent.oid = i.inhparent
+	JOIN pg_namespace n ON n.oid = parent.relnamespace
+	WHERE parent.relname = 'sessions'
+	AND n.nspname = current_schema()
+	AND c.relispartition
+	ORDER BY c.relname`
+
+	rows, err := p.pool.Query(ctx, query)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list partitions: %w", err)
+	}
+	defer rows.Close()
+
+	var infos []providers.PartitionInfo
+	for rows.Next() {
+		var name, boundExpr string
+		var sizeBytes, rowCount int64
+
+		if err := rows.Scan(&name, &boundExpr, &sizeBytes, &rowCount); err != nil {
+			return nil, fmt.Errorf("postgres: scan partition: %w", err)
+		}
+
+		matches := partBoundRe.FindStringSubmatch(boundExpr)
+		if len(matches) != 3 {
+			continue
+		}
+
+		startDate, ok := parsePartitionDate(matches[1])
+		if !ok {
+			continue
+		}
+		endDate, ok := parsePartitionDate(matches[2])
+		if !ok {
+			continue
+		}
+
+		infos = append(infos, providers.PartitionInfo{
+			Name:      name,
+			StartDate: startDate,
+			EndDate:   endDate,
+			RowCount:  rowCount,
+			SizeBytes: sizeBytes,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate partitions: %w", err)
+	}
+	if infos == nil {
+		infos = []providers.PartitionInfo{}
+	}
+	return infos, nil
+}
+
+// --- Batch operations -------------------------------------------------------
+
+func (p *Provider) GetSessionsOlderThan(ctx context.Context, cutoff time.Time, batchSize int) ([]*session.Session, error) {
+	query := `SELECT ` + sessionColumns + ` FROM sessions WHERE updated_at < $1 ORDER BY updated_at ASC LIMIT $2`
+
+	rows, err := p.pool.Query(ctx, query, cutoff, batchSize)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: get sessions older than: %w", err)
+	}
+	return collectSessions(rows)
+}
+
+func (p *Provider) DeleteSessionsBatch(ctx context.Context, sessionIDs []string) error {
+	if len(sessionIDs) == 0 {
+		return nil
+	}
+
+	tx, err := p.beginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := deleteChildRows(ctx, tx, "session_id = ANY($1)", sessionIDs); err != nil {
+		return err
+	}
+
+	if _, err := tx.Exec(ctx, "DELETE FROM sessions WHERE id = ANY($1)", sessionIDs); err != nil {
+		return fmt.Errorf("postgres: delete sessions batch: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+// --- Infrastructure ---------------------------------------------------------
+
+func (p *Provider) Ping(ctx context.Context) error {
+	return p.pool.Ping(ctx)
+}
+
+func (p *Provider) Close() error {
+	if p.ownsPool {
+		p.pool.Close()
+	}
+	return nil
+}
+
+// --- ISO week helper --------------------------------------------------------
+
+// isoWeekStart returns the Monday 00:00 UTC of the given ISO year/week.
+func isoWeekStart(isoYear, isoWeek int) time.Time {
+	// Jan 4 is always in ISO week 1.
+	jan4 := time.Date(isoYear, time.January, 4, 0, 0, 0, 0, time.UTC)
+	// Go back to Monday of that week.
+	offset := int(time.Monday - jan4.Weekday())
+	if jan4.Weekday() == time.Sunday {
+		offset = -6
+	}
+	week1Monday := jan4.AddDate(0, 0, offset)
+	return week1Monday.AddDate(0, 0, (isoWeek-1)*7)
+}

--- a/internal/session/providers/postgres/provider_test.go
+++ b/internal/session/providers/postgres/provider_test.go
@@ -1,0 +1,1050 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/altairalabs/omnia/internal/session"
+	pgmigrate "github.com/altairalabs/omnia/internal/session/postgres"
+	"github.com/altairalabs/omnia/internal/session/providers"
+)
+
+var testConnStr string
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+
+	if testing.Short() {
+		os.Exit(m.Run())
+	}
+
+	ctx := context.Background()
+
+	container, err := tcpostgres.Run(ctx, "postgres:16-alpine",
+		tcpostgres.WithDatabase("omnia_test"),
+		tcpostgres.WithUsername("test"),
+		tcpostgres.WithPassword("test"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start postgres container: %v\n", err)
+		os.Exit(1)
+	}
+
+	testConnStr, err = container.ConnectionString(ctx, "sslmode=disable")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get connection string: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	if err := container.Terminate(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to terminate container: %v\n", err)
+	}
+
+	os.Exit(code)
+}
+
+// freshDB creates an isolated database, runs migrations, and returns a pgxpool.Pool.
+func freshDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+
+	dbName := fmt.Sprintf("test_%d", time.Now().UnixNano())
+
+	db, err := sql.Open("pgx", testConnStr)
+	require.NoError(t, err)
+	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbName))
+	require.NoError(t, err)
+	require.NoError(t, db.Close())
+
+	connStr := replaceDBName(testConnStr, dbName)
+
+	// Run migrations.
+	logger := zap.New(zap.UseDevMode(true))
+	mg, err := pgmigrate.NewMigrator(connStr, logger)
+	require.NoError(t, err)
+	require.NoError(t, mg.Up())
+	require.NoError(t, mg.Close())
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, connStr)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		pool.Close()
+		mainDB, err := sql.Open("pgx", testConnStr)
+		if err == nil {
+			_, _ = mainDB.Exec(fmt.Sprintf("DROP DATABASE %s WITH (FORCE)", dbName))
+			_ = mainDB.Close()
+		}
+	})
+
+	return pool
+}
+
+func replaceDBName(connStr, newDB string) string {
+	qIdx := len(connStr)
+	for i, c := range connStr {
+		if c == '?' {
+			qIdx = i
+			break
+		}
+	}
+	slashIdx := 0
+	for i := qIdx - 1; i >= 0; i-- {
+		if connStr[i] == '/' {
+			slashIdx = i
+			break
+		}
+	}
+	return connStr[:slashIdx+1] + newDB + connStr[qIdx:]
+}
+
+func newProvider(t *testing.T) *Provider {
+	t.Helper()
+	pool := freshDB(t)
+	return NewFromPool(pool)
+}
+
+func makeSession(id string, now time.Time) *session.Session {
+	return &session.Session{
+		ID:                id,
+		AgentName:         "test-agent",
+		Namespace:         "default",
+		WorkspaceName:     "test-workspace",
+		Status:            session.SessionStatusActive,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+		MessageCount:      0,
+		ToolCallCount:     0,
+		TotalInputTokens:  0,
+		TotalOutputTokens: 0,
+		EstimatedCostUSD:  0,
+		Tags:              []string{"tag1", "tag2"},
+		State:             map[string]string{"key": "value"},
+	}
+}
+
+func makeMessage(id string, seq int32, now time.Time) *session.Message {
+	return &session.Message{
+		ID:          id,
+		Role:        session.RoleUser,
+		Content:     "Hello, world!",
+		Timestamp:   now,
+		SequenceNum: seq,
+	}
+}
+
+// --- Session CRUD -----------------------------------------------------------
+
+func TestCreateGetSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	s.ExpiresAt = now.Add(time.Hour)
+	s.EndedAt = now.Add(30 * time.Minute)
+	s.LastMessagePreview = "Hello!"
+	s.EstimatedCostUSD = 1.234567
+
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	got, err := p.GetSession(ctx, s.ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, s.ID, got.ID)
+	assert.Equal(t, s.AgentName, got.AgentName)
+	assert.Equal(t, s.Namespace, got.Namespace)
+	assert.Equal(t, s.WorkspaceName, got.WorkspaceName)
+	assert.Equal(t, s.Status, got.Status)
+	assert.WithinDuration(t, s.CreatedAt, got.CreatedAt, time.Microsecond)
+	assert.WithinDuration(t, s.UpdatedAt, got.UpdatedAt, time.Microsecond)
+	assert.WithinDuration(t, s.ExpiresAt, got.ExpiresAt, time.Microsecond)
+	assert.WithinDuration(t, s.EndedAt, got.EndedAt, time.Microsecond)
+	assert.Equal(t, s.Tags, got.Tags)
+	assert.Equal(t, s.State, got.State)
+	assert.Equal(t, s.LastMessagePreview, got.LastMessagePreview)
+	assert.InDelta(t, s.EstimatedCostUSD, got.EstimatedCostUSD, 0.000001)
+}
+
+func TestCreateSession_Duplicate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	err := p.CreateSession(ctx, s)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate")
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	_, err := p.GetSession(ctx, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+}
+
+func TestUpdateSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	s.Status = session.SessionStatusCompleted
+	s.UpdatedAt = now.Add(time.Minute)
+	s.EndedAt = now.Add(time.Minute)
+	s.MessageCount = 5
+	s.Tags = []string{"updated"}
+	s.State = map[string]string{"new": "state"}
+	require.NoError(t, p.UpdateSession(ctx, s))
+
+	got, err := p.GetSession(ctx, s.ID)
+	require.NoError(t, err)
+	assert.Equal(t, session.SessionStatusCompleted, got.Status)
+	assert.Equal(t, int32(5), got.MessageCount)
+	assert.Equal(t, []string{"updated"}, got.Tags)
+	assert.Equal(t, map[string]string{"new": "state"}, got.State)
+}
+
+func TestUpdateSession_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	err := p.UpdateSession(ctx, s)
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+}
+
+func TestDeleteSession(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	msg := makeMessage("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", 1, now)
+	require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+
+	require.NoError(t, p.DeleteSession(ctx, s.ID))
+
+	_, err := p.GetSession(ctx, s.ID)
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+
+	// Messages should be gone too.
+	msgs, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{})
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+	assert.Nil(t, msgs)
+}
+
+func TestDeleteSession_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	err := p.DeleteSession(ctx, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11")
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+}
+
+// --- Messages ---------------------------------------------------------------
+
+func TestAppendGetMessages(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	msg := &session.Message{
+		ID:           "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+		Role:         session.RoleUser,
+		Content:      "Hello!",
+		Timestamp:    now,
+		InputTokens:  10,
+		OutputTokens: 20,
+		SequenceNum:  1,
+	}
+	require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+
+	msgs, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, msg.ID, msgs[0].ID)
+	assert.Equal(t, msg.Content, msgs[0].Content)
+	assert.Equal(t, msg.Role, msgs[0].Role)
+	assert.Equal(t, int32(10), msgs[0].InputTokens)
+	assert.Equal(t, int32(20), msgs[0].OutputTokens)
+	assert.Equal(t, int32(1), msgs[0].SequenceNum)
+}
+
+func TestAppendMessage_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	msg := makeMessage("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", 1, now)
+	err := p.AppendMessage(ctx, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", msg)
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+}
+
+func TestGetMessages_Ordering(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	for i := 1; i <= 3; i++ {
+		msg := makeMessage(fmt.Sprintf("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a%02d", i), int32(i), now.Add(time.Duration(i)*time.Second))
+		require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+	}
+
+	// ASC (default)
+	msgs, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{})
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, int32(1), msgs[0].SequenceNum)
+	assert.Equal(t, int32(3), msgs[2].SequenceNum)
+
+	// DESC
+	msgs, err = p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{SortOrder: providers.SortDesc})
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, int32(3), msgs[0].SequenceNum)
+	assert.Equal(t, int32(1), msgs[2].SequenceNum)
+}
+
+func TestGetMessages_Pagination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	for i := 1; i <= 5; i++ {
+		msg := makeMessage(fmt.Sprintf("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a%02d", i), int32(i), now.Add(time.Duration(i)*time.Second))
+		require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+	}
+
+	// Page 1
+	msgs, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, int32(1), msgs[0].SequenceNum)
+
+	// Page 2
+	msgs, err = p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, int32(3), msgs[0].SequenceNum)
+}
+
+func TestGetMessages_FilterSeq(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	for i := 1; i <= 5; i++ {
+		msg := makeMessage(fmt.Sprintf("b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a%02d", i), int32(i), now.Add(time.Duration(i)*time.Second))
+		require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+	}
+
+	// AfterSeq=2
+	msgs, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{AfterSeq: 2})
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, int32(3), msgs[0].SequenceNum)
+
+	// BeforeSeq=4
+	msgs, err = p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{BeforeSeq: 4})
+	require.NoError(t, err)
+	require.Len(t, msgs, 3)
+	assert.Equal(t, int32(3), msgs[2].SequenceNum)
+
+	// Combined
+	msgs, err = p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{AfterSeq: 1, BeforeSeq: 4})
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, int32(2), msgs[0].SequenceNum)
+	assert.Equal(t, int32(3), msgs[1].SequenceNum)
+}
+
+func TestGetMessages_FilterRoles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	msgs := []*session.Message{
+		{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", Role: session.RoleUser, Content: "user msg", Timestamp: now, SequenceNum: 1},
+		{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", Role: session.RoleAssistant, Content: "assistant msg", Timestamp: now.Add(time.Second), SequenceNum: 2},
+		{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a03", Role: session.RoleSystem, Content: "system msg", Timestamp: now.Add(2 * time.Second), SequenceNum: 3},
+	}
+	for _, msg := range msgs {
+		require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+	}
+
+	result, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{Roles: []session.MessageRole{session.RoleUser, session.RoleSystem}})
+	require.NoError(t, err)
+	require.Len(t, result, 2)
+	assert.Equal(t, session.RoleUser, result[0].Role)
+	assert.Equal(t, session.RoleSystem, result[1].Role)
+}
+
+func TestGetMessages_Empty(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	msgs, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{})
+	require.NoError(t, err)
+	assert.Empty(t, msgs)
+	assert.NotNil(t, msgs, "should return empty slice, not nil")
+}
+
+func TestGetMessages_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	_, err := p.GetMessages(ctx, "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", providers.MessageQueryOpts{})
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+}
+
+func TestGetMessages_MetadataRoundtrip(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	msg := &session.Message{
+		ID:          "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11",
+		Role:        session.RoleUser,
+		Content:     "Hello!",
+		Timestamp:   now,
+		SequenceNum: 1,
+		Metadata:    map[string]string{"source": "api", "version": "1.0"},
+	}
+	require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+
+	msgs, err := p.GetMessages(ctx, s.ID, providers.MessageQueryOpts{})
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, map[string]string{"source": "api", "version": "1.0"}, msgs[0].Metadata)
+}
+
+// --- ListSessions -----------------------------------------------------------
+
+func TestListSessions_All(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	for i := range 3 {
+		s := makeSession(fmt.Sprintf("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a%02d", i), now.Add(time.Duration(i)*time.Second))
+		require.NoError(t, p.CreateSession(ctx, s))
+	}
+
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), page.TotalCount)
+	assert.Len(t, page.Sessions, 3)
+	assert.False(t, page.HasMore)
+}
+
+func TestListSessions_FilterAgent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	s1.AgentName = "agent-a"
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(time.Second))
+	s2.AgentName = "agent-b"
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{AgentName: "agent-a"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+	assert.Equal(t, "agent-a", page.Sessions[0].AgentName)
+}
+
+func TestListSessions_FilterNamespace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	s1.Namespace = "ns-a"
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(time.Second))
+	s2.Namespace = "ns-b"
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Namespace: "ns-a"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+	assert.Equal(t, "ns-a", page.Sessions[0].Namespace)
+}
+
+func TestListSessions_FilterStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	s1.Status = session.SessionStatusActive
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(time.Second))
+	s2.Status = session.SessionStatusCompleted
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Status: session.SessionStatusActive})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+	assert.Equal(t, session.SessionStatusActive, page.Sessions[0].Status)
+}
+
+func TestListSessions_FilterTags(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	s1.Tags = []string{"alpha", "beta"}
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(time.Second))
+	s2.Tags = []string{"beta", "gamma"}
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+
+	// Filter for "alpha" — only s1
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"alpha"}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+
+	// Filter for "beta" — both
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"beta"}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), page.TotalCount)
+
+	// Filter for "alpha" AND "beta" — only s1
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"alpha", "beta"}})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+}
+
+func TestListSessions_FilterDateRange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now.Add(-2*time.Hour))
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(-1*time.Hour))
+	s3 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a03", now)
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+	require.NoError(t, p.CreateSession(ctx, s3))
+
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{
+		CreatedAfter:  now.Add(-90 * time.Minute),
+		CreatedBefore: now.Add(-30 * time.Minute),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+}
+
+func TestListSessions_SortOrder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(time.Second))
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+
+	// Default (DESC)
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, s2.ID, page.Sessions[0].ID)
+
+	// ASC
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{SortOrder: providers.SortAsc})
+	require.NoError(t, err)
+	assert.Equal(t, s1.ID, page.Sessions[0].ID)
+}
+
+func TestListSessions_Pagination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	for i := range 5 {
+		s := makeSession(fmt.Sprintf("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a%02d", i), now.Add(time.Duration(i)*time.Second))
+		require.NoError(t, p.CreateSession(ctx, s))
+	}
+
+	// Page 1
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Limit: 2})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 2)
+	assert.Equal(t, int64(5), page.TotalCount)
+	assert.True(t, page.HasMore)
+
+	// Page 2
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Limit: 2, Offset: 2})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 2)
+	assert.True(t, page.HasMore)
+
+	// Last page
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Limit: 2, Offset: 4})
+	require.NoError(t, err)
+	assert.Len(t, page.Sessions, 1)
+	assert.False(t, page.HasMore)
+}
+
+// --- SearchSessions ---------------------------------------------------------
+
+func TestSearchSessions_Basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(time.Second))
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+
+	// Add messages with searchable content.
+	msg1 := &session.Message{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", Role: session.RoleUser, Content: "Tell me about Kubernetes deployments", Timestamp: now, SequenceNum: 1}
+	msg2 := &session.Message{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", Role: session.RoleUser, Content: "What is a Redis cache", Timestamp: now.Add(time.Second), SequenceNum: 1}
+	require.NoError(t, p.AppendMessage(ctx, s1.ID, msg1))
+	require.NoError(t, p.AppendMessage(ctx, s2.ID, msg2))
+
+	// Search for "kubernetes"
+	page, err := p.SearchSessions(ctx, "kubernetes", providers.SessionListOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+	assert.Equal(t, s1.ID, page.Sessions[0].ID)
+}
+
+func TestSearchSessions_NoResults(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	require.NoError(t, p.CreateSession(ctx, s))
+
+	msg := &session.Message{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", Role: session.RoleUser, Content: "Hello world", Timestamp: now, SequenceNum: 1}
+	require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
+
+	page, err := p.SearchSessions(ctx, "nonexistentterm", providers.SessionListOpts{})
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), page.TotalCount)
+	assert.Empty(t, page.Sessions)
+}
+
+func TestSearchSessions_WithFilters(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	s1 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now)
+	s1.AgentName = "agent-a"
+	s2 := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now.Add(time.Second))
+	s2.AgentName = "agent-b"
+	require.NoError(t, p.CreateSession(ctx, s1))
+	require.NoError(t, p.CreateSession(ctx, s2))
+
+	// Both sessions have "kubernetes" in messages.
+	msg1 := &session.Message{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", Role: session.RoleUser, Content: "Kubernetes pods", Timestamp: now, SequenceNum: 1}
+	msg2 := &session.Message{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", Role: session.RoleUser, Content: "Kubernetes services", Timestamp: now.Add(time.Second), SequenceNum: 1}
+	require.NoError(t, p.AppendMessage(ctx, s1.ID, msg1))
+	require.NoError(t, p.AppendMessage(ctx, s2.ID, msg2))
+
+	// Search with agent filter.
+	page, err := p.SearchSessions(ctx, "kubernetes", providers.SessionListOpts{AgentName: "agent-a"})
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), page.TotalCount)
+	assert.Equal(t, "agent-a", page.Sessions[0].AgentName)
+}
+
+// --- Partitions -------------------------------------------------------------
+
+func TestCreatePartition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	// Create a partition far in the future to avoid collision with initial partitions.
+	futureDate := time.Date(2030, 6, 15, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, p.CreatePartition(ctx, futureDate))
+
+	// Verify partitions were created for all 4 tables.
+	pool := p.pool
+	for _, table := range partitionTables {
+		isoYear, isoWeek := futureDate.ISOWeek()
+		partName := fmt.Sprintf("%s_w%04d_%02d", table, isoYear, isoWeek)
+		var exists bool
+		err := pool.QueryRow(ctx, `SELECT EXISTS (
+			SELECT 1 FROM pg_class WHERE relname = $1
+		)`, partName).Scan(&exists)
+		require.NoError(t, err)
+		assert.True(t, exists, "partition %s should exist", partName)
+	}
+}
+
+func TestCreatePartition_AlreadyExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	futureDate := time.Date(2030, 7, 15, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, p.CreatePartition(ctx, futureDate))
+
+	err := p.CreatePartition(ctx, futureDate)
+	assert.ErrorIs(t, err, providers.ErrPartitionExists)
+}
+
+func TestDropPartition(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	futureDate := time.Date(2030, 8, 15, 0, 0, 0, 0, time.UTC)
+	require.NoError(t, p.CreatePartition(ctx, futureDate))
+	require.NoError(t, p.DropPartition(ctx, futureDate))
+
+	// Verify sessions partition is gone.
+	isoYear, isoWeek := futureDate.ISOWeek()
+	partName := fmt.Sprintf("sessions_w%04d_%02d", isoYear, isoWeek)
+	var exists bool
+	err := p.pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM pg_class WHERE relname = $1
+	)`, partName).Scan(&exists)
+	require.NoError(t, err)
+	assert.False(t, exists)
+}
+
+func TestDropPartition_NotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	farFuture := time.Date(2040, 1, 1, 0, 0, 0, 0, time.UTC)
+	err := p.DropPartition(ctx, farFuture)
+	assert.ErrorIs(t, err, providers.ErrPartitionNotFound)
+}
+
+func TestListPartitions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+
+	infos, err := p.ListPartitions(ctx)
+	require.NoError(t, err)
+	// Initial migrations create partitions (4 weeks back + 2 weeks ahead).
+	assert.GreaterOrEqual(t, len(infos), 5, "should have at least 5 partitions from initial migration")
+
+	for _, info := range infos {
+		assert.NotEmpty(t, info.Name)
+		assert.False(t, info.StartDate.IsZero())
+		assert.False(t, info.EndDate.IsZero())
+		assert.True(t, info.EndDate.After(info.StartDate))
+	}
+}
+
+// --- Batch operations -------------------------------------------------------
+
+func TestGetSessionsOlderThan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	// Create old and new sessions.
+	old := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", now.Add(-2*time.Hour))
+	old.UpdatedAt = now.Add(-2 * time.Hour)
+	recent := makeSession("a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02", now)
+	require.NoError(t, p.CreateSession(ctx, old))
+	require.NoError(t, p.CreateSession(ctx, recent))
+
+	sessions, err := p.GetSessionsOlderThan(ctx, now.Add(-time.Hour), 10)
+	require.NoError(t, err)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, old.ID, sessions[0].ID)
+}
+
+func TestDeleteSessionsBatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	ids := []string{
+		"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01",
+		"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a02",
+		"a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a03",
+	}
+	for i, id := range ids {
+		s := makeSession(id, now.Add(time.Duration(i)*time.Second))
+		require.NoError(t, p.CreateSession(ctx, s))
+	}
+
+	// Delete first two.
+	require.NoError(t, p.DeleteSessionsBatch(ctx, ids[:2]))
+
+	// Verify first two are gone, third remains.
+	_, err := p.GetSession(ctx, ids[0])
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+	_, err = p.GetSession(ctx, ids[1])
+	assert.ErrorIs(t, err, session.ErrSessionNotFound)
+	_, err = p.GetSession(ctx, ids[2])
+	assert.NoError(t, err)
+}
+
+// --- Infrastructure ---------------------------------------------------------
+
+func TestPing(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	assert.NoError(t, p.Ping(context.Background()))
+}
+
+func TestClose_OwnsPool(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	pool := freshDB(t)
+	p := &Provider{pool: pool, ownsPool: true}
+	assert.NoError(t, p.Close())
+
+	// Pool should be closed — Ping should fail.
+	err := pool.Ping(context.Background())
+	assert.Error(t, err)
+}
+
+func TestClose_SharedPool(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	pool := freshDB(t)
+	p := &Provider{pool: pool, ownsPool: false}
+	assert.NoError(t, p.Close())
+
+	// Pool should still be usable.
+	assert.NoError(t, pool.Ping(context.Background()))
+}
+
+func TestNew_ConnectionError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	cfg := DefaultConfig()
+	cfg.ConnString = "postgres://invalid:5432/nonexistent?sslmode=disable&connect_timeout=1"
+	_, err := New(cfg)
+	assert.Error(t, err)
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	assert.Equal(t, int32(10), cfg.MaxConns)
+	assert.Equal(t, int32(2), cfg.MinConns)
+	assert.Equal(t, time.Hour, cfg.MaxConnLifetime)
+	assert.Equal(t, 30*time.Minute, cfg.MaxConnIdleTime)
+	assert.Equal(t, time.Minute, cfg.HealthCheckPeriod)
+	assert.Empty(t, cfg.ConnString)
+	assert.Nil(t, cfg.TLS)
+}


### PR DESCRIPTION
## Summary
- Implement `WarmStoreProvider` interface (#361) with PostgreSQL backend using `pgx/v5` connection pooling
- All 17 interface methods: session CRUD, message append/query, list/search with pagination, partition management (create/drop/list), batch operations (get older than/delete batch), ping/close
- Full integration test suite (38 tests) using testcontainers with postgres:16-alpine against the partitioned schema from #358
- Add pre-commit coverage exclusion for postgres provider (requires Docker, tested via integration)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/session/providers/postgres/ -v -count=1` — 38/38 pass
- [x] `go test ./internal/session/... -v -count=1` — all session packages pass
- [x] Pre-commit hooks pass (formatting, vet, lint, build, tests, generated code)