### PR TITLE
feat: add dev-mode license nagging across controllers and dashboard

### DIFF
--- a/charts/omnia/templates/arena-controller-deployment.yaml
+++ b/charts/omnia/templates/arena-controller-deployment.yaml
@@ -61,6 +61,9 @@ spec:
             {{- if .Values.enterprise.arena.worker.serviceAccount.create }}
             - --worker-service-account-name={{ .Values.enterprise.arena.worker.serviceAccount.name | default (printf "%s-arena-worker" (include "omnia.fullname" .)) }}
             {{- end }}
+            {{- if .Values.devMode }}
+            - --dev-mode
+            {{- end }}
             {{- if .Values.webhook.enabled }}
             - --enable-webhooks
             {{- end }}

--- a/charts/omnia/templates/clusterrole.yaml
+++ b/charts/omnia/templates/clusterrole.yaml
@@ -231,6 +231,7 @@ rules:
       - arenajobs
       - arenasources
       - arenatemplatesources
+      - sessionprivacypolicies
     verbs:
       - create
       - delete
@@ -246,6 +247,7 @@ rules:
       - arenajobs/finalizers
       - arenasources/finalizers
       - arenatemplatesources/finalizers
+      - sessionprivacypolicies/finalizers
     verbs:
       - update
   - apiGroups:
@@ -255,6 +257,7 @@ rules:
       - arenajobs/status
       - arenasources/status
       - arenatemplatesources/status
+      - sessionprivacypolicies/status
     verbs:
       - get
       - patch

--- a/charts/omnia/templates/dashboard/configmap.yaml
+++ b/charts/omnia/templates/dashboard/configmap.yaml
@@ -9,6 +9,8 @@ data:
   # Operator API URL (server-side for proxy)
   {{- if .Values.dashboard.operatorApiUrl }}
   OPERATOR_API_URL: {{ .Values.dashboard.operatorApiUrl | quote }}
+  {{- else if .Values.enterprise.enabled }}
+  OPERATOR_API_URL: "http://{{ include "omnia.fullname" . }}-arena-controller:{{ ((.Values.enterprise.arena.controller).api).port | default 8082 }}"
   {{- end }}
 
   # Mode settings (demo mode defaults to false, not exposed in config)

--- a/dashboard/src/app/layout.test.tsx
+++ b/dashboard/src/app/layout.test.tsx
@@ -30,6 +30,7 @@ vi.mock("@/components/layout", () => ({
   ReadOnlyBanner: () => null,
   DemoModeBanner: () => null,
   LicenseExpiryBanner: () => null,
+  DevModeLicenseBanner: () => null,
   WorkspaceContent: ({ children }: { children: React.ReactNode }) => children,
 }));
 

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -3,7 +3,7 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { AuthWrapper } from "@/components/auth-wrapper";
-import { Sidebar, ReadOnlyBanner, DemoModeBanner, LicenseExpiryBanner, WorkspaceContent } from "@/components/layout";
+import { Sidebar, ReadOnlyBanner, DemoModeBanner, LicenseExpiryBanner, DevModeLicenseBanner, WorkspaceContent } from "@/components/layout";
 
 const inter = Inter({
   variable: "--font-inter",
@@ -41,6 +41,7 @@ export default function RootLayout({
                 <DemoModeBanner />
                 <ReadOnlyBanner />
                 <LicenseExpiryBanner />
+                <DevModeLicenseBanner />
                 <main className="flex-1 overflow-auto bg-background">
                   <WorkspaceContent>
                     {children}

--- a/dashboard/src/components/layout/dev-mode-license-banner.tsx
+++ b/dashboard/src/components/layout/dev-mode-license-banner.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { ShieldAlert } from "lucide-react";
+import { useLicense } from "@/hooks/use-license";
+
+/**
+ * Banner displayed when the instance is running with a development license.
+ * Detects dev mode by checking license.id === "dev-mode".
+ */
+export function DevModeLicenseBanner() {
+  const { license, isLoading } = useLicense();
+
+  if (isLoading || license.id !== "dev-mode") {
+    return null;
+  }
+
+  return (
+    <div className="bg-orange-500/10 border-b border-orange-500/20 px-4 py-2">
+      <div className="flex items-center justify-center gap-2 text-sm text-orange-600 dark:text-orange-400">
+        <ShieldAlert className="h-3.5 w-3.5" />
+        <span>
+          <strong>Development License</strong> — This instance is using a
+          development license not intended for production workloads. Obtain a
+          valid license at{" "}
+          <a
+            href="https://altairalabs.ai/licensing"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:no-underline"
+          >
+            altairalabs.ai/licensing
+          </a>
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/index.ts
+++ b/dashboard/src/components/layout/index.ts
@@ -3,5 +3,6 @@ export { Header } from "./header";
 export { ReadOnlyBanner } from "./read-only-banner";
 export { DemoModeBanner } from "./demo-mode-banner";
 export { LicenseExpiryBanner } from "./license-expiry-banner";
+export { DevModeLicenseBanner } from "./dev-mode-license-banner";
 export { UserMenu } from "./user-menu";
 export { WorkspaceContent } from "./workspace-content";

--- a/ee/cmd/omnia-arena-controller/api/server_test.go
+++ b/ee/cmd/omnia-arena-controller/api/server_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestNewServer(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 	if s == nil {
 		t.Fatal("NewServer() returned nil")
 	}
@@ -30,7 +30,7 @@ func TestNewServer(t *testing.T) {
 }
 
 func TestHandleHealthz(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
 	w := httptest.NewRecorder()
@@ -46,7 +46,7 @@ func TestHandleHealthz(t *testing.T) {
 }
 
 func TestHandleRenderTemplate_MethodNotAllowed(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	methods := []string{http.MethodGet, http.MethodPut, http.MethodDelete, http.MethodPatch}
 	for _, method := range methods {
@@ -64,7 +64,7 @@ func TestHandleRenderTemplate_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandleRenderTemplate_InvalidJSON(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/render-template", bytes.NewBufferString("invalid json"))
 	w := httptest.NewRecorder()
@@ -77,7 +77,7 @@ func TestHandleRenderTemplate_InvalidJSON(t *testing.T) {
 }
 
 func TestHandleRenderTemplate_MissingTemplatePath(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	body := RenderTemplateRequest{
 		OutputPath:  "/output",
@@ -99,7 +99,7 @@ func TestHandleRenderTemplate_MissingTemplatePath(t *testing.T) {
 }
 
 func TestHandleRenderTemplate_MissingOutputPath(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	body := RenderTemplateRequest{
 		TemplatePath: "/template",
@@ -121,7 +121,7 @@ func TestHandleRenderTemplate_MissingOutputPath(t *testing.T) {
 }
 
 func TestHandleRenderTemplate_MissingProjectName(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	body := RenderTemplateRequest{
 		TemplatePath: "/template",
@@ -143,7 +143,7 @@ func TestHandleRenderTemplate_MissingProjectName(t *testing.T) {
 }
 
 func TestHandlePreviewTemplate_MethodNotAllowed(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	methods := []string{http.MethodGet, http.MethodPut, http.MethodDelete, http.MethodPatch}
 	for _, method := range methods {
@@ -161,7 +161,7 @@ func TestHandlePreviewTemplate_MethodNotAllowed(t *testing.T) {
 }
 
 func TestHandlePreviewTemplate_InvalidJSON(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/preview-template", bytes.NewBufferString("invalid json"))
 	w := httptest.NewRecorder()
@@ -174,7 +174,7 @@ func TestHandlePreviewTemplate_InvalidJSON(t *testing.T) {
 }
 
 func TestHandlePreviewTemplate_MissingTemplatePath(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	body := PreviewTemplateRequest{
 		ProjectName: "test",
@@ -195,7 +195,7 @@ func TestHandlePreviewTemplate_MissingTemplatePath(t *testing.T) {
 }
 
 func TestHandlePreviewTemplate_MissingProjectName(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	body := PreviewTemplateRequest{
 		TemplatePath: "/template",
@@ -216,7 +216,7 @@ func TestHandlePreviewTemplate_MissingProjectName(t *testing.T) {
 }
 
 func TestServerShutdown_NilServer(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	// Server is nil before Start is called
 	err := s.Shutdown(context.Background())
@@ -228,7 +228,7 @@ func TestServerShutdown_NilServer(t *testing.T) {
 func TestServerStart_InvalidAddress(t *testing.T) {
 	// Test that Start returns an error when the address is invalid
 	// This covers the Start() function without needing goroutines
-	s := NewServer("invalid:::address", logr.Discard())
+	s := NewServer("invalid:::address", logr.Discard(), nil)
 
 	err := s.Start(context.Background())
 	if err == nil {
@@ -237,7 +237,7 @@ func TestServerStart_InvalidAddress(t *testing.T) {
 }
 
 func TestHandleRenderTemplate_InvalidTemplatePath(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	body := RenderTemplateRequest{
 		TemplatePath: "/nonexistent/path",
@@ -269,8 +269,45 @@ func TestHandleRenderTemplate_InvalidTemplatePath(t *testing.T) {
 	}
 }
 
+func TestHandleGetLicense_NilValidator(t *testing.T) {
+	s := NewServer(":8080", logr.Discard(), nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/license", nil)
+	w := httptest.NewRecorder()
+
+	s.handleGetLicense(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusOK)
+	}
+
+	var resp licenseResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to unmarshal response: %v", err)
+	}
+	if resp.ID != "open-core" {
+		t.Errorf("id = %q, want %q", resp.ID, "open-core")
+	}
+	if resp.Tier != "open-core" {
+		t.Errorf("tier = %q, want %q", resp.Tier, "open-core")
+	}
+}
+
+func TestHandleGetLicense_MethodNotAllowed(t *testing.T) {
+	s := NewServer(":8080", logr.Discard(), nil)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/license", nil)
+	w := httptest.NewRecorder()
+
+	s.handleGetLicense(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want %d", w.Code, http.StatusMethodNotAllowed)
+	}
+}
+
 func TestHandlePreviewTemplate_InvalidTemplatePath(t *testing.T) {
-	s := NewServer(":8080", logr.Discard())
+	s := NewServer(":8080", logr.Discard(), nil)
 
 	body := PreviewTemplateRequest{
 		TemplatePath: "/nonexistent/path",

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -195,6 +195,11 @@ func (r *ArenaJobReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			}
 			return ctrl.Result{}, nil // Don't requeue - license must change
 		}
+
+		if r.LicenseValidator.IsDevMode() && r.Recorder != nil {
+			r.Recorder.Event(arenaJob, corev1.EventTypeWarning, "DevModeLicense",
+				"Using development license - not licensed for production use")
+		}
 	}
 
 	// Validate the referenced ArenaSource

--- a/ee/internal/controller/arenasource_controller.go
+++ b/ee/internal/controller/arenasource_controller.go
@@ -168,6 +168,11 @@ func (r *ArenaSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			}
 			return ctrl.Result{}, nil // Don't requeue - license must change
 		}
+
+		if r.LicenseValidator.IsDevMode() && r.Recorder != nil {
+			r.Recorder.Event(source, corev1.EventTypeWarning, "DevModeLicense",
+				"Using development license - not licensed for production use")
+		}
 	}
 
 	// Parse interval duration

--- a/ee/pkg/license/validator.go
+++ b/ee/pkg/license/validator.go
@@ -217,6 +217,11 @@ func (v *Validator) GetLicenseOrDefault(ctx context.Context) *License {
 	return license
 }
 
+// IsDevMode returns whether the validator is running in development mode.
+func (v *Validator) IsDevMode() bool {
+	return v.devMode
+}
+
 // InvalidateCache clears the license cache.
 func (v *Validator) InvalidateCache() {
 	v.mu.Lock()

--- a/hack/pre-commit
+++ b/hack/pre-commit
@@ -345,7 +345,7 @@ fi
 #
 print_header "Running go vet"
 
-if go vet ./... 2>&1; then
+if GOWORK=off go vet ./... 2>&1; then
     print_success "go vet passed"
 else
     print_error "go vet found issues"
@@ -365,7 +365,7 @@ if ! command -v golangci-lint &> /dev/null; then
     print_info "Skipping lint check..."
 else
     # Use --new-from-rev=HEAD to only check changes
-    if golangci-lint run --new-from-rev=HEAD --timeout=3m ./... 2>&1; then
+    if GOWORK=off golangci-lint run --new-from-rev=HEAD --timeout=3m ./... 2>&1; then
         print_success "Linting passed"
     else
         print_error "Linting failed"
@@ -378,7 +378,7 @@ fi
 #
 print_header "Building"
 
-if go build ./... 2>&1; then
+if GOWORK=off go build ./... 2>&1; then
     print_success "Build successful"
 else
     print_error "Build failed"
@@ -391,7 +391,7 @@ fi
 print_header "Running Tests with Coverage"
 
 # Run tests with coverage
-TEST_OUTPUT=$(go test -short -timeout 120s -coverprofile=coverage.out ./... 2>&1)
+TEST_OUTPUT=$(GOWORK=off go test -short -timeout 120s -coverprofile=coverage.out ./... 2>&1)
 TEST_EXIT_CODE=$?
 
 if [ $TEST_EXIT_CODE -ne 0 ]; then


### PR DESCRIPTION
## Summary

- **Controller nagging**: Louder startup banner, daily periodic WARNING log, and `DevModeLicense` Warning events emitted on every ArenaSource/ArenaJob reconciliation when `--dev-mode` is active
- **License API endpoint**: `GET /api/v1/license` on the arena controller API server, mapping Go JWT-style fields (`lid`/`iat`/`exp`) to dashboard-expected fields (`id`/`issuedAt`/`expiresAt`). Auto-wires `OPERATOR_API_URL` in the dashboard configmap when enterprise is enabled
- **Dashboard banner**: Orange warning banner when `license.id === "dev-mode"`, with link to altairalabs.ai/licensing
- **RBAC fix**: Adds `sessionprivacypolicies` to the enterprise ClusterRole (was missing, causing "cannot list" errors)
- **Pre-commit fix**: Adds `GOWORK=off` to `go vet`/`go build`/`golangci-lint`/`go test` in the pre-commit hook to avoid `promptkit-local` workspace interference

## Test plan
- [x] `go build ./ee/cmd/omnia-arena-controller/` compiles
- [x] `go test ./ee/cmd/omnia-arena-controller/api/... -count=1 -v` — all pass (85%+ coverage)
- [x] `go test ./ee/internal/controller/... -count=1 -v` — all 126 pass
- [x] `cd dashboard && npx next build` succeeds
- [x] Dashboard vitest suite passes (91.7% coverage)
- [x] All pre-commit checks pass (lint, vet, build, tests, coverage, helm validation)
- [ ] Deploy with `--dev-mode` and verify banner appears in dashboard
- [ ] `kubectl describe arenasource` shows `DevModeLicense` Warning event
- [ ] Verify daily log warning fires (can test by reducing ticker interval temporarily)