### PR TITLE
feat: integrate arena assertions into eval pipeline (#497)

### DIFF
--- a/ee/pkg/evals/dispatcher.go
+++ b/ee/pkg/evals/dispatcher.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package evals
+
+import (
+	"github.com/altairalabs/omnia/internal/session"
+	api "github.com/altairalabs/omnia/internal/session/api"
+)
+
+// NewEvalDispatcher returns an EvalRunner that dispatches to the correct
+// eval implementation based on the definition's Type field.
+// Arena assertions are routed to RunArenaAssertion; all other deterministic
+// types (rule, contains, max_length, etc.) fall through to api.RunRuleEval.
+func NewEvalDispatcher() EvalRunner {
+	return func(def api.EvalDefinition, msgs []session.Message) (api.EvaluateResultItem, error) {
+		if def.Type == EvalTypeArenaAssertion {
+			return RunArenaAssertion(def, msgs)
+		}
+		return api.RunRuleEval(def, msgs)
+	}
+}
+
+// isDeterministicEval returns true for eval types that are deterministic
+// (not requiring an LLM call) and can be run synchronously in-process.
+func isDeterministicEval(evalType string) bool {
+	return evalType != evalTypeLLMJudge
+}

--- a/ee/pkg/evals/dispatcher_test.go
+++ b/ee/pkg/evals/dispatcher_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package evals
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/session"
+	api "github.com/altairalabs/omnia/internal/session/api"
+)
+
+func TestNewEvalDispatcher_RuleType(t *testing.T) {
+	dispatcher := NewEvalDispatcher()
+
+	def := api.EvalDefinition{
+		ID:      "e1",
+		Type:    "contains",
+		Trigger: "per_turn",
+		Params:  map[string]any{"value": "hello"},
+	}
+
+	messages := []session.Message{
+		{ID: "m1", Role: session.RoleAssistant, Content: "hello world", Timestamp: time.Now()},
+	}
+
+	result, err := dispatcher(def, messages)
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	assert.Equal(t, "e1", result.EvalID)
+}
+
+func TestNewEvalDispatcher_ArenaAssertion(t *testing.T) {
+	dispatcher := NewEvalDispatcher()
+
+	def := api.EvalDefinition{
+		ID:      "e2",
+		Type:    EvalTypeArenaAssertion,
+		Trigger: "on_session_complete",
+		Params: map[string]any{
+			"assertion_type": "content_includes_any",
+			"assertion_params": map[string]any{
+				"patterns": []any{"hello"},
+			},
+		},
+	}
+
+	messages := []session.Message{
+		{ID: "m1", Role: session.RoleAssistant, Content: "hello world", Timestamp: time.Now()},
+	}
+
+	result, err := dispatcher(def, messages)
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+	assert.Equal(t, "e2", result.EvalID)
+	assert.Equal(t, EvalTypeArenaAssertion, result.EvalType)
+}
+
+func TestNewEvalDispatcher_ArenaAssertionError(t *testing.T) {
+	dispatcher := NewEvalDispatcher()
+
+	def := api.EvalDefinition{
+		ID:      "e3",
+		Type:    EvalTypeArenaAssertion,
+		Trigger: "on_session_complete",
+		Params:  map[string]any{},
+	}
+
+	_, err := dispatcher(def, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "assertion_type")
+}
+
+func TestNewEvalDispatcher_UnknownTypeFallsThrough(t *testing.T) {
+	dispatcher := NewEvalDispatcher()
+
+	def := api.EvalDefinition{
+		ID:      "e4",
+		Type:    "max_length",
+		Trigger: "per_turn",
+		Params:  map[string]any{"maxLength": float64(1000)},
+	}
+
+	messages := []session.Message{
+		{ID: "m1", Role: session.RoleAssistant, Content: "short", Timestamp: time.Now()},
+	}
+
+	result, err := dispatcher(def, messages)
+	require.NoError(t, err)
+	assert.True(t, result.Passed)
+}
+
+func TestIsDeterministicEval(t *testing.T) {
+	tests := []struct {
+		evalType string
+		expected bool
+	}{
+		{"rule", true},
+		{EvalTypeArenaAssertion, true},
+		{"contains", true},
+		{"max_length", true},
+		{"similarity", true},
+		{evalTypeLLMJudge, false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.evalType, func(t *testing.T) {
+			assert.Equal(t, tc.expected, isDeterministicEval(tc.evalType))
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add eval dispatcher (`ee/pkg/evals/dispatcher.go`) that routes `arena_assertion` evals to `RunArenaAssertion()` and all other deterministic types to `api.RunRuleEval()`
- Wire dispatcher as default runner in both `EvalWorker` and `EvalListener`, replacing direct `api.RunRuleEval` calls
- Update filter functions to include `arena_assertion` alongside `rule` evals (exclude only `llm_judge`)
- Add `pack_assertions` loading in `PromptPackLoader` — converts PromptPack assertions into `EvalDef` entries with type `arena_assertion` and trigger `on_session_complete`

## Test plan

- [x] Dispatcher tests: rule dispatch, arena_assertion dispatch, error handling, unknown type fallthrough, `isDeterministicEval`
- [x] Worker filter tests updated to verify arena_assertion is included in per_turn and on_session_complete filters
- [x] PromptPack loader tests for `pack_assertions` parsing, empty input, and no-params cases
- [x] EvalListener tests for arena_assertion flowing through `runSingleEval` on both per_turn and on_session_complete triggers
- [x] All pre-commit checks pass (lint, vet, build, coverage ≥80% on all changed files)

Closes #497