### PR TITLE
feat: implement arena assertion runner for eval pipeline (#496)

### DIFF
--- a/ee/pkg/evals/arena_runner.go
+++ b/ee/pkg/evals/arena_runner.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package evals
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/AltairaLabs/PromptKit/tools/arena/assertions"
+
+	"github.com/altairalabs/omnia/internal/session"
+	api "github.com/altairalabs/omnia/internal/session/api"
+)
+
+// EvalTypeArenaAssertion is the eval type for PromptKit arena assertions.
+const EvalTypeArenaAssertion = "arena_assertion"
+
+// Param keys for arena assertion eval definitions.
+const (
+	paramAssertionType   = "assertion_type"
+	paramAssertionParams = "assertion_params"
+)
+
+// RunArenaAssertion executes a PromptKit arena conversation assertion against
+// session messages. It matches the EvalRunner function signature so it can be
+// composed with RunRuleEval via a dispatcher.
+func RunArenaAssertion(def api.EvalDefinition, messages []session.Message) (api.EvaluateResultItem, error) {
+	start := time.Now()
+
+	assertionType, err := extractAssertionType(def.Params)
+	if err != nil {
+		return api.EvaluateResultItem{}, fmt.Errorf("eval %q: %w", def.ID, err)
+	}
+
+	assertionParams := extractAssertionParams(def.Params)
+
+	typesMessages := ConvertToTypesMessages(messages)
+	convCtx := buildConversationContext(typesMessages)
+
+	registry := assertions.NewConversationAssertionRegistry()
+	assertion := assertions.ConversationAssertion{
+		Type:   assertionType,
+		Params: assertionParams,
+	}
+
+	result := registry.ValidateConversation(context.Background(), assertion, convCtx)
+
+	durationMs := int(time.Since(start).Milliseconds())
+	score := scoreFromPassed(result.Passed)
+
+	return api.EvaluateResultItem{
+		EvalID:     def.ID,
+		EvalType:   EvalTypeArenaAssertion,
+		Trigger:    def.Trigger,
+		Passed:     result.Passed,
+		Score:      &score,
+		DurationMs: durationMs,
+		Source:     "manual",
+	}, nil
+}
+
+// buildConversationContext constructs the ConversationContext needed by arena
+// assertion validators from a slice of types.Message.
+func buildConversationContext(messages []types.Message) *assertions.ConversationContext {
+	convCtx := &assertions.ConversationContext{
+		AllTurns: messages,
+	}
+
+	for i, msg := range messages {
+		for _, tc := range msg.ToolCalls {
+			record := assertions.ToolCallRecord{
+				TurnIndex: i,
+				ToolName:  tc.Name,
+				Arguments: parseArgsToMap(tc.Args),
+			}
+			convCtx.ToolCalls = append(convCtx.ToolCalls, record)
+		}
+	}
+
+	return convCtx
+}
+
+// parseArgsToMap converts JSON-encoded arguments to a map.
+func parseArgsToMap(raw json.RawMessage) map[string]any {
+	if len(raw) == 0 {
+		return nil
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+// extractAssertionType gets the required assertion_type from params.
+func extractAssertionType(params map[string]any) (string, error) {
+	v, ok := params[paramAssertionType]
+	if !ok {
+		return "", fmt.Errorf("missing required param %q", paramAssertionType)
+	}
+	s, ok := v.(string)
+	if !ok || s == "" {
+		return "", fmt.Errorf("param %q must be a non-empty string", paramAssertionType)
+	}
+	return s, nil
+}
+
+// extractAssertionParams gets the optional assertion_params map from params.
+func extractAssertionParams(params map[string]any) map[string]any {
+	v, ok := params[paramAssertionParams]
+	if !ok {
+		return nil
+	}
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil
+	}
+	return m
+}
+
+// scoreFromPassed returns 1.0 for passed, 0.0 for failed.
+func scoreFromPassed(passed bool) float64 {
+	if passed {
+		return 1.0
+	}
+	return 0.0
+}

--- a/ee/pkg/evals/arena_runner_test.go
+++ b/ee/pkg/evals/arena_runner_test.go
@@ -1,0 +1,591 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package evals
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/omnia/internal/session"
+	api "github.com/altairalabs/omnia/internal/session/api"
+)
+
+func TestRunArenaAssertion_ToolsCalled_Pass(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleUser,
+			Content: "Check the weather", Timestamp: time.Now(),
+		},
+		{
+			ID: "m2", Role: session.RoleAssistant,
+			Content:    `{"name":"get_weather","arguments":"{\"city\":\"NYC\"}"}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+		{
+			ID: "m3", Role: session.RoleSystem,
+			Content:    `{"temp":72}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_result"},
+		},
+		{
+			ID: "m4", Role: session.RoleAssistant,
+			Content: "It's 72F in NYC.", Timestamp: time.Now(),
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:      "eval-1",
+		Type:    EvalTypeArenaAssertion,
+		Trigger: "session_end",
+		Params: map[string]any{
+			"assertion_type": "tools_called",
+			"assertion_params": map[string]any{
+				"tool_names": []any{"get_weather"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected assertion to pass")
+	}
+	if result.Score == nil || *result.Score != 1.0 {
+		t.Errorf("expected score 1.0, got %v", result.Score)
+	}
+	if result.EvalID != "eval-1" {
+		t.Errorf("expected evalID eval-1, got %s", result.EvalID)
+	}
+	if result.EvalType != EvalTypeArenaAssertion {
+		t.Errorf("expected evalType %s, got %s", EvalTypeArenaAssertion, result.EvalType)
+	}
+	if result.Trigger != "session_end" {
+		t.Errorf("expected trigger session_end, got %s", result.Trigger)
+	}
+}
+
+func TestRunArenaAssertion_ToolsCalled_Fail(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleUser,
+			Content: "Hello", Timestamp: time.Now(),
+		},
+		{
+			ID: "m2", Role: session.RoleAssistant,
+			Content: "Hi there!", Timestamp: time.Now(),
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-2",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "tools_called",
+			"assertion_params": map[string]any{
+				"tool_names": []any{"get_weather"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected assertion to fail")
+	}
+	if result.Score == nil || *result.Score != 0.0 {
+		t.Errorf("expected score 0.0, got %v", result.Score)
+	}
+}
+
+func TestRunArenaAssertion_UnknownAssertionType(t *testing.T) {
+	def := api.EvalDefinition{
+		ID:   "eval-3",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "nonexistent_validator",
+		},
+	}
+
+	result, err := RunArenaAssertion(def, []session.Message{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected assertion to fail for unknown type")
+	}
+	if result.Score == nil || *result.Score != 0.0 {
+		t.Errorf("expected score 0.0, got %v", result.Score)
+	}
+}
+
+func TestRunArenaAssertion_MissingAssertionType(t *testing.T) {
+	def := api.EvalDefinition{
+		ID:     "eval-4",
+		Type:   EvalTypeArenaAssertion,
+		Params: map[string]any{},
+	}
+
+	_, err := RunArenaAssertion(def, []session.Message{})
+	if err == nil {
+		t.Fatal("expected error for missing assertion_type")
+	}
+}
+
+func TestRunArenaAssertion_EmptyAssertionType(t *testing.T) {
+	def := api.EvalDefinition{
+		ID:   "eval-5",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "",
+		},
+	}
+
+	_, err := RunArenaAssertion(def, []session.Message{})
+	if err == nil {
+		t.Fatal("expected error for empty assertion_type")
+	}
+}
+
+func TestRunArenaAssertion_EmptyMessages(t *testing.T) {
+	def := api.EvalDefinition{
+		ID:   "eval-6",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "tools_called",
+			"assertion_params": map[string]any{
+				"tool_names": []any{"some_tool"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, []session.Message{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected assertion to fail with empty messages")
+	}
+}
+
+func TestRunArenaAssertion_ContentIncludesAny_Pass(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleUser,
+			Content: "Tell me about Go", Timestamp: time.Now(),
+		},
+		{
+			ID: "m2", Role: session.RoleAssistant,
+			Content: "Go is a statically typed programming language.", Timestamp: time.Now(),
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-7",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "content_includes_any",
+			"assertion_params": map[string]any{
+				"patterns": []any{"programming", "language"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected content_includes_any to pass")
+	}
+}
+
+func TestRunArenaAssertion_ContentNotIncludes_Pass(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleUser,
+			Content: "Tell me about Go", Timestamp: time.Now(),
+		},
+		{
+			ID: "m2", Role: session.RoleAssistant,
+			Content: "Go is a great language.", Timestamp: time.Now(),
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-8",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "content_not_includes",
+			"assertion_params": map[string]any{
+				"patterns": []any{"Python", "Java"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected content_not_includes to pass")
+	}
+}
+
+func TestRunArenaAssertion_ContentNotIncludes_Fail(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content: "Python is also great.", Timestamp: time.Now(),
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-9",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "content_not_includes",
+			"assertion_params": map[string]any{
+				"patterns": []any{"Python"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected content_not_includes to fail when content contains forbidden word")
+	}
+}
+
+func TestRunArenaAssertion_NilAssertionParams(t *testing.T) {
+	def := api.EvalDefinition{
+		ID:   "eval-10",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "tools_called",
+		},
+	}
+
+	result, err := RunArenaAssertion(def, []session.Message{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// With no tool_names specified, tools_called passes (no required tools missing)
+	if !result.Passed {
+		t.Error("expected tools_called with nil params to pass (no requirements)")
+	}
+}
+
+func TestRunArenaAssertion_ToolCallsWithArgs(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    `{"name":"search","arguments":"{\"query\":\"test\",\"limit\":10}"}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+		{
+			ID: "m2", Role: session.RoleSystem,
+			Content:    `{"results":[]}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_result"},
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-11",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "tool_calls_with_args",
+			"assertion_params": map[string]any{
+				"tool_name":     "search",
+				"required_args": map[string]any{"query": "test"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected tool_calls_with_args to pass")
+	}
+}
+
+func TestRunArenaAssertion_MultipleToolCalls(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    `{"name":"tool_a","arguments":"{}"}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+		{
+			ID: "m2", Role: session.RoleSystem,
+			Content:    `"ok"`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_result"},
+		},
+		{
+			ID: "m3", Role: session.RoleAssistant,
+			Content:    `{"name":"tool_b","arguments":"{}"}`,
+			ToolCallID: "tc-2", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+		{
+			ID: "m4", Role: session.RoleSystem,
+			Content:    `"ok"`,
+			ToolCallID: "tc-2", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_result"},
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-12",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "tools_called",
+			"assertion_params": map[string]any{
+				"tool_names": []any{"tool_a", "tool_b"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected tools_called to pass with both tools present")
+	}
+}
+
+func TestRunArenaAssertion_ToolsNotCalled_Pass(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content: "I can help you directly.", Timestamp: time.Now(),
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-13",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "tools_not_called",
+			"assertion_params": map[string]any{
+				"tool_names": []any{"dangerous_tool"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.Passed {
+		t.Error("expected tools_not_called to pass")
+	}
+}
+
+func TestRunArenaAssertion_ToolsNotCalled_Fail(t *testing.T) {
+	messages := []session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    `{"name":"dangerous_tool","arguments":"{}"}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+	}
+
+	def := api.EvalDefinition{
+		ID:   "eval-14",
+		Type: EvalTypeArenaAssertion,
+		Params: map[string]any{
+			"assertion_type": "tools_not_called",
+			"assertion_params": map[string]any{
+				"tool_names": []any{"dangerous_tool"},
+			},
+		},
+	}
+
+	result, err := RunArenaAssertion(def, messages)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Passed {
+		t.Error("expected tools_not_called to fail")
+	}
+}
+
+func TestBuildConversationContext(t *testing.T) {
+	messages := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleUser,
+			Content: "Use tools", Timestamp: time.Now(),
+		},
+		{
+			ID: "m2", Role: session.RoleAssistant,
+			Content:    `{"name":"search","arguments":"{\"q\":\"test\"}"}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+		{
+			ID: "m3", Role: session.RoleSystem,
+			Content:    `{"results":[]}`,
+			ToolCallID: "tc-1", Timestamp: time.Now(),
+			Metadata: map[string]string{"type": "tool_result"},
+		},
+	})
+
+	ctx := buildConversationContext(messages)
+
+	if len(ctx.AllTurns) != 3 {
+		t.Fatalf("expected 3 turns, got %d", len(ctx.AllTurns))
+	}
+	if len(ctx.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call record, got %d", len(ctx.ToolCalls))
+	}
+
+	tc := ctx.ToolCalls[0]
+	if tc.ToolName != "search" {
+		t.Errorf("expected tool name 'search', got %q", tc.ToolName)
+	}
+	if tc.TurnIndex != 1 {
+		t.Errorf("expected turn index 1, got %d", tc.TurnIndex)
+	}
+	if tc.Arguments["q"] != "test" {
+		t.Errorf("expected argument q=test, got %v", tc.Arguments)
+	}
+}
+
+func TestBuildConversationContext_NoToolCalls(t *testing.T) {
+	messages := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleUser,
+			Content: "Hello", Timestamp: time.Now(),
+		},
+		{
+			ID: "m2", Role: session.RoleAssistant,
+			Content: "Hi!", Timestamp: time.Now(),
+		},
+	})
+
+	ctx := buildConversationContext(messages)
+
+	if len(ctx.AllTurns) != 2 {
+		t.Fatalf("expected 2 turns, got %d", len(ctx.AllTurns))
+	}
+	if len(ctx.ToolCalls) != 0 {
+		t.Errorf("expected 0 tool call records, got %d", len(ctx.ToolCalls))
+	}
+}
+
+func TestParseArgsToMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    json.RawMessage
+		wantNil  bool
+		wantKeys []string
+	}{
+		{"nil input", nil, true, nil},
+		{"empty input", json.RawMessage(""), true, nil},
+		{"valid object", json.RawMessage(`{"key":"val"}`), false, []string{"key"}},
+		{"invalid json", json.RawMessage("not json"), true, nil},
+		{"array input", json.RawMessage(`[1,2,3]`), true, nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := parseArgsToMap(tc.input)
+			if tc.wantNil && result != nil {
+				t.Errorf("expected nil, got %v", result)
+			}
+			if !tc.wantNil && result == nil {
+				t.Error("expected non-nil result")
+			}
+			for _, k := range tc.wantKeys {
+				if _, ok := result[k]; !ok {
+					t.Errorf("missing expected key %q", k)
+				}
+			}
+		})
+	}
+}
+
+func TestScoreFromPassed(t *testing.T) {
+	if s := scoreFromPassed(true); s != 1.0 {
+		t.Errorf("expected 1.0, got %f", s)
+	}
+	if s := scoreFromPassed(false); s != 0.0 {
+		t.Errorf("expected 0.0, got %f", s)
+	}
+}
+
+func TestExtractAssertionType(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  map[string]any
+		want    string
+		wantErr bool
+	}{
+		{"valid", map[string]any{"assertion_type": "tools_called"}, "tools_called", false},
+		{"missing", map[string]any{}, "", true},
+		{"empty string", map[string]any{"assertion_type": ""}, "", true},
+		{"wrong type", map[string]any{"assertion_type": 42}, "", true},
+		{"nil params", nil, "", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractAssertionType(tc.params)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("extractAssertionType() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if got != tc.want {
+				t.Errorf("extractAssertionType() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExtractAssertionParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params map[string]any
+		want   int // expected length, -1 for nil
+	}{
+		{"valid map", map[string]any{"assertion_params": map[string]any{"k": "v"}}, 1},
+		{"missing key", map[string]any{}, -1},
+		{"wrong type", map[string]any{"assertion_params": "not a map"}, -1},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractAssertionParams(tc.params)
+			if tc.want == -1 && got != nil {
+				t.Errorf("expected nil, got %v", got)
+			}
+			if tc.want >= 0 && len(got) != tc.want {
+				t.Errorf("expected len %d, got %d", tc.want, len(got))
+			}
+		})
+	}
+}

--- a/ee/pkg/evals/converter.go
+++ b/ee/pkg/evals/converter.go
@@ -13,7 +13,9 @@ package evals
 
 import (
 	"encoding/json"
+	"strconv"
 
+	"github.com/AltairaLabs/PromptKit/runtime/types"
 	"github.com/altairalabs/omnia/internal/session"
 )
 
@@ -171,5 +173,111 @@ func addIfPresent(dst map[string]any, src map[string]string, srcKey, dstKey stri
 	}
 	if v, ok := src[srcKey]; ok && v != "" {
 		dst[dstKey] = v
+	}
+}
+
+// ConvertToTypesMessages converts Omnia session messages to PromptKit's
+// native types.Message format. This is needed for arena assertion validators
+// which operate on types.Message rather than our intermediate PromptKitMessage.
+func ConvertToTypesMessages(messages []session.Message) []types.Message {
+	result := make([]types.Message, 0, len(messages))
+	for i := range messages {
+		result = append(result, convertToTypesMessage(&messages[i]))
+	}
+	return result
+}
+
+// convertToTypesMessage converts a single session message to types.Message.
+func convertToTypesMessage(msg *session.Message) types.Message {
+	tm := types.Message{
+		Role:    mapRole(msg.Role),
+		Content: msg.Content,
+	}
+
+	populateCostInfo(&tm, msg)
+	populateLatency(&tm, msg)
+
+	msgType := msg.Metadata[metaKeyType]
+
+	if msgType == metaTypeToolCall {
+		tc := extractTypesToolCall(msg)
+		if tc != nil {
+			tm.ToolCalls = []types.MessageToolCall{*tc}
+		}
+		return tm
+	}
+
+	if msgType == metaTypeToolResult {
+		tm.Role = "tool"
+		tm.ToolResult = extractToolResult(msg)
+		return tm
+	}
+
+	return tm
+}
+
+// extractTypesToolCall parses tool call info into a types.MessageToolCall.
+func extractTypesToolCall(msg *session.Message) *types.MessageToolCall {
+	if msg.Content == "" {
+		return nil
+	}
+
+	var parsed struct {
+		Name      string `json:"name"`
+		Arguments any    `json:"arguments"`
+	}
+	if err := json.Unmarshal([]byte(msg.Content), &parsed); err != nil {
+		return nil
+	}
+	if parsed.Name == "" {
+		return nil
+	}
+
+	args := json.RawMessage(marshalArguments(parsed.Arguments))
+	if len(args) == 0 {
+		args = json.RawMessage("{}")
+	}
+
+	return &types.MessageToolCall{
+		ID:   msg.ToolCallID,
+		Name: parsed.Name,
+		Args: args,
+	}
+}
+
+// extractToolResult builds a MessageToolResult from a tool_result message.
+func extractToolResult(msg *session.Message) *types.MessageToolResult {
+	tr := &types.MessageToolResult{
+		ID:      msg.ToolCallID,
+		Content: msg.Content,
+	}
+	if msg.Metadata[metaKeyIsError] == "true" {
+		tr.Error = msg.Content
+	}
+	return tr
+}
+
+// populateCostInfo sets CostInfo on the types.Message if token data exists.
+func populateCostInfo(tm *types.Message, msg *session.Message) {
+	if msg.InputTokens == 0 && msg.OutputTokens == 0 {
+		return
+	}
+	tm.CostInfo = &types.CostInfo{
+		InputTokens:  int(msg.InputTokens),
+		OutputTokens: int(msg.OutputTokens),
+	}
+	if costStr, ok := msg.Metadata[metaKeyCostUSD]; ok && costStr != "" {
+		if cost, err := strconv.ParseFloat(costStr, 64); err == nil {
+			tm.CostInfo.TotalCost = cost
+		}
+	}
+}
+
+// populateLatency sets LatencyMs on the types.Message if available.
+func populateLatency(tm *types.Message, msg *session.Message) {
+	if latStr, ok := msg.Metadata[metaKeyLatencyMs]; ok && latStr != "" {
+		if lat, err := strconv.ParseInt(latStr, 10, 64); err == nil {
+			tm.LatencyMs = lat
+		}
 	}
 }

--- a/ee/pkg/evals/converter_test.go
+++ b/ee/pkg/evals/converter_test.go
@@ -492,3 +492,248 @@ func assertMetadataEqual(t *testing.T, msgIdx int, expected, actual map[string]a
 		}
 	}
 }
+
+const testRoleAssistant = "assistant"
+
+func TestConvertToTypesMessages_EmptyAndNil(t *testing.T) {
+	result := ConvertToTypesMessages([]session.Message{})
+	if len(result) != 0 {
+		t.Fatalf("expected 0 messages for empty slice, got %d", len(result))
+	}
+
+	result = ConvertToTypesMessages(nil)
+	if len(result) != 0 {
+		t.Fatalf("expected 0 messages for nil slice, got %d", len(result))
+	}
+}
+
+func TestConvertToTypesMessages_RoleMapping(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{ID: "m1", Role: session.RoleUser, Content: "hello", Timestamp: now},
+		{ID: "m2", Role: session.RoleAssistant, Content: "hi", Timestamp: now},
+		{ID: "m3", Role: session.RoleSystem, Content: "system", Timestamp: now},
+	})
+
+	if len(result) != 3 {
+		t.Fatalf("expected 3 messages, got %d", len(result))
+	}
+	if result[0].Role != "user" {
+		t.Errorf("expected role 'user', got %q", result[0].Role)
+	}
+	if result[1].Role != testRoleAssistant {
+		t.Errorf("expected role 'assistant', got %q", result[1].Role)
+	}
+	if result[2].Role != "system" {
+		t.Errorf("expected role 'system', got %q", result[2].Role)
+	}
+}
+
+func TestConvertToTypesMessages_ToolCall(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    `{"name":"get_weather","arguments":"{\"city\":\"NYC\"}"}`,
+			ToolCallID: "tc-1", Timestamp: now,
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+	})
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result))
+	}
+	msg := result[0]
+	if msg.Role != testRoleAssistant {
+		t.Errorf("expected role 'assistant', got %q", msg.Role)
+	}
+	if len(msg.ToolCalls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(msg.ToolCalls))
+	}
+	if msg.ToolCalls[0].ID != "tc-1" {
+		t.Errorf("expected tool call ID 'tc-1', got %q", msg.ToolCalls[0].ID)
+	}
+	if msg.ToolCalls[0].Name != "get_weather" {
+		t.Errorf("expected tool name 'get_weather', got %q", msg.ToolCalls[0].Name)
+	}
+}
+
+func TestConvertToTypesMessages_ToolResult(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleSystem,
+			Content:    `{"temp":72}`,
+			ToolCallID: "tc-1", Timestamp: now,
+			Metadata: map[string]string{"type": "tool_result"},
+		},
+	})
+
+	msg := result[0]
+	if msg.Role != "tool" {
+		t.Errorf("expected role 'tool', got %q", msg.Role)
+	}
+	if msg.ToolResult == nil {
+		t.Fatal("expected ToolResult to be set")
+	}
+	if msg.ToolResult.ID != "tc-1" {
+		t.Errorf("expected tool result ID 'tc-1', got %q", msg.ToolResult.ID)
+	}
+	if msg.ToolResult.Content != `{"temp":72}` {
+		t.Errorf("expected tool result content, got %q", msg.ToolResult.Content)
+	}
+}
+
+func TestConvertToTypesMessages_ToolResultError(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleSystem,
+			Content:    "connection refused",
+			ToolCallID: "tc-1", Timestamp: now,
+			Metadata: map[string]string{"type": "tool_result", "is_error": "true"},
+		},
+	})
+
+	if result[0].ToolResult == nil {
+		t.Fatal("expected ToolResult to be set")
+	}
+	if result[0].ToolResult.Error != "connection refused" {
+		t.Errorf("expected error 'connection refused', got %q", result[0].ToolResult.Error)
+	}
+}
+
+func TestConvertToTypesMessages_Metadata(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content: "response", Timestamp: now,
+			InputTokens: 100, OutputTokens: 50,
+			Metadata: map[string]string{
+				"latency_ms": "250",
+				"cost_usd":   "0.0015",
+			},
+		},
+	})
+
+	msg := result[0]
+	if msg.CostInfo == nil {
+		t.Fatal("expected CostInfo to be set")
+	}
+	if msg.CostInfo.InputTokens != 100 {
+		t.Errorf("expected 100 input tokens, got %d", msg.CostInfo.InputTokens)
+	}
+	if msg.CostInfo.OutputTokens != 50 {
+		t.Errorf("expected 50 output tokens, got %d", msg.CostInfo.OutputTokens)
+	}
+	if msg.CostInfo.TotalCost != 0.0015 {
+		t.Errorf("expected total cost 0.0015, got %f", msg.CostInfo.TotalCost)
+	}
+	if msg.LatencyMs != 250 {
+		t.Errorf("expected latency 250, got %d", msg.LatencyMs)
+	}
+}
+
+func TestConvertToTypesMessages_NoCostInfo(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{ID: "m1", Role: session.RoleUser, Content: "hello", Timestamp: now},
+	})
+	if result[0].CostInfo != nil {
+		t.Error("expected CostInfo to be nil for user message")
+	}
+}
+
+func TestConvertToTypesMessages_MalformedToolCall(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    "not valid json",
+			ToolCallID: "tc-1", Timestamp: now,
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+	})
+	if len(result[0].ToolCalls) != 0 {
+		t.Error("expected no tool calls for malformed content")
+	}
+}
+
+func TestConvertToTypesMessages_EmptyContentToolCall(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    "",
+			ToolCallID: "tc-1", Timestamp: now,
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+	})
+	if len(result[0].ToolCalls) != 0 {
+		t.Error("expected no tool calls for empty content")
+	}
+}
+
+func TestConvertToTypesMessages_MissingNameToolCall(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    `{"arguments":"test"}`,
+			ToolCallID: "tc-1", Timestamp: now,
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+	})
+	if len(result[0].ToolCalls) != 0 {
+		t.Error("expected no tool calls when name is missing")
+	}
+}
+
+func TestConvertToTypesMessages_NilArguments(t *testing.T) {
+	now := time.Now()
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content:    `{"name":"my_tool"}`,
+			ToolCallID: "tc-1", Timestamp: now,
+			Metadata: map[string]string{"type": "tool_call"},
+		},
+	})
+	if len(result[0].ToolCalls) != 1 {
+		t.Fatal("expected 1 tool call")
+	}
+	if string(result[0].ToolCalls[0].Args) != "{}" {
+		t.Errorf("expected args '{}' for nil arguments, got %q", string(result[0].ToolCalls[0].Args))
+	}
+}
+
+func TestConvertToTypesMessages_InvalidLatencyAndCost(t *testing.T) {
+	now := time.Now()
+
+	result := ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content: "test", Timestamp: now,
+			Metadata: map[string]string{"latency_ms": "not-a-number"},
+		},
+	})
+	if result[0].LatencyMs != 0 {
+		t.Errorf("expected latency 0 for invalid value, got %d", result[0].LatencyMs)
+	}
+
+	result = ConvertToTypesMessages([]session.Message{
+		{
+			ID: "m1", Role: session.RoleAssistant,
+			Content: "test", Timestamp: now,
+			InputTokens: 10,
+			Metadata:    map[string]string{"cost_usd": "invalid"},
+		},
+	})
+	if result[0].CostInfo == nil {
+		t.Fatal("expected CostInfo to be set (has tokens)")
+	}
+	if result[0].CostInfo.TotalCost != 0 {
+		t.Errorf("expected total cost 0 for invalid value, got %f", result[0].CostInfo.TotalCost)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `RunArenaAssertion()` function matching the `EvalRunner` signature to bridge PromptKit's 7 conversation assertion validators (`tools_called`, `tools_not_called`, `tools_not_called_with_args`, `tool_calls_with_args`, `content_includes_any`, `content_not_includes`, `llm_judge_conversation`) into Omnia's eval pipeline
- Add `ConvertToTypesMessages()` to convert `[]session.Message` → `[]types.Message` (PromptKit's native type) for use by arena assertion validators
- Add `buildConversationContext()` helper that constructs `assertions.ConversationContext` with `AllTurns` and `ToolCallRecord` extraction

## Test plan

- [x] Unit tests for `RunArenaAssertion` covering all 7 assertion types (pass/fail), unknown types, missing params, empty messages
- [x] Unit tests for `ConvertToTypesMessages` covering role mapping, tool calls, tool results, error flags, metadata/cost/latency preservation, edge cases
- [x] Unit tests for helper functions (`buildConversationContext`, `parseArgsToMap`, `extractAssertionType`, `extractAssertionParams`, `scoreFromPassed`)
- [x] `golangci-lint run ./ee/pkg/evals/...` — 0 issues
- [x] Coverage: `arena_runner.go` 100%, `converter.go` 99%