### PR TITLE
feat: implement GCP Cloud KMS encryption provider

### DIFF
--- a/ee/pkg/encryption/factory.go
+++ b/ee/pkg/encryption/factory.go
@@ -18,7 +18,7 @@ func NewProvider(cfg ProviderConfig) (Provider, error) {
 	case ProviderAWSKMS:
 		return newAWSKMSProvider(cfg)
 	case ProviderGCPKMS:
-		return nil, fmt.Errorf("%w: gcp-kms (see https://github.com/AltairaLabs/Omnia/issues/438)", ErrProviderNotImplemented)
+		return newGCPKMSProvider(cfg)
 	case ProviderVault:
 		return nil, fmt.Errorf("%w: vault (see https://github.com/AltairaLabs/Omnia/issues/439)", ErrProviderNotImplemented)
 	default:

--- a/ee/pkg/encryption/gcp_kms.go
+++ b/ee/pkg/encryption/gcp_kms.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+
+	kms "cloud.google.com/go/kms/apiv1"
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"google.golang.org/api/option"
+)
+
+// gcpKMSClient abstracts the GCP Cloud KMS operations for testability.
+type gcpKMSClient interface {
+	Encrypt(ctx context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error)
+	Decrypt(ctx context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error)
+	GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error)
+	Close() error
+}
+
+// gcpKMSClientWrapper wraps the real KMS client to satisfy the gcpKMSClient interface.
+type gcpKMSClientWrapper struct {
+	client *kms.KeyManagementClient
+}
+
+func (w *gcpKMSClientWrapper) Encrypt(
+	ctx context.Context, req *kmspb.EncryptRequest,
+) (*kmspb.EncryptResponse, error) {
+	return w.client.Encrypt(ctx, req)
+}
+
+func (w *gcpKMSClientWrapper) Decrypt(
+	ctx context.Context, req *kmspb.DecryptRequest,
+) (*kmspb.DecryptResponse, error) {
+	return w.client.Decrypt(ctx, req)
+}
+
+func (w *gcpKMSClientWrapper) GetCryptoKey(
+	ctx context.Context, req *kmspb.GetCryptoKeyRequest,
+) (*kmspb.CryptoKey, error) {
+	return w.client.GetCryptoKey(ctx, req)
+}
+
+func (w *gcpKMSClientWrapper) Close() error {
+	return w.client.Close()
+}
+
+type gcpKMSProvider struct {
+	client gcpKMSClient
+	keyID  string
+}
+
+func newGCPKMSProvider(cfg ProviderConfig) (*gcpKMSProvider, error) {
+	if cfg.KeyID == "" {
+		return nil, fmt.Errorf("gcp-kms: key ID is required")
+	}
+
+	var opts []option.ClientOption
+	if creds := cfg.Credentials["credentials-json"]; creds != "" {
+		//nolint:staticcheck // same pattern as blobstore_gcs.go
+		opts = append(opts, option.WithCredentialsJSON([]byte(creds)))
+	}
+
+	client, err := kms.NewKeyManagementClient(context.Background(), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("gcp-kms: failed to create client: %w", err)
+	}
+
+	return &gcpKMSProvider{
+		client: &gcpKMSClientWrapper{client: client},
+		keyID:  cfg.KeyID,
+	}, nil
+}
+
+func (p *gcpKMSProvider) Encrypt(ctx context.Context, plaintext []byte) (*EncryptOutput, error) {
+	// Generate a random AES-256 DEK locally.
+	dek := make([]byte, aesKeySize)
+	if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+		return nil, fmt.Errorf("%w: failed to generate DEK: %v", ErrEncryptionFailed, err)
+	}
+
+	// Wrap the DEK using GCP Cloud KMS.
+	wrapResp, err := p.client.Encrypt(ctx, &kmspb.EncryptRequest{
+		Name:                        p.keyID,
+		Plaintext:                   dek,
+		PlaintextCrc32C:             nil,
+		AdditionalAuthenticatedData: nil,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: KMS Encrypt (wrap DEK) failed: %v", ErrEncryptionFailed, err)
+	}
+
+	// Encrypt locally with AES-256-GCM.
+	nonce, ciphertext, err := aesGCMEncrypt(dek, plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Package into envelope.
+	envBytes, err := sealEnvelope(wrapResp.Ciphertext, nonce, ciphertext, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &EncryptOutput{
+		Ciphertext: envBytes,
+		KeyID:      p.keyID,
+		Algorithm:  "AES-256-GCM+GCP-KMS",
+	}, nil
+}
+
+func (p *gcpKMSProvider) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	env, err := parseAndValidateEnvelope(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unwrap the DEK using GCP Cloud KMS.
+	decryptResp, err := p.client.Decrypt(ctx, &kmspb.DecryptRequest{
+		Name:       p.keyID,
+		Ciphertext: env.WrappedDEK,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: KMS Decrypt failed: %v", ErrDecryptionFailed, err)
+	}
+
+	return aesGCMDecrypt(decryptResp.Plaintext, env.Nonce, env.Ciphertext)
+}
+
+func (p *gcpKMSProvider) GetKeyMetadata(ctx context.Context) (*KeyMetadata, error) {
+	resp, err := p.client.GetCryptoKey(ctx, &kmspb.GetCryptoKeyRequest{
+		Name: p.keyID,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrKeyNotFound, err)
+	}
+
+	meta := &KeyMetadata{
+		KeyID:   p.keyID,
+		Enabled: true,
+	}
+
+	if resp.Primary != nil {
+		meta.Algorithm = resp.Primary.Algorithm.String()
+		if resp.Primary.CreateTime != nil {
+			meta.CreatedAt = resp.Primary.CreateTime.AsTime()
+		}
+		if resp.Primary.State == kmspb.CryptoKeyVersion_CRYPTO_KEY_VERSION_STATE_UNSPECIFIED ||
+			resp.Primary.State == kmspb.CryptoKeyVersion_DESTROYED ||
+			resp.Primary.State == kmspb.CryptoKeyVersion_DESTROY_SCHEDULED {
+			meta.Enabled = false
+		}
+	}
+
+	if resp.DestroyScheduledDuration != nil {
+		meta.ExpiresAt = resp.CreateTime.AsTime().Add(resp.DestroyScheduledDuration.AsDuration())
+	}
+
+	return meta, nil
+}
+
+func (p *gcpKMSProvider) Close() error {
+	return p.client.Close()
+}
+
+// newGCPKMSProviderWithClient creates a provider with an injected client for testing.
+func newGCPKMSProviderWithClient(client gcpKMSClient, keyID string) *gcpKMSProvider {
+	return &gcpKMSProvider{
+		client: client,
+		keyID:  keyID,
+	}
+}

--- a/ee/pkg/encryption/gcp_kms_mock_test.go
+++ b/ee/pkg/encryption/gcp_kms_mock_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"context"
+	"time"
+
+	"cloud.google.com/go/kms/apiv1/kmspb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// mockGCPKMSClient is a test double for the gcpKMSClient interface.
+type mockGCPKMSClient struct {
+	EncryptFn      func(ctx context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error)
+	DecryptFn      func(ctx context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error)
+	GetCryptoKeyFn func(ctx context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error)
+}
+
+func (m *mockGCPKMSClient) Encrypt(ctx context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error) {
+	return m.EncryptFn(ctx, req)
+}
+
+func (m *mockGCPKMSClient) Decrypt(ctx context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error) {
+	return m.DecryptFn(ctx, req)
+}
+
+func (m *mockGCPKMSClient) GetCryptoKey(ctx context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+	return m.GetCryptoKeyFn(ctx, req)
+}
+
+func (m *mockGCPKMSClient) Close() error {
+	return nil
+}
+
+// newMockGCPKMSClient creates a mock GCP KMS client that wraps/unwraps DEKs
+// by XORing with a fixed key (same pattern as AWS and Azure mocks).
+func newMockGCPKMSClient() *mockGCPKMSClient {
+	xorKey := []byte("mock-kms-wrapping-key-32bytes!!!")
+
+	return &mockGCPKMSClient{
+		EncryptFn: func(_ context.Context, req *kmspb.EncryptRequest) (*kmspb.EncryptResponse, error) {
+			wrapped := make([]byte, len(req.Plaintext))
+			for i, b := range req.Plaintext {
+				wrapped[i] = b ^ xorKey[i%len(xorKey)]
+			}
+			return &kmspb.EncryptResponse{
+				Ciphertext: wrapped,
+				Name:       req.Name,
+			}, nil
+		},
+		DecryptFn: func(_ context.Context, req *kmspb.DecryptRequest) (*kmspb.DecryptResponse, error) {
+			unwrapped := make([]byte, len(req.Ciphertext))
+			for i, b := range req.Ciphertext {
+				unwrapped[i] = b ^ xorKey[i%len(xorKey)]
+			}
+			return &kmspb.DecryptResponse{
+				Plaintext: unwrapped,
+			}, nil
+		},
+		GetCryptoKeyFn: func(_ context.Context, req *kmspb.GetCryptoKeyRequest) (*kmspb.CryptoKey, error) {
+			created := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+			return &kmspb.CryptoKey{
+				Name:       req.Name,
+				CreateTime: timestamppb.New(created),
+				Primary: &kmspb.CryptoKeyVersion{
+					Algorithm:  kmspb.CryptoKeyVersion_GOOGLE_SYMMETRIC_ENCRYPTION,
+					State:      kmspb.CryptoKeyVersion_ENABLED,
+					CreateTime: timestamppb.New(created),
+				},
+				DestroyScheduledDuration: durationpb.New(24 * time.Hour),
+			}, nil
+		},
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/altairalabs/omnia
 go 1.25.1
 
 require (
+	cloud.google.com/go/kms v1.25.0
 	cloud.google.com/go/storage v1.59.2
 	github.com/AltairaLabs/PromptKit/pkg v1.1.10
 	github.com/AltairaLabs/PromptKit/runtime v1.1.10
@@ -17,6 +18,7 @@ require (
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
+	github.com/aws/aws-sdk-go-v2/service/kms v1.50.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.96.0
 	github.com/cyphar/filepath-securejoin v0.6.1
 	github.com/go-git/go-git/v5 v5.16.4
@@ -69,6 +71,7 @@ require (
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
 	cloud.google.com/go/iam v1.5.3 // indirect
+	cloud.google.com/go/longrunning v0.7.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	dario.cat/mergo v1.0.2 // indirect
 	github.com/99designs/go-keychain v0.0.0-20191008050251-8e49817e8af4 // indirect
@@ -99,7 +102,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.17 // indirect
-	github.com/aws/aws-sdk-go-v2/service/kms v1.50.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdB
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
 cloud.google.com/go/iam v1.5.3 h1:+vMINPiDF2ognBJ97ABAYYwRgsaqxPbQDlMnbHMjolc=
 cloud.google.com/go/iam v1.5.3/go.mod h1:MR3v9oLkZCTlaqljW6Eb2d3HGDGK5/bDv93jhfISFvU=
+cloud.google.com/go/kms v1.25.0 h1:gVqvGGUmz0nYCmtoxWmdc1wli2L1apgP8U4fghPGSbQ=
+cloud.google.com/go/kms v1.25.0/go.mod h1:XIdHkzfj0bUO3E+LvwPg+oc7s58/Ns8Nd8Sdtljihbk=
 cloud.google.com/go/logging v1.13.1 h1:O7LvmO0kGLaHY/gq8cV7T0dyp6zJhYAOtZPX4TF3QtY=
 cloud.google.com/go/logging v1.13.1/go.mod h1:XAQkfkMBxQRjQek96WLPNze7vsOmay9H5PqfsNYDqvw=
 cloud.google.com/go/longrunning v0.7.0 h1:FV0+SYF1RIj59gyoWDRi45GiYUMM3K1qO51qoboQT1E=


### PR DESCRIPTION
## Summary
- Implements the GCP Cloud KMS encryption provider for envelope encryption (#438)
- Generates DEKs locally and wraps via GCP KMS `Encrypt` (GCP lacks `GenerateDataKey`)
- Follows the same patterns as AWS KMS and Azure Key Vault providers
- Wires up `gcp-kms` provider type in the factory

## Test plan
- [x] 13 unit tests covering encrypt/decrypt round-trip, error paths, key metadata, disabled keys
- [x] Coverage at 83.3% on `gcp_kms.go` (above 80% threshold)
- [x] golangci-lint clean
- [x] All pre-commit checks pass

Closes #438