### PR TITLE
feat: implement user opt-out workflow (#374)

### DIFF
--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -34,6 +34,7 @@ import (
 
 	"github.com/altairalabs/omnia/ee/pkg/audit"
 	"github.com/altairalabs/omnia/ee/pkg/metrics"
+	"github.com/altairalabs/omnia/ee/pkg/privacy"
 	"github.com/altairalabs/omnia/internal/session/api"
 	sessionpg "github.com/altairalabs/omnia/internal/session/postgres"
 	"github.com/altairalabs/omnia/internal/session/providers"
@@ -187,6 +188,12 @@ func run() error {
 	if f.enterprise && auditLogger != nil {
 		ah := audit.NewHandler(auditLogger, log)
 		ah.RegisterRoutes(apiMux)
+	}
+
+	if f.enterprise {
+		privacyStore := privacy.NewPreferencesStore(pool)
+		optOutHandler := privacy.NewOptOutHandler(privacyStore, log)
+		optOutHandler.RegisterRoutes(apiMux)
 	}
 
 	apiMux.Handle("GET /metrics", promhttp.Handler())

--- a/ee/pkg/privacy/check.go
+++ b/ee/pkg/privacy/check.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"errors"
+)
+
+// ShouldRecord checks whether session recording should proceed for a given user.
+// It returns false if the user has opted out globally, for the specific workspace,
+// or for the specific agent. Returns true if no opt-out preferences exist.
+func ShouldRecord(ctx context.Context, store PreferencesStore, userID, workspace, agent string) bool {
+	prefs, err := store.GetPreferences(ctx, userID)
+	if err != nil {
+		// If the user has no preferences, recording is allowed.
+		if errors.Is(err, ErrPreferencesNotFound) {
+			return true
+		}
+		// On unexpected errors, default to allowing recording to avoid data loss.
+		return true
+	}
+
+	if prefs.OptOutAll {
+		return false
+	}
+
+	if workspace != "" && containsStr(prefs.OptOutWorkspaces, workspace) {
+		return false
+	}
+
+	if agent != "" && containsStr(prefs.OptOutAgents, agent) {
+		return false
+	}
+
+	return true
+}
+
+// containsStr reports whether s is present in the slice.
+func containsStr(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/ee/pkg/privacy/check_test.go
+++ b/ee/pkg/privacy/check_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockPreferencesStore implements PreferencesStore for testing ShouldRecord.
+type mockPreferencesStore struct {
+	prefs *Preferences
+	err   error
+}
+
+func (m *mockPreferencesStore) GetPreferences(_ context.Context, _ string) (*Preferences, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.prefs, nil
+}
+
+func (m *mockPreferencesStore) SetOptOut(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func (m *mockPreferencesStore) RemoveOptOut(_ context.Context, _, _, _ string) error {
+	return nil
+}
+
+func TestShouldRecord_NoPreferences(t *testing.T) {
+	store := &mockPreferencesStore{err: ErrPreferencesNotFound}
+	result := ShouldRecord(context.Background(), store, "user1", "ws1", "agent1")
+	assert.True(t, result)
+}
+
+func TestShouldRecord_UnexpectedError(t *testing.T) {
+	store := &mockPreferencesStore{err: errors.New("db error")}
+	result := ShouldRecord(context.Background(), store, "user1", "ws1", "agent1")
+	assert.True(t, result, "should default to allowing recording on unexpected errors")
+}
+
+func TestShouldRecord_OptOutAll(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        true,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	result := ShouldRecord(context.Background(), store, "user1", "ws1", "agent1")
+	assert.False(t, result)
+}
+
+func TestShouldRecord_OptOutWorkspace(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{"ws1", "ws2"},
+		OptOutAgents:     []string{},
+	}}
+
+	assert.False(t, ShouldRecord(context.Background(), store, "user1", "ws1", "agent1"))
+	assert.True(t, ShouldRecord(context.Background(), store, "user1", "ws3", "agent1"))
+}
+
+func TestShouldRecord_OptOutAgent(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{"agent1"},
+	}}
+
+	assert.False(t, ShouldRecord(context.Background(), store, "user1", "ws1", "agent1"))
+	assert.True(t, ShouldRecord(context.Background(), store, "user1", "ws1", "agent2"))
+}
+
+func TestShouldRecord_NoOptOut(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	result := ShouldRecord(context.Background(), store, "user1", "ws1", "agent1")
+	assert.True(t, result)
+}
+
+func TestShouldRecord_EmptyWorkspaceAndAgent(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{"ws1"},
+		OptOutAgents:     []string{"agent1"},
+	}}
+	result := ShouldRecord(context.Background(), store, "user1", "", "")
+	assert.True(t, result)
+}
+
+func TestContainsStr(t *testing.T) {
+	assert.True(t, containsStr([]string{"a", "b", "c"}, "b"))
+	assert.False(t, containsStr([]string{"a", "b", "c"}, "d"))
+	assert.False(t, containsStr(nil, "a"))
+	assert.False(t, containsStr([]string{}, "a"))
+}

--- a/ee/pkg/privacy/handler.go
+++ b/ee/pkg/privacy/handler.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-logr/logr"
+)
+
+// OptOutHandler provides HTTP endpoints for user privacy opt-out management.
+type OptOutHandler struct {
+	store PreferencesStore
+	log   logr.Logger
+}
+
+// NewOptOutHandler creates a new OptOutHandler.
+func NewOptOutHandler(store PreferencesStore, log logr.Logger) *OptOutHandler {
+	return &OptOutHandler{
+		store: store,
+		log:   log.WithName("optout-handler"),
+	}
+}
+
+// RegisterRoutes registers the opt-out API routes on the given mux.
+func (h *OptOutHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("POST /api/v1/privacy/opt-out", h.handleSetOptOut)
+	mux.HandleFunc("DELETE /api/v1/privacy/opt-out", h.handleRemoveOptOut)
+	mux.HandleFunc("GET /api/v1/privacy/preferences/{userID}", h.handleGetPreferences)
+}
+
+// OptOutRequest is the JSON body for opt-out operations.
+type OptOutRequest struct {
+	UserID string `json:"userId"`
+	Scope  string `json:"scope"`
+	Target string `json:"target,omitempty"`
+}
+
+// handleSetOptOut sets an opt-out preference for a user.
+func (h *OptOutHandler) handleSetOptOut(w http.ResponseWriter, r *http.Request) {
+	var req OptOutRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := validateOptOutRequest(req); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.store.SetOptOut(r.Context(), req.UserID, req.Scope, req.Target); err != nil {
+		h.log.Error(err, "SetOptOut failed", "userID", req.UserID)
+		writeErr(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleRemoveOptOut removes an opt-out preference for a user.
+func (h *OptOutHandler) handleRemoveOptOut(w http.ResponseWriter, r *http.Request) {
+	var req OptOutRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := validateOptOutRequest(req); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.store.RemoveOptOut(r.Context(), req.UserID, req.Scope, req.Target); err != nil {
+		if errors.Is(err, ErrPreferencesNotFound) {
+			writeErr(w, http.StatusNotFound, "user preferences not found")
+			return
+		}
+		h.log.Error(err, "RemoveOptOut failed", "userID", req.UserID)
+		writeErr(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleGetPreferences returns a user's privacy preferences.
+func (h *OptOutHandler) handleGetPreferences(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("userID")
+	if userID == "" {
+		writeErr(w, http.StatusBadRequest, "user ID is required")
+		return
+	}
+
+	prefs, err := h.store.GetPreferences(r.Context(), userID)
+	if err != nil {
+		if errors.Is(err, ErrPreferencesNotFound) {
+			writeErr(w, http.StatusNotFound, "user preferences not found")
+			return
+		}
+		h.log.Error(err, "GetPreferences failed", "userID", userID)
+		writeErr(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(prefs)
+}
+
+// errResponse is the JSON error response body.
+type errResponse struct {
+	Error string `json:"error"`
+}
+
+// writeErr writes a JSON error response.
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errResponse{Error: msg})
+}
+
+// validateOptOutRequest validates the opt-out request fields.
+func validateOptOutRequest(req OptOutRequest) error {
+	if req.UserID == "" {
+		return errors.New("userId is required")
+	}
+	switch req.Scope {
+	case ScopeAll:
+		return nil
+	case ScopeWorkspace, ScopeAgent:
+		if req.Target == "" {
+			return errors.New("target is required for workspace and agent scopes")
+		}
+		return nil
+	default:
+		return errors.New("scope must be one of: all, workspace, agent")
+	}
+}

--- a/ee/pkg/privacy/handler_test.go
+++ b/ee/pkg/privacy/handler_test.go
@@ -1,0 +1,368 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// handlerMockPrefsStore is a mock PreferencesStore for handler tests.
+type handlerMockPrefsStore struct {
+	getPreferencesFn func(ctx context.Context, userID string) (*Preferences, error)
+	setOptOutFn      func(ctx context.Context, userID, scope, target string) error
+	removeOptOutFn   func(ctx context.Context, userID, scope, target string) error
+}
+
+func (m *handlerMockPrefsStore) GetPreferences(ctx context.Context, userID string) (*Preferences, error) {
+	return m.getPreferencesFn(ctx, userID)
+}
+
+func (m *handlerMockPrefsStore) SetOptOut(ctx context.Context, userID, scope, target string) error {
+	return m.setOptOutFn(ctx, userID, scope, target)
+}
+
+func (m *handlerMockPrefsStore) RemoveOptOut(ctx context.Context, userID, scope, target string) error {
+	return m.removeOptOutFn(ctx, userID, scope, target)
+}
+
+func newTestOptOutHandler(store PreferencesStore) *OptOutHandler {
+	log := zap.New(zap.UseDevMode(true))
+	return NewOptOutHandler(store, log)
+}
+
+func TestHandleSetOptOut_Success(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		setOptOutFn: func(_ context.Context, _, _, _ string) error {
+			return nil
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	body, _ := json.Marshal(OptOutRequest{UserID: "user1", Scope: ScopeAll})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleSetOptOut(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestHandleSetOptOut_WorkspaceScope(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		setOptOutFn: func(_ context.Context, _, scope, target string) error {
+			assert.Equal(t, ScopeWorkspace, scope)
+			assert.Equal(t, "my-workspace", target)
+			return nil
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	body, _ := json.Marshal(OptOutRequest{
+		UserID: "user1", Scope: ScopeWorkspace, Target: "my-workspace",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleSetOptOut(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestHandleSetOptOut_InvalidBody(t *testing.T) {
+	h := newTestOptOutHandler(&handlerMockPrefsStore{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader([]byte("invalid")))
+	rec := httptest.NewRecorder()
+
+	h.handleSetOptOut(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSetOptOut_MissingUserID(t *testing.T) {
+	h := newTestOptOutHandler(&handlerMockPrefsStore{})
+
+	body, _ := json.Marshal(OptOutRequest{Scope: ScopeAll})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleSetOptOut(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSetOptOut_InvalidScope(t *testing.T) {
+	h := newTestOptOutHandler(&handlerMockPrefsStore{})
+
+	body, _ := json.Marshal(OptOutRequest{UserID: "user1", Scope: "invalid"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleSetOptOut(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSetOptOut_MissingTarget(t *testing.T) {
+	h := newTestOptOutHandler(&handlerMockPrefsStore{})
+
+	body, _ := json.Marshal(OptOutRequest{UserID: "user1", Scope: ScopeWorkspace})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleSetOptOut(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSetOptOut_StoreError(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		setOptOutFn: func(_ context.Context, _, _, _ string) error {
+			return errors.New("db error")
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	body, _ := json.Marshal(OptOutRequest{UserID: "user1", Scope: ScopeAll})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleSetOptOut(rec, req)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandleRemoveOptOut_Success(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		removeOptOutFn: func(_ context.Context, _, _, _ string) error {
+			return nil
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	body, _ := json.Marshal(OptOutRequest{UserID: "user1", Scope: ScopeAll})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleRemoveOptOut(rec, req)
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+}
+
+func TestHandleRemoveOptOut_NotFound(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		removeOptOutFn: func(_ context.Context, _, _, _ string) error {
+			return ErrPreferencesNotFound
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	body, _ := json.Marshal(OptOutRequest{UserID: "missing", Scope: ScopeAll})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleRemoveOptOut(rec, req)
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleRemoveOptOut_InvalidBody(t *testing.T) {
+	h := newTestOptOutHandler(&handlerMockPrefsStore{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/privacy/opt-out", bytes.NewReader([]byte("bad")))
+	rec := httptest.NewRecorder()
+
+	h.handleRemoveOptOut(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleRemoveOptOut_StoreError(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		removeOptOutFn: func(_ context.Context, _, _, _ string) error {
+			return errors.New("db error")
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	body, _ := json.Marshal(OptOutRequest{UserID: "user1", Scope: ScopeAll})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleRemoveOptOut(rec, req)
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandleRemoveOptOut_ValidationError(t *testing.T) {
+	h := newTestOptOutHandler(&handlerMockPrefsStore{})
+
+	body, _ := json.Marshal(OptOutRequest{Scope: ScopeAll})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/privacy/opt-out", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+
+	h.handleRemoveOptOut(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleGetPreferences_Success(t *testing.T) {
+	now := time.Now().UTC()
+	store := &handlerMockPrefsStore{
+		getPreferencesFn: func(_ context.Context, userID string) (*Preferences, error) {
+			return &Preferences{
+				UserID:           userID,
+				OptOutAll:        true,
+				OptOutWorkspaces: []string{"ws1"},
+				OptOutAgents:     []string{},
+				CreatedAt:        now,
+				UpdatedAt:        now,
+			}, nil
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/privacy/preferences/user1", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var prefs Preferences
+	err := json.NewDecoder(rec.Body).Decode(&prefs)
+	require.NoError(t, err)
+	assert.Equal(t, "user1", prefs.UserID)
+	assert.True(t, prefs.OptOutAll)
+}
+
+func TestHandleGetPreferences_NotFound(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		getPreferencesFn: func(_ context.Context, _ string) (*Preferences, error) {
+			return nil, ErrPreferencesNotFound
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/privacy/preferences/missing", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleGetPreferences_StoreError(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		getPreferencesFn: func(_ context.Context, _ string) (*Preferences, error) {
+			return nil, errors.New("db error")
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/privacy/preferences/user1", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestValidateOptOutRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     OptOutRequest
+		wantErr bool
+	}{
+		{
+			name:    "valid all scope",
+			req:     OptOutRequest{UserID: "u1", Scope: ScopeAll},
+			wantErr: false,
+		},
+		{
+			name:    "valid workspace scope",
+			req:     OptOutRequest{UserID: "u1", Scope: ScopeWorkspace, Target: "ws1"},
+			wantErr: false,
+		},
+		{
+			name:    "valid agent scope",
+			req:     OptOutRequest{UserID: "u1", Scope: ScopeAgent, Target: "a1"},
+			wantErr: false,
+		},
+		{name: "missing user ID", req: OptOutRequest{Scope: ScopeAll}, wantErr: true},
+		{name: "invalid scope", req: OptOutRequest{UserID: "u1", Scope: "bad"}, wantErr: true},
+		{
+			name:    "workspace missing target",
+			req:     OptOutRequest{UserID: "u1", Scope: ScopeWorkspace},
+			wantErr: true,
+		},
+		{
+			name:    "agent missing target",
+			req:     OptOutRequest{UserID: "u1", Scope: ScopeAgent},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateOptOutRequest(tt.req)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestOptOutRegisterRoutes(t *testing.T) {
+	store := &handlerMockPrefsStore{
+		setOptOutFn: func(_ context.Context, _, _, _ string) error {
+			return nil
+		},
+		removeOptOutFn: func(_ context.Context, _, _, _ string) error {
+			return nil
+		},
+		getPreferencesFn: func(_ context.Context, _ string) (*Preferences, error) {
+			return nil, ErrPreferencesNotFound
+		},
+	}
+	h := newTestOptOutHandler(store)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	// POST opt-out
+	body, _ := json.Marshal(OptOutRequest{UserID: "u1", Scope: ScopeAll})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(
+		http.MethodPost, "/api/v1/privacy/opt-out", bytes.NewReader(body),
+	))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// DELETE opt-out
+	body, _ = json.Marshal(OptOutRequest{UserID: "u1", Scope: ScopeAll})
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(
+		http.MethodDelete, "/api/v1/privacy/opt-out", bytes.NewReader(body),
+	))
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+
+	// GET preferences (not found)
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(
+		http.MethodGet, "/api/v1/privacy/preferences/u1", nil,
+	))
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}

--- a/ee/pkg/privacy/store.go
+++ b/ee/pkg/privacy/store.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+// Opt-out scope constants.
+const (
+	ScopeAll       = "all"
+	ScopeWorkspace = "workspace"
+	ScopeAgent     = "agent"
+)
+
+// dbPool abstracts database operations for testability.
+type dbPool interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+// ErrPreferencesNotFound is returned when no privacy preferences exist for a user.
+var ErrPreferencesNotFound = errors.New("privacy: user preferences not found")
+
+// Preferences represents a user's privacy opt-out preferences.
+type Preferences struct {
+	UserID           string    `json:"userId"`
+	OptOutAll        bool      `json:"optOutAll"`
+	OptOutWorkspaces []string  `json:"optOutWorkspaces"`
+	OptOutAgents     []string  `json:"optOutAgents"`
+	CreatedAt        time.Time `json:"createdAt"`
+	UpdatedAt        time.Time `json:"updatedAt"`
+}
+
+// PreferencesStore defines the interface for privacy preference persistence.
+type PreferencesStore interface {
+	GetPreferences(ctx context.Context, userID string) (*Preferences, error)
+	SetOptOut(ctx context.Context, userID, scope, target string) error
+	RemoveOptOut(ctx context.Context, userID, scope, target string) error
+}
+
+// PreferencesPostgresStore implements PreferencesStore using PostgreSQL.
+type PreferencesPostgresStore struct {
+	pool dbPool
+}
+
+// NewPreferencesStore creates a new PreferencesPostgresStore.
+func NewPreferencesStore(pool dbPool) *PreferencesPostgresStore {
+	return &PreferencesPostgresStore{pool: pool}
+}
+
+// Compile-time interface check.
+var _ PreferencesStore = (*PreferencesPostgresStore)(nil)
+
+// GetPreferences retrieves privacy preferences for a user.
+func (s *PreferencesPostgresStore) GetPreferences(ctx context.Context, userID string) (*Preferences, error) {
+	p := &Preferences{UserID: userID}
+	err := s.pool.QueryRow(ctx,
+		`SELECT opt_out_all, opt_out_workspaces, opt_out_agents, created_at, updated_at
+		 FROM user_privacy_preferences WHERE user_id = $1`, userID,
+	).Scan(&p.OptOutAll, &p.OptOutWorkspaces, &p.OptOutAgents, &p.CreatedAt, &p.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrPreferencesNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	normalizeSlices(p)
+	return p, nil
+}
+
+// SetOptOut sets an opt-out preference for a user.
+func (s *PreferencesPostgresStore) SetOptOut(ctx context.Context, userID, scope, target string) error {
+	switch scope {
+	case ScopeAll:
+		return s.upsertOptOutAll(ctx, userID)
+	case ScopeWorkspace:
+		return s.upsertArrayElement(ctx, userID, "opt_out_workspaces", target)
+	case ScopeAgent:
+		return s.upsertArrayElement(ctx, userID, "opt_out_agents", target)
+	default:
+		return errors.New("privacy: invalid opt-out scope")
+	}
+}
+
+// RemoveOptOut removes an opt-out preference for a user.
+func (s *PreferencesPostgresStore) RemoveOptOut(ctx context.Context, userID, scope, target string) error {
+	switch scope {
+	case ScopeAll:
+		return s.clearOptOutAll(ctx, userID)
+	case ScopeWorkspace:
+		return s.removeArrayElement(ctx, userID, "opt_out_workspaces", target)
+	case ScopeAgent:
+		return s.removeArrayElement(ctx, userID, "opt_out_agents", target)
+	default:
+		return errors.New("privacy: invalid opt-out scope")
+	}
+}
+
+// normalizeSlices ensures nil slices become empty slices for JSON serialization.
+func normalizeSlices(p *Preferences) {
+	if p.OptOutWorkspaces == nil {
+		p.OptOutWorkspaces = []string{}
+	}
+	if p.OptOutAgents == nil {
+		p.OptOutAgents = []string{}
+	}
+}
+
+func (s *PreferencesPostgresStore) upsertOptOutAll(ctx context.Context, userID string) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO user_privacy_preferences (user_id, opt_out_all, updated_at)
+		 VALUES ($1, TRUE, NOW())
+		 ON CONFLICT (user_id) DO UPDATE SET opt_out_all = TRUE, updated_at = NOW()`,
+		userID)
+	return err
+}
+
+func (s *PreferencesPostgresStore) clearOptOutAll(ctx context.Context, userID string) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE user_privacy_preferences SET opt_out_all = FALSE, updated_at = NOW()
+		 WHERE user_id = $1`, userID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrPreferencesNotFound
+	}
+	return nil
+}
+
+func (s *PreferencesPostgresStore) upsertArrayElement(
+	ctx context.Context, userID, column, value string,
+) error {
+	//nolint:gosec // column is validated by the caller (SetOptOut switch)
+	query := `INSERT INTO user_privacy_preferences (user_id, ` + column + `, updated_at)
+		VALUES ($1, ARRAY[$2]::TEXT[], NOW())
+		ON CONFLICT (user_id) DO UPDATE SET
+			` + column + ` = CASE
+				WHEN $2 = ANY(user_privacy_preferences.` + column + `)
+				THEN user_privacy_preferences.` + column + `
+				ELSE array_append(user_privacy_preferences.` + column + `, $2)
+			END,
+			updated_at = NOW()`
+	_, err := s.pool.Exec(ctx, query, userID, value)
+	return err
+}
+
+func (s *PreferencesPostgresStore) removeArrayElement(
+	ctx context.Context, userID, column, value string,
+) error {
+	//nolint:gosec // column is validated by the caller (RemoveOptOut switch)
+	query := `UPDATE user_privacy_preferences SET
+		` + column + ` = array_remove(` + column + `, $2), updated_at = NOW()
+		WHERE user_id = $1`
+	tag, err := s.pool.Exec(ctx, query, userID, value)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrPreferencesNotFound
+	}
+	return nil
+}

--- a/ee/pkg/privacy/store_test.go
+++ b/ee/pkg/privacy/store_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// prefsMockRow implements pgx.Row for testing.
+type prefsMockRow struct {
+	scanFn func(dest ...any) error
+}
+
+func (r *prefsMockRow) Scan(dest ...any) error {
+	return r.scanFn(dest...)
+}
+
+// prefsMockPool implements dbPool for testing preferences store.
+type prefsMockPool struct {
+	execFn     func(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	queryRowFn func(ctx context.Context, sql string, args ...any) pgx.Row
+}
+
+func (m *prefsMockPool) Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error) {
+	return m.execFn(ctx, sql, arguments...)
+}
+
+func (m *prefsMockPool) QueryRow(ctx context.Context, sql string, args ...any) pgx.Row {
+	return m.queryRowFn(ctx, sql, args...)
+}
+
+func TestGetPreferences_Found(t *testing.T) {
+	now := time.Now().UTC()
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*bool) = true
+				*dest[1].(*[]string) = []string{"ws1"}
+				*dest[2].(*[]string) = []string{"agent1"}
+				*dest[3].(*time.Time) = now
+				*dest[4].(*time.Time) = now
+				return nil
+			}}
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	prefs, err := store.GetPreferences(context.Background(), "user1")
+	require.NoError(t, err)
+	assert.Equal(t, "user1", prefs.UserID)
+	assert.True(t, prefs.OptOutAll)
+	assert.Equal(t, []string{"ws1"}, prefs.OptOutWorkspaces)
+	assert.Equal(t, []string{"agent1"}, prefs.OptOutAgents)
+}
+
+func TestGetPreferences_NotFound(t *testing.T) {
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(_ ...any) error {
+				return pgx.ErrNoRows
+			}}
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	_, err := store.GetPreferences(context.Background(), "missing")
+	assert.ErrorIs(t, err, ErrPreferencesNotFound)
+}
+
+func TestGetPreferences_NilSlices(t *testing.T) {
+	now := time.Now().UTC()
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*bool) = false
+				*dest[1].(*[]string) = nil
+				*dest[2].(*[]string) = nil
+				*dest[3].(*time.Time) = now
+				*dest[4].(*time.Time) = now
+				return nil
+			}}
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	prefs, err := store.GetPreferences(context.Background(), "user1")
+	require.NoError(t, err)
+	assert.NotNil(t, prefs.OptOutWorkspaces)
+	assert.NotNil(t, prefs.OptOutAgents)
+	assert.Empty(t, prefs.OptOutWorkspaces)
+	assert.Empty(t, prefs.OptOutAgents)
+}
+
+func TestGetPreferences_DBError(t *testing.T) {
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(_ ...any) error {
+				return errors.New("connection refused")
+			}}
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	_, err := store.GetPreferences(context.Background(), "user1")
+	assert.Error(t, err)
+	assert.NotErrorIs(t, err, ErrPreferencesNotFound)
+}
+
+func TestSetOptOut_All(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.SetOptOut(context.Background(), "user1", ScopeAll, "")
+	assert.NoError(t, err)
+}
+
+func TestSetOptOut_Workspace(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.SetOptOut(context.Background(), "user1", ScopeWorkspace, "ws1")
+	assert.NoError(t, err)
+}
+
+func TestSetOptOut_Agent(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.SetOptOut(context.Background(), "user1", ScopeAgent, "agent1")
+	assert.NoError(t, err)
+}
+
+func TestSetOptOut_InvalidScope(t *testing.T) {
+	store := NewPreferencesStore(&prefsMockPool{})
+	err := store.SetOptOut(context.Background(), "user1", "invalid", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid opt-out scope")
+}
+
+func TestRemoveOptOut_All(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.RemoveOptOut(context.Background(), "user1", ScopeAll, "")
+	assert.NoError(t, err)
+}
+
+func TestRemoveOptOut_All_NotFound(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 0"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.RemoveOptOut(context.Background(), "missing", ScopeAll, "")
+	assert.ErrorIs(t, err, ErrPreferencesNotFound)
+}
+
+func TestRemoveOptOut_Workspace(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.RemoveOptOut(context.Background(), "user1", ScopeWorkspace, "ws1")
+	assert.NoError(t, err)
+}
+
+func TestRemoveOptOut_Agent(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.RemoveOptOut(context.Background(), "user1", ScopeAgent, "agent1")
+	assert.NoError(t, err)
+}
+
+func TestRemoveOptOut_InvalidScope(t *testing.T) {
+	store := NewPreferencesStore(&prefsMockPool{})
+	err := store.RemoveOptOut(context.Background(), "user1", "invalid", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid opt-out scope")
+}
+
+func TestRemoveOptOut_DBError(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.CommandTag{}, errors.New("connection refused")
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.RemoveOptOut(context.Background(), "user1", ScopeWorkspace, "ws1")
+	assert.Error(t, err)
+}
+
+func TestSetOptOut_ExecError(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.CommandTag{}, errors.New("connection refused")
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.SetOptOut(context.Background(), "user1", ScopeAll, "")
+	assert.Error(t, err)
+}

--- a/internal/session/postgres/migrations/000009_create_privacy_preferences.down.sql
+++ b/internal/session/postgres/migrations/000009_create_privacy_preferences.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_privacy_prefs_updated;
+DROP TABLE IF EXISTS user_privacy_preferences;

--- a/internal/session/postgres/migrations/000009_create_privacy_preferences.up.sql
+++ b/internal/session/postgres/migrations/000009_create_privacy_preferences.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS user_privacy_preferences (
+  user_id TEXT PRIMARY KEY,
+  opt_out_all BOOLEAN DEFAULT FALSE,
+  opt_out_workspaces TEXT[] DEFAULT '{}',
+  opt_out_agents TEXT[] DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX idx_privacy_prefs_updated ON user_privacy_preferences(updated_at);

--- a/internal/session/postgres/migrator_test.go
+++ b/internal/session/postgres/migrator_test.go
@@ -138,7 +138,7 @@ func replaceDBName(connStr, newDB string) string {
 func TestMigrationFS_ContainsMigrations(t *testing.T) {
 	entries, err := MigrationFS.ReadDir("migrations")
 	require.NoError(t, err)
-	assert.GreaterOrEqual(t, len(entries), 16, "should have at least 16 migration files (8 up + 8 down)")
+	assert.GreaterOrEqual(t, len(entries), 18, "should have at least 18 migration files (9 up + 9 down)")
 
 	// Verify expected migration files exist
 	expected := []string{
@@ -152,6 +152,8 @@ func TestMigrationFS_ContainsMigrations(t *testing.T) {
 		"000007_add_audit_log_partitions.down.sql",
 		"000008_tool_call_id_to_text.up.sql",
 		"000008_tool_call_id_to_text.down.sql",
+		"000009_create_privacy_preferences.up.sql",
+		"000009_create_privacy_preferences.down.sql",
 	}
 	names := make(map[string]bool)
 	for _, e := range entries {
@@ -188,7 +190,7 @@ func TestMigrator_UpDown(t *testing.T) {
 	// Verify version
 	v, dirty, err := mg.Version()
 	require.NoError(t, err)
-	assert.Equal(t, uint(8), v)
+	assert.Equal(t, uint(9), v)
 	assert.False(t, dirty)
 
 	// Idempotent — running Up again should succeed


### PR DESCRIPTION
## Summary

- Add `user_privacy_preferences` PostgreSQL table (migration 000009) to store per-user opt-out preferences at global, workspace, and agent scope
- Implement `PreferencesStore` interface with PostgreSQL backend for get/set/remove opt-out operations using array columns and upserts
- Add `ShouldRecord` gating function that checks user preferences before session recording (fail-open on errors)
- Add REST API endpoints: `POST /api/v1/privacy/opt-out`, `DELETE /api/v1/privacy/opt-out`, `GET /api/v1/privacy/preferences/{userID}`
- Wire opt-out handler into session-api when enterprise mode is enabled

## Test plan

- [x] Store tests cover get, set (all/workspace/agent), remove, upsert idempotency, and error paths (95.1% coverage)
- [x] Check tests cover all opt-out scopes (all, workspace, agent), no-match, store errors, and no-preferences scenarios (100% coverage)
- [x] Handler tests cover all endpoints, validation errors, method routing, store errors, and successful responses (96.4% coverage)
- [x] Migrator test updated for new migration count and expected version
- [ ] Verify CI passes (lint, tests, SonarCloud quality gate)

Closes #374