### PR TITLE
fix: align Go version in EE Dockerfiles to 1.26

### DIFF
--- a/ee/Dockerfile.arena-controller
+++ b/ee/Dockerfile.arena-controller
@@ -1,5 +1,5 @@
 # Build the arena controller binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/ee/Dockerfile.arena-dev-console
+++ b/ee/Dockerfile.arena-dev-console
@@ -1,5 +1,5 @@
 # Build the arena dev console binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/ee/Dockerfile.arena-worker
+++ b/ee/Dockerfile.arena-worker
@@ -1,5 +1,5 @@
 # Build the arena worker binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/ee/Dockerfile.promptkit-lsp
+++ b/ee/Dockerfile.promptkit-lsp
@@ -1,5 +1,5 @@
 # Build the promptkit-lsp binary
-FROM golang:1.25 AS builder
+FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary
Fixes #534 — aligns all enterprise Dockerfiles from Go 1.25 to Go 1.26, matching the core Dockerfiles.

## Changes
- `ee/Dockerfile.arena-controller`: 1.25 → 1.26
- `ee/Dockerfile.arena-worker`: 1.25 → 1.26
- `ee/Dockerfile.arena-dev-console`: 1.25 → 1.26
- `ee/Dockerfile.promptkit-lsp`: 1.25 → 1.26

## Test plan
- [ ] Verify all Dockerfiles now use golang:1.26
- [ ] CI builds pass