### PR TITLE
feat: implement AWS KMS encryption provider

### DIFF
--- a/ee/pkg/encryption/aes_gcm.go
+++ b/ee/pkg/encryption/aes_gcm.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// aesGCMEncrypt encrypts plaintext with AES-256-GCM using the provided DEK.
+// Returns nonce and ciphertext.
+func aesGCMEncrypt(dek, plaintext []byte) (nonce, ciphertext []byte, err error) {
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: AES cipher creation failed: %v", ErrEncryptionFailed, err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: GCM creation failed: %v", ErrEncryptionFailed, err)
+	}
+
+	nonce = make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, nil, fmt.Errorf("%w: failed to generate nonce: %v", ErrEncryptionFailed, err)
+	}
+
+	ciphertext = gcm.Seal(nil, nonce, plaintext, nil)
+	return nonce, ciphertext, nil
+}
+
+// aesGCMDecrypt decrypts ciphertext with AES-256-GCM using the provided DEK and nonce.
+func aesGCMDecrypt(dek, nonce, ciphertext []byte) ([]byte, error) {
+	block, err := aes.NewCipher(dek)
+	if err != nil {
+		return nil, fmt.Errorf("%w: AES cipher creation failed: %v", ErrDecryptionFailed, err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("%w: GCM creation failed: %v", ErrDecryptionFailed, err)
+	}
+
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: AES-GCM decryption failed: %v", ErrDecryptionFailed, err)
+	}
+	return plaintext, nil
+}
+
+// parseAndValidateEnvelope unmarshals and validates an envelope from ciphertext bytes.
+func parseAndValidateEnvelope(data []byte) (*envelope, error) {
+	var env envelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("%w: invalid envelope: %v", ErrDecryptionFailed, err)
+	}
+	if env.Version != envelopeVersion {
+		return nil, fmt.Errorf("%w: unsupported envelope version: %d", ErrDecryptionFailed, env.Version)
+	}
+	return &env, nil
+}
+
+// sealEnvelope creates an envelope JSON from the components.
+func sealEnvelope(wrappedDEK, nonce, ciphertext []byte, keyVersion string) ([]byte, error) {
+	env := envelope{
+		Version:    envelopeVersion,
+		WrappedDEK: wrappedDEK,
+		Nonce:      nonce,
+		Ciphertext: ciphertext,
+		KeyVersion: keyVersion,
+	}
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("%w: failed to marshal envelope: %v", ErrEncryptionFailed, err)
+	}
+	return envBytes, nil
+}

--- a/ee/pkg/encryption/aws_kms.go
+++ b/ee/pkg/encryption/aws_kms.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+// kmsClient abstracts the AWS KMS operations for testability.
+type kmsClient interface {
+	GenerateDataKey(
+		ctx context.Context, params *kms.GenerateDataKeyInput, optFns ...func(*kms.Options),
+	) (*kms.GenerateDataKeyOutput, error)
+	Decrypt(
+		ctx context.Context, params *kms.DecryptInput, optFns ...func(*kms.Options),
+	) (*kms.DecryptOutput, error)
+	DescribeKey(
+		ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options),
+	) (*kms.DescribeKeyOutput, error)
+}
+
+type awsKMSProvider struct {
+	client kmsClient
+	keyID  string
+}
+
+func newAWSKMSProvider(cfg ProviderConfig) (*awsKMSProvider, error) {
+	if cfg.KeyID == "" {
+		return nil, fmt.Errorf("aws-kms: key ID is required")
+	}
+
+	region := cfg.Credentials["region"]
+	if region == "" {
+		return nil, fmt.Errorf("aws-kms: region is required")
+	}
+
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(region),
+	}
+
+	accessKeyID := cfg.Credentials["access-key-id"]
+	secretAccessKey := cfg.Credentials["secret-access-key"]
+	if accessKeyID != "" && secretAccessKey != "" {
+		opts = append(opts, config.WithCredentialsProvider(
+			credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, ""),
+		))
+	}
+
+	awsCfg, err := config.LoadDefaultConfig(context.Background(), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("aws-kms: failed to load AWS config: %w", err)
+	}
+
+	client := kms.NewFromConfig(awsCfg)
+	return &awsKMSProvider{
+		client: client,
+		keyID:  cfg.KeyID,
+	}, nil
+}
+
+func (p *awsKMSProvider) Encrypt(ctx context.Context, plaintext []byte) (*EncryptOutput, error) {
+	// Generate a data encryption key via AWS KMS.
+	genResp, err := p.client.GenerateDataKey(ctx, &kms.GenerateDataKeyInput{
+		KeyId:   aws.String(p.keyID),
+		KeySpec: types.DataKeySpecAes256,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: KMS GenerateDataKey failed: %v", ErrEncryptionFailed, err)
+	}
+
+	// Encrypt locally with AES-256-GCM.
+	nonce, ciphertext, err := aesGCMEncrypt(genResp.Plaintext, plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Package into envelope.
+	envBytes, err := sealEnvelope(genResp.CiphertextBlob, nonce, ciphertext, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &EncryptOutput{
+		Ciphertext: envBytes,
+		KeyID:      p.keyID,
+		Algorithm:  "AES-256-GCM+AES-256-KMS",
+	}, nil
+}
+
+func (p *awsKMSProvider) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	env, err := parseAndValidateEnvelope(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unwrap the DEK using AWS KMS.
+	decryptResp, err := p.client.Decrypt(ctx, &kms.DecryptInput{
+		CiphertextBlob: env.WrappedDEK,
+		KeyId:          aws.String(p.keyID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: KMS Decrypt failed: %v", ErrDecryptionFailed, err)
+	}
+
+	return aesGCMDecrypt(decryptResp.Plaintext, env.Nonce, env.Ciphertext)
+}
+
+func (p *awsKMSProvider) GetKeyMetadata(ctx context.Context) (*KeyMetadata, error) {
+	resp, err := p.client.DescribeKey(ctx, &kms.DescribeKeyInput{
+		KeyId: aws.String(p.keyID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrKeyNotFound, err)
+	}
+
+	meta := &KeyMetadata{
+		KeyID:   p.keyID,
+		Enabled: true,
+	}
+
+	if resp.KeyMetadata != nil {
+		meta.Enabled = resp.KeyMetadata.Enabled
+		if resp.KeyMetadata.CreationDate != nil {
+			meta.CreatedAt = *resp.KeyMetadata.CreationDate
+		}
+		if resp.KeyMetadata.ValidTo != nil {
+			meta.ExpiresAt = *resp.KeyMetadata.ValidTo
+		}
+		meta.Algorithm = string(resp.KeyMetadata.KeySpec)
+	}
+
+	return meta, nil
+}
+
+func (p *awsKMSProvider) Close() error {
+	return nil
+}
+
+// newAWSKMSProviderWithClient creates a provider with an injected client for testing.
+func newAWSKMSProviderWithClient(client kmsClient, keyID string) *awsKMSProvider {
+	return &awsKMSProvider{
+		client: client,
+		keyID:  keyID,
+	}
+}

--- a/ee/pkg/encryption/aws_kms_mock_test.go
+++ b/ee/pkg/encryption/aws_kms_mock_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"io"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/aws/aws-sdk-go-v2/service/kms/types"
+)
+
+// mockKMSClient is a test double for the kmsClient interface.
+type mockKMSClient struct {
+	GenerateDataKeyFn func(
+		ctx context.Context, params *kms.GenerateDataKeyInput, optFns ...func(*kms.Options),
+	) (*kms.GenerateDataKeyOutput, error)
+
+	DecryptFn func(
+		ctx context.Context, params *kms.DecryptInput, optFns ...func(*kms.Options),
+	) (*kms.DecryptOutput, error)
+
+	DescribeKeyFn func(
+		ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options),
+	) (*kms.DescribeKeyOutput, error)
+}
+
+func (m *mockKMSClient) GenerateDataKey(
+	ctx context.Context, params *kms.GenerateDataKeyInput, optFns ...func(*kms.Options),
+) (*kms.GenerateDataKeyOutput, error) {
+	return m.GenerateDataKeyFn(ctx, params, optFns...)
+}
+
+func (m *mockKMSClient) Decrypt(
+	ctx context.Context, params *kms.DecryptInput, optFns ...func(*kms.Options),
+) (*kms.DecryptOutput, error) {
+	return m.DecryptFn(ctx, params, optFns...)
+}
+
+func (m *mockKMSClient) DescribeKey(
+	ctx context.Context, params *kms.DescribeKeyInput, optFns ...func(*kms.Options),
+) (*kms.DescribeKeyOutput, error) {
+	return m.DescribeKeyFn(ctx, params, optFns...)
+}
+
+// newMockKMSClient creates a mock AWS KMS client that generates real DEKs
+// and "wraps" them by XORing with a fixed key (same pattern as Azure mock).
+func newMockKMSClient() *mockKMSClient {
+	xorKey := []byte("mock-kms-wrapping-key-32bytes!!!")
+
+	return &mockKMSClient{
+		GenerateDataKeyFn: func(
+			_ context.Context, params *kms.GenerateDataKeyInput, _ ...func(*kms.Options),
+		) (*kms.GenerateDataKeyOutput, error) {
+			// Generate a real AES-256 DEK.
+			dek := make([]byte, aesKeySize)
+			if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+				return nil, err
+			}
+
+			// "Wrap" via XOR.
+			wrapped := make([]byte, len(dek))
+			for i, b := range dek {
+				wrapped[i] = b ^ xorKey[i%len(xorKey)]
+			}
+
+			return &kms.GenerateDataKeyOutput{
+				Plaintext:      dek,
+				CiphertextBlob: wrapped,
+				KeyId:          params.KeyId,
+			}, nil
+		},
+		DecryptFn: func(
+			_ context.Context, params *kms.DecryptInput, _ ...func(*kms.Options),
+		) (*kms.DecryptOutput, error) {
+			// "Unwrap" via XOR.
+			unwrapped := make([]byte, len(params.CiphertextBlob))
+			for i, b := range params.CiphertextBlob {
+				unwrapped[i] = b ^ xorKey[i%len(xorKey)]
+			}
+
+			return &kms.DecryptOutput{
+				Plaintext: unwrapped,
+				KeyId:     params.KeyId,
+			}, nil
+		},
+		DescribeKeyFn: func(
+			_ context.Context, params *kms.DescribeKeyInput, _ ...func(*kms.Options),
+		) (*kms.DescribeKeyOutput, error) {
+			enabled := true
+			created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			return &kms.DescribeKeyOutput{
+				KeyMetadata: &types.KeyMetadata{
+					KeyId:        params.KeyId,
+					Enabled:      enabled,
+					KeySpec:      types.KeySpecSymmetricDefault,
+					CreationDate: &created,
+				},
+			}, nil
+		},
+	}
+}

--- a/ee/pkg/encryption/factory.go
+++ b/ee/pkg/encryption/factory.go
@@ -16,7 +16,7 @@ func NewProvider(cfg ProviderConfig) (Provider, error) {
 	case ProviderAzureKeyVault:
 		return newAzureKeyVaultProvider(cfg)
 	case ProviderAWSKMS:
-		return nil, fmt.Errorf("%w: aws-kms (see https://github.com/AltairaLabs/Omnia/issues/437)", ErrProviderNotImplemented)
+		return newAWSKMSProvider(cfg)
 	case ProviderGCPKMS:
 		return nil, fmt.Errorf("%w: gcp-kms (see https://github.com/AltairaLabs/Omnia/issues/438)", ErrProviderNotImplemented)
 	case ProviderVault:

--- a/go.mod
+++ b/go.mod
@@ -99,6 +99,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/kms v1.50.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -127,6 +127,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 h1:RuNSMooz
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17/go.mod h1:F2xxQ9TZz5gDWsclCtPQscGpP0VUOc8RqgFM3vDENmU=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 h1:bGeHBsGZx0Dvu/eJC0Lh9adJa3M1xREcndxLNZlve2U=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17/go.mod h1:dcW24lbU0CzHusTE8LLHhRLI42ejmINN8Lcr22bwh/g=
+github.com/aws/aws-sdk-go-v2/service/kms v1.50.0 h1:XSvRJBoDObL6Sn4cRmvH9wqjxjL7wf1ZDolUEyP7hw4=
+github.com/aws/aws-sdk-go-v2/service/kms v1.50.0/go.mod h1:1SdcmEGUEQE1mrU2sIgeHtcMSxHuybhPvuEPANzIDfI=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0 h1:oeu8VPlOre74lBA/PMhxa5vewaMIMmILM+RraSyB8KA=
 github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0/go.mod h1:5jggDlZ2CLQhwJBiZJb4vfk4f0GxWdEDruWKEJ1xOdo=
 github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 h1:VrhDvQib/i0lxvr3zqlUwLwJP4fpmpyD9wYG1vfSu+Y=


### PR DESCRIPTION
## Summary
- Implement AWS KMS envelope encryption provider using `GenerateDataKey` for DEK generation and AES-256-GCM for local encryption, following the same pattern as the existing Azure Key Vault provider
- Wire up `ProviderAWSKMS` in the factory (previously returned `ErrProviderNotImplemented`)
- Add comprehensive test suite (13 tests) mirroring Azure provider coverage, including round-trip, error paths, tampered ciphertext, and key metadata

Closes #437

## Test plan
- [x] `go build ./ee/pkg/encryption/...` compiles
- [x] `go test ./ee/pkg/encryption/... -count=1 -v` — all 34 tests pass
- [x] `golangci-lint run ./ee/pkg/encryption/...` — 0 issues
- [x] Coverage on `aws_kms.go`: 89.2%
- [x] Pre-commit hook passes all checks