### PR TITLE
fix: use runtime config for dev-mode banner

### DIFF
--- a/charts/omnia/templates/dashboard/configmap.yaml
+++ b/charts/omnia/templates/dashboard/configmap.yaml
@@ -14,6 +14,9 @@ data:
   {{- end }}
 
   # Mode settings (demo mode defaults to false, not exposed in config)
+  {{- if .Values.devMode }}
+  NEXT_PUBLIC_DEV_MODE: "true"
+  {{- end }}
   NEXT_PUBLIC_READ_ONLY_MODE: {{ .Values.dashboard.readOnlyMode | quote }}
   {{- if .Values.dashboard.readOnlyMessage }}
   NEXT_PUBLIC_READ_ONLY_MESSAGE: {{ .Values.dashboard.readOnlyMessage | quote }}

--- a/dashboard/src/app/api/config/route.ts
+++ b/dashboard/src/app/api/config/route.ts
@@ -10,6 +10,7 @@ import { NextResponse } from "next/server";
 
 export async function GET() {
   return NextResponse.json({
+    devMode: process.env.NEXT_PUBLIC_DEV_MODE === "true",
     demoMode: process.env.NEXT_PUBLIC_DEMO_MODE === "true",
     readOnlyMode: process.env.NEXT_PUBLIC_READ_ONLY_MODE === "true",
     readOnlyMessage: process.env.NEXT_PUBLIC_READ_ONLY_MESSAGE || "This dashboard is in read-only mode",

--- a/dashboard/src/components/layout/dev-mode-license-banner.tsx
+++ b/dashboard/src/components/layout/dev-mode-license-banner.tsx
@@ -1,16 +1,16 @@
 "use client";
 
 import { ShieldAlert } from "lucide-react";
-import { useLicense } from "@/hooks/use-license";
+import { useDevMode } from "@/hooks/use-runtime-config";
 
 /**
  * Banner displayed when the instance is running with a development license.
- * Detects dev mode by checking license.id === "dev-mode".
+ * Detects dev mode via NEXT_PUBLIC_DEV_MODE runtime config (set by Helm when devMode=true).
  */
 export function DevModeLicenseBanner() {
-  const { license, isLoading } = useLicense();
+  const { isDevMode, loading } = useDevMode();
 
-  if (isLoading || license.id !== "dev-mode") {
+  if (loading || !isDevMode) {
     return null;
   }
 

--- a/dashboard/src/hooks/use-runtime-config.test.tsx
+++ b/dashboard/src/hooks/use-runtime-config.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor } from "@testing-library/react";
 import {
   useRuntimeConfig,
+  useDevMode,
   useDemoMode,
   useReadOnlyMode,
   useGrafanaUrl,
@@ -88,6 +89,43 @@ describe("useRuntimeConfig", () => {
     // Should fall back to default config
     expect(result.current.config).toBeDefined();
     consoleSpy.mockRestore();
+  });
+});
+
+describe("useDevMode", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("should return isDevMode and loading state", () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ devMode: true, demoMode: false, readOnlyMode: false, readOnlyMessage: "", wsProxyUrl: "", grafanaUrl: "", lokiEnabled: false, tempoEnabled: false }),
+    });
+
+    const { result } = renderHook(() => useDevMode());
+
+    expect(result.current).toHaveProperty("isDevMode");
+    expect(result.current).toHaveProperty("loading");
+    expect(typeof result.current.isDevMode).toBe("boolean");
+    expect(typeof result.current.loading).toBe("boolean");
+  });
+
+  it("should reflect dev mode from config", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ devMode: true, demoMode: false, readOnlyMode: false, readOnlyMessage: "", wsProxyUrl: "", grafanaUrl: "", lokiEnabled: false, tempoEnabled: false }),
+    });
+
+    const { result } = renderHook(() => useDevMode());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(typeof result.current.isDevMode).toBe("boolean");
   });
 });
 

--- a/dashboard/src/hooks/use-runtime-config.ts
+++ b/dashboard/src/hooks/use-runtime-config.ts
@@ -6,6 +6,7 @@ import { getRuntimeConfig, type RuntimeConfig } from "@/lib/config";
 // Use NEXT_PUBLIC_* as build-time defaults to avoid flash of wrong state
 // The API route will provide the runtime values if different
 const defaultConfig: RuntimeConfig = {
+  devMode: process.env.NEXT_PUBLIC_DEV_MODE === "true",
   demoMode: process.env.NEXT_PUBLIC_DEMO_MODE === "true",
   readOnlyMode: process.env.NEXT_PUBLIC_READ_ONLY_MODE === "true",
   readOnlyMessage: process.env.NEXT_PUBLIC_READ_ONLY_MESSAGE || "This dashboard is in read-only mode",
@@ -55,6 +56,14 @@ export function useRuntimeConfig() {
   }, []);
 
   return { config, loading };
+}
+
+/**
+ * Check if dev mode is enabled (development license, not for production).
+ */
+export function useDevMode() {
+  const { config, loading } = useRuntimeConfig();
+  return { isDevMode: config.devMode, loading };
 }
 
 /**

--- a/dashboard/src/lib/config.test.ts
+++ b/dashboard/src/lib/config.test.ts
@@ -45,6 +45,7 @@ describe("config", () => {
       const config = await getConfig();
 
       expect(config).toEqual({
+        devMode: false,
         demoMode: false,
         readOnlyMode: false,
         readOnlyMessage: "This dashboard is in read-only mode",
@@ -68,6 +69,7 @@ describe("config", () => {
       const config = await getConfig();
 
       expect(config).toEqual({
+        devMode: false,
         demoMode: false,
         readOnlyMode: false,
         readOnlyMessage: "This dashboard is in read-only mode",

--- a/dashboard/src/lib/config.ts
+++ b/dashboard/src/lib/config.ts
@@ -7,6 +7,7 @@
  */
 
 export interface RuntimeConfig {
+  devMode: boolean;
   demoMode: boolean;
   readOnlyMode: boolean;
   readOnlyMessage: string;
@@ -24,6 +25,7 @@ let cachedConfig: RuntimeConfig | null = null;
 let configPromise: Promise<RuntimeConfig> | null = null;
 
 const defaultConfig: RuntimeConfig = {
+  devMode: false,
   demoMode: false,
   readOnlyMode: false,
   readOnlyMessage: "This dashboard is in read-only mode",


### PR DESCRIPTION
## Summary
- The dev-mode banner relied on a fragile multi-hop fetch chain (browser → Next.js `/api/license` → arena controller `/api/v1/license`) that silently fell back to open-core license if any link failed
- Switched to the existing runtime config pattern (`Helm configmap → pod env → /api/config → client`), matching how `demoMode`, `readOnlyMode`, and `enterpriseEnabled` already work
- Adds `NEXT_PUBLIC_DEV_MODE` to the dashboard configmap when `devMode=true` in Helm values

## Test plan
- [x] `npx next build` succeeds
- [x] All dashboard tests pass with coverage (91.7%)
- [x] `go build ./ee/cmd/omnia-arena-controller/` compiles
- [ ] Deploy with `ENABLE_ENTERPRISE=true tilt up` and verify orange dev-mode banner appears