### PR TITLE
feat: implement HashiCorp Vault Transit encryption provider (#439)

### DIFF
--- a/ee/pkg/encryption/factory.go
+++ b/ee/pkg/encryption/factory.go
@@ -20,7 +20,7 @@ func NewProvider(cfg ProviderConfig) (Provider, error) {
 	case ProviderGCPKMS:
 		return newGCPKMSProvider(cfg)
 	case ProviderVault:
-		return nil, fmt.Errorf("%w: vault (see https://github.com/AltairaLabs/Omnia/issues/439)", ErrProviderNotImplemented)
+		return newVaultProvider(cfg)
 	default:
 		return nil, fmt.Errorf("unknown encryption provider type: %q", cfg.ProviderType)
 	}

--- a/ee/pkg/encryption/vault_transit.go
+++ b/ee/pkg/encryption/vault_transit.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+const (
+	defaultMountPath       = "transit"
+	vaultHTTPClientTimeout = 30 * time.Second
+	vaultTokenHeader       = "X-Vault-Token"
+	vaultAlgorithm         = "AES-256-GCM+VAULT-TRANSIT"
+)
+
+// vaultTransitClient abstracts the Vault Transit operations for testability.
+type vaultTransitClient interface {
+	GenerateDataKey(ctx context.Context, keyName string) (*vaultDataKeyResponse, error)
+	DecryptDEK(ctx context.Context, keyName string, ciphertext string) ([]byte, error)
+	ReadKey(ctx context.Context, keyName string) (*vaultKeyInfo, error)
+}
+
+// vaultDataKeyResponse holds the response from the Vault datakey endpoint.
+type vaultDataKeyResponse struct {
+	Plaintext  []byte // decoded from base64
+	Ciphertext string // vault:v1:... (opaque, stored in envelope)
+}
+
+// vaultKeyInfo holds metadata about a Vault Transit key.
+type vaultKeyInfo struct {
+	Name            string
+	Type            string
+	LatestVersion   int
+	MinDecryptVer   int
+	DeletionAllowed bool
+	CreatedAt       time.Time
+}
+
+// vaultHTTPClient is the real HTTP implementation of vaultTransitClient.
+type vaultHTTPClient struct {
+	httpClient *http.Client
+	addr       string
+	token      string
+	mountPath  string
+}
+
+// vaultAPIResponse is the generic Vault API JSON response wrapper.
+type vaultAPIResponse struct {
+	Data json.RawMessage `json:"data"`
+}
+
+// vaultDataKeyData is the data field from the datakey endpoint.
+type vaultDataKeyData struct {
+	Plaintext  string `json:"plaintext"`
+	Ciphertext string `json:"ciphertext"`
+}
+
+// vaultDecryptData is the data field from the decrypt endpoint.
+type vaultDecryptData struct {
+	Plaintext string `json:"plaintext"`
+}
+
+// vaultKeyData is the data field from the keys endpoint.
+type vaultKeyData struct {
+	Name                 string                       `json:"name"`
+	Type                 string                       `json:"type"`
+	LatestVersion        int                          `json:"latest_version"`
+	MinDecryptionVersion int                          `json:"min_decryption_version"`
+	DeletionAllowed      bool                         `json:"deletion_allowed"`
+	Keys                 map[string]vaultKeyVersionTS `json:"keys"`
+}
+
+// vaultKeyVersionTS captures the creation time from key version metadata.
+type vaultKeyVersionTS struct {
+	CreationTime string `json:"creation_time"`
+}
+
+func (c *vaultHTTPClient) GenerateDataKey(ctx context.Context, keyName string) (*vaultDataKeyResponse, error) {
+	url := fmt.Sprintf("%s/v1/%s/datakey/plaintext/%s", c.addr, c.mountPath, keyName)
+	body := []byte(`{"bits":256}`)
+
+	respBody, err := c.doRequest(ctx, http.MethodPost, url, body)
+	if err != nil {
+		return nil, fmt.Errorf("vault datakey request failed: %w", err)
+	}
+
+	var apiResp vaultAPIResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("vault datakey: invalid response JSON: %w", err)
+	}
+
+	var data vaultDataKeyData
+	if err := json.Unmarshal(apiResp.Data, &data); err != nil {
+		return nil, fmt.Errorf("vault datakey: invalid data JSON: %w", err)
+	}
+
+	plaintext, err := base64.StdEncoding.DecodeString(data.Plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("vault datakey: invalid base64 plaintext: %w", err)
+	}
+
+	return &vaultDataKeyResponse{
+		Plaintext:  plaintext,
+		Ciphertext: data.Ciphertext,
+	}, nil
+}
+
+func (c *vaultHTTPClient) DecryptDEK(ctx context.Context, keyName string, ciphertext string) ([]byte, error) {
+	url := fmt.Sprintf("%s/v1/%s/decrypt/%s", c.addr, c.mountPath, keyName)
+
+	reqBody, err := json.Marshal(map[string]string{"ciphertext": ciphertext})
+	if err != nil {
+		return nil, fmt.Errorf("vault decrypt: failed to marshal request: %w", err)
+	}
+
+	respBody, err := c.doRequest(ctx, http.MethodPost, url, reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("vault decrypt request failed: %w", err)
+	}
+
+	var apiResp vaultAPIResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("vault decrypt: invalid response JSON: %w", err)
+	}
+
+	var data vaultDecryptData
+	if err := json.Unmarshal(apiResp.Data, &data); err != nil {
+		return nil, fmt.Errorf("vault decrypt: invalid data JSON: %w", err)
+	}
+
+	plaintext, err := base64.StdEncoding.DecodeString(data.Plaintext)
+	if err != nil {
+		return nil, fmt.Errorf("vault decrypt: invalid base64 plaintext: %w", err)
+	}
+
+	return plaintext, nil
+}
+
+func (c *vaultHTTPClient) ReadKey(ctx context.Context, keyName string) (*vaultKeyInfo, error) {
+	url := fmt.Sprintf("%s/v1/%s/keys/%s", c.addr, c.mountPath, keyName)
+
+	respBody, err := c.doRequest(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("vault read key request failed: %w", err)
+	}
+
+	var apiResp vaultAPIResponse
+	if err := json.Unmarshal(respBody, &apiResp); err != nil {
+		return nil, fmt.Errorf("vault read key: invalid response JSON: %w", err)
+	}
+
+	var data vaultKeyData
+	if err := json.Unmarshal(apiResp.Data, &data); err != nil {
+		return nil, fmt.Errorf("vault read key: invalid data JSON: %w", err)
+	}
+
+	info := &vaultKeyInfo{
+		Name:            data.Name,
+		Type:            data.Type,
+		LatestVersion:   data.LatestVersion,
+		MinDecryptVer:   data.MinDecryptionVersion,
+		DeletionAllowed: data.DeletionAllowed,
+	}
+
+	// Parse creation time from version "1" if available.
+	if v1, ok := data.Keys["1"]; ok && v1.CreationTime != "" {
+		if t, err := time.Parse(time.RFC3339Nano, v1.CreationTime); err == nil {
+			info.CreatedAt = t
+		}
+	}
+
+	return info, nil
+}
+
+func (c *vaultHTTPClient) doRequest(ctx context.Context, method, url string, body []byte) ([]byte, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set(vaultTokenHeader, c.token)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("vault returned HTTP %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	return respBody, nil
+}
+
+// vaultProvider implements the Provider interface using HashiCorp Vault Transit.
+type vaultProvider struct {
+	client vaultTransitClient
+	keyID  string
+}
+
+func newVaultProvider(cfg ProviderConfig) (*vaultProvider, error) {
+	if cfg.VaultURL == "" {
+		return nil, fmt.Errorf("vault: vault URL is required")
+	}
+	if cfg.KeyID == "" {
+		return nil, fmt.Errorf("vault: key ID is required")
+	}
+
+	token := cfg.Credentials["token"]
+	if token == "" {
+		return nil, fmt.Errorf("vault: token credential is required")
+	}
+
+	mountPath := cfg.Credentials["mount-path"]
+	if mountPath == "" {
+		mountPath = defaultMountPath
+	}
+
+	client := &vaultHTTPClient{
+		httpClient: &http.Client{Timeout: vaultHTTPClientTimeout},
+		addr:       cfg.VaultURL,
+		token:      token,
+		mountPath:  mountPath,
+	}
+
+	return &vaultProvider{
+		client: client,
+		keyID:  cfg.KeyID,
+	}, nil
+}
+
+func (p *vaultProvider) Encrypt(ctx context.Context, plaintext []byte) (*EncryptOutput, error) {
+	// Generate a data encryption key via Vault Transit.
+	resp, err := p.client.GenerateDataKey(ctx, p.keyID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: Vault GenerateDataKey failed: %v", ErrEncryptionFailed, err)
+	}
+
+	// Encrypt locally with AES-256-GCM.
+	nonce, ciphertext, err := aesGCMEncrypt(resp.Plaintext, plaintext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Store the Vault ciphertext string as the wrapped DEK.
+	wrappedDEK := []byte(resp.Ciphertext)
+
+	// Package into envelope.
+	envBytes, err := sealEnvelope(wrappedDEK, nonce, ciphertext, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return &EncryptOutput{
+		Ciphertext: envBytes,
+		KeyID:      p.keyID,
+		Algorithm:  vaultAlgorithm,
+	}, nil
+}
+
+func (p *vaultProvider) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	env, err := parseAndValidateEnvelope(ciphertext)
+	if err != nil {
+		return nil, err
+	}
+
+	// Unwrap the DEK using Vault Transit.
+	dek, err := p.client.DecryptDEK(ctx, p.keyID, string(env.WrappedDEK))
+	if err != nil {
+		return nil, fmt.Errorf("%w: Vault Decrypt failed: %v", ErrDecryptionFailed, err)
+	}
+
+	return aesGCMDecrypt(dek, env.Nonce, env.Ciphertext)
+}
+
+func (p *vaultProvider) GetKeyMetadata(ctx context.Context) (*KeyMetadata, error) {
+	info, err := p.client.ReadKey(ctx, p.keyID)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrKeyNotFound, err)
+	}
+
+	return &KeyMetadata{
+		KeyID:      p.keyID,
+		KeyVersion: strconv.Itoa(info.LatestVersion),
+		Algorithm:  info.Type,
+		CreatedAt:  info.CreatedAt,
+		Enabled:    true,
+	}, nil
+}
+
+func (p *vaultProvider) Close() error {
+	return nil
+}
+
+// newVaultProviderWithClient creates a provider with an injected client for testing.
+func newVaultProviderWithClient(client vaultTransitClient, keyID string) *vaultProvider {
+	return &vaultProvider{
+		client: client,
+		keyID:  keyID,
+	}
+}

--- a/ee/pkg/encryption/vault_transit_http_test.go
+++ b/ee/pkg/encryption/vault_transit_http_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestVaultServer(t *testing.T, handler http.HandlerFunc) (*httptest.Server, *vaultHTTPClient) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	client := &vaultHTTPClient{
+		httpClient: srv.Client(),
+		addr:       srv.URL,
+		token:      "s.test-token",
+		mountPath:  "transit",
+	}
+	return srv, client
+}
+
+func TestVaultHTTPClient_GenerateDataKey(t *testing.T) {
+	plaintext := make([]byte, 32)
+	for i := range plaintext {
+		plaintext[i] = byte(i)
+	}
+
+	srv, client := newTestVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/transit/datakey/plaintext/my-key", r.URL.Path)
+		assert.Equal(t, "s.test-token", r.Header.Get("X-Vault-Token"))
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"plaintext":  base64.StdEncoding.EncodeToString(plaintext),
+				"ciphertext": "vault:v1:abc123",
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	})
+	defer srv.Close()
+
+	result, err := client.GenerateDataKey(context.Background(), "my-key")
+	require.NoError(t, err)
+	assert.Equal(t, plaintext, result.Plaintext)
+	assert.Equal(t, "vault:v1:abc123", result.Ciphertext)
+}
+
+func TestVaultHTTPClient_GenerateDataKey_HTTPError(t *testing.T) {
+	srv, client := newTestVaultServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte(`{"errors":["permission denied"]}`)) //nolint:errcheck
+	})
+	defer srv.Close()
+
+	_, err := client.GenerateDataKey(context.Background(), "my-key")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 403")
+}
+
+func TestVaultHTTPClient_DecryptDEK(t *testing.T) {
+	expectedPlaintext := make([]byte, 32)
+	for i := range expectedPlaintext {
+		expectedPlaintext[i] = byte(i)
+	}
+
+	srv, client := newTestVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.Equal(t, "/v1/transit/decrypt/my-key", r.URL.Path)
+
+		var body map[string]string
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		assert.Equal(t, "vault:v1:abc123", body["ciphertext"])
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"plaintext": base64.StdEncoding.EncodeToString(expectedPlaintext),
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	})
+	defer srv.Close()
+
+	result, err := client.DecryptDEK(context.Background(), "my-key", "vault:v1:abc123")
+	require.NoError(t, err)
+	assert.Equal(t, expectedPlaintext, result)
+}
+
+func TestVaultHTTPClient_DecryptDEK_HTTPError(t *testing.T) {
+	srv, client := newTestVaultServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"errors":["invalid ciphertext"]}`)) //nolint:errcheck
+	})
+	defer srv.Close()
+
+	_, err := client.DecryptDEK(context.Background(), "my-key", "vault:v1:bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 400")
+}
+
+func TestVaultHTTPClient_ReadKey(t *testing.T) {
+	srv, client := newTestVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/v1/transit/keys/my-key", r.URL.Path)
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"name":                   "my-key",
+				"type":                   "aes256-gcm96",
+				"latest_version":         1,
+				"min_decryption_version": 1,
+				"deletion_allowed":       false,
+				"keys": map[string]any{
+					"1": map[string]any{
+						"creation_time": "2026-01-01T00:00:00Z",
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	})
+	defer srv.Close()
+
+	info, err := client.ReadKey(context.Background(), "my-key")
+	require.NoError(t, err)
+	assert.Equal(t, "my-key", info.Name)
+	assert.Equal(t, "aes256-gcm96", info.Type)
+	assert.Equal(t, 1, info.LatestVersion)
+	assert.Equal(t, 1, info.MinDecryptVer)
+	assert.False(t, info.DeletionAllowed)
+	assert.False(t, info.CreatedAt.IsZero())
+}
+
+func TestVaultHTTPClient_ReadKey_HTTPError(t *testing.T) {
+	srv, client := newTestVaultServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"errors":["no key found"]}`)) //nolint:errcheck
+	})
+	defer srv.Close()
+
+	_, err := client.ReadKey(context.Background(), "nonexistent")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "HTTP 404")
+}
+
+func TestVaultHTTPClient_CustomMountPath(t *testing.T) {
+	srv, client := newTestVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/custom-transit/keys/my-key", r.URL.Path)
+
+		resp := map[string]any{
+			"data": map[string]any{
+				"name":           "my-key",
+				"type":           "aes256-gcm96",
+				"latest_version": 1,
+				"keys":           map[string]any{},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp) //nolint:errcheck
+	})
+	defer srv.Close()
+
+	client.mountPath = "custom-transit"
+	info, err := client.ReadKey(context.Background(), "my-key")
+	require.NoError(t, err)
+	assert.Equal(t, "my-key", info.Name)
+}

--- a/ee/pkg/encryption/vault_transit_mock_test.go
+++ b/ee/pkg/encryption/vault_transit_mock_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package encryption
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"time"
+)
+
+// mockVaultTransitClient is a test double for the vaultTransitClient interface.
+type mockVaultTransitClient struct {
+	GenerateDataKeyFn func(ctx context.Context, keyName string) (*vaultDataKeyResponse, error)
+	DecryptDEKFn      func(ctx context.Context, keyName string, ciphertext string) ([]byte, error)
+	ReadKeyFn         func(ctx context.Context, keyName string) (*vaultKeyInfo, error)
+}
+
+func (m *mockVaultTransitClient) GenerateDataKey(ctx context.Context, keyName string) (*vaultDataKeyResponse, error) {
+	return m.GenerateDataKeyFn(ctx, keyName)
+}
+
+func (m *mockVaultTransitClient) DecryptDEK(ctx context.Context, keyName string, ciphertext string) ([]byte, error) {
+	return m.DecryptDEKFn(ctx, keyName, ciphertext)
+}
+
+func (m *mockVaultTransitClient) ReadKey(ctx context.Context, keyName string) (*vaultKeyInfo, error) {
+	return m.ReadKeyFn(ctx, keyName)
+}
+
+// newMockVaultTransitClient creates a mock Vault Transit client that generates real DEKs
+// and "wraps" them by XORing with a fixed key (same pattern as AWS and GCP mocks).
+func newMockVaultTransitClient() *mockVaultTransitClient {
+	xorKey := []byte("mock-kms-wrapping-key-32bytes!!!")
+
+	return &mockVaultTransitClient{
+		GenerateDataKeyFn: func(_ context.Context, _ string) (*vaultDataKeyResponse, error) {
+			// Generate a real AES-256 DEK.
+			dek := make([]byte, aesKeySize)
+			if _, err := io.ReadFull(rand.Reader, dek); err != nil {
+				return nil, err
+			}
+
+			// "Wrap" via XOR and encode as vault-style ciphertext.
+			wrapped := make([]byte, len(dek))
+			for i, b := range dek {
+				wrapped[i] = b ^ xorKey[i%len(xorKey)]
+			}
+			vaultCiphertext := fmt.Sprintf("vault:v1:%s", base64.StdEncoding.EncodeToString(wrapped))
+
+			return &vaultDataKeyResponse{
+				Plaintext:  dek,
+				Ciphertext: vaultCiphertext,
+			}, nil
+		},
+		DecryptDEKFn: func(_ context.Context, _ string, ciphertext string) ([]byte, error) {
+			// Strip "vault:v1:" prefix and decode.
+			const prefix = "vault:v1:"
+			if len(ciphertext) <= len(prefix) {
+				return nil, fmt.Errorf("invalid vault ciphertext format")
+			}
+			encoded := ciphertext[len(prefix):]
+			wrapped, err := base64.StdEncoding.DecodeString(encoded)
+			if err != nil {
+				return nil, fmt.Errorf("invalid base64 in ciphertext: %w", err)
+			}
+
+			// "Unwrap" via XOR.
+			unwrapped := make([]byte, len(wrapped))
+			for i, b := range wrapped {
+				unwrapped[i] = b ^ xorKey[i%len(xorKey)]
+			}
+
+			return unwrapped, nil
+		},
+		ReadKeyFn: func(_ context.Context, keyName string) (*vaultKeyInfo, error) {
+			return &vaultKeyInfo{
+				Name:            keyName,
+				Type:            "aes256-gcm96",
+				LatestVersion:   1,
+				MinDecryptVer:   1,
+				DeletionAllowed: false,
+				CreatedAt:       time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			}, nil
+		},
+	}
+}


### PR DESCRIPTION
## Summary
- Implement the fourth encryption provider using HashiCorp Vault's Transit secrets engine
- Uses raw `net/http` client (no Vault SDK) to call the `datakey/plaintext`, `decrypt`, and `keys` endpoints
- Token-based auth via `X-Vault-Token` header with configurable Transit mount path (default `"transit"`)
- Algorithm: `AES-256-GCM+VAULT-TRANSIT` (envelope encryption with Vault-managed DEK generation)

## Changes
| File | Action |
|------|--------|
| `ee/pkg/encryption/vault_transit.go` | **New** — Provider + HTTP client implementation |
| `ee/pkg/encryption/vault_transit_mock_test.go` | **New** — Mock client (XOR wrapping pattern) |
| `ee/pkg/encryption/vault_transit_http_test.go` | **New** — HTTP client tests via `httptest` |
| `ee/pkg/encryption/factory.go` | **Modified** — Wire up `ProviderVault` (was `ErrProviderNotImplemented`) |
| `ee/pkg/encryption/encryption_test.go` | **Modified** — Updated factory test + 14 provider tests |

## Design decisions
- **No Vault SDK**: The Transit API is 3 simple REST endpoints — using `net/http` avoids the large `github.com/hashicorp/vault/api` dependency tree
- **DEK generation via Vault**: Uses `POST /transit/datakey/plaintext/:name` which returns both plaintext and wrapped DEK in one call (like AWS `GenerateDataKey`)
- **No new dependencies**: All stdlib (`net/http`, `encoding/json`, `encoding/base64`)

Closes #439

## Test plan
- [x] All 65 encryption package tests pass
- [x] `golangci-lint` clean (0 issues)
- [x] `vault_transit.go` coverage: 86.4% (threshold: 80%)
- [x] Pre-commit hooks pass