### PR TITLE
feat: add React Error Boundaries to dashboard

### DIFF
--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Inter, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/providers";
 import { AuthWrapper } from "@/components/auth-wrapper";
+import { ErrorBoundary } from "@/components/error-boundary";
 import { Sidebar, ReadOnlyBanner, DemoModeBanner, LicenseExpiryBanner, DevModeLicenseBanner, WorkspaceContent } from "@/components/layout";
 
 const inter = Inter({
@@ -43,9 +44,11 @@ export default function RootLayout({
                 <LicenseExpiryBanner />
                 <DevModeLicenseBanner />
                 <main className="flex-1 overflow-auto bg-background">
-                  <WorkspaceContent>
-                    {children}
-                  </WorkspaceContent>
+                  <ErrorBoundary>
+                    <WorkspaceContent>
+                      {children}
+                    </WorkspaceContent>
+                  </ErrorBoundary>
                 </main>
               </div>
             </div>

--- a/dashboard/src/components/error-boundary.test.tsx
+++ b/dashboard/src/components/error-boundary.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Tests for ErrorBoundary and withErrorBoundary.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBoundary, withErrorBoundary } from "./error-boundary";
+
+// Suppress console.error for expected React error boundary logs
+const originalConsoleError = console.error;
+beforeEach(() => {
+  console.error = vi.fn();
+});
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+function ThrowingComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) {
+    throw new Error("Test error");
+  }
+  return <div>Child content</div>;
+}
+
+describe("ErrorBoundary", () => {
+  it("renders children when no error occurs", () => {
+    render(
+      <ErrorBoundary>
+        <div>Hello world</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Hello world")).toBeInTheDocument();
+  });
+
+  it("renders default fallback when a child throws", () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(
+      screen.getByText("An unexpected error occurred. Please try again.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Try again" })).toBeInTheDocument();
+  });
+
+  it("renders custom fallback when provided", () => {
+    render(
+      <ErrorBoundary fallback={<div>Custom fallback</div>}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Custom fallback")).toBeInTheDocument();
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+  });
+
+  it("resets error state when Try again is clicked", () => {
+    let shouldThrow = true;
+
+    function ConditionalThrow() {
+      if (shouldThrow) {
+        throw new Error("Test error");
+      }
+      return <div>Recovered content</div>;
+    }
+
+    render(
+      <ErrorBoundary>
+        <ConditionalThrow />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+
+    // Fix the error before retrying
+    shouldThrow = false;
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+
+    expect(screen.getByText("Recovered content")).toBeInTheDocument();
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+  });
+
+  it("calls onError callback when an error is caught", () => {
+    const onError = vi.fn();
+
+    render(
+      <ErrorBoundary onError={onError}>
+        <ThrowingComponent shouldThrow={true} />
+      </ErrorBoundary>
+    );
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: "Test error" }),
+      expect.objectContaining({ componentStack: expect.any(String) })
+    );
+  });
+});
+
+describe("withErrorBoundary", () => {
+  it("wraps a component with an error boundary", () => {
+    function MyComponent() {
+      return <div>Wrapped component</div>;
+    }
+
+    const WrappedComponent = withErrorBoundary(MyComponent);
+    render(<WrappedComponent />);
+
+    expect(screen.getByText("Wrapped component")).toBeInTheDocument();
+  });
+
+  it("catches errors from the wrapped component", () => {
+    function FailingComponent() {
+      throw new Error("Wrapped error");
+      return null;
+    }
+
+    const WrappedComponent = withErrorBoundary(FailingComponent);
+    render(<WrappedComponent />);
+
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("sets displayName on the wrapped component", () => {
+    function MyNamedComponent() {
+      return <div>Named</div>;
+    }
+
+    const Wrapped = withErrorBoundary(MyNamedComponent);
+    expect(Wrapped.displayName).toBe("withErrorBoundary(MyNamedComponent)");
+  });
+
+  it("passes errorBoundaryProps to the ErrorBoundary", () => {
+    const onError = vi.fn();
+
+    function Failing() {
+      throw new Error("props test");
+      return null;
+    }
+
+    const Wrapped = withErrorBoundary(Failing, {
+      fallback: <div>HOC fallback</div>,
+      onError,
+    });
+
+    render(<Wrapped />);
+
+    expect(screen.getByText("HOC fallback")).toBeInTheDocument();
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
+});

--- a/dashboard/src/components/error-boundary.tsx
+++ b/dashboard/src/components/error-boundary.tsx
@@ -1,0 +1,90 @@
+/**
+ * React Error Boundary component for catching and displaying runtime errors.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  fallback?: React.ReactNode;
+  onError?: (error: Error, errorInfo: React.ErrorInfo) => void;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    this.props.onError?.(error, errorInfo);
+  }
+
+  private handleReset = (): void => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render(): React.ReactNode {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback;
+    }
+
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>Something went wrong</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              An unexpected error occurred. Please try again.
+            </p>
+            <Button onClick={this.handleReset} variant="outline">
+              Try again
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+}
+
+export function withErrorBoundary<P extends object>(
+  Component: React.ComponentType<P>,
+  errorBoundaryProps?: Omit<ErrorBoundaryProps, "children">
+): React.FC<P> {
+  const displayName = Component.displayName || Component.name || "Component";
+
+  const WrappedComponent: React.FC<P> = (props: P) => (
+    <ErrorBoundary {...errorBoundaryProps}>
+      <Component {...props} />
+    </ErrorBoundary>
+  );
+
+  WrappedComponent.displayName = `withErrorBoundary(${displayName})`;
+
+  return WrappedComponent;
+}

--- a/dashboard/src/components/page-error-boundary.test.tsx
+++ b/dashboard/src/components/page-error-boundary.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for PageErrorBoundary component.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { PageErrorBoundary } from "./page-error-boundary";
+
+// Suppress console.error for expected React error boundary logs
+const originalConsoleError = console.error;
+beforeEach(() => {
+  console.error = vi.fn();
+});
+afterEach(() => {
+  console.error = originalConsoleError;
+});
+
+describe("PageErrorBoundary", () => {
+  it("renders children when no error occurs", () => {
+    render(
+      <PageErrorBoundary>
+        <div>Page content</div>
+      </PageErrorBoundary>
+    );
+
+    expect(screen.getByText("Page content")).toBeInTheDocument();
+  });
+
+  it("renders page error fallback when a child throws", () => {
+    function ThrowingChild() {
+      throw new Error("Page error");
+      return null;
+    }
+
+    render(
+      <PageErrorBoundary>
+        <ThrowingChild />
+      </PageErrorBoundary>
+    );
+
+    expect(screen.getByText("Page error")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This page encountered an unexpected error. You can try going back or returning to the dashboard."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Go to dashboard" })).toHaveAttribute(
+      "href",
+      "/"
+    );
+  });
+
+  it("does not show default ErrorBoundary fallback", () => {
+    function ThrowingChild() {
+      throw new Error("Page error");
+      return null;
+    }
+
+    render(
+      <PageErrorBoundary>
+        <ThrowingChild />
+      </PageErrorBoundary>
+    );
+
+    // Should show page-level fallback, not the default "Something went wrong"
+    expect(screen.queryByText("Something went wrong")).not.toBeInTheDocument();
+    expect(screen.queryByText("Try again")).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/page-error-boundary.tsx
+++ b/dashboard/src/components/page-error-boundary.tsx
@@ -1,0 +1,51 @@
+/**
+ * Page-level error boundary with navigation-aware fallback UI.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import React from "react";
+import Link from "next/link";
+import { ErrorBoundary } from "@/components/error-boundary";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+function PageErrorFallback() {
+  return (
+    <div className="flex flex-col flex-1">
+      <div className="flex items-center justify-center flex-1 p-8">
+        <Card className="w-full max-w-md">
+          <CardHeader>
+            <CardTitle>Page error</CardTitle>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <p className="text-sm text-muted-foreground">
+              This page encountered an unexpected error. You can try going back
+              or returning to the dashboard.
+            </p>
+            <div className="flex gap-2">
+              <Button variant="outline" asChild>
+                <Link href="/">Go to dashboard</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+interface PageErrorBoundaryProps {
+  children: React.ReactNode;
+}
+
+export function PageErrorBoundary({ children }: Readonly<PageErrorBoundaryProps>) {
+  return (
+    <ErrorBoundary fallback={<PageErrorFallback />}>
+      {children}
+    </ErrorBoundary>
+  );
+}


### PR DESCRIPTION
## Summary
- Add `ErrorBoundary` class component with default fallback UI (Card + "Try again" button) and `withErrorBoundary` HOC for wrapping page components
- Add `PageErrorBoundary` wrapper with navigation-aware fallback (shows "Go to dashboard" link)
- Wrap root layout children with `<ErrorBoundary>` to prevent full white-screen crashes on unhandled runtime errors

Closes #530

## Test plan
- [x] `ErrorBoundary` renders children normally when no error
- [x] Default fallback renders with "Something went wrong" and "Try again" button
- [x] Custom `fallback` prop is used when provided
- [x] "Try again" button resets error state and re-renders children
- [x] `onError` callback fires with error and errorInfo
- [x] `withErrorBoundary` HOC wraps components and catches errors
- [x] `PageErrorBoundary` shows page-level fallback with dashboard link
- [x] ESLint: 0 errors
- [x] TypeScript: passes
- [x] Per-file coverage: 100% on both new files
- [x] Full test suite: 200 files, 2989 tests passing