### PR TITLE
feat: add OTLP ingestion endpoint to session-api

### DIFF
--- a/charts/omnia/templates/session-api/deployment.yaml
+++ b/charts/omnia/templates/session-api/deployment.yaml
@@ -66,6 +66,14 @@ spec:
             - name: ENTERPRISE_ENABLED
               value: "true"
             {{- end }}
+            {{- if .Values.sessionApi.otlp.enabled }}
+            - name: OTLP_ENABLED
+              value: "true"
+            - name: OTLP_GRPC_ADDR
+              value: ":{{ .Values.sessionApi.otlp.grpcPort }}"
+            - name: OTLP_HTTP_ADDR
+              value: ":{{ .Values.sessionApi.otlp.httpPort }}"
+            {{- end }}
             {{- with .Values.sessionApi.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -79,6 +87,14 @@ spec:
             - name: metrics
               containerPort: 9090
               protocol: TCP
+            {{- if .Values.sessionApi.otlp.enabled }}
+            - name: otlp-grpc
+              containerPort: {{ .Values.sessionApi.otlp.grpcPort }}
+              protocol: TCP
+            - name: otlp-http
+              containerPort: {{ .Values.sessionApi.otlp.httpPort }}
+              protocol: TCP
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/omnia/templates/session-api/service.yaml
+++ b/charts/omnia/templates/session-api/service.yaml
@@ -12,6 +12,16 @@ spec:
       targetPort: api
       protocol: TCP
       name: api
+    {{- if .Values.sessionApi.otlp.enabled }}
+    - port: {{ .Values.sessionApi.otlp.grpcPort }}
+      targetPort: otlp-grpc
+      protocol: TCP
+      name: otlp-grpc
+    - port: {{ .Values.sessionApi.otlp.httpPort }}
+      targetPort: otlp-http
+      protocol: TCP
+      name: otlp-http
+    {{- end }}
   selector:
     {{- include "omnia.sessionApi.selectorLabels" . | nindent 4 }}
 {{- end }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -700,6 +700,14 @@ sessionApi:
   affinity: {}
   # -- Topology spread constraints for distributing pods across failure domains
   topologySpreadConstraints: []
+  # OTLP ingestion endpoint for external agent frameworks
+  otlp:
+    # -- Enable OTLP trace ingestion (gRPC + HTTP)
+    enabled: false
+    # -- gRPC listen port (standard OTLP port)
+    grpcPort: 4317
+    # -- HTTP listen port (standard OTLP port)
+    httpPort: 4318
   # -- Additional environment variables for the session-api container
   extraEnv: []
 

--- a/docs/src/content/docs/how-to/configure-otlp-ingestion.md
+++ b/docs/src/content/docs/how-to/configure-otlp-ingestion.md
@@ -1,0 +1,264 @@
+---
+title: "Ingest Traces from External Agents"
+description: "Send OpenTelemetry GenAI traces from LangChain, OpenAI, AWS Bedrock, and other frameworks to Omnia"
+---
+
+Omnia's session-api includes an OTLP ingestion endpoint that accepts OpenTelemetry traces and converts them into session data. This lets any OTel-instrumented agent framework record conversations in Omnia without using the Omnia-specific WebSocket facade.
+
+## Overview
+
+```
+External agents (LangChain, CrewAI, OpenAI SDK, AWS Bedrock, etc.)
+    |
+    |  OTLP/HTTP (JSON or Protobuf)  :4318/v1/traces
+    |  OTLP/gRPC (Protobuf)          :4317
+    |
+    v
+Session API  -->  Transformer  -->  Session Store (Postgres)
+```
+
+The endpoint supports:
+
+- **OTLP/HTTP** with `application/json` or `application/x-protobuf` (recommended for external agents)
+- **OTLP/gRPC** (recommended for in-cluster sidecars)
+- All three generations of OTel GenAI semantic conventions (current, deprecated, and legacy OpenLLMetry)
+
+## Enable OTLP Ingestion
+
+OTLP is disabled by default. Enable it in your Helm values:
+
+```yaml
+sessionApi:
+  otlp:
+    enabled: true
+    grpcPort: 4317  # standard OTLP gRPC port
+    httpPort: 4318  # standard OTLP HTTP port
+```
+
+Deploy the update:
+
+```bash
+helm upgrade omnia oci://ghcr.io/altairalabs/omnia \
+  --namespace omnia-system \
+  -f values.yaml
+```
+
+The session-api pods will now expose two additional ports for OTLP ingestion.
+
+## Send Traces from Python (OpenAI SDK)
+
+The simplest way to test is with the OpenTelemetry Python SDK:
+
+```bash
+pip install opentelemetry-api opentelemetry-sdk \
+  opentelemetry-exporter-otlp-proto-http
+```
+
+```python
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+
+resource = Resource.create({
+    "service.name": "my-agent",
+    "service.namespace": "default",
+})
+provider = TracerProvider(resource=resource)
+exporter = OTLPSpanExporter(
+    endpoint="http://omnia-session-api.omnia-system:4318/v1/traces"
+)
+provider.add_span_processor(BatchSpanProcessor(exporter))
+trace.set_tracer_provider(provider)
+
+tracer = trace.get_tracer("my-agent")
+with tracer.start_as_current_span("chat gpt-4") as span:
+    span.set_attribute("gen_ai.conversation.id", "conv-123")
+    span.set_attribute("gen_ai.request.model", "gpt-4")
+    span.set_attribute("gen_ai.provider.name", "openai")
+    span.set_attribute("gen_ai.usage.input_tokens", 150)
+    span.set_attribute("gen_ai.usage.output_tokens", 75)
+
+provider.shutdown()
+```
+
+## Send Traces from LangChain (via OpenLLMetry)
+
+[OpenLLMetry](https://github.com/traceloop/openllmetry) is the most popular OpenTelemetry instrumentation for LLM frameworks. It auto-instruments LangChain, OpenAI, Anthropic, and more.
+
+```bash
+pip install traceloop-sdk
+```
+
+```python
+from traceloop.sdk import Traceloop
+
+Traceloop.init(
+    app_name="my-langchain-agent",
+    api_endpoint="http://omnia-session-api.omnia-system:4318",
+    disable_batch=False,
+)
+```
+
+OpenLLMetry uses the legacy indexed attribute format (`gen_ai.prompt.0.role`, `gen_ai.prompt.0.content`, etc.). Omnia supports this format natively.
+
+> **Tip**: Set `TRACELOOP_TRACE_CONTENT=true` to include message content in traces. Without it, only token counts and metadata are captured.
+
+## Send Traces from AWS Bedrock (via ADOT)
+
+AWS Distro for OpenTelemetry (ADOT) works with the standard OTLP exporter. Configure the OTLP endpoint in your ADOT collector config:
+
+```yaml
+exporters:
+  otlphttp:
+    endpoint: "http://omnia-session-api.omnia-system:4318"
+
+service:
+  pipelines:
+    traces:
+      exporters: [otlphttp]
+```
+
+For Python agents using Bedrock with the OpenTelemetry SDK directly:
+
+```python
+import os
+os.environ["OTEL_EXPORTER_OTLP_ENDPOINT"] = "http://omnia-session-api.omnia-system:4318"
+os.environ["OTEL_SERVICE_NAME"] = "bedrock-agent"
+```
+
+AWS Bedrock emits `gen_ai.system = "aws.bedrock"` following the OTel GenAI semantic conventions.
+
+## Session Identification
+
+Omnia resolves a session ID from spans using this priority chain:
+
+1. `gen_ai.conversation.id` (OTel GenAI convention)
+2. `session.id` (span attribute)
+3. `langfuse.session.id` (Langfuse convention)
+4. `session.id` on the resource (resource attribute)
+5. Trace ID hex string (always available as a fallback)
+
+If your framework does not set a conversation ID, all spans within the same trace will be grouped into the same session automatically via the trace ID.
+
+To explicitly group spans across multiple traces into one session, set `gen_ai.conversation.id`:
+
+```python
+span.set_attribute("gen_ai.conversation.id", "my-session-123")
+```
+
+## Supported Attribute Conventions
+
+The transformer handles three generations of OTel GenAI attributes:
+
+### Current OTel GenAI (v1.37+)
+
+| Attribute | Purpose |
+|-----------|---------|
+| `gen_ai.provider.name` | Provider (openai, anthropic, aws.bedrock) |
+| `gen_ai.request.model` | Requested model |
+| `gen_ai.response.model` | Actual model used (preferred) |
+| `gen_ai.input.messages` | Structured input messages (JSON array) |
+| `gen_ai.output.messages` | Structured output messages (JSON array) |
+| `gen_ai.usage.input_tokens` | Input token count |
+| `gen_ai.usage.output_tokens` | Output token count |
+| `gen_ai.conversation.id` | Session identifier |
+
+### Legacy OpenLLMetry (most deployed)
+
+| Attribute | Purpose |
+|-----------|---------|
+| `gen_ai.system` | Provider name (deprecated, maps to `gen_ai.provider.name`) |
+| `gen_ai.prompt.{i}.role` | Message role at index i |
+| `gen_ai.prompt.{i}.content` | Message content at index i |
+| `gen_ai.completion.{i}.role` | Completion role at index i |
+| `gen_ai.completion.{i}.content` | Completion content at index i |
+| `gen_ai.usage.prompt_tokens` | Input tokens (deprecated name) |
+| `gen_ai.usage.completion_tokens` | Output tokens (deprecated name) |
+
+### Span Events
+
+Some tools put message content in a span event instead of attributes. Omnia checks for the `gen_ai.client.inference.operation.details` event and extracts `gen_ai.input.messages` / `gen_ai.output.messages` from it.
+
+## Data Mapping
+
+| OTel Concept | Omnia Session Field |
+|-------------|-------------------|
+| Conversation ID / Trace ID | `session.id` |
+| `service.name` resource attribute | `session.agentName` |
+| `service.namespace` resource attribute | `session.namespace` |
+| `gen_ai.provider.name` / `gen_ai.system` | `session.state["gen_ai.provider"]` |
+| `gen_ai.response.model` / `gen_ai.request.model` | `session.state["gen_ai.model"]` and `message.metadata["gen_ai.model"]` |
+| Input/output messages | `session.messages` (with role and content) |
+| Token usage | `session.totalInputTokens` / `session.totalOutputTokens` |
+
+## Exposing the Endpoint Externally
+
+For agents running outside the cluster (e.g., in AWS Lambda, ECS, or a separate VPC), expose the OTLP HTTP endpoint via an ingress or load balancer:
+
+```yaml
+# Example: expose via a Kubernetes Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: omnia-otlp
+  namespace: omnia-system
+spec:
+  rules:
+    - host: otlp.example.com
+      http:
+        paths:
+          - path: /v1/traces
+            pathType: Exact
+            backend:
+              service:
+                name: omnia-session-api
+                port:
+                  number: 4318
+```
+
+> **Important**: The OTLP endpoint does not currently require authentication. When exposing externally, protect it with a network policy, API gateway, or ingress authentication.
+
+## Verifying Ingestion
+
+After sending traces, verify sessions were created:
+
+```bash
+# List sessions via the session API
+curl -s http://omnia-session-api.omnia-system:8080/api/v1/sessions | jq .
+
+# Get a specific session
+curl -s http://omnia-session-api.omnia-system:8080/api/v1/sessions/conv-123 | jq .
+```
+
+Sessions created via OTLP ingestion appear in the Omnia dashboard alongside sessions from native Omnia agents.
+
+## Troubleshooting
+
+### No sessions appearing
+
+1. Check that `sessionApi.otlp.enabled` is `true` in your Helm values
+2. Verify the session-api pods are running with OTLP ports:
+   ```bash
+   kubectl get pods -n omnia-system -l app.kubernetes.io/component=session-api
+   kubectl logs -n omnia-system -l app.kubernetes.io/component=session-api
+   ```
+3. Confirm the OTLP port is reachable:
+   ```bash
+   kubectl port-forward -n omnia-system svc/omnia-session-api 4318:4318
+   curl -X POST http://localhost:4318/v1/traces \
+     -H "Content-Type: application/json" \
+     -d '{}'
+   ```
+
+### Messages missing content
+
+Most frameworks disable content capture by default to avoid sending PII. Enable it:
+
+- **OpenLLMetry**: `TRACELOOP_TRACE_CONTENT=true`
+- **OTel Python OpenAI**: `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true`
+
+### Sessions not grouping correctly
+
+If each span creates a separate session, ensure your agent sets `gen_ai.conversation.id` consistently across related spans. Without it, the trace ID is used, and each new trace creates a new session.

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,9 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0
 	go.opentelemetry.io/otel/sdk v1.40.0
 	go.opentelemetry.io/otel/trace v1.40.0
+	go.opentelemetry.io/proto/otlp v1.9.0
 	go.uber.org/zap v1.27.1
+	golang.org/x/time v0.14.0
 	google.golang.org/api v0.265.0
 	google.golang.org/grpc v1.78.0
 	google.golang.org/protobuf v1.36.11
@@ -241,7 +243,6 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.40.0 // indirect
-	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
@@ -256,7 +257,6 @@ require (
 	golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2 // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect

--- a/internal/session/otlp/attributes.go
+++ b/internal/session/otlp/attributes.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package otlp provides an OTLP ingestion endpoint that converts OpenTelemetry
+// GenAI traces into Omnia session data.
+package otlp
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+
+	"github.com/altairalabs/omnia/internal/session"
+)
+
+// Current OTel GenAI semantic convention attribute keys (v1.37+).
+// See: https://opentelemetry.io/docs/specs/semconv/gen-ai/
+const (
+	AttrGenAIConversationID = "gen_ai.conversation.id"
+	AttrGenAIOperationName  = "gen_ai.operation.name"
+	AttrGenAIRequestModel   = "gen_ai.request.model"
+	AttrGenAIResponseModel  = "gen_ai.response.model"
+	AttrGenAIProviderName   = "gen_ai.provider.name"
+	AttrGenAIOutputMessages = "gen_ai.output.messages"
+	AttrGenAIInputMessages  = "gen_ai.input.messages"
+	AttrGenAIUsageInput     = "gen_ai.usage.input_tokens"
+	AttrGenAIUsageOutput    = "gen_ai.usage.output_tokens"
+)
+
+// Deprecated attribute keys still widely emitted by OpenLLMetry and others.
+const (
+	AttrGenAISystem              = "gen_ai.system"
+	AttrGenAIUsagePromptTokens   = "gen_ai.usage.prompt_tokens"
+	AttrGenAIUsageComplTokens    = "gen_ai.usage.completion_tokens"
+	AttrGenAIPromptPrefix        = "gen_ai.prompt."
+	AttrGenAICompletionPrefix    = "gen_ai.completion."
+	AttrLLMUsageTotalTokens      = "llm.usage.total_tokens"
+	AttrTraceloopAssocProperties = "traceloop.association.properties"
+)
+
+// Session ID fallback attribute keys used by various tools.
+const (
+	AttrSessionID         = "session.id"
+	AttrLangfuseSessionID = "langfuse.session.id"
+)
+
+// Resource attribute keys.
+const (
+	AttrServiceName      = "service.name"
+	AttrServiceNamespace = "service.namespace"
+)
+
+// getStringAttr retrieves a string attribute value from a KeyValue slice.
+func getStringAttr(attrs []*commonpb.KeyValue, key string) string {
+	for _, kv := range attrs {
+		if kv.GetKey() == key {
+			if sv := kv.GetValue().GetStringValue(); sv != "" {
+				return sv
+			}
+		}
+	}
+	return ""
+}
+
+// getIntAttr retrieves an integer attribute value from a KeyValue slice.
+func getIntAttr(attrs []*commonpb.KeyValue, key string) int64 {
+	for _, kv := range attrs {
+		if kv.GetKey() == key {
+			return kv.GetValue().GetIntValue()
+		}
+	}
+	return 0
+}
+
+// getArrayAttr retrieves an array attribute value from a KeyValue slice.
+func getArrayAttr(attrs []*commonpb.KeyValue, key string) []*commonpb.AnyValue {
+	for _, kv := range attrs {
+		if kv.GetKey() == key {
+			if arr := kv.GetValue().GetArrayValue(); arr != nil {
+				return arr.GetValues()
+			}
+		}
+	}
+	return nil
+}
+
+// getStringAttrMulti tries multiple keys in priority order, returning the first non-empty value.
+func getStringAttrMulti(attrs []*commonpb.KeyValue, keys ...string) string {
+	for _, key := range keys {
+		if v := getStringAttr(attrs, key); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// getIntAttrMulti tries multiple keys in priority order, returning the first non-zero value.
+func getIntAttrMulti(attrs []*commonpb.KeyValue, keys ...string) int64 {
+	for _, key := range keys {
+		if v := getIntAttr(attrs, key); v != 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+// extractSessionID resolves a session identifier from span and resource attributes.
+// Priority: gen_ai.conversation.id → session.id → langfuse.session.id → traceID hex.
+func extractSessionID(spanAttrs, resourceAttrs []*commonpb.KeyValue, traceID []byte) string {
+	if id := getStringAttrMulti(spanAttrs, AttrGenAIConversationID, AttrSessionID, AttrLangfuseSessionID); id != "" {
+		return id
+	}
+	if id := getStringAttrMulti(resourceAttrs, AttrSessionID, AttrLangfuseSessionID); id != "" {
+		return id
+	}
+	if len(traceID) > 0 {
+		return fmt.Sprintf("%x", traceID)
+	}
+	return ""
+}
+
+// extractProviderName returns the GenAI provider, checking both current and deprecated keys.
+func extractProviderName(attrs []*commonpb.KeyValue) string {
+	return getStringAttrMulti(attrs, AttrGenAIProviderName, AttrGenAISystem)
+}
+
+// extractModel returns the model name, preferring response model over request model.
+func extractModel(attrs []*commonpb.KeyValue) string {
+	return getStringAttrMulti(attrs, AttrGenAIResponseModel, AttrGenAIRequestModel)
+}
+
+// extractTokenUsage retrieves input and output token counts, checking both
+// current and deprecated attribute names.
+func extractTokenUsage(attrs []*commonpb.KeyValue) (inputTokens, outputTokens int64) {
+	inputTokens = getIntAttrMulti(attrs, AttrGenAIUsageInput, AttrGenAIUsagePromptTokens)
+	outputTokens = getIntAttrMulti(attrs, AttrGenAIUsageOutput, AttrGenAIUsageComplTokens)
+	return
+}
+
+// indexedMessage is a single message extracted from OpenLLMetry indexed attributes.
+type indexedMessage struct {
+	index   int
+	role    string
+	content string
+}
+
+// extractIndexedMessages parses OpenLLMetry legacy indexed attributes.
+// It handles the gen_ai.prompt.{i}.role / gen_ai.prompt.{i}.content format
+// and gen_ai.completion.{i}.role / gen_ai.completion.{i}.content format.
+func extractIndexedMessages(attrs []*commonpb.KeyValue, prefix string) []indexedMessage {
+	roleMap := make(map[int]string)
+	contentMap := make(map[int]string)
+
+	for _, kv := range attrs {
+		key := kv.GetKey()
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+		rest := key[len(prefix):]
+		parts := strings.SplitN(rest, ".", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		idx, err := strconv.Atoi(parts[0])
+		if err != nil {
+			continue
+		}
+		switch parts[1] {
+		case "role":
+			roleMap[idx] = kv.GetValue().GetStringValue()
+		case "content":
+			contentMap[idx] = kv.GetValue().GetStringValue()
+		}
+	}
+
+	return buildIndexedMessages(roleMap, contentMap)
+}
+
+// buildIndexedMessages combines role and content maps into sorted messages.
+func buildIndexedMessages(roleMap, contentMap map[int]string) []indexedMessage {
+	indices := make(map[int]struct{})
+	for idx := range roleMap {
+		indices[idx] = struct{}{}
+	}
+	for idx := range contentMap {
+		indices[idx] = struct{}{}
+	}
+
+	msgs := make([]indexedMessage, 0, len(indices))
+	for idx := range indices {
+		content := contentMap[idx]
+		if content == "" {
+			continue
+		}
+		msgs = append(msgs, indexedMessage{
+			index:   idx,
+			role:    roleMap[idx],
+			content: content,
+		})
+	}
+
+	sort.Slice(msgs, func(i, j int) bool { return msgs[i].index < msgs[j].index })
+	return msgs
+}
+
+// indexedToSessionMessages converts indexed messages to session Messages.
+func indexedToSessionMessages(indexed []indexedMessage) []*session.Message {
+	if len(indexed) == 0 {
+		return nil
+	}
+	msgs := make([]*session.Message, 0, len(indexed))
+	for _, im := range indexed {
+		role := toMessageRole(im.role)
+		if role == "" {
+			role = session.RoleAssistant
+		}
+		msgs = append(msgs, &session.Message{
+			Role:    role,
+			Content: im.content,
+		})
+	}
+	return msgs
+}
+
+// toMessageRole maps a GenAI role string to a session.MessageRole.
+func toMessageRole(role string) session.MessageRole {
+	switch role {
+	case "user":
+		return session.RoleUser
+	case "assistant":
+		return session.RoleAssistant
+	case "system":
+		return session.RoleSystem
+	default:
+		return ""
+	}
+}

--- a/internal/session/otlp/attributes_test.go
+++ b/internal/session/otlp/attributes_test.go
@@ -1,0 +1,258 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/session"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+)
+
+func TestGetStringAttr(t *testing.T) {
+	attrs := []*commonpb.KeyValue{
+		{Key: "foo", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "bar"}}},
+		{Key: "empty", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: ""}}},
+		{Key: "int", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 42}}},
+	}
+
+	assert.Equal(t, "bar", getStringAttr(attrs, "foo"))
+	assert.Equal(t, "", getStringAttr(attrs, "empty"))
+	assert.Equal(t, "", getStringAttr(attrs, "int"))
+	assert.Equal(t, "", getStringAttr(attrs, "missing"))
+	assert.Equal(t, "", getStringAttr(nil, "foo"))
+}
+
+func TestGetIntAttr(t *testing.T) {
+	attrs := []*commonpb.KeyValue{
+		{Key: "count", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 100}}},
+		{Key: "str", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "hello"}}},
+	}
+
+	assert.Equal(t, int64(100), getIntAttr(attrs, "count"))
+	assert.Equal(t, int64(0), getIntAttr(attrs, "str"))
+	assert.Equal(t, int64(0), getIntAttr(attrs, "missing"))
+	assert.Equal(t, int64(0), getIntAttr(nil, "count"))
+}
+
+func TestGetArrayAttr(t *testing.T) {
+	items := []*commonpb.AnyValue{
+		{Value: &commonpb.AnyValue_StringValue{StringValue: "a"}},
+		{Value: &commonpb.AnyValue_StringValue{StringValue: "b"}},
+	}
+	attrs := []*commonpb.KeyValue{
+		{Key: "list", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{Values: items},
+		}}},
+		{Key: "str", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "hello"}}},
+	}
+
+	result := getArrayAttr(attrs, "list")
+	assert.Len(t, result, 2)
+	assert.Equal(t, "a", result[0].GetStringValue())
+
+	assert.Nil(t, getArrayAttr(attrs, "str"))
+	assert.Nil(t, getArrayAttr(attrs, "missing"))
+	assert.Nil(t, getArrayAttr(nil, "list"))
+}
+
+func TestGetStringAttrMulti(t *testing.T) {
+	attrs := []*commonpb.KeyValue{
+		{Key: "b", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "second"}}},
+	}
+
+	assert.Equal(t, "second", getStringAttrMulti(attrs, "a", "b"))
+	assert.Equal(t, "", getStringAttrMulti(attrs, "x", "y"))
+}
+
+func TestGetIntAttrMulti(t *testing.T) {
+	attrs := []*commonpb.KeyValue{
+		{Key: "old", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 50}}},
+	}
+
+	assert.Equal(t, int64(50), getIntAttrMulti(attrs, "new", "old"))
+	assert.Equal(t, int64(0), getIntAttrMulti(attrs, "x", "y"))
+}
+
+func TestExtractSessionID(t *testing.T) {
+	t.Run("from conversation id", func(t *testing.T) {
+		spanAttrs := []*commonpb.KeyValue{
+			{Key: AttrGenAIConversationID, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "conv-123"}}},
+		}
+		assert.Equal(t, "conv-123", extractSessionID(spanAttrs, nil, nil))
+	})
+
+	t.Run("from session.id", func(t *testing.T) {
+		spanAttrs := []*commonpb.KeyValue{
+			{Key: AttrSessionID, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "sess-456"}}},
+		}
+		assert.Equal(t, "sess-456", extractSessionID(spanAttrs, nil, nil))
+	})
+
+	t.Run("from langfuse.session.id", func(t *testing.T) {
+		spanAttrs := []*commonpb.KeyValue{
+			{Key: AttrLangfuseSessionID, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "lf-789"}}},
+		}
+		assert.Equal(t, "lf-789", extractSessionID(spanAttrs, nil, nil))
+	})
+
+	t.Run("from resource session.id", func(t *testing.T) {
+		resAttrs := []*commonpb.KeyValue{
+			{Key: AttrSessionID, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "res-sess"}}},
+		}
+		assert.Equal(t, "res-sess", extractSessionID(nil, resAttrs, nil))
+	})
+
+	t.Run("fallback to trace ID", func(t *testing.T) {
+		traceID := []byte{0xab, 0xcd, 0xef, 0x01}
+		assert.Equal(t, "abcdef01", extractSessionID(nil, nil, traceID))
+	})
+
+	t.Run("empty when nothing available", func(t *testing.T) {
+		assert.Equal(t, "", extractSessionID(nil, nil, nil))
+	})
+
+	t.Run("priority order", func(t *testing.T) {
+		spanAttrs := []*commonpb.KeyValue{
+			{Key: AttrGenAIConversationID, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "conv"}}},
+			{Key: AttrSessionID, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "sess"}}},
+		}
+		assert.Equal(t, "conv", extractSessionID(spanAttrs, nil, []byte{0x01}))
+	})
+}
+
+func TestExtractProviderName(t *testing.T) {
+	t.Run("current attr", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: AttrGenAIProviderName, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "openai"}}},
+		}
+		assert.Equal(t, "openai", extractProviderName(attrs))
+	})
+
+	t.Run("deprecated gen_ai.system", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: AttrGenAISystem, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "anthropic"}}},
+		}
+		assert.Equal(t, "anthropic", extractProviderName(attrs))
+	})
+}
+
+func TestExtractModel(t *testing.T) {
+	t.Run("response model preferred", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: AttrGenAIRequestModel, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "gpt-4"}}},
+			{Key: AttrGenAIResponseModel, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "gpt-4-0613"}}},
+		}
+		assert.Equal(t, "gpt-4-0613", extractModel(attrs))
+	})
+
+	t.Run("falls back to request model", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: AttrGenAIRequestModel, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "gpt-4"}}},
+		}
+		assert.Equal(t, "gpt-4", extractModel(attrs))
+	})
+}
+
+func TestExtractTokenUsage(t *testing.T) {
+	t.Run("current attribute names", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: AttrGenAIUsageInput, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 150}}},
+			{Key: AttrGenAIUsageOutput, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 75}}},
+		}
+		input, output := extractTokenUsage(attrs)
+		assert.Equal(t, int64(150), input)
+		assert.Equal(t, int64(75), output)
+	})
+
+	t.Run("deprecated attribute names", func(t *testing.T) {
+		attrs := []*commonpb.KeyValue{
+			{Key: AttrGenAIUsagePromptTokens, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 200}}},
+			{Key: AttrGenAIUsageComplTokens, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 100}}},
+		}
+		input, output := extractTokenUsage(attrs)
+		assert.Equal(t, int64(200), input)
+		assert.Equal(t, int64(100), output)
+	})
+
+	t.Run("empty", func(t *testing.T) {
+		input, output := extractTokenUsage(nil)
+		assert.Equal(t, int64(0), input)
+		assert.Equal(t, int64(0), output)
+	})
+}
+
+func TestExtractIndexedMessages(t *testing.T) {
+	attrs := []*commonpb.KeyValue{
+		{Key: "gen_ai.prompt.0.role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "system"}}},
+		{Key: "gen_ai.prompt.0.content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "You are helpful."}}},
+		{Key: "gen_ai.prompt.1.role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "user"}}},
+		{Key: "gen_ai.prompt.1.content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "Hello!"}}},
+		{Key: "gen_ai.prompt.2.role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "assistant"}}},
+		// index 2 has no content — should be skipped.
+		{Key: "unrelated.attr", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "ignored"}}},
+	}
+
+	msgs := extractIndexedMessages(attrs, AttrGenAIPromptPrefix)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, 0, msgs[0].index)
+	assert.Equal(t, "system", msgs[0].role)
+	assert.Equal(t, "You are helpful.", msgs[0].content)
+	assert.Equal(t, 1, msgs[1].index)
+	assert.Equal(t, "user", msgs[1].role)
+	assert.Equal(t, "Hello!", msgs[1].content)
+}
+
+func TestExtractIndexedMessages_Completion(t *testing.T) {
+	attrs := []*commonpb.KeyValue{
+		{Key: "gen_ai.completion.0.role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "assistant"}}},
+		{Key: "gen_ai.completion.0.content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "Here is the answer."}}},
+	}
+
+	msgs := extractIndexedMessages(attrs, AttrGenAICompletionPrefix)
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "assistant", msgs[0].role)
+	assert.Equal(t, "Here is the answer.", msgs[0].content)
+}
+
+func TestIndexedToSessionMessages(t *testing.T) {
+	indexed := []indexedMessage{
+		{index: 0, role: "user", content: "Hi"},
+		{index: 1, role: "", content: "Response"},
+	}
+
+	msgs := indexedToSessionMessages(indexed)
+	require.Len(t, msgs, 2)
+	assert.Equal(t, session.RoleUser, msgs[0].Role)
+	assert.Equal(t, session.RoleAssistant, msgs[1].Role) // default
+}
+
+func TestIndexedToSessionMessages_Empty(t *testing.T) {
+	assert.Nil(t, indexedToSessionMessages(nil))
+}
+
+func TestToMessageRole(t *testing.T) {
+	assert.Equal(t, session.RoleUser, toMessageRole("user"))
+	assert.Equal(t, session.RoleAssistant, toMessageRole("assistant"))
+	assert.Equal(t, session.RoleSystem, toMessageRole("system"))
+	assert.Equal(t, session.MessageRole(""), toMessageRole("unknown"))
+	assert.Equal(t, session.MessageRole(""), toMessageRole(""))
+}

--- a/internal/session/otlp/handler.go
+++ b/internal/session/otlp/handler.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlp
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+)
+
+// maxBodySize is the maximum allowed request body size (4 MB).
+const maxBodySize = 4 * 1024 * 1024
+
+// Supported Content-Type values.
+const (
+	contentTypeProtobuf = "application/x-protobuf"
+	contentTypeJSON     = "application/json"
+)
+
+// Handler serves the OTLP/HTTP trace export endpoint.
+// Supports both application/x-protobuf and application/json content types.
+type Handler struct {
+	transformer *Transformer
+	log         logr.Logger
+}
+
+// NewHandler creates a new HTTP OTLP handler.
+func NewHandler(transformer *Transformer, log logr.Logger) *Handler {
+	return &Handler{
+		transformer: transformer,
+		log:         log.WithName("otlp-handler"),
+	}
+}
+
+// ServeHTTP handles POST /v1/traces requests.
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	ct := r.Header.Get("Content-Type")
+	if ct != contentTypeProtobuf && ct != contentTypeJSON {
+		http.Error(w, "unsupported content type; expected application/x-protobuf or application/json", http.StatusUnsupportedMediaType)
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxBodySize+1))
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+	if len(body) > maxBodySize {
+		http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	req, err := unmarshalRequest(body, ct)
+	if err != nil {
+		http.Error(w, "invalid payload", http.StatusBadRequest)
+		return
+	}
+
+	processed, procErr := h.transformer.ProcessExport(r.Context(), req.GetResourceSpans())
+	if procErr != nil {
+		h.log.Error(procErr, "partial export failure", "processed", processed)
+	}
+
+	h.writeResponse(w, ct)
+}
+
+// unmarshalRequest decodes the request body based on content type.
+func unmarshalRequest(body []byte, contentType string) (*coltracepb.ExportTraceServiceRequest, error) {
+	req := &coltracepb.ExportTraceServiceRequest{}
+	if contentType == contentTypeJSON {
+		return req, protojson.Unmarshal(body, req)
+	}
+	return req, proto.Unmarshal(body, req)
+}
+
+// writeResponse serializes and writes the response in the same format as the request.
+func (h *Handler) writeResponse(w http.ResponseWriter, contentType string) {
+	resp := &coltracepb.ExportTraceServiceResponse{}
+
+	var respBytes []byte
+	var err error
+	if contentType == contentTypeJSON {
+		respBytes, err = protojson.Marshal(resp)
+	} else {
+		respBytes, err = proto.Marshal(resp)
+	}
+	if err != nil {
+		http.Error(w, "failed to serialize response", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", contentType)
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(respBytes)
+}
+
+// RegisterRoutes registers the OTLP/HTTP handler on the given mux.
+func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
+	mux.Handle("POST /v1/traces", h)
+}

--- a/internal/session/otlp/handler_test.go
+++ b/internal/session/otlp/handler_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlp
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+)
+
+func newTestHandler() (*Handler, *MockSessionWriter) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+	handler := NewHandler(transformer, logr.Discard())
+	return handler, writer
+}
+
+func buildExportRequest(conversationID string) *coltracepb.ExportTraceServiceRequest {
+	attrs := combineAttrs(
+		outputMsgAttrs(makeMessageValue("assistant", "HTTP response")),
+		tokenAttrs(30, 15),
+	)
+	span := makeSpan(conversationID, uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("staging", "http-agent", span)
+	return &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{rs},
+	}
+}
+
+func TestHandler_Protobuf(t *testing.T) {
+	handler, writer := newTestHandler()
+
+	req := buildExportRequest("http-conv-1")
+	body, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", contentTypeProtobuf)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, contentTypeProtobuf, rec.Header().Get("Content-Type"))
+
+	resp := &coltracepb.ExportTraceServiceResponse{}
+	require.NoError(t, proto.Unmarshal(rec.Body.Bytes(), resp))
+
+	assert.NotNil(t, writer.sessions["http-conv-1"])
+	assert.Len(t, writer.messages["http-conv-1"], 1)
+}
+
+func TestHandler_JSON(t *testing.T) {
+	handler, writer := newTestHandler()
+
+	req := buildExportRequest("json-conv-1")
+	body, err := protojson.Marshal(req)
+	require.NoError(t, err)
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", contentTypeJSON)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, contentTypeJSON, rec.Header().Get("Content-Type"))
+
+	resp := &coltracepb.ExportTraceServiceResponse{}
+	require.NoError(t, protojson.Unmarshal(rec.Body.Bytes(), resp))
+
+	assert.NotNil(t, writer.sessions["json-conv-1"])
+	assert.Len(t, writer.messages["json-conv-1"], 1)
+}
+
+func TestHandler_WrongMethod(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	httpReq := httptest.NewRequest(http.MethodGet, "/v1/traces", nil)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+}
+
+func TestHandler_WrongContentType(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", strings.NewReader("{}"))
+	httpReq.Header.Set("Content-Type", "text/plain")
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, rec.Code)
+}
+
+func TestHandler_InvalidProtobuf(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", strings.NewReader("not-protobuf"))
+	httpReq.Header.Set("Content-Type", contentTypeProtobuf)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_InvalidJSON(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", strings.NewReader("{invalid"))
+	httpReq.Header.Set("Content-Type", contentTypeJSON)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandler_BodyTooLarge(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	largeBody := make([]byte, maxBodySize+1)
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader(largeBody))
+	httpReq.Header.Set("Content-Type", contentTypeProtobuf)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestHandler_EmptyBody(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader([]byte{}))
+	httpReq.Header.Set("Content-Type", contentTypeProtobuf)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_EmptyJSON(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", strings.NewReader("{}"))
+	httpReq.Header.Set("Content-Type", contentTypeJSON)
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandler_RegisterRoutes(t *testing.T) {
+	handler, _ := newTestHandler()
+
+	mux := http.NewServeMux()
+	handler.RegisterRoutes(mux)
+
+	req := &coltracepb.ExportTraceServiceRequest{}
+	body, err := proto.Marshal(req)
+	require.NoError(t, err)
+
+	httpReq := httptest.NewRequest(http.MethodPost, "/v1/traces", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", contentTypeProtobuf)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, httpReq)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}

--- a/internal/session/otlp/receiver.go
+++ b/internal/session/otlp/receiver.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlp
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+)
+
+// Receiver implements the OTLP gRPC TraceService.
+type Receiver struct {
+	coltracepb.UnimplementedTraceServiceServer
+	transformer *Transformer
+	log         logr.Logger
+}
+
+// NewReceiver creates a new gRPC OTLP trace receiver.
+func NewReceiver(transformer *Transformer, log logr.Logger) *Receiver {
+	return &Receiver{
+		transformer: transformer,
+		log:         log.WithName("otlp-receiver"),
+	}
+}
+
+// Export implements TraceServiceServer.Export by delegating to the transformer.
+func (r *Receiver) Export(ctx context.Context, req *coltracepb.ExportTraceServiceRequest) (*coltracepb.ExportTraceServiceResponse, error) {
+	processed, err := r.transformer.ProcessExport(ctx, req.GetResourceSpans())
+	if err != nil {
+		r.log.Error(err, "partial export failure", "processed", processed)
+	}
+	return &coltracepb.ExportTraceServiceResponse{}, nil
+}

--- a/internal/session/otlp/receiver_test.go
+++ b/internal/session/otlp/receiver_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+)
+
+func TestReceiver_Export(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+	receiver := NewReceiver(transformer, logr.Discard())
+
+	attrs := outputMsgAttrs(makeMessageValue("assistant", "Hi there!"))
+	attrs = append(attrs, tokenAttrs(25, 10)...)
+	span := makeSpan("grpc-conv-1", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("prod", "grpc-agent", span)
+
+	req := &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{rs},
+	}
+
+	resp, err := receiver.Export(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	sess := writer.sessions["grpc-conv-1"]
+	require.NotNil(t, sess)
+	assert.Equal(t, "grpc-agent", sess.AgentName)
+
+	msgs := writer.messages["grpc-conv-1"]
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "Hi there!", msgs[0].Content)
+}
+
+func TestReceiver_Export_EmptyRequest(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+	receiver := NewReceiver(transformer, logr.Discard())
+
+	req := &coltracepb.ExportTraceServiceRequest{}
+
+	resp, err := receiver.Export(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Empty(t, writer.sessions)
+}
+
+func TestReceiver_Export_PartialFailure(t *testing.T) {
+	writer := newMockWriter()
+	writer.appendErr = assert.AnError
+
+	transformer := NewTransformer(writer, logr.Discard())
+	receiver := NewReceiver(transformer, logr.Discard())
+
+	attrs := outputMsgAttrs(makeMessageValue("assistant", "Hello"))
+	span := makeSpan("grpc-fail", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("ns", "agent", span)
+
+	req := &coltracepb.ExportTraceServiceRequest{
+		ResourceSpans: []*tracepb.ResourceSpans{rs},
+	}
+
+	resp, err := receiver.Export(context.Background(), req)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+}

--- a/internal/session/otlp/transformer.go
+++ b/internal/session/otlp/transformer.go
@@ -1,0 +1,407 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+
+	"github.com/altairalabs/omnia/internal/session"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// SessionWriter is the subset of SessionService used by the transformer.
+type SessionWriter interface {
+	GetSession(ctx context.Context, sessionID string) (*session.Session, error)
+	CreateSession(ctx context.Context, sess *session.Session) error
+	AppendMessage(ctx context.Context, sessionID string, msg *session.Message) error
+	UpdateSessionStats(ctx context.Context, sessionID string, update session.SessionStatsUpdate) error
+}
+
+// Transformer converts OTLP GenAI spans into session data.
+type Transformer struct {
+	writer SessionWriter
+	log    logr.Logger
+}
+
+// NewTransformer creates a new Transformer.
+func NewTransformer(writer SessionWriter, log logr.Logger) *Transformer {
+	return &Transformer{
+		writer: writer,
+		log:    log.WithName("otlp-transformer"),
+	}
+}
+
+// spanContext holds resource-level attributes extracted once per ResourceSpans.
+type spanContext struct {
+	namespace     string
+	agentName     string
+	resourceAttrs []*commonpb.KeyValue
+}
+
+// ProcessExport processes an OTLP export request and returns the number of
+// spans that were successfully processed.
+func (t *Transformer) ProcessExport(ctx context.Context, resourceSpans []*tracepb.ResourceSpans) (int, error) {
+	var processed int
+	var firstErr error
+
+	for _, rs := range resourceSpans {
+		n, err := t.processResourceSpans(ctx, rs)
+		processed += n
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return processed, firstErr
+}
+
+// processResourceSpans extracts resource attributes and iterates over scope spans.
+func (t *Transformer) processResourceSpans(ctx context.Context, rs *tracepb.ResourceSpans) (int, error) {
+	var resourceAttrs []*commonpb.KeyValue
+	if rs.GetResource() != nil {
+		resourceAttrs = rs.GetResource().GetAttributes()
+	}
+
+	sc := spanContext{
+		namespace:     getStringAttr(resourceAttrs, AttrServiceNamespace),
+		agentName:     getStringAttr(resourceAttrs, AttrServiceName),
+		resourceAttrs: resourceAttrs,
+	}
+
+	var processed int
+	var firstErr error
+
+	for _, scopeSpans := range rs.GetScopeSpans() {
+		n, err := t.processScopeSpans(ctx, sc, scopeSpans)
+		processed += n
+		if err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+
+	return processed, firstErr
+}
+
+// processScopeSpans iterates over spans within a scope.
+func (t *Transformer) processScopeSpans(ctx context.Context, sc spanContext, ss *tracepb.ScopeSpans) (int, error) {
+	spans := ss.GetSpans()
+	sortSpansByTime(spans)
+
+	var processed int
+	var firstErr error
+
+	for _, span := range spans {
+		if err := t.processSpan(ctx, sc, span); err != nil {
+			t.log.Error(err, "failed to process span", "spanID", fmt.Sprintf("%x", span.GetSpanId()))
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		processed++
+	}
+
+	return processed, firstErr
+}
+
+// processSpan extracts conversation ID, ensures the session exists, and
+// appends output messages and token usage.
+func (t *Transformer) processSpan(ctx context.Context, sc spanContext, span *tracepb.Span) error {
+	attrs := span.GetAttributes()
+
+	sessionID := extractSessionID(attrs, sc.resourceAttrs, span.GetTraceId())
+	if sessionID == "" {
+		return nil // no way to identify a session — skip
+	}
+
+	if err := t.ensureSession(ctx, sessionID, sc, attrs); err != nil {
+		return fmt.Errorf("ensuring session %s: %w", sessionID, err)
+	}
+
+	timestamp := spanTimestamp(span)
+	model := extractModel(attrs)
+	msgs := t.resolveMessages(attrs, span.GetEvents(), timestamp, model)
+
+	for _, msg := range msgs {
+		if err := t.writer.AppendMessage(ctx, sessionID, msg); err != nil {
+			return fmt.Errorf("appending message to session %s: %w", sessionID, err)
+		}
+	}
+
+	return t.updateTokenUsage(ctx, sessionID, attrs)
+}
+
+// ensureSession creates the session if it does not already exist.
+func (t *Transformer) ensureSession(ctx context.Context, sessionID string, sc spanContext, spanAttrs []*commonpb.KeyValue) error {
+	_, err := t.writer.GetSession(ctx, sessionID)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, session.ErrSessionNotFound) {
+		return err
+	}
+
+	now := time.Now()
+	sess := &session.Session{
+		ID:        sessionID,
+		AgentName: sc.agentName,
+		Namespace: sc.namespace,
+		CreatedAt: now,
+		UpdatedAt: now,
+		Status:    session.SessionStatusActive,
+		State:     buildSessionState(spanAttrs),
+	}
+
+	return t.writer.CreateSession(ctx, sess)
+}
+
+// buildSessionState extracts metadata for the session state map.
+func buildSessionState(attrs []*commonpb.KeyValue) map[string]string {
+	state := make(map[string]string)
+	if provider := extractProviderName(attrs); provider != "" {
+		state["gen_ai.provider"] = provider
+	}
+	if model := extractModel(attrs); model != "" {
+		state["gen_ai.model"] = model
+	}
+	if len(state) == 0 {
+		return nil
+	}
+	return state
+}
+
+// resolveMessages extracts messages using multiple strategies in priority order:
+// 1. Current OTel: gen_ai.input.messages / gen_ai.output.messages (structured)
+// 2. Span events: gen_ai.client.inference.operation.details event
+// 3. Legacy OpenLLMetry: gen_ai.prompt.{i}.* / gen_ai.completion.{i}.*
+func (t *Transformer) resolveMessages(attrs []*commonpb.KeyValue, events []*tracepb.Span_Event, timestamp time.Time, model string) []*session.Message {
+	// Strategy 1: current OTel structured attributes.
+	msgs := extractStructuredMessages(attrs, timestamp)
+
+	// Strategy 2: span events.
+	if len(msgs) == 0 {
+		msgs = extractMessagesFromEvents(events, timestamp)
+	}
+
+	// Strategy 3: legacy OpenLLMetry indexed attributes.
+	if len(msgs) == 0 {
+		msgs = extractLegacyMessages(attrs, timestamp)
+	}
+
+	applyMessageDefaults(msgs, model)
+	return msgs
+}
+
+// extractStructuredMessages parses gen_ai.input.messages and gen_ai.output.messages.
+func extractStructuredMessages(attrs []*commonpb.KeyValue, timestamp time.Time) []*session.Message {
+	var msgs []*session.Message
+
+	inputValues := getArrayAttr(attrs, AttrGenAIInputMessages)
+	for _, v := range inputValues {
+		if msg := parseMessageValue(v, timestamp); msg != nil {
+			msgs = append(msgs, msg)
+		}
+	}
+
+	outputValues := getArrayAttr(attrs, AttrGenAIOutputMessages)
+	for _, v := range outputValues {
+		msg := parseMessageValueWithDefault(v, session.RoleAssistant, timestamp)
+		if msg != nil {
+			msgs = append(msgs, msg)
+		}
+	}
+
+	return msgs
+}
+
+// extractMessagesFromEvents checks span events for the consolidated
+// gen_ai.client.inference.operation.details event.
+func extractMessagesFromEvents(events []*tracepb.Span_Event, timestamp time.Time) []*session.Message {
+	for _, event := range events {
+		if event.GetName() != "gen_ai.client.inference.operation.details" {
+			continue
+		}
+		return extractStructuredMessages(event.GetAttributes(), timestamp)
+	}
+	return nil
+}
+
+// extractLegacyMessages parses OpenLLMetry indexed attributes.
+func extractLegacyMessages(attrs []*commonpb.KeyValue, timestamp time.Time) []*session.Message {
+	// Input: gen_ai.prompt.{i}.role / gen_ai.prompt.{i}.content
+	inputIndexed := extractIndexedMessages(attrs, AttrGenAIPromptPrefix)
+	outputIndexed := extractIndexedMessages(attrs, AttrGenAICompletionPrefix)
+	msgs := make([]*session.Message, 0, len(inputIndexed)+len(outputIndexed))
+	for _, im := range inputIndexed {
+		msg := indexedToSingleMessage(im, timestamp)
+		msgs = append(msgs, msg)
+	}
+
+	// Output: gen_ai.completion.{i}.role / gen_ai.completion.{i}.content
+	for _, im := range outputIndexed {
+		msg := indexedToSingleMessage(im, timestamp)
+		if msg.Role == "" {
+			msg.Role = session.RoleAssistant
+		}
+		msgs = append(msgs, msg)
+	}
+
+	return msgs
+}
+
+// indexedToSingleMessage converts a single indexedMessage to a session.Message.
+func indexedToSingleMessage(im indexedMessage, timestamp time.Time) *session.Message {
+	role := toMessageRole(im.role)
+	if role == "" {
+		role = session.RoleAssistant
+	}
+	return &session.Message{
+		ID:        uuid.New().String(),
+		Role:      role,
+		Content:   im.content,
+		Timestamp: timestamp,
+	}
+}
+
+// applyMessageDefaults sets IDs and model metadata on messages that lack them.
+func applyMessageDefaults(msgs []*session.Message, model string) {
+	for _, msg := range msgs {
+		if msg.ID == "" {
+			msg.ID = uuid.New().String()
+		}
+		if model != "" {
+			if msg.Metadata == nil {
+				msg.Metadata = make(map[string]string)
+			}
+			msg.Metadata["gen_ai.model"] = model
+		}
+	}
+}
+
+// updateTokenUsage extracts token counts and applies them as a stats update.
+func (t *Transformer) updateTokenUsage(ctx context.Context, sessionID string, attrs []*commonpb.KeyValue) error {
+	inputTokens, outputTokens := extractTokenUsage(attrs)
+	if inputTokens == 0 && outputTokens == 0 {
+		return nil
+	}
+
+	update := session.SessionStatsUpdate{
+		AddInputTokens:  int32(inputTokens),
+		AddOutputTokens: int32(outputTokens),
+	}
+
+	return t.writer.UpdateSessionStats(ctx, sessionID, update)
+}
+
+// parseMessageValue extracts role and content from a kvlist AnyValue.
+func parseMessageValue(v *commonpb.AnyValue, timestamp time.Time) *session.Message {
+	return parseMessageValueWithDefault(v, "", timestamp)
+}
+
+// parseMessageValueWithDefault extracts role and content from a kvlist AnyValue,
+// using the provided default role when the message lacks an explicit role.
+func parseMessageValueWithDefault(v *commonpb.AnyValue, defaultRole session.MessageRole, timestamp time.Time) *session.Message {
+	kvl := v.GetKvlistValue()
+	if kvl == nil {
+		return nil
+	}
+
+	role, content := extractRoleAndContent(kvl.GetValues())
+	if content == "" {
+		return nil
+	}
+
+	msgRole := toMessageRole(role)
+	if msgRole == "" {
+		msgRole = defaultRole
+	}
+	if msgRole == "" {
+		return nil
+	}
+
+	return &session.Message{
+		ID:        uuid.New().String(),
+		Role:      msgRole,
+		Content:   content,
+		Timestamp: timestamp,
+	}
+}
+
+// extractRoleAndContent reads role and content from a kvlist's key-value pairs.
+// Content can come from a "content" key or from "parts" (new spec format).
+func extractRoleAndContent(kvs []*commonpb.KeyValue) (role, content string) {
+	for _, kv := range kvs {
+		switch kv.GetKey() {
+		case "role":
+			role = kv.GetValue().GetStringValue()
+		case "content":
+			content = kv.GetValue().GetStringValue()
+		case "parts":
+			if content == "" {
+				content = extractContentFromParts(kv.GetValue())
+			}
+		}
+	}
+	return
+}
+
+// extractContentFromParts extracts text content from the "parts" array format
+// used by the current OTel GenAI spec.
+func extractContentFromParts(v *commonpb.AnyValue) string {
+	arr := v.GetArrayValue()
+	if arr == nil {
+		return ""
+	}
+	for _, part := range arr.GetValues() {
+		kvl := part.GetKvlistValue()
+		if kvl == nil {
+			continue
+		}
+		partType := getStringAttr(kvl.GetValues(), "type")
+		if partType == "text" || partType == "" {
+			if c := getStringAttr(kvl.GetValues(), "content"); c != "" {
+				return c
+			}
+		}
+	}
+	return ""
+}
+
+// spanTimestamp converts the span's StartTimeUnixNano to a time.Time.
+func spanTimestamp(span *tracepb.Span) time.Time {
+	nanos := span.GetStartTimeUnixNano()
+	if nanos == 0 {
+		return time.Now()
+	}
+	return time.Unix(0, int64(nanos))
+}
+
+// sortSpansByTime sorts spans by start time ascending.
+func sortSpansByTime(spans []*tracepb.Span) {
+	sort.Slice(spans, func(i, j int) bool {
+		return spans[i].GetStartTimeUnixNano() < spans[j].GetStartTimeUnixNano()
+	})
+}

--- a/internal/session/otlp/transformer_test.go
+++ b/internal/session/otlp/transformer_test.go
@@ -1,0 +1,537 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package otlp
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/session"
+
+	commonpb "go.opentelemetry.io/proto/otlp/common/v1"
+	resourcepb "go.opentelemetry.io/proto/otlp/resource/v1"
+	tracepb "go.opentelemetry.io/proto/otlp/trace/v1"
+)
+
+// MockSessionWriter is a test double for SessionWriter.
+type MockSessionWriter struct {
+	sessions map[string]*session.Session
+	messages map[string][]*session.Message
+	stats    map[string]session.SessionStatsUpdate
+
+	getSessionErr   error
+	createErr       error
+	appendErr       error
+	updateStatsErr  error
+	createCallCount int
+}
+
+func newMockWriter() *MockSessionWriter {
+	return &MockSessionWriter{
+		sessions: make(map[string]*session.Session),
+		messages: make(map[string][]*session.Message),
+		stats:    make(map[string]session.SessionStatsUpdate),
+	}
+}
+
+func (m *MockSessionWriter) GetSession(_ context.Context, sessionID string) (*session.Session, error) {
+	if m.getSessionErr != nil {
+		return nil, m.getSessionErr
+	}
+	if s, ok := m.sessions[sessionID]; ok {
+		return s, nil
+	}
+	return nil, session.ErrSessionNotFound
+}
+
+func (m *MockSessionWriter) CreateSession(_ context.Context, sess *session.Session) error {
+	m.createCallCount++
+	if m.createErr != nil {
+		return m.createErr
+	}
+	m.sessions[sess.ID] = sess
+	return nil
+}
+
+func (m *MockSessionWriter) AppendMessage(_ context.Context, sessionID string, msg *session.Message) error {
+	if m.appendErr != nil {
+		return m.appendErr
+	}
+	m.messages[sessionID] = append(m.messages[sessionID], msg)
+	return nil
+}
+
+func (m *MockSessionWriter) UpdateSessionStats(_ context.Context, sessionID string, update session.SessionStatsUpdate) error {
+	if m.updateStatsErr != nil {
+		return m.updateStatsErr
+	}
+	m.stats[sessionID] = update
+	return nil
+}
+
+// --- helpers for building OTLP test data ---
+
+func makeSpan(conversationID string, startNano uint64, attrs []*commonpb.KeyValue) *tracepb.Span {
+	if conversationID != "" {
+		attrs = append([]*commonpb.KeyValue{
+			{Key: AttrGenAIConversationID, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: conversationID}}},
+		}, attrs...)
+	}
+	return &tracepb.Span{
+		TraceId:           []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+		SpanId:            []byte{0x01},
+		StartTimeUnixNano: startNano,
+		Attributes:        attrs,
+	}
+}
+
+func makeMessageValue(role, content string) *commonpb.AnyValue {
+	return &commonpb.AnyValue{Value: &commonpb.AnyValue_KvlistValue{
+		KvlistValue: &commonpb.KeyValueList{Values: []*commonpb.KeyValue{
+			{Key: "role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: role}}},
+			{Key: "content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: content}}},
+		}},
+	}}
+}
+
+func makeResourceSpans(namespace, agentName string, spans ...*tracepb.Span) *tracepb.ResourceSpans {
+	return &tracepb.ResourceSpans{
+		Resource: &resourcepb.Resource{
+			Attributes: []*commonpb.KeyValue{
+				{Key: AttrServiceNamespace, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: namespace}}},
+				{Key: AttrServiceName, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: agentName}}},
+			},
+		},
+		ScopeSpans: []*tracepb.ScopeSpans{
+			{Spans: spans},
+		},
+	}
+}
+
+func outputMsgAttrs(msgs ...*commonpb.AnyValue) []*commonpb.KeyValue {
+	return []*commonpb.KeyValue{
+		{Key: AttrGenAIOutputMessages, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{Values: msgs},
+		}}},
+	}
+}
+
+func tokenAttrs(input, output int64) []*commonpb.KeyValue {
+	return []*commonpb.KeyValue{
+		{Key: AttrGenAIUsageInput, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: input}}},
+		{Key: AttrGenAIUsageOutput, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: output}}},
+	}
+}
+
+func combineAttrs(groups ...[]*commonpb.KeyValue) []*commonpb.KeyValue {
+	var result []*commonpb.KeyValue
+	for _, g := range groups {
+		result = append(result, g...)
+	}
+	return result
+}
+
+// --- tests ---
+
+func TestProcessExport_CurrentOTelFormat(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	attrs := combineAttrs(
+		outputMsgAttrs(makeMessageValue("assistant", "Hello! How can I help?")),
+		tokenAttrs(50, 20),
+	)
+	span := makeSpan("conv-123", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("default", "my-agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+
+	sess := writer.sessions["conv-123"]
+	require.NotNil(t, sess)
+	assert.Equal(t, "my-agent", sess.AgentName)
+	assert.Equal(t, "default", sess.Namespace)
+
+	msgs := writer.messages["conv-123"]
+	require.Len(t, msgs, 1)
+	assert.Equal(t, session.RoleAssistant, msgs[0].Role)
+	assert.Equal(t, "Hello! How can I help?", msgs[0].Content)
+
+	stats := writer.stats["conv-123"]
+	assert.Equal(t, int32(50), stats.AddInputTokens)
+	assert.Equal(t, int32(20), stats.AddOutputTokens)
+}
+
+func TestProcessExport_LegacyOpenLLMetryFormat(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	attrs := []*commonpb.KeyValue{
+		{Key: "gen_ai.system", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "openai"}}},
+		{Key: "gen_ai.request.model", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "gpt-4"}}},
+		{Key: "gen_ai.prompt.0.role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "system"}}},
+		{Key: "gen_ai.prompt.0.content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "You are a mathematician."}}},
+		{Key: "gen_ai.prompt.1.role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "user"}}},
+		{Key: "gen_ai.prompt.1.content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "calculate 5 + 5"}}},
+		{Key: "gen_ai.completion.0.role", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "assistant"}}},
+		{Key: "gen_ai.completion.0.content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "5 + 5 = 10"}}},
+		{Key: "gen_ai.usage.prompt_tokens", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 125}}},
+		{Key: "gen_ai.usage.completion_tokens", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_IntValue{IntValue: 47}}},
+	}
+
+	span := makeSpan("conv-legacy", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("default", "langchain-agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+
+	msgs := writer.messages["conv-legacy"]
+	require.Len(t, msgs, 3)
+	assert.Equal(t, session.RoleSystem, msgs[0].Role)
+	assert.Equal(t, "You are a mathematician.", msgs[0].Content)
+	assert.Equal(t, session.RoleUser, msgs[1].Role)
+	assert.Equal(t, "calculate 5 + 5", msgs[1].Content)
+	assert.Equal(t, session.RoleAssistant, msgs[2].Role)
+	assert.Equal(t, "5 + 5 = 10", msgs[2].Content)
+
+	// Model metadata on messages.
+	assert.Equal(t, "gpt-4", msgs[0].Metadata["gen_ai.model"])
+
+	// Deprecated token names should work.
+	stats := writer.stats["conv-legacy"]
+	assert.Equal(t, int32(125), stats.AddInputTokens)
+	assert.Equal(t, int32(47), stats.AddOutputTokens)
+
+	// Session state should contain provider.
+	sess := writer.sessions["conv-legacy"]
+	assert.Equal(t, "openai", sess.State["gen_ai.provider"])
+}
+
+func TestProcessExport_SpanEvents(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	// Build a span with messages in the event, not attributes.
+	eventAttrs := combineAttrs(
+		outputMsgAttrs(makeMessageValue("assistant", "From event")),
+	)
+	span := makeSpan("conv-events", uint64(time.Now().UnixNano()), nil)
+	span.Events = []*tracepb.Span_Event{
+		{
+			Name:       "gen_ai.client.inference.operation.details",
+			Attributes: eventAttrs,
+		},
+	}
+
+	rs := makeResourceSpans("ns", "agent", span)
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+
+	msgs := writer.messages["conv-events"]
+	require.Len(t, msgs, 1)
+	assert.Equal(t, "From event", msgs[0].Content)
+}
+
+func TestProcessExport_SessionIDFallbackToTraceID(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	// Span with no conversation ID — should use trace ID.
+	span := &tracepb.Span{
+		TraceId:           []byte{0xab, 0xcd, 0xef, 0x01, 0x23, 0x45, 0x67, 0x89},
+		SpanId:            []byte{0x01},
+		StartTimeUnixNano: uint64(time.Now().UnixNano()),
+		Attributes: []*commonpb.KeyValue{
+			{Key: AttrGenAIRequestModel, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "gpt-4"}}},
+		},
+	}
+
+	rs := makeResourceSpans("ns", "agent", span)
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+
+	// Session should be created with hex trace ID.
+	assert.Contains(t, writer.sessions, "abcdef0123456789")
+}
+
+func TestProcessExport_ExistingSession(t *testing.T) {
+	writer := newMockWriter()
+	writer.sessions["conv-123"] = &session.Session{ID: "conv-123"}
+
+	transformer := NewTransformer(writer, logr.Discard())
+
+	attrs := outputMsgAttrs(makeMessageValue("assistant", "Follow-up"))
+	span := makeSpan("conv-123", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("default", "my-agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.Equal(t, 0, writer.createCallCount, "should not create session again")
+}
+
+func TestProcessExport_SkipsSpanWithNoSessionID(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	// Span with no conversation ID and no trace ID.
+	span := &tracepb.Span{
+		SpanId:            []byte{0x01},
+		StartTimeUnixNano: uint64(time.Now().UnixNano()),
+		Attributes: []*commonpb.KeyValue{
+			{Key: "http.method", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "GET"}}},
+		},
+	}
+
+	rs := makeResourceSpans("default", "my-agent", span)
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.Empty(t, writer.sessions)
+}
+
+func TestProcessExport_NoTokenUsage(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	attrs := outputMsgAttrs(makeMessageValue("assistant", "response"))
+	span := makeSpan("conv-456", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("default", "agent", span)
+
+	_, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Empty(t, writer.stats)
+}
+
+func TestProcessExport_CreateSessionError(t *testing.T) {
+	writer := newMockWriter()
+	writer.createErr = errors.New("db error")
+
+	transformer := NewTransformer(writer, logr.Discard())
+
+	span := makeSpan("conv-err", uint64(time.Now().UnixNano()), nil)
+	rs := makeResourceSpans("default", "agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	assert.Error(t, err)
+	assert.Equal(t, 0, processed)
+}
+
+func TestProcessExport_AppendMessageError(t *testing.T) {
+	writer := newMockWriter()
+	writer.appendErr = errors.New("append failed")
+
+	transformer := NewTransformer(writer, logr.Discard())
+
+	attrs := outputMsgAttrs(makeMessageValue("assistant", "response"))
+	span := makeSpan("conv-append-err", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("default", "agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	assert.Error(t, err)
+	assert.Equal(t, 0, processed)
+}
+
+func TestProcessExport_UpdateStatsError(t *testing.T) {
+	writer := newMockWriter()
+	writer.updateStatsErr = errors.New("stats failed")
+
+	transformer := NewTransformer(writer, logr.Discard())
+
+	span := makeSpan("conv-stats-err", uint64(time.Now().UnixNano()), tokenAttrs(10, 5))
+	rs := makeResourceSpans("default", "agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	assert.Error(t, err)
+	assert.Equal(t, 0, processed)
+}
+
+func TestProcessExport_MultipleSpansSortedByTime(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	base := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+
+	span2 := makeSpan("conv-sort", uint64(base.Add(2*time.Second).UnixNano()),
+		outputMsgAttrs(makeMessageValue("assistant", "second")))
+	span1 := makeSpan("conv-sort", uint64(base.Add(1*time.Second).UnixNano()),
+		outputMsgAttrs(makeMessageValue("assistant", "first")))
+
+	rs := makeResourceSpans("ns", "agent", span2, span1)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 2, processed)
+
+	msgs := writer.messages["conv-sort"]
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "first", msgs[0].Content)
+	assert.Equal(t, "second", msgs[1].Content)
+}
+
+func TestProcessExport_NilResource(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	attrs := outputMsgAttrs(makeMessageValue("assistant", "hello"))
+	span := makeSpan("conv-nil-res", uint64(time.Now().UnixNano()), attrs)
+
+	rs := &tracepb.ResourceSpans{
+		Resource: nil,
+		ScopeSpans: []*tracepb.ScopeSpans{
+			{Spans: []*tracepb.Span{span}},
+		},
+	}
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+
+	sess := writer.sessions["conv-nil-res"]
+	require.NotNil(t, sess)
+	assert.Equal(t, "", sess.AgentName)
+}
+
+func TestProcessExport_EmptyResourceSpans(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	processed, err := transformer.ProcessExport(context.Background(), nil)
+	require.NoError(t, err)
+	assert.Equal(t, 0, processed)
+}
+
+func TestProcessExport_EmptyOutputMessages(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	span := makeSpan("conv-no-msg", uint64(time.Now().UnixNano()), tokenAttrs(10, 5))
+	rs := makeResourceSpans("ns", "agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+	assert.Empty(t, writer.messages)
+}
+
+func TestProcessExport_GetSessionErr_NonNotFound(t *testing.T) {
+	writer := newMockWriter()
+	writer.getSessionErr = errors.New("db connection failed")
+
+	transformer := NewTransformer(writer, logr.Discard())
+
+	span := makeSpan("conv-db-err", uint64(time.Now().UnixNano()), nil)
+	rs := makeResourceSpans("ns", "agent", span)
+
+	_, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db connection failed")
+}
+
+func TestProcessExport_InputAndOutputMessages(t *testing.T) {
+	writer := newMockWriter()
+	transformer := NewTransformer(writer, logr.Discard())
+
+	inputMsgs := []*commonpb.AnyValue{
+		makeMessageValue("user", "What is AI?"),
+	}
+	outputMsgs := []*commonpb.AnyValue{
+		makeMessageValue("assistant", "AI is..."),
+	}
+
+	attrs := []*commonpb.KeyValue{
+		{Key: AttrGenAIInputMessages, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{Values: inputMsgs},
+		}}},
+		{Key: AttrGenAIOutputMessages, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_ArrayValue{
+			ArrayValue: &commonpb.ArrayValue{Values: outputMsgs},
+		}}},
+	}
+
+	span := makeSpan("conv-io", uint64(time.Now().UnixNano()), attrs)
+	rs := makeResourceSpans("ns", "agent", span)
+
+	processed, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
+	require.NoError(t, err)
+	assert.Equal(t, 1, processed)
+
+	msgs := writer.messages["conv-io"]
+	require.Len(t, msgs, 2)
+	assert.Equal(t, session.RoleUser, msgs[0].Role)
+	assert.Equal(t, session.RoleAssistant, msgs[1].Role)
+}
+
+func TestSpanTimestamp(t *testing.T) {
+	expected := time.Date(2025, 6, 15, 10, 0, 0, 0, time.UTC)
+	span := &tracepb.Span{StartTimeUnixNano: uint64(expected.UnixNano())}
+
+	result := spanTimestamp(span)
+	assert.True(t, expected.Equal(result))
+}
+
+func TestSpanTimestamp_Zero(t *testing.T) {
+	span := &tracepb.Span{StartTimeUnixNano: 0}
+	result := spanTimestamp(span)
+	assert.WithinDuration(t, time.Now(), result, 2*time.Second)
+}
+
+func TestExtractContentFromParts(t *testing.T) {
+	// Test the new OTel "parts" format.
+	partsValue := &commonpb.AnyValue{Value: &commonpb.AnyValue_ArrayValue{
+		ArrayValue: &commonpb.ArrayValue{Values: []*commonpb.AnyValue{
+			{Value: &commonpb.AnyValue_KvlistValue{
+				KvlistValue: &commonpb.KeyValueList{Values: []*commonpb.KeyValue{
+					{Key: "type", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "text"}}},
+					{Key: "content", Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "Hello from parts"}}},
+				}},
+			}},
+		}},
+	}}
+
+	result := extractContentFromParts(partsValue)
+	assert.Equal(t, "Hello from parts", result)
+}
+
+func TestExtractContentFromParts_Empty(t *testing.T) {
+	assert.Equal(t, "", extractContentFromParts(nil))
+	assert.Equal(t, "", extractContentFromParts(&commonpb.AnyValue{}))
+}
+
+func TestBuildSessionState(t *testing.T) {
+	attrs := []*commonpb.KeyValue{
+		{Key: AttrGenAIProviderName, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "openai"}}},
+		{Key: AttrGenAIRequestModel, Value: &commonpb.AnyValue{Value: &commonpb.AnyValue_StringValue{StringValue: "gpt-4"}}},
+	}
+
+	state := buildSessionState(attrs)
+	assert.Equal(t, "openai", state["gen_ai.provider"])
+	assert.Equal(t, "gpt-4", state["gen_ai.model"])
+}
+
+func TestBuildSessionState_Empty(t *testing.T) {
+	assert.Nil(t, buildSessionState(nil))
+}


### PR DESCRIPTION
## Summary

- Add gRPC (`:4317`) and HTTP (`:4318`) OTLP endpoints to session-api so any OTel-instrumented agent framework can record sessions without the Omnia-specific WebSocket facade
- Support all three OTel GenAI convention generations: current v1.37+ structured attributes, legacy OpenLLMetry indexed attributes (`gen_ai.prompt.{i}.*`), and span events
- HTTP endpoint accepts both `application/json` and `application/x-protobuf` for external agent compatibility (gRPC recommended for in-cluster use)
- Session ID fallback chain: `gen_ai.conversation.id` → `session.id` → `langfuse.session.id` → resource `session.id` → trace ID hex
- Disabled by default — enable via `sessionApi.otlp.enabled: true` in Helm values
- Includes how-to documentation covering Python/OpenAI SDK, LangChain/OpenLLMetry, and AWS Bedrock/ADOT

## New files

| File | Purpose |
|------|---------|
| `internal/session/otlp/attributes.go` | GenAI convention constants + attribute extraction helpers |
| `internal/session/otlp/transformer.go` | Span-to-session conversion with 3-strategy message resolution |
| `internal/session/otlp/receiver.go` | gRPC TraceServiceServer |
| `internal/session/otlp/handler.go` | HTTP handler for `POST /v1/traces` |
| `internal/session/otlp/*_test.go` | 49 tests, 93%+ coverage |
| `docs/.../configure-otlp-ingestion.md` | How-to guide |

## Modified files

| File | Change |
|------|--------|
| `cmd/session-api/main.go` | OTLP flags, env vars, server wiring |
| `charts/omnia/values.yaml` | `sessionApi.otlp` config block |
| `charts/omnia/templates/session-api/deployment.yaml` | Conditional OTLP env vars + ports |
| `charts/omnia/templates/session-api/service.yaml` | Conditional OTLP service ports |

## Test plan

- [x] `go test ./internal/session/otlp/... -count=1 -v` — 49 tests pass
- [x] Coverage: attributes.go 97.5%, handler.go 87.5%, receiver.go 100%, transformer.go 92.1%
- [x] `golangci-lint run` — 0 issues
- [x] `helm template` renders correctly with OTLP enabled and disabled
- [ ] CI passes

Closes #444