### PR TITLE
feat: add GDPR/HIPAA/CCPA compliance presets (#377)

### DIFF
--- a/charts/omnia/templates/enterprise/compliance-ccpa.yaml
+++ b/charts/omnia/templates/enterprise/compliance-ccpa.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.enterprise.enabled (index .Values.compliance.presets "ccpa") }}
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: SessionPrivacyPolicy
+metadata:
+  name: ccpa-compliant
+  labels:
+    omnia.altairalabs.ai/compliance-preset: ccpa
+    {{- include "omnia.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  level: workspace
+  recording:
+    enabled: true
+    facadeData: true
+    richData: false
+    pii:
+      redact: true
+      encrypt: false
+      patterns:
+        - ssn
+        - credit_card
+        - email
+      strategy: mask
+  retention:
+    facade:
+      warmDays: 30
+      coldDays: 30
+  userOptOut:
+    enabled: true
+    honorDeleteRequests: true
+    deleteWithinDays: 45
+  auditLog:
+    enabled: true
+    retentionDays: 365
+{{- end }}

--- a/charts/omnia/templates/enterprise/compliance-gdpr.yaml
+++ b/charts/omnia/templates/enterprise/compliance-gdpr.yaml
@@ -1,0 +1,40 @@
+{{- if and .Values.enterprise.enabled (index .Values.compliance.presets "gdpr") }}
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: SessionPrivacyPolicy
+metadata:
+  name: gdpr-compliant
+  labels:
+    omnia.altairalabs.ai/compliance-preset: gdpr
+    {{- include "omnia.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  level: workspace
+  recording:
+    enabled: true
+    facadeData: true
+    richData: true
+    pii:
+      redact: true
+      encrypt: true
+      patterns:
+        - ssn
+        - credit_card
+        - phone_number
+        - email
+        - ip_address
+      strategy: replace
+  retention:
+    facade:
+      warmDays: 30
+      coldDays: 90
+  userOptOut:
+    enabled: true
+    honorDeleteRequests: true
+    deleteWithinDays: 30
+  auditLog:
+    enabled: true
+    retentionDays: 365
+{{- end }}

--- a/charts/omnia/templates/enterprise/compliance-hipaa.yaml
+++ b/charts/omnia/templates/enterprise/compliance-hipaa.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.enterprise.enabled (index .Values.compliance.presets "hipaa") }}
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: SessionPrivacyPolicy
+metadata:
+  name: hipaa-compliant
+  labels:
+    omnia.altairalabs.ai/compliance-preset: hipaa
+    {{- include "omnia.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  level: workspace
+  recording:
+    enabled: true
+    facadeData: true
+    richData: true
+    pii:
+      redact: true
+      encrypt: true
+      patterns:
+        - ssn
+        - credit_card
+        - phone_number
+        - email
+        - ip_address
+        - "custom:^[A-Z]{2,4}-?\\d{6,10}$"
+      strategy: replace
+  retention:
+    facade:
+      warmDays: 30
+      coldDays: 2555
+  encryption:
+    enabled: true
+  userOptOut:
+    enabled: true
+    honorDeleteRequests: true
+    deleteWithinDays: 30
+  auditLog:
+    enabled: true
+    retentionDays: 2555
+{{- end }}

--- a/charts/omnia/tests/compliance-presets_test.yaml
+++ b/charts/omnia/tests/compliance-presets_test.yaml
@@ -1,0 +1,161 @@
+suite: compliance presets
+templates:
+  - templates/enterprise/compliance-gdpr.yaml
+  - templates/enterprise/compliance-hipaa.yaml
+  - templates/enterprise/compliance-ccpa.yaml
+tests:
+  - it: should not render any preset when enterprise is disabled
+    set:
+      enterprise.enabled: false
+      compliance.presets.gdpr: true
+      compliance.presets.hipaa: true
+      compliance.presets.ccpa: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should not render any preset when all presets are false
+    set:
+      enterprise.enabled: true
+      compliance.presets.gdpr: false
+      compliance.presets.hipaa: false
+      compliance.presets.ccpa: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render only GDPR when gdpr preset is enabled
+    set:
+      enterprise.enabled: true
+      compliance.presets.gdpr: true
+      compliance.presets.hipaa: false
+      compliance.presets.ccpa: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: gdpr-compliant
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["omnia.altairalabs.ai/compliance-preset"]
+          value: gdpr
+        documentIndex: 0
+      - equal:
+          path: spec.level
+          value: workspace
+        documentIndex: 0
+      - equal:
+          path: spec.recording.pii.redact
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.recording.pii.encrypt
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.recording.pii.strategy
+          value: replace
+        documentIndex: 0
+      - equal:
+          path: spec.retention.facade.warmDays
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.retention.facade.coldDays
+          value: 90
+        documentIndex: 0
+      - equal:
+          path: spec.userOptOut.enabled
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.userOptOut.deleteWithinDays
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.auditLog.enabled
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.auditLog.retentionDays
+          value: 365
+        documentIndex: 0
+
+  - it: should render only HIPAA when hipaa preset is enabled
+    set:
+      enterprise.enabled: true
+      compliance.presets.gdpr: false
+      compliance.presets.hipaa: true
+      compliance.presets.ccpa: false
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: hipaa-compliant
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["omnia.altairalabs.ai/compliance-preset"]
+          value: hipaa
+        documentIndex: 0
+      - equal:
+          path: spec.retention.facade.coldDays
+          value: 2555
+        documentIndex: 0
+      - equal:
+          path: spec.encryption.enabled
+          value: true
+        documentIndex: 0
+      - equal:
+          path: spec.auditLog.retentionDays
+          value: 2555
+        documentIndex: 0
+
+  - it: should render only CCPA when ccpa preset is enabled
+    set:
+      enterprise.enabled: true
+      compliance.presets.gdpr: false
+      compliance.presets.hipaa: false
+      compliance.presets.ccpa: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: ccpa-compliant
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["omnia.altairalabs.ai/compliance-preset"]
+          value: ccpa
+        documentIndex: 0
+      - equal:
+          path: spec.recording.richData
+          value: false
+        documentIndex: 0
+      - equal:
+          path: spec.recording.pii.encrypt
+          value: false
+        documentIndex: 0
+      - equal:
+          path: spec.recording.pii.strategy
+          value: mask
+        documentIndex: 0
+      - equal:
+          path: spec.retention.facade.coldDays
+          value: 30
+        documentIndex: 0
+      - equal:
+          path: spec.userOptOut.deleteWithinDays
+          value: 45
+        documentIndex: 0
+
+  - it: should render all presets when all are enabled
+    set:
+      enterprise.enabled: true
+      compliance.presets.gdpr: true
+      compliance.presets.hipaa: true
+      compliance.presets.ccpa: true
+    asserts:
+      - hasDocuments:
+          count: 3

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -729,6 +729,21 @@ sessionPrivacy:
       honorDeleteRequests: true
 
 # ============================================================================
+# Compliance Presets
+# Pre-configured SessionPrivacyPolicy resources for regulatory compliance.
+# Requires enterprise.enabled=true. Multiple presets can be enabled together.
+# ============================================================================
+
+compliance:
+  presets:
+    # -- Deploy a GDPR-compliant SessionPrivacyPolicy (EU data protection)
+    gdpr: false
+    # -- Deploy a HIPAA-compliant SessionPrivacyPolicy (US healthcare)
+    hipaa: false
+    # -- Deploy a CCPA-compliant SessionPrivacyPolicy (California consumer privacy)
+    ccpa: false
+
+# ============================================================================
 # Workspace Multi-Tenancy Configuration
 # Multi-tenant workspace isolation with namespace, RBAC, and quotas
 # ============================================================================

--- a/ee/pkg/compliance/presets.go
+++ b/ee/pkg/compliance/presets.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package compliance
+
+import (
+	"fmt"
+
+	eev1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+)
+
+// PresetName represents a supported compliance preset identifier.
+type PresetName string
+
+const (
+	// PresetGDPR is the EU General Data Protection Regulation preset.
+	PresetGDPR PresetName = "gdpr"
+	// PresetHIPAA is the US Health Insurance Portability and Accountability Act preset.
+	PresetHIPAA PresetName = "hipaa"
+	// PresetCCPA is the California Consumer Privacy Act preset.
+	PresetCCPA PresetName = "ccpa"
+)
+
+// validPresets is the set of all supported preset names.
+var validPresets = map[PresetName]bool{
+	PresetGDPR:  true,
+	PresetHIPAA: true,
+	PresetCCPA:  true,
+}
+
+// int32Ptr returns a pointer to the given int32 value.
+func int32Ptr(v int32) *int32 {
+	return &v
+}
+
+// GetPreset returns the SessionPrivacyPolicySpec for a named compliance preset.
+// Returns an error if the preset name is not recognized.
+func GetPreset(name string) (*eev1alpha1.SessionPrivacyPolicySpec, error) {
+	preset := PresetName(name)
+	if !validPresets[preset] {
+		return nil, fmt.Errorf("unknown compliance preset: %q", name)
+	}
+
+	switch preset {
+	case PresetGDPR:
+		return gdprPreset(), nil
+	case PresetHIPAA:
+		return hipaaPreset(), nil
+	case PresetCCPA:
+		return ccpaPreset(), nil
+	default:
+		return nil, fmt.Errorf("unknown compliance preset: %q", name)
+	}
+}
+
+// ListPresets returns all supported preset names.
+func ListPresets() []PresetName {
+	return []PresetName{PresetGDPR, PresetHIPAA, PresetCCPA}
+}
+
+func gdprPreset() *eev1alpha1.SessionPrivacyPolicySpec {
+	return &eev1alpha1.SessionPrivacyPolicySpec{
+		Level: eev1alpha1.PolicyLevelWorkspace,
+		Recording: eev1alpha1.RecordingConfig{
+			Enabled:    true,
+			FacadeData: true,
+			RichData:   true,
+			PII: &eev1alpha1.PIIConfig{
+				Redact:   true,
+				Encrypt:  true,
+				Patterns: gdprPIIPatterns(),
+				Strategy: eev1alpha1.RedactionStrategyReplace,
+			},
+		},
+		Retention: &eev1alpha1.PrivacyRetentionConfig{
+			Facade: &eev1alpha1.PrivacyRetentionTierConfig{
+				WarmDays: int32Ptr(30),
+				ColdDays: int32Ptr(90),
+			},
+		},
+		UserOptOut: &eev1alpha1.UserOptOutConfig{
+			Enabled:             true,
+			HonorDeleteRequests: true,
+			DeleteWithinDays:    int32Ptr(30),
+		},
+		AuditLog: &eev1alpha1.AuditLogConfig{
+			Enabled:       true,
+			RetentionDays: int32Ptr(365),
+		},
+	}
+}
+
+func hipaaPreset() *eev1alpha1.SessionPrivacyPolicySpec {
+	return &eev1alpha1.SessionPrivacyPolicySpec{
+		Level: eev1alpha1.PolicyLevelWorkspace,
+		Recording: eev1alpha1.RecordingConfig{
+			Enabled:    true,
+			FacadeData: true,
+			RichData:   true,
+			PII: &eev1alpha1.PIIConfig{
+				Redact:   true,
+				Encrypt:  true,
+				Patterns: hipaaPIIPatterns(),
+				Strategy: eev1alpha1.RedactionStrategyReplace,
+			},
+		},
+		Retention: &eev1alpha1.PrivacyRetentionConfig{
+			Facade: &eev1alpha1.PrivacyRetentionTierConfig{
+				WarmDays: int32Ptr(30),
+				ColdDays: int32Ptr(2555),
+			},
+		},
+		Encryption: &eev1alpha1.EncryptionConfig{
+			Enabled: true,
+		},
+		UserOptOut: &eev1alpha1.UserOptOutConfig{
+			Enabled:             true,
+			HonorDeleteRequests: true,
+			DeleteWithinDays:    int32Ptr(30),
+		},
+		AuditLog: &eev1alpha1.AuditLogConfig{
+			Enabled:       true,
+			RetentionDays: int32Ptr(2555),
+		},
+	}
+}
+
+func ccpaPreset() *eev1alpha1.SessionPrivacyPolicySpec {
+	return &eev1alpha1.SessionPrivacyPolicySpec{
+		Level: eev1alpha1.PolicyLevelWorkspace,
+		Recording: eev1alpha1.RecordingConfig{
+			Enabled:    true,
+			FacadeData: true,
+			RichData:   false,
+			PII: &eev1alpha1.PIIConfig{
+				Redact:   true,
+				Encrypt:  false,
+				Patterns: ccpaPIIPatterns(),
+				Strategy: eev1alpha1.RedactionStrategyMask,
+			},
+		},
+		Retention: &eev1alpha1.PrivacyRetentionConfig{
+			Facade: &eev1alpha1.PrivacyRetentionTierConfig{
+				WarmDays: int32Ptr(30),
+				ColdDays: int32Ptr(30),
+			},
+		},
+		UserOptOut: &eev1alpha1.UserOptOutConfig{
+			Enabled:             true,
+			HonorDeleteRequests: true,
+			DeleteWithinDays:    int32Ptr(45),
+		},
+		AuditLog: &eev1alpha1.AuditLogConfig{
+			Enabled:       true,
+			RetentionDays: int32Ptr(365),
+		},
+	}
+}
+
+func gdprPIIPatterns() []string {
+	return []string{
+		"ssn",
+		"credit_card",
+		"phone_number",
+		"email",
+		"ip_address",
+	}
+}
+
+func hipaaPIIPatterns() []string {
+	return []string{
+		"ssn",
+		"credit_card",
+		"phone_number",
+		"email",
+		"ip_address",
+		"custom:^[A-Z]{2,4}-?\\d{6,10}$",
+	}
+}
+
+func ccpaPIIPatterns() []string {
+	return []string{
+		"ssn",
+		"credit_card",
+		"email",
+	}
+}

--- a/ee/pkg/compliance/presets_test.go
+++ b/ee/pkg/compliance/presets_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package compliance
+
+import (
+	"testing"
+
+	eev1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+)
+
+func TestGetPreset_GDPR(t *testing.T) {
+	spec, err := GetPreset("gdpr")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRecordingEnabled(t, spec)
+	assertPIIRedactionEnabled(t, spec)
+	assertPIIEncryptionEnabled(t, spec)
+	assertPIIStrategy(t, spec, eev1alpha1.RedactionStrategyReplace)
+	assertUserOptOutEnabled(t, spec)
+	assertHonorDeleteRequests(t, spec)
+	assertDeleteWithinDays(t, spec, 30)
+	assertAuditLogEnabled(t, spec)
+	assertAuditLogRetentionDays(t, spec, 365)
+	assertRetentionWarmDays(t, spec, 30)
+	assertRetentionColdDays(t, spec, 90)
+
+	assertPIIPatternsContain(t, spec, "ssn", "credit_card", "phone_number", "email", "ip_address")
+}
+
+func TestGetPreset_HIPAA(t *testing.T) {
+	spec, err := GetPreset("hipaa")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRecordingEnabled(t, spec)
+	assertPIIRedactionEnabled(t, spec)
+	assertPIIEncryptionEnabled(t, spec)
+	assertPIIStrategy(t, spec, eev1alpha1.RedactionStrategyReplace)
+	assertUserOptOutEnabled(t, spec)
+	assertHonorDeleteRequests(t, spec)
+	assertDeleteWithinDays(t, spec, 30)
+	assertAuditLogEnabled(t, spec)
+	assertAuditLogRetentionDays(t, spec, 2555)
+	assertRetentionColdDays(t, spec, 2555)
+
+	if spec.Encryption == nil || !spec.Encryption.Enabled {
+		t.Error("HIPAA preset must have encryption enabled")
+	}
+
+	assertPIIPatternsContain(t, spec, "ssn", "credit_card", "phone_number", "email", "ip_address")
+
+	// HIPAA must include medical record number pattern
+	found := false
+	for _, p := range spec.Recording.PII.Patterns {
+		if p == "custom:^[A-Z]{2,4}-?\\d{6,10}$" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("HIPAA preset must include medical record number custom pattern")
+	}
+}
+
+func TestGetPreset_CCPA(t *testing.T) {
+	spec, err := GetPreset("ccpa")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	assertRecordingEnabled(t, spec)
+	assertPIIRedactionEnabled(t, spec)
+	assertPIIStrategy(t, spec, eev1alpha1.RedactionStrategyMask)
+	assertUserOptOutEnabled(t, spec)
+	assertHonorDeleteRequests(t, spec)
+	assertDeleteWithinDays(t, spec, 45)
+	assertAuditLogEnabled(t, spec)
+	assertRetentionWarmDays(t, spec, 30)
+	assertRetentionColdDays(t, spec, 30)
+
+	if spec.Recording.RichData {
+		t.Error("CCPA preset should not enable rich data recording")
+	}
+
+	if spec.Recording.PII.Encrypt {
+		t.Error("CCPA preset should not require PII encryption")
+	}
+}
+
+func TestGetPreset_Unknown(t *testing.T) {
+	_, err := GetPreset("unknown")
+	if err == nil {
+		t.Fatal("expected error for unknown preset")
+	}
+}
+
+func TestGetPreset_EmptyName(t *testing.T) {
+	_, err := GetPreset("")
+	if err == nil {
+		t.Fatal("expected error for empty preset name")
+	}
+}
+
+func TestListPresets(t *testing.T) {
+	presets := ListPresets()
+	if len(presets) != 3 {
+		t.Fatalf("expected 3 presets, got %d", len(presets))
+	}
+
+	expected := map[PresetName]bool{
+		PresetGDPR:  true,
+		PresetHIPAA: true,
+		PresetCCPA:  true,
+	}
+	for _, p := range presets {
+		if !expected[p] {
+			t.Errorf("unexpected preset: %s", p)
+		}
+	}
+}
+
+func TestAllPresetsHaveWorkspaceLevel(t *testing.T) {
+	for _, name := range ListPresets() {
+		spec, err := GetPreset(string(name))
+		if err != nil {
+			t.Fatalf("unexpected error for preset %s: %v", name, err)
+		}
+		if spec.Level != eev1alpha1.PolicyLevelWorkspace {
+			t.Errorf("preset %s: expected workspace level, got %s", name, spec.Level)
+		}
+	}
+}
+
+func TestAllPresetsHaveAuditLogging(t *testing.T) {
+	for _, name := range ListPresets() {
+		spec, err := GetPreset(string(name))
+		if err != nil {
+			t.Fatalf("unexpected error for preset %s: %v", name, err)
+		}
+		assertAuditLogEnabled(t, spec)
+	}
+}
+
+func TestAllPresetsHaveUserOptOut(t *testing.T) {
+	for _, name := range ListPresets() {
+		spec, err := GetPreset(string(name))
+		if err != nil {
+			t.Fatalf("unexpected error for preset %s: %v", name, err)
+		}
+		assertUserOptOutEnabled(t, spec)
+		assertHonorDeleteRequests(t, spec)
+	}
+}
+
+func TestAllPresetsHavePIIRedaction(t *testing.T) {
+	for _, name := range ListPresets() {
+		spec, err := GetPreset(string(name))
+		if err != nil {
+			t.Fatalf("unexpected error for preset %s: %v", name, err)
+		}
+		assertPIIRedactionEnabled(t, spec)
+	}
+}
+
+func TestAllPresetsHaveRetention(t *testing.T) {
+	for _, name := range ListPresets() {
+		spec, err := GetPreset(string(name))
+		if err != nil {
+			t.Fatalf("unexpected error for preset %s: %v", name, err)
+		}
+		if spec.Retention == nil {
+			t.Errorf("preset %s: retention must not be nil", name)
+		}
+		if spec.Retention.Facade == nil {
+			t.Errorf("preset %s: facade retention must not be nil", name)
+		}
+	}
+}
+
+// --- assertion helpers ---
+
+func assertRecordingEnabled(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec) {
+	t.Helper()
+	if !spec.Recording.Enabled {
+		t.Error("recording must be enabled")
+	}
+}
+
+func assertPIIRedactionEnabled(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec) {
+	t.Helper()
+	if spec.Recording.PII == nil {
+		t.Fatal("PII config must not be nil")
+	}
+	if !spec.Recording.PII.Redact {
+		t.Error("PII redaction must be enabled")
+	}
+}
+
+func assertPIIEncryptionEnabled(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec) {
+	t.Helper()
+	if spec.Recording.PII == nil {
+		t.Fatal("PII config must not be nil")
+	}
+	if !spec.Recording.PII.Encrypt {
+		t.Error("PII encryption must be enabled")
+	}
+}
+
+func assertPIIStrategy(
+	t *testing.T,
+	spec *eev1alpha1.SessionPrivacyPolicySpec,
+	expected eev1alpha1.RedactionStrategy,
+) {
+	t.Helper()
+	if spec.Recording.PII.Strategy != expected {
+		t.Errorf("expected PII strategy %s, got %s", expected, spec.Recording.PII.Strategy)
+	}
+}
+
+func assertUserOptOutEnabled(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec) {
+	t.Helper()
+	if spec.UserOptOut == nil {
+		t.Fatal("userOptOut must not be nil")
+	}
+	if !spec.UserOptOut.Enabled {
+		t.Error("userOptOut must be enabled")
+	}
+}
+
+func assertHonorDeleteRequests(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec) {
+	t.Helper()
+	if spec.UserOptOut == nil {
+		t.Fatal("userOptOut must not be nil")
+	}
+	if !spec.UserOptOut.HonorDeleteRequests {
+		t.Error("honorDeleteRequests must be enabled")
+	}
+}
+
+func assertDeleteWithinDays(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec, expected int32) {
+	t.Helper()
+	if spec.UserOptOut == nil || spec.UserOptOut.DeleteWithinDays == nil {
+		t.Fatal("deleteWithinDays must not be nil")
+	}
+	if *spec.UserOptOut.DeleteWithinDays != expected {
+		t.Errorf("expected deleteWithinDays %d, got %d", expected, *spec.UserOptOut.DeleteWithinDays)
+	}
+}
+
+func assertAuditLogEnabled(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec) {
+	t.Helper()
+	if spec.AuditLog == nil {
+		t.Fatal("auditLog must not be nil")
+	}
+	if !spec.AuditLog.Enabled {
+		t.Error("auditLog must be enabled")
+	}
+}
+
+func assertAuditLogRetentionDays(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec, expected int32) {
+	t.Helper()
+	if spec.AuditLog == nil || spec.AuditLog.RetentionDays == nil {
+		t.Fatal("auditLog retentionDays must not be nil")
+	}
+	if *spec.AuditLog.RetentionDays != expected {
+		t.Errorf("expected auditLog retentionDays %d, got %d", expected, *spec.AuditLog.RetentionDays)
+	}
+}
+
+func assertRetentionWarmDays(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec, expected int32) {
+	t.Helper()
+	if spec.Retention == nil || spec.Retention.Facade == nil || spec.Retention.Facade.WarmDays == nil {
+		t.Fatal("retention facade warmDays must not be nil")
+	}
+	if *spec.Retention.Facade.WarmDays != expected {
+		t.Errorf("expected warmDays %d, got %d", expected, *spec.Retention.Facade.WarmDays)
+	}
+}
+
+func assertRetentionColdDays(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec, expected int32) {
+	t.Helper()
+	if spec.Retention == nil || spec.Retention.Facade == nil || spec.Retention.Facade.ColdDays == nil {
+		t.Fatal("retention facade coldDays must not be nil")
+	}
+	if *spec.Retention.Facade.ColdDays != expected {
+		t.Errorf("expected coldDays %d, got %d", expected, *spec.Retention.Facade.ColdDays)
+	}
+}
+
+func assertPIIPatternsContain(t *testing.T, spec *eev1alpha1.SessionPrivacyPolicySpec, patterns ...string) {
+	t.Helper()
+	if spec.Recording.PII == nil {
+		t.Fatal("PII config must not be nil")
+	}
+	patternSet := make(map[string]bool, len(spec.Recording.PII.Patterns))
+	for _, p := range spec.Recording.PII.Patterns {
+		patternSet[p] = true
+	}
+	for _, expected := range patterns {
+		if !patternSet[expected] {
+			t.Errorf("expected PII pattern %q not found", expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Add pre-configured `SessionPrivacyPolicy` Helm templates for GDPR, HIPAA, and CCPA regulatory compliance frameworks
- Each preset is gated behind `enterprise.enabled` and `compliance.presets.<name>` Helm values (all default to `false`)
- Add Go presets package (`ee/pkg/compliance`) with `GetPreset(name)` and `ListPresets()` API for programmatic access
- Add helm-unittest test suite validating conditional rendering and preset field values

## Preset Details

| Preset | PII Redaction | PII Encryption | Cold Retention | Audit Log Retention | Delete Window | Strategy |
|--------|:---:|:---:|---:|---:|---:|---|
| GDPR | Yes | Yes | 90 days | 365 days | 30 days | replace |
| HIPAA | Yes | Yes | 7 years (2555d) | 7 years (2555d) | 30 days | replace |
| CCPA | Yes | No | 30 days | 365 days | 45 days | mask |

## Test plan
- [x] Go tests pass: `go test ./ee/pkg/compliance/... -count=1 -v` (11/11 pass, 93.8% coverage)
- [x] golangci-lint clean: `golangci-lint run ./ee/pkg/compliance/...`
- [x] Helm lint passes: `helm lint charts/omnia`
- [x] Templates render correctly with each preset enabled
- [x] Templates do NOT render when `enterprise.enabled=false`
- [x] Pre-commit hooks pass (formatting, vet, lint, build, tests, coverage, generated code, helm validation)
- [ ] CI/SonarCloud quality gate

Closes #377