### PR TITLE
refactor: extract shared SetCondition helper across controllers

### DIFF
--- a/ee/internal/controller/arenajob_controller_test.go
+++ b/ee/internal/controller/arenajob_controller_test.go
@@ -429,8 +429,7 @@ var _ = Describe("ArenaJob Controller", func() {
 				},
 			}
 
-			reconciler := &ArenaJobReconciler{}
-			reconciler.setCondition(job, ArenaJobConditionTypeReady, metav1.ConditionTrue, "TestReason", "Test message")
+			SetCondition(&job.Status.Conditions, job.Generation, ArenaJobConditionTypeReady, metav1.ConditionTrue, "TestReason", "Test message")
 
 			condition := meta.FindStatusCondition(job.Status.Conditions, ArenaJobConditionTypeReady)
 			Expect(condition).NotTo(BeNil())

--- a/ee/internal/controller/arenasource_controller_test.go
+++ b/ee/internal/controller/arenasource_controller_test.go
@@ -821,8 +821,7 @@ var _ = Describe("ArenaSource Controller", func() {
 				},
 			}
 
-			reconciler := &ArenaSourceReconciler{}
-			reconciler.setCondition(source, ArenaSourceConditionTypeReady, metav1.ConditionTrue, "TestReason", "Test message")
+			SetCondition(&source.Status.Conditions, source.Generation, ArenaSourceConditionTypeReady, metav1.ConditionTrue, "TestReason", "Test message")
 
 			condition := meta.FindStatusCondition(source.Status.Conditions, ArenaSourceConditionTypeReady)
 			Expect(condition).NotTo(BeNil())

--- a/ee/internal/controller/arenatemplatesource_controller.go
+++ b/ee/internal/controller/arenatemplatesource_controller.go
@@ -22,7 +22,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -139,7 +138,7 @@ func (r *ArenaTemplateSourceReconciler) Reconcile(ctx context.Context, req ctrl.
 		if job, ok := r.inProgress.LoadAndDelete(req.NamespacedName); ok {
 			job.(*templateFetchJob).cancel()
 		}
-		r.setCondition(source, ArenaTemplateSourceConditionTypeReady, metav1.ConditionFalse,
+		SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeReady, metav1.ConditionFalse,
 			"Suspended", "ArenaTemplateSource reconciliation is suspended")
 		if err := r.Status().Update(ctx, source); err != nil {
 			log.Error(err, "Failed to update status")
@@ -154,7 +153,7 @@ func (r *ArenaTemplateSourceReconciler) Reconcile(ctx context.Context, req ctrl.
 		if err := r.LicenseValidator.ValidateArenaSource(ctx, sourceType); err != nil {
 			log.Info("Source type not allowed by license", "type", sourceType, "error", err)
 			source.Status.Phase = omniav1alpha1.ArenaTemplateSourcePhaseError
-			r.setCondition(source, ArenaTemplateSourceConditionTypeReady, metav1.ConditionFalse,
+			SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeReady, metav1.ConditionFalse,
 				"LicenseViolation", err.Error())
 			if r.Recorder != nil {
 				r.Recorder.Event(source, corev1.EventTypeWarning, "LicenseViolation",
@@ -237,13 +236,13 @@ func (r *ArenaTemplateSourceReconciler) Reconcile(ctx context.Context, req ctrl.
 		source.Status.HeadVersion = version
 		source.Status.Phase = omniav1alpha1.ArenaTemplateSourcePhaseReady
 
-		r.setCondition(source, ArenaTemplateSourceConditionTypeFetching, metav1.ConditionFalse,
+		SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeFetching, metav1.ConditionFalse,
 			"FetchComplete", "Successfully fetched content")
-		r.setCondition(source, ArenaTemplateSourceConditionTypeTemplatesScanned, metav1.ConditionTrue,
+		SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeTemplatesScanned, metav1.ConditionTrue,
 			"ScanComplete", fmt.Sprintf("Discovered %d templates", len(result.templates)))
-		r.setCondition(source, ArenaTemplateSourceConditionTypeArtifactAvailable, metav1.ConditionTrue,
+		SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeArtifactAvailable, metav1.ConditionTrue,
 			"ArtifactAvailable", fmt.Sprintf("Content synced at revision %s", result.artifact.Revision))
-		r.setCondition(source, ArenaTemplateSourceConditionTypeReady, metav1.ConditionTrue,
+		SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeReady, metav1.ConditionTrue,
 			"Ready", "ArenaTemplateSource is ready")
 
 		nextFetch := metav1.NewTime(time.Now().Add(syncInterval))
@@ -295,7 +294,7 @@ func (r *ArenaTemplateSourceReconciler) Reconcile(ctx context.Context, req ctrl.
 
 	// Set phase to fetching
 	source.Status.Phase = omniav1alpha1.ArenaTemplateSourcePhaseFetching
-	r.setCondition(source, ArenaTemplateSourceConditionTypeFetching, metav1.ConditionTrue,
+	SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeFetching, metav1.ConditionTrue,
 		"FetchInProgress", "Fetching templates from source")
 	now := metav1.Now()
 	source.Status.LastFetchTime = &now
@@ -820,9 +819,9 @@ func (r *ArenaTemplateSourceReconciler) handleFetchError(ctx context.Context, so
 
 	source.Status.Phase = omniav1alpha1.ArenaTemplateSourcePhaseError
 	source.Status.Message = err.Error()
-	r.setCondition(source, ArenaTemplateSourceConditionTypeFetching, metav1.ConditionFalse,
+	SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeFetching, metav1.ConditionFalse,
 		"FetchFailed", err.Error())
-	r.setCondition(source, ArenaTemplateSourceConditionTypeReady, metav1.ConditionFalse,
+	SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeReady, metav1.ConditionFalse,
 		"FetchError", err.Error())
 
 	if r.Recorder != nil {
@@ -832,23 +831,6 @@ func (r *ArenaTemplateSourceReconciler) handleFetchError(ctx context.Context, so
 	if statusErr := r.Status().Update(ctx, source); statusErr != nil {
 		log.Error(statusErr, "Failed to update status after fetch error")
 	}
-}
-
-// setCondition sets a condition on the ArenaTemplateSource status.
-func (r *ArenaTemplateSourceReconciler) setCondition(
-	source *omniav1alpha1.ArenaTemplateSource,
-	conditionType string,
-	status metav1.ConditionStatus,
-	reason, message string,
-) {
-	meta.SetStatusCondition(&source.Status.Conditions, metav1.Condition{
-		Type:               conditionType,
-		Status:             status,
-		ObservedGeneration: source.Generation,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	})
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/ee/internal/controller/arenatemplatesource_controller_test.go
+++ b/ee/internal/controller/arenatemplatesource_controller_test.go
@@ -384,8 +384,6 @@ spec:
 
 	Context("Condition management", func() {
 		It("should set conditions correctly", func() {
-			reconciler := &ArenaTemplateSourceReconciler{}
-
 			source := &omniav1alpha1.ArenaTemplateSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test",
@@ -394,7 +392,7 @@ spec:
 				},
 			}
 
-			reconciler.setCondition(source, ArenaTemplateSourceConditionTypeReady,
+			SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeReady,
 				metav1.ConditionTrue, "Ready", "Source is ready")
 
 			Expect(source.Status.Conditions).To(HaveLen(1))
@@ -406,8 +404,6 @@ spec:
 		})
 
 		It("should update existing condition", func() {
-			reconciler := &ArenaTemplateSourceReconciler{}
-
 			source := &omniav1alpha1.ArenaTemplateSource{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test",
@@ -427,7 +423,7 @@ spec:
 				},
 			}
 
-			reconciler.setCondition(source, ArenaTemplateSourceConditionTypeReady,
+			SetCondition(&source.Status.Conditions, source.Generation, ArenaTemplateSourceConditionTypeReady,
 				metav1.ConditionTrue, "Ready", "Now ready")
 
 			Expect(source.Status.Conditions).To(HaveLen(1))

--- a/ee/internal/controller/helpers.go
+++ b/ee/internal/controller/helpers.go
@@ -8,6 +8,22 @@ Functional Source License. See ee/LICENSE for details.
 
 package controller
 
+import (
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// SetCondition sets a status condition on the given conditions slice.
+func SetCondition(conditions *[]metav1.Condition, generation int64, condType string, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		ObservedGeneration: generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
 // ptr is a helper function for creating pointers to values.
 func ptr[T any](v T) *T {
 	return &v

--- a/ee/internal/controller/sessionprivacypolicy_controller.go
+++ b/ee/internal/controller/sessionprivacypolicy_controller.go
@@ -15,7 +15,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -134,8 +133,8 @@ func (r *SessionPrivacyPolicyReconciler) handleOrphanedPolicy(
 	log.Info("no parent policy found", "level", policy.Spec.Level)
 
 	msg := fmt.Sprintf("no parent policy found for %s-level policy", policy.Spec.Level)
-	r.setCondition(policy, ConditionTypeParentFound, metav1.ConditionFalse, EventReasonParentNotFound, msg)
-	r.setCondition(policy, ConditionTypeReady, metav1.ConditionFalse,
+	SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeParentFound, metav1.ConditionFalse, EventReasonParentNotFound, msg)
+	SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeReady, metav1.ConditionFalse,
 		EventReasonParentNotFound, "policy requires a parent but none was found")
 	policy.Status.Phase = omniav1alpha1.SessionPrivacyPolicyPhaseError
 	r.recordEvent(policy, corev1.EventTypeWarning, EventReasonParentNotFound,
@@ -154,10 +153,10 @@ func (r *SessionPrivacyPolicyReconciler) setParentFoundCondition(
 	policy *omniav1alpha1.SessionPrivacyPolicy, parent *omniav1alpha1.SessionPrivacyPolicy,
 ) {
 	if policy.Spec.Level == omniav1alpha1.PolicyLevelGlobal {
-		r.setCondition(policy, ConditionTypeParentFound, metav1.ConditionTrue,
+		SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeParentFound, metav1.ConditionTrue,
 			"NotApplicable", "global policies have no parent")
 	} else {
-		r.setCondition(policy, ConditionTypeParentFound, metav1.ConditionTrue,
+		SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeParentFound, metav1.ConditionTrue,
 			EventReasonPolicyValidated, fmt.Sprintf("parent policy found: %s", parent.Name))
 	}
 }
@@ -169,9 +168,9 @@ func (r *SessionPrivacyPolicyReconciler) handleStoreError(
 	log := logf.FromContext(ctx)
 	log.Error(err, "failed to store effective policy")
 
-	r.setCondition(policy, ConditionTypeEffectivePolicyStored, metav1.ConditionFalse,
+	SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeEffectivePolicyStored, metav1.ConditionFalse,
 		EventReasonConfigMapSyncFailed, err.Error())
-	r.setCondition(policy, ConditionTypeReady, metav1.ConditionFalse,
+	SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeReady, metav1.ConditionFalse,
 		EventReasonConfigMapSyncFailed, "failed to store effective policy in ConfigMap")
 	policy.Status.Phase = omniav1alpha1.SessionPrivacyPolicyPhaseError
 	r.recordEvent(policy, corev1.EventTypeWarning, EventReasonConfigMapSyncFailed, err.Error())
@@ -186,9 +185,9 @@ func (r *SessionPrivacyPolicyReconciler) handleStoreError(
 
 // setSuccessStatus sets the success conditions on the policy.
 func (r *SessionPrivacyPolicyReconciler) setSuccessStatus(policy *omniav1alpha1.SessionPrivacyPolicy) {
-	r.setCondition(policy, ConditionTypeEffectivePolicyStored, metav1.ConditionTrue,
+	SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeEffectivePolicyStored, metav1.ConditionTrue,
 		EventReasonEffectivePolicyComputed, "effective policy stored in ConfigMap")
-	r.setCondition(policy, ConditionTypeReady, metav1.ConditionTrue,
+	SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeReady, metav1.ConditionTrue,
 		EventReasonPolicyValidated, "policy is active and effective policy is stored")
 	policy.Status.Phase = omniav1alpha1.SessionPrivacyPolicyPhaseActive
 	r.recordEvent(policy, corev1.EventTypeNormal, EventReasonEffectivePolicyComputed,
@@ -729,23 +728,6 @@ func (r *SessionPrivacyPolicyReconciler) cleanupEffectivePolicy(ctx context.Cont
 	return nil
 }
 
-// setCondition sets a condition on the SessionPrivacyPolicy status.
-func (r *SessionPrivacyPolicyReconciler) setCondition(
-	policy *omniav1alpha1.SessionPrivacyPolicy,
-	conditionType string,
-	status metav1.ConditionStatus,
-	reason, message string,
-) {
-	meta.SetStatusCondition(&policy.Status.Conditions, metav1.Condition{
-		Type:               conditionType,
-		Status:             status,
-		ObservedGeneration: policy.Generation,
-		Reason:             reason,
-		Message:            message,
-		LastTransitionTime: metav1.Now(),
-	})
-}
-
 // setErrorStatus sets an error status on the policy and persists it.
 func (r *SessionPrivacyPolicyReconciler) setErrorStatus(
 	ctx context.Context,
@@ -753,7 +735,7 @@ func (r *SessionPrivacyPolicyReconciler) setErrorStatus(
 	reason, message string,
 ) {
 	log := logf.FromContext(ctx)
-	r.setCondition(policy, ConditionTypeReady, metav1.ConditionFalse, reason, message)
+	SetCondition(&policy.Status.Conditions, policy.Generation, ConditionTypeReady, metav1.ConditionFalse, reason, message)
 	policy.Status.Phase = omniav1alpha1.SessionPrivacyPolicyPhaseError
 	r.recordEvent(policy, corev1.EventTypeWarning, reason, message)
 	if statusErr := r.Status().Update(ctx, policy); statusErr != nil {

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -18,9 +18,22 @@ package controller
 
 import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 )
+
+// SetCondition sets a status condition on the given conditions slice.
+func SetCondition(conditions *[]metav1.Condition, generation int64, condType string, status metav1.ConditionStatus, reason, message string) {
+	meta.SetStatusCondition(conditions, metav1.Condition{
+		Type:               condType,
+		Status:             status,
+		ObservedGeneration: generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}
 
 // Helper functions for creating pointers
 func ptr[T any](v T) *T {


### PR DESCRIPTION
## Summary

Closes #528

- Extract the copy-pasted `setCondition` receiver method from 10 controllers (6 core + 4 enterprise) into a single exported `SetCondition(conditions, generation, condType, status, reason, message)` helper function
- Add `SetCondition` to `internal/controller/helpers.go` for core controllers and `ee/internal/controller/helpers.go` for enterprise controllers (duplicated to avoid cross-package dependency)
- Remove unused `"k8s.io/apimachinery/pkg/api/meta"` imports from all 10 controllers since `meta.SetStatusCondition` is now called only from the helper
- Consolidate the duplicate `errMsgFailedToUpdateStatus` constant from `provider_controller.go` with the existing `logMsgFailedToUpdateStatus` in `constants.go`, and replace inline `"Failed to update status"` strings in `promptpack_controller.go`
- Net reduction of ~141 lines of duplicated code

## Test plan

- [x] `go build ./internal/controller/...` and `go build ./ee/internal/controller/...` pass
- [x] `go vet` passes on both packages
- [x] `golangci-lint run` passes (no new issues; only pre-existing complexity warnings)
- [x] Formatting verified with `gofmt`
- [ ] CI envtest suite (etcd not available locally in worktree)