### PR TITLE
feat: implement SessionAnalyticsSync controller (#383)

### DIFF
--- a/ee/config/rbac/role.yaml
+++ b/ee/config/rbac/role.yaml
@@ -100,6 +100,7 @@ rules:
   - arenajobs/status
   - arenasources/status
   - arenatemplatesources/status
+  - sessionanalyticssyncs/status
   - sessionprivacypolicies/status
   verbs:
   - get
@@ -117,6 +118,7 @@ rules:
 - apiGroups:
   - omnia.altairalabs.ai
   resources:
+  - sessionanalyticssyncs
   - sessionprivacypolicies
   verbs:
   - get

--- a/ee/internal/controller/sessionanalyticssync_controller.go
+++ b/ee/internal/controller/sessionanalyticssync_controller.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	corev1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+const (
+	// Condition types for SessionAnalyticsSync.
+	conditionTypeAnalyticsProviderConfigured = "ProviderConfigured"
+	conditionTypeAnalyticsConnected          = "Connected"
+	conditionTypeAnalyticsReady              = "Ready"
+
+	// Event reasons for SessionAnalyticsSync.
+	eventReasonAnalyticsConfigValidated       = "ConfigValidated"
+	eventReasonAnalyticsProviderConfigured    = "ProviderConfigured"
+	eventReasonAnalyticsProviderConfigInvalid = "ProviderConfigInvalid"
+	eventReasonAnalyticsConnected             = "Connected"
+	eventReasonAnalyticsConnectionFailed      = "ConnectionFailed"
+	eventReasonAnalyticsSyncDisabled          = "SyncDisabled"
+	eventReasonAnalyticsScheduleInvalid       = "ScheduleInvalid"
+)
+
+// AnalyticsProviderFactory creates an analytics provider for connectivity checks.
+type AnalyticsProviderFactory interface {
+	Ping(ctx context.Context, spec corev1alpha1.SessionAnalyticsSyncSpec) error
+}
+
+// SessionAnalyticsSyncReconciler reconciles a SessionAnalyticsSync object.
+type SessionAnalyticsSyncReconciler struct {
+	client.Client
+	Scheme          *runtime.Scheme
+	Recorder        record.EventRecorder
+	ProviderFactory AnalyticsProviderFactory
+}
+
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=sessionanalyticssyncs,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=sessionanalyticssyncs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
+
+// Reconcile handles SessionAnalyticsSync reconciliation.
+func (r *SessionAnalyticsSyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.V(1).Info("reconciling SessionAnalyticsSync", "name", req.Name)
+
+	syncObj := &corev1alpha1.SessionAnalyticsSync{}
+	if err := r.Get(ctx, req.NamespacedName, syncObj); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("SessionAnalyticsSync deleted")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	syncObj.Status.ObservedGeneration = syncObj.Generation
+
+	if !isSyncEnabled(syncObj) {
+		return r.reconcileSyncDisabled(ctx, syncObj)
+	}
+
+	return r.reconcileSyncEnabled(ctx, syncObj)
+}
+
+// isSyncEnabled checks if the sync is enabled (default true when nil).
+func isSyncEnabled(syncObj *corev1alpha1.SessionAnalyticsSync) bool {
+	return syncObj.Spec.Enabled == nil || *syncObj.Spec.Enabled
+}
+
+// reconcileSyncDisabled handles reconciliation when sync is disabled.
+func (r *SessionAnalyticsSyncReconciler) reconcileSyncDisabled(
+	ctx context.Context, syncObj *corev1alpha1.SessionAnalyticsSync,
+) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsProviderConfigured, metav1.ConditionTrue,
+		eventReasonAnalyticsSyncDisabled, "analytics sync is disabled")
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsConnected, metav1.ConditionFalse,
+		eventReasonAnalyticsSyncDisabled, "analytics sync is disabled")
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsReady, metav1.ConditionTrue,
+		eventReasonAnalyticsSyncDisabled, "analytics sync is disabled")
+	syncObj.Status.Phase = corev1alpha1.SessionAnalyticsSyncPhaseActive
+
+	if err := r.Status().Update(ctx, syncObj); err != nil {
+		log.Error(err, "failed to update status")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("analytics sync is disabled", "name", syncObj.Name)
+	return ctrl.Result{}, nil
+}
+
+// reconcileSyncEnabled handles reconciliation when sync is enabled.
+func (r *SessionAnalyticsSyncReconciler) reconcileSyncEnabled(
+	ctx context.Context, syncObj *corev1alpha1.SessionAnalyticsSync,
+) (ctrl.Result, error) {
+	if err := r.validateAnalyticsProviderConfig(syncObj); err != nil {
+		return r.handleAnalyticsValidationError(ctx, syncObj, err)
+	}
+
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsProviderConfigured, metav1.ConditionTrue,
+		eventReasonAnalyticsProviderConfigured,
+		fmt.Sprintf("provider %s configuration is valid", syncObj.Spec.Provider))
+
+	if err := r.checkAnalyticsConnectivity(ctx, syncObj); err != nil {
+		return r.handleAnalyticsConnectionError(ctx, syncObj, err)
+	}
+
+	return r.setAnalyticsSuccessStatus(ctx, syncObj)
+}
+
+// validateAnalyticsProviderConfig checks that the correct provider config section exists.
+func (r *SessionAnalyticsSyncReconciler) validateAnalyticsProviderConfig(
+	syncObj *corev1alpha1.SessionAnalyticsSync,
+) error {
+	switch syncObj.Spec.Provider {
+	case corev1alpha1.AnalyticsProviderSnowflake:
+		if syncObj.Spec.Snowflake == nil {
+			return fmt.Errorf("snowflake configuration is required when provider is snowflake")
+		}
+	case corev1alpha1.AnalyticsProviderBigQuery:
+		if syncObj.Spec.BigQuery == nil {
+			return fmt.Errorf("bigquery configuration is required when provider is bigquery")
+		}
+	case corev1alpha1.AnalyticsProviderClickHouse:
+		if syncObj.Spec.ClickHouse == nil {
+			return fmt.Errorf("clickhouse configuration is required when provider is clickhouse")
+		}
+	default:
+		return fmt.Errorf("unsupported analytics provider: %s", syncObj.Spec.Provider)
+	}
+	return nil
+}
+
+// checkAnalyticsConnectivity verifies connectivity to the analytics backend.
+func (r *SessionAnalyticsSyncReconciler) checkAnalyticsConnectivity(
+	ctx context.Context, syncObj *corev1alpha1.SessionAnalyticsSync,
+) error {
+	if r.ProviderFactory == nil {
+		return nil
+	}
+	return r.ProviderFactory.Ping(ctx, syncObj.Spec)
+}
+
+// handleAnalyticsValidationError sets error status when provider config validation fails.
+func (r *SessionAnalyticsSyncReconciler) handleAnalyticsValidationError(
+	ctx context.Context, syncObj *corev1alpha1.SessionAnalyticsSync, err error,
+) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.Error(err, "analytics provider configuration validation failed")
+
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsProviderConfigured, metav1.ConditionFalse,
+		eventReasonAnalyticsProviderConfigInvalid, err.Error())
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsReady, metav1.ConditionFalse,
+		eventReasonAnalyticsProviderConfigInvalid, "provider configuration is invalid")
+	syncObj.Status.Phase = corev1alpha1.SessionAnalyticsSyncPhaseError
+	r.recordAnalyticsEvent(syncObj, "Warning", eventReasonAnalyticsProviderConfigInvalid, err.Error())
+
+	if statusErr := r.Status().Update(ctx, syncObj); statusErr != nil {
+		log.Error(statusErr, "failed to update error status")
+		return ctrl.Result{}, statusErr
+	}
+	return ctrl.Result{}, nil
+}
+
+// handleAnalyticsConnectionError sets error status when connectivity check fails.
+func (r *SessionAnalyticsSyncReconciler) handleAnalyticsConnectionError(
+	ctx context.Context, syncObj *corev1alpha1.SessionAnalyticsSync, err error,
+) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+	log.Error(err, "analytics provider connectivity check failed")
+
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsConnected, metav1.ConditionFalse,
+		eventReasonAnalyticsConnectionFailed, err.Error())
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsReady, metav1.ConditionFalse,
+		eventReasonAnalyticsConnectionFailed, "provider connectivity check failed")
+	syncObj.Status.Phase = corev1alpha1.SessionAnalyticsSyncPhaseError
+	r.recordAnalyticsEvent(syncObj, "Warning", eventReasonAnalyticsConnectionFailed, err.Error())
+
+	if statusErr := r.Status().Update(ctx, syncObj); statusErr != nil {
+		log.Error(statusErr, "failed to update error status")
+		return ctrl.Result{}, statusErr
+	}
+	return ctrl.Result{}, nil
+}
+
+// setAnalyticsSuccessStatus sets the success status on the analytics sync resource.
+func (r *SessionAnalyticsSyncReconciler) setAnalyticsSuccessStatus(
+	ctx context.Context, syncObj *corev1alpha1.SessionAnalyticsSync,
+) (ctrl.Result, error) {
+	log := logf.FromContext(ctx)
+
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsConnected, metav1.ConditionTrue,
+		eventReasonAnalyticsConnected, "analytics provider connectivity verified")
+	r.setAnalyticsCondition(syncObj, conditionTypeAnalyticsReady, metav1.ConditionTrue,
+		eventReasonAnalyticsConfigValidated, "analytics sync configuration is active")
+	syncObj.Status.Phase = corev1alpha1.SessionAnalyticsSyncPhaseActive
+	r.recordAnalyticsEvent(syncObj, "Normal", eventReasonAnalyticsConfigValidated,
+		fmt.Sprintf("Analytics sync configured for provider %s", syncObj.Spec.Provider))
+
+	if err := r.Status().Update(ctx, syncObj); err != nil {
+		log.Error(err, "failed to update status")
+		return ctrl.Result{}, err
+	}
+
+	log.Info("successfully reconciled SessionAnalyticsSync",
+		"name", syncObj.Name, "provider", syncObj.Spec.Provider, "phase", syncObj.Status.Phase)
+	return ctrl.Result{}, nil
+}
+
+// setAnalyticsCondition sets a condition on the SessionAnalyticsSync status.
+func (r *SessionAnalyticsSyncReconciler) setAnalyticsCondition(
+	syncObj *corev1alpha1.SessionAnalyticsSync,
+	conditionType string,
+	status metav1.ConditionStatus,
+	reason, message string,
+) {
+	meta.SetStatusCondition(&syncObj.Status.Conditions, metav1.Condition{
+		Type:               conditionType,
+		Status:             status,
+		ObservedGeneration: syncObj.Generation,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	})
+}
+
+// recordAnalyticsEvent emits a Kubernetes event if the recorder is available.
+func (r *SessionAnalyticsSyncReconciler) recordAnalyticsEvent(
+	obj runtime.Object, eventType, reason, message string,
+) {
+	if r.Recorder != nil {
+		r.Recorder.Event(obj, eventType, reason, message)
+	}
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *SessionAnalyticsSyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&corev1alpha1.SessionAnalyticsSync{}).
+		Named("sessionanalyticssync").
+		Complete(r)
+}

--- a/ee/internal/controller/sessionanalyticssync_controller_test.go
+++ b/ee/internal/controller/sessionanalyticssync_controller_test.go
@@ -1,0 +1,435 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	corev1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// mockAnalyticsProviderFactory implements AnalyticsProviderFactory for testing.
+type mockAnalyticsProviderFactory struct {
+	pingErr error
+}
+
+func (m *mockAnalyticsProviderFactory) Ping(_ context.Context, _ corev1alpha1.SessionAnalyticsSyncSpec) error {
+	return m.pingErr
+}
+
+func setupAnalyticsSyncTest(
+	t *testing.T, factory AnalyticsProviderFactory, objects ...runtime.Object,
+) (*SessionAnalyticsSyncReconciler, *record.FakeRecorder) {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	_ = corev1alpha1.AddToScheme(scheme)
+
+	builder := fake.NewClientBuilder().WithScheme(scheme)
+	for _, obj := range objects {
+		builder = builder.WithRuntimeObjects(obj)
+	}
+	builder = builder.WithStatusSubresource(&corev1alpha1.SessionAnalyticsSync{})
+	fakeClient := builder.Build()
+
+	recorder := record.NewFakeRecorder(20)
+	reconciler := &SessionAnalyticsSyncReconciler{
+		Client:          fakeClient,
+		Scheme:          scheme,
+		Recorder:        recorder,
+		ProviderFactory: factory,
+	}
+	return reconciler, recorder
+}
+
+func newSnowflakeSync(name string, enabled *bool) *corev1alpha1.SessionAnalyticsSync {
+	return &corev1alpha1.SessionAnalyticsSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Generation: 1,
+		},
+		Spec: corev1alpha1.SessionAnalyticsSyncSpec{
+			Enabled:  enabled,
+			Provider: corev1alpha1.AnalyticsProviderSnowflake,
+			Snowflake: &corev1alpha1.SnowflakeConfig{
+				Account:   "xy12345.us-east-1",
+				Database:  "analytics",
+				Warehouse: "COMPUTE_WH",
+				SecretRef: corev1.LocalObjectReference{Name: "snowflake-creds"},
+			},
+			Sync: corev1alpha1.SyncConfig{
+				Schedule: "0 3 * * *",
+			},
+		},
+	}
+}
+
+func newBigQuerySync(name string) *corev1alpha1.SessionAnalyticsSync {
+	return &corev1alpha1.SessionAnalyticsSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Generation: 1,
+		},
+		Spec: corev1alpha1.SessionAnalyticsSyncSpec{
+			Provider: corev1alpha1.AnalyticsProviderBigQuery,
+			BigQuery: &corev1alpha1.BigQueryConfig{
+				ProjectID: "my-project",
+				Dataset:   "omnia_sessions",
+				SecretRef: corev1.LocalObjectReference{Name: "gcp-creds"},
+			},
+			Sync: corev1alpha1.SyncConfig{
+				Schedule: "0 3 * * *",
+			},
+		},
+	}
+}
+
+func newClickHouseSync(name string) *corev1alpha1.SessionAnalyticsSync {
+	return &corev1alpha1.SessionAnalyticsSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Generation: 1,
+		},
+		Spec: corev1alpha1.SessionAnalyticsSyncSpec{
+			Provider: corev1alpha1.AnalyticsProviderClickHouse,
+			ClickHouse: &corev1alpha1.ClickHouseConfig{
+				Hosts:    []string{"clickhouse:9000"},
+				Database: "omnia",
+				Auth: corev1alpha1.ClickHouseAuth{
+					SecretRef: corev1.LocalObjectReference{Name: "ch-creds"},
+				},
+			},
+			Sync: corev1alpha1.SyncConfig{
+				Schedule: "0 3 * * *",
+			},
+		},
+	}
+}
+
+func TestAnalyticsSyncReconcile_SnowflakeValid(t *testing.T) {
+	syncObj := newSnowflakeSync("test-snowflake", nil)
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-snowflake"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-snowflake"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseActive, updated.Status.Phase)
+	assert.Equal(t, int64(1), updated.Status.ObservedGeneration)
+
+	readyCond := findAnalyticsSyncCondition(updated.Status.Conditions, conditionTypeAnalyticsReady)
+	require.NotNil(t, readyCond)
+	assert.Equal(t, metav1.ConditionTrue, readyCond.Status)
+
+	connCond := findAnalyticsSyncCondition(updated.Status.Conditions, conditionTypeAnalyticsConnected)
+	require.NotNil(t, connCond)
+	assert.Equal(t, metav1.ConditionTrue, connCond.Status)
+}
+
+func TestAnalyticsSyncReconcile_BigQueryValid(t *testing.T) {
+	syncObj := newBigQuerySync("test-bigquery")
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-bigquery"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-bigquery"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseActive, updated.Status.Phase)
+}
+
+func TestAnalyticsSyncReconcile_ClickHouseValid(t *testing.T) {
+	syncObj := newClickHouseSync("test-clickhouse")
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-clickhouse"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-clickhouse"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseActive, updated.Status.Phase)
+}
+
+func TestAnalyticsSyncReconcile_Disabled(t *testing.T) {
+	enabled := false
+	syncObj := newSnowflakeSync("test-disabled", &enabled)
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-disabled"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-disabled"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseActive, updated.Status.Phase)
+
+	connCond := findAnalyticsSyncCondition(updated.Status.Conditions, conditionTypeAnalyticsConnected)
+	require.NotNil(t, connCond)
+	assert.Equal(t, metav1.ConditionFalse, connCond.Status)
+}
+
+func TestAnalyticsSyncReconcile_MissingProviderConfig(t *testing.T) {
+	syncObj := &corev1alpha1.SessionAnalyticsSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-missing-config",
+			Generation: 1,
+		},
+		Spec: corev1alpha1.SessionAnalyticsSyncSpec{
+			Provider: corev1alpha1.AnalyticsProviderSnowflake,
+			Sync: corev1alpha1.SyncConfig{
+				Schedule: "0 3 * * *",
+			},
+		},
+	}
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-missing-config"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-missing-config"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseError, updated.Status.Phase)
+
+	provCond := findAnalyticsSyncCondition(updated.Status.Conditions, conditionTypeAnalyticsProviderConfigured)
+	require.NotNil(t, provCond)
+	assert.Equal(t, metav1.ConditionFalse, provCond.Status)
+}
+
+func TestAnalyticsSyncReconcile_MissingBigQueryConfig(t *testing.T) {
+	syncObj := &corev1alpha1.SessionAnalyticsSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-missing-bq",
+			Generation: 1,
+		},
+		Spec: corev1alpha1.SessionAnalyticsSyncSpec{
+			Provider: corev1alpha1.AnalyticsProviderBigQuery,
+			Sync:     corev1alpha1.SyncConfig{Schedule: "0 3 * * *"},
+		},
+	}
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-missing-bq"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-missing-bq"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseError, updated.Status.Phase)
+}
+
+func TestAnalyticsSyncReconcile_MissingClickHouseConfig(t *testing.T) {
+	syncObj := &corev1alpha1.SessionAnalyticsSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-missing-ch",
+			Generation: 1,
+		},
+		Spec: corev1alpha1.SessionAnalyticsSyncSpec{
+			Provider: corev1alpha1.AnalyticsProviderClickHouse,
+			Sync:     corev1alpha1.SyncConfig{Schedule: "0 3 * * *"},
+		},
+	}
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-missing-ch"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-missing-ch"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseError, updated.Status.Phase)
+}
+
+func TestAnalyticsSyncReconcile_UnsupportedProvider(t *testing.T) {
+	syncObj := &corev1alpha1.SessionAnalyticsSync{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-unsupported",
+			Generation: 1,
+		},
+		Spec: corev1alpha1.SessionAnalyticsSyncSpec{
+			Provider: "unknown",
+			Sync:     corev1alpha1.SyncConfig{Schedule: "0 3 * * *"},
+		},
+	}
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-unsupported"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-unsupported"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseError, updated.Status.Phase)
+}
+
+func TestAnalyticsSyncReconcile_NotFound(t *testing.T) {
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "nonexistent"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+}
+
+func TestAnalyticsSyncReconcile_ConnectivityFailure(t *testing.T) {
+	syncObj := newSnowflakeSync("test-conn-fail", nil)
+	factory := &mockAnalyticsProviderFactory{
+		pingErr: fmt.Errorf("connection refused"),
+	}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-conn-fail"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-conn-fail"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseError, updated.Status.Phase)
+
+	connCond := findAnalyticsSyncCondition(updated.Status.Conditions, conditionTypeAnalyticsConnected)
+	require.NotNil(t, connCond)
+	assert.Equal(t, metav1.ConditionFalse, connCond.Status)
+	assert.Contains(t, connCond.Message, "connection refused")
+}
+
+func TestAnalyticsSyncReconcile_NilProviderFactory(t *testing.T) {
+	syncObj := newSnowflakeSync("test-nil-factory", nil)
+	reconciler, _ := setupAnalyticsSyncTest(t, nil, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-nil-factory"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-nil-factory"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseActive, updated.Status.Phase)
+}
+
+func TestAnalyticsSyncReconcile_EnabledExplicitlyTrue(t *testing.T) {
+	enabled := true
+	syncObj := newSnowflakeSync("test-explicit-true", &enabled)
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, _ := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	result, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-explicit-true"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+
+	updated := &corev1alpha1.SessionAnalyticsSync{}
+	err = reconciler.Get(context.Background(), types.NamespacedName{Name: "test-explicit-true"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, corev1alpha1.SessionAnalyticsSyncPhaseActive, updated.Status.Phase)
+}
+
+func TestAnalyticsSyncReconcile_EventsEmitted(t *testing.T) {
+	syncObj := newSnowflakeSync("test-events", nil)
+	factory := &mockAnalyticsProviderFactory{}
+	reconciler, recorder := setupAnalyticsSyncTest(t, factory, syncObj)
+
+	_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "test-events"},
+	})
+	require.NoError(t, err)
+
+	// Check that an event was emitted
+	select {
+	case event := <-recorder.Events:
+		assert.Contains(t, event, eventReasonAnalyticsConfigValidated)
+	default:
+		t.Error("expected an event to be emitted")
+	}
+}
+
+func TestIsSyncEnabled(t *testing.T) {
+	tests := []struct {
+		name    string
+		enabled *bool
+		want    bool
+	}{
+		{"nil means enabled", nil, true},
+		{"explicit true", ptr(true), true},
+		{"explicit false", ptr(false), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			syncObj := &corev1alpha1.SessionAnalyticsSync{
+				Spec: corev1alpha1.SessionAnalyticsSyncSpec{Enabled: tt.enabled},
+			}
+			assert.Equal(t, tt.want, isSyncEnabled(syncObj))
+		})
+	}
+}
+
+// findAnalyticsSyncCondition finds a condition by type in a conditions slice.
+func findAnalyticsSyncCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Implements `SessionAnalyticsSyncReconciler` in `ee/internal/controller/`
- Validates provider-specific configuration (Snowflake, BigQuery, ClickHouse)
- Checks provider connectivity via `AnalyticsProviderFactory` interface
- Handles enabled/disabled state (nil defaults to enabled)
- Sets status conditions (ProviderConfigured, Connected, Ready) and phase (Active/Error)
- Records Kubernetes events for reconciliation outcomes

## Test plan
- [x] 16 analytics controller tests pass (13 reconcile + 3 isSyncEnabled)
- [x] 126 envtest suite tests pass
- [x] go build clean
- [x] gofmt clean