### PR TITLE
refactor: extract shared queryBuilder and nullable helpers into pgutil

### DIFF
--- a/ee/pkg/audit/logger_test.go
+++ b/ee/pkg/audit/logger_test.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/altairalabs/omnia/ee/pkg/metrics"
+	"github.com/altairalabs/omnia/internal/pgutil"
 	"github.com/altairalabs/omnia/internal/session/api"
 )
 
@@ -150,29 +151,15 @@ func TestLogEvent_AllFields(t *testing.T) {
 }
 
 func TestNullHelpers(t *testing.T) {
-	assert.Nil(t, nullString(""))
-	assert.Equal(t, "hello", *nullString("hello"))
+	assert.Nil(t, pgutil.NullString(""))
+	assert.Equal(t, "hello", *pgutil.NullString("hello"))
 
-	assert.Nil(t, nullInt(0))
-	assert.Equal(t, 42, *nullInt(42))
+	assert.Nil(t, pgutil.NullInt(0))
+	assert.Equal(t, 42, *pgutil.NullInt(42))
 
-	assert.Equal(t, "", derefString(nil))
+	assert.Equal(t, "", pgutil.DerefString(nil))
 	s := "test"
-	assert.Equal(t, "test", derefString(&s))
-}
-
-func TestQueryBuilder(t *testing.T) {
-	qb := &queryBuilder{}
-	assert.Equal(t, "", qb.where())
-
-	qb.add("session_id = $?", "abc")
-	qb.add("workspace = $?", "prod")
-	assert.Equal(t, " AND session_id = $1 AND workspace = $2", qb.where())
-	assert.Equal(t, []any{"abc", "prod"}, qb.args)
-
-	query := qb.appendPagination("SELECT * FROM t WHERE 1=1"+qb.where(), 10, 5)
-	assert.Contains(t, query, "LIMIT $3")
-	assert.Contains(t, query, "OFFSET $4")
+	assert.Equal(t, "test", pgutil.DerefString(&s))
 }
 
 func TestBuildQueryFilters(t *testing.T) {
@@ -204,8 +191,7 @@ func TestBuildQueryFilters(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			qb := buildQueryFilters(tt.opts)
-			assert.Len(t, qb.clauses, tt.wantClauses)
-			assert.Len(t, qb.args, tt.wantClauses)
+			assert.Len(t, qb.Args(), tt.wantClauses)
 		})
 	}
 }

--- a/internal/pgutil/nullable.go
+++ b/internal/pgutil/nullable.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pgutil
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// NullString returns nil when s is empty, otherwise a pointer to s.
+// Useful for mapping Go strings to nullable TEXT/VARCHAR columns.
+func NullString(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// DerefString returns the empty string when s is nil, otherwise *s.
+func DerefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// NullInt returns nil when v is zero, otherwise a pointer to v.
+func NullInt(v int) *int {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}
+
+// NullInt32 returns nil when v is zero, otherwise a pointer to v.
+func NullInt32(v int32) *int32 {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}
+
+// NullInt64 returns nil when v is zero, otherwise a pointer to v.
+func NullInt64(v int64) *int64 {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}
+
+// NullTime returns nil when t is the zero value, otherwise a pointer to t.
+func NullTime(t time.Time) *time.Time {
+	if t.IsZero() {
+		return nil
+	}
+	return &t
+}
+
+// TimeOrZero returns the zero time when t is nil, otherwise *t.
+func TimeOrZero(t *time.Time) time.Time {
+	if t == nil {
+		return time.Time{}
+	}
+	return *t
+}
+
+// MarshalJSONB marshals m to JSON bytes. Returns "{}" when m is nil.
+func MarshalJSONB(m map[string]string) []byte {
+	if m == nil {
+		return []byte("{}")
+	}
+	b, _ := json.Marshal(m)
+	return b
+}
+
+// UnmarshalJSONB unmarshals JSON bytes into a map[string]string.
+// Returns nil when data is empty or does not contain valid key/value pairs.
+func UnmarshalJSONB(data []byte) map[string]string {
+	if len(data) == 0 {
+		return nil
+	}
+	var m map[string]string
+	if json.Unmarshal(data, &m) != nil || len(m) == 0 {
+		return nil
+	}
+	return m
+}

--- a/internal/pgutil/nullable_test.go
+++ b/internal/pgutil/nullable_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pgutil
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNullString(t *testing.T) {
+	if got := NullString(""); got != nil {
+		t.Errorf("expected nil for empty string, got %v", got)
+	}
+	if got := NullString("hello"); got == nil || *got != "hello" {
+		t.Errorf("expected pointer to %q, got %v", "hello", got)
+	}
+}
+
+func TestDerefString(t *testing.T) {
+	if got := DerefString(nil); got != "" {
+		t.Errorf("expected empty string for nil, got %q", got)
+	}
+	s := "world"
+	if got := DerefString(&s); got != "world" {
+		t.Errorf("expected %q, got %q", "world", got)
+	}
+}
+
+func TestNullInt(t *testing.T) {
+	if got := NullInt(0); got != nil {
+		t.Errorf("expected nil for zero, got %v", got)
+	}
+	if got := NullInt(42); got == nil || *got != 42 {
+		t.Errorf("expected pointer to 42, got %v", got)
+	}
+}
+
+func TestNullInt32(t *testing.T) {
+	if got := NullInt32(0); got != nil {
+		t.Errorf("expected nil for zero, got %v", got)
+	}
+	if got := NullInt32(7); got == nil || *got != 7 {
+		t.Errorf("expected pointer to 7, got %v", got)
+	}
+}
+
+func TestNullInt64(t *testing.T) {
+	if got := NullInt64(0); got != nil {
+		t.Errorf("expected nil for zero, got %v", got)
+	}
+	if got := NullInt64(99); got == nil || *got != 99 {
+		t.Errorf("expected pointer to 99, got %v", got)
+	}
+}
+
+func TestNullTime(t *testing.T) {
+	if got := NullTime(time.Time{}); got != nil {
+		t.Errorf("expected nil for zero time, got %v", got)
+	}
+	now := time.Now()
+	if got := NullTime(now); got == nil || !got.Equal(now) {
+		t.Errorf("expected pointer to %v, got %v", now, got)
+	}
+}
+
+func TestTimeOrZero(t *testing.T) {
+	if got := TimeOrZero(nil); !got.IsZero() {
+		t.Errorf("expected zero time for nil, got %v", got)
+	}
+	now := time.Now()
+	if got := TimeOrZero(&now); !got.Equal(now) {
+		t.Errorf("expected %v, got %v", now, got)
+	}
+}
+
+func TestMarshalJSONB_Nil(t *testing.T) {
+	got := MarshalJSONB(nil)
+	if string(got) != "{}" {
+		t.Errorf("expected %q, got %q", "{}", string(got))
+	}
+}
+
+func TestMarshalJSONB_NonNil(t *testing.T) {
+	m := map[string]string{"key": "value"}
+	got := MarshalJSONB(m)
+	if string(got) != `{"key":"value"}` {
+		t.Errorf("expected %q, got %q", `{"key":"value"}`, string(got))
+	}
+}
+
+func TestUnmarshalJSONB_Empty(t *testing.T) {
+	if got := UnmarshalJSONB(nil); got != nil {
+		t.Errorf("expected nil for nil input, got %v", got)
+	}
+	if got := UnmarshalJSONB([]byte{}); got != nil {
+		t.Errorf("expected nil for empty input, got %v", got)
+	}
+}
+
+func TestUnmarshalJSONB_EmptyObject(t *testing.T) {
+	if got := UnmarshalJSONB([]byte("{}")); got != nil {
+		t.Errorf("expected nil for empty JSON object, got %v", got)
+	}
+}
+
+func TestUnmarshalJSONB_InvalidJSON(t *testing.T) {
+	if got := UnmarshalJSONB([]byte("not json")); got != nil {
+		t.Errorf("expected nil for invalid JSON, got %v", got)
+	}
+}
+
+func TestUnmarshalJSONB_Valid(t *testing.T) {
+	got := UnmarshalJSONB([]byte(`{"a":"1","b":"2"}`))
+	if got == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if got["a"] != "1" || got["b"] != "2" {
+		t.Errorf("unexpected map: %v", got)
+	}
+}

--- a/internal/pgutil/querybuilder.go
+++ b/internal/pgutil/querybuilder.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package pgutil provides shared PostgreSQL helpers: a parameterized query
+// builder and nullable type conversion functions used across multiple packages.
+package pgutil
+
+import (
+	"strconv"
+	"strings"
+)
+
+// QueryBuilder accumulates parameterized WHERE clauses and their arguments.
+// Use "$?" as a placeholder in clause strings; it is replaced with the
+// positional parameter number (e.g. "$1", "$2") when Add is called.
+type QueryBuilder struct {
+	clauses []string
+	args    []any
+}
+
+// Args returns the accumulated query arguments.
+func (qb *QueryBuilder) Args() []any {
+	return qb.args
+}
+
+// SetArgs replaces the internal argument slice. This is useful when a
+// QueryBuilder must share arguments with a preceding builder (e.g. CTE +
+// outer query).
+func (qb *QueryBuilder) SetArgs(args []any) {
+	qb.args = args
+}
+
+// Add appends a clause with a single argument. Every "$?" in clause is
+// replaced with the next positional parameter number.
+func (qb *QueryBuilder) Add(clause string, arg any) {
+	qb.args = append(qb.args, arg)
+	qb.clauses = append(qb.clauses, strings.ReplaceAll(clause, "$?", "$"+strconv.Itoa(len(qb.args))))
+}
+
+// Where returns the accumulated clauses joined with " AND " and prefixed
+// with " AND ". If no clauses have been added, it returns an empty string.
+// The caller is expected to include "WHERE 1=1" (or equivalent) before the
+// returned fragment.
+func (qb *QueryBuilder) Where() string {
+	if len(qb.clauses) == 0 {
+		return ""
+	}
+	return " AND " + strings.Join(qb.clauses, " AND ")
+}
+
+// AppendPagination appends LIMIT and OFFSET clauses to query when the
+// respective values are greater than zero. Arguments are tracked internally.
+func (qb *QueryBuilder) AppendPagination(query string, limit, offset int) string {
+	if limit > 0 {
+		qb.args = append(qb.args, limit)
+		query += " LIMIT $" + strconv.Itoa(len(qb.args))
+	}
+	if offset > 0 {
+		qb.args = append(qb.args, offset)
+		query += " OFFSET $" + strconv.Itoa(len(qb.args))
+	}
+	return query
+}

--- a/internal/pgutil/querybuilder_test.go
+++ b/internal/pgutil/querybuilder_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package pgutil
+
+import (
+	"testing"
+)
+
+func TestQueryBuilder_Add(t *testing.T) {
+	qb := &QueryBuilder{}
+	qb.Add("name=$?", "alice")
+	qb.Add("age > $?", 30)
+
+	if len(qb.Args()) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(qb.Args()))
+	}
+	if qb.Args()[0] != "alice" {
+		t.Errorf("expected arg[0]=%q, got %v", "alice", qb.Args()[0])
+	}
+	if qb.Args()[1] != 30 {
+		t.Errorf("expected arg[1]=%d, got %v", 30, qb.Args()[1])
+	}
+}
+
+func TestQueryBuilder_Where_Empty(t *testing.T) {
+	qb := &QueryBuilder{}
+	if got := qb.Where(); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+func TestQueryBuilder_Where_SingleClause(t *testing.T) {
+	qb := &QueryBuilder{}
+	qb.Add("status=$?", "active")
+
+	want := " AND status=$1"
+	if got := qb.Where(); got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestQueryBuilder_Where_MultipleClauses(t *testing.T) {
+	qb := &QueryBuilder{}
+	qb.Add("a=$?", 1)
+	qb.Add("b=$?", 2)
+	qb.Add("c=$?", 3)
+
+	want := " AND a=$1 AND b=$2 AND c=$3"
+	if got := qb.Where(); got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestQueryBuilder_SetArgs(t *testing.T) {
+	qb := &QueryBuilder{}
+	existing := []any{"pre-existing"}
+	qb.SetArgs(existing)
+	qb.Add("x=$?", "val")
+
+	if len(qb.Args()) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(qb.Args()))
+	}
+	if qb.Args()[0] != "pre-existing" {
+		t.Errorf("expected first arg to be pre-existing, got %v", qb.Args()[0])
+	}
+
+	want := " AND x=$2"
+	if got := qb.Where(); got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
+func TestQueryBuilder_AppendPagination_Both(t *testing.T) {
+	qb := &QueryBuilder{}
+	qb.Add("id=$?", 1)
+
+	result := qb.AppendPagination("SELECT * FROM t WHERE 1=1"+qb.Where(), 10, 20)
+	want := "SELECT * FROM t WHERE 1=1 AND id=$1 LIMIT $2 OFFSET $3"
+	if result != want {
+		t.Errorf("expected %q, got %q", want, result)
+	}
+	if len(qb.Args()) != 3 {
+		t.Fatalf("expected 3 args, got %d", len(qb.Args()))
+	}
+	if qb.Args()[1] != 10 {
+		t.Errorf("expected limit arg=10, got %v", qb.Args()[1])
+	}
+	if qb.Args()[2] != 20 {
+		t.Errorf("expected offset arg=20, got %v", qb.Args()[2])
+	}
+}
+
+func TestQueryBuilder_AppendPagination_LimitOnly(t *testing.T) {
+	qb := &QueryBuilder{}
+	result := qb.AppendPagination("SELECT * FROM t", 5, 0)
+	want := "SELECT * FROM t LIMIT $1"
+	if result != want {
+		t.Errorf("expected %q, got %q", want, result)
+	}
+	if len(qb.Args()) != 1 {
+		t.Fatalf("expected 1 arg, got %d", len(qb.Args()))
+	}
+}
+
+func TestQueryBuilder_AppendPagination_OffsetOnly(t *testing.T) {
+	qb := &QueryBuilder{}
+	result := qb.AppendPagination("SELECT * FROM t", 0, 10)
+	want := "SELECT * FROM t OFFSET $1"
+	if result != want {
+		t.Errorf("expected %q, got %q", want, result)
+	}
+}
+
+func TestQueryBuilder_AppendPagination_Neither(t *testing.T) {
+	qb := &QueryBuilder{}
+	result := qb.AppendPagination("SELECT * FROM t", 0, 0)
+	want := "SELECT * FROM t"
+	if result != want {
+		t.Errorf("expected %q, got %q", want, result)
+	}
+	if len(qb.Args()) != 0 {
+		t.Errorf("expected 0 args, got %d", len(qb.Args()))
+	}
+}

--- a/internal/session/providers/postgres/reencryption.go
+++ b/internal/session/providers/postgres/reencryption.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	"github.com/altairalabs/omnia/ee/pkg/encryption"
+	"github.com/altairalabs/omnia/internal/pgutil"
 	"github.com/altairalabs/omnia/internal/session"
 )
 
@@ -73,7 +74,7 @@ func (p *Provider) GetEncryptedMessageBatch(
 func (p *Provider) UpdateMessageContent(ctx context.Context, _ string, msg *session.Message) error {
 	query := `UPDATE messages SET content = $1, metadata = $2 WHERE id = $3`
 
-	_, err := p.pool.Exec(ctx, query, msg.Content, marshalJSONB(msg.Metadata), msg.ID)
+	_, err := p.pool.Exec(ctx, query, msg.Content, pgutil.MarshalJSONB(msg.Metadata), msg.ID)
 	if err != nil {
 		return fmt.Errorf("updating message content: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Created `internal/pgutil` package with shared `QueryBuilder` type and nullable helper functions (`NullString`, `DerefString`, `NullInt`, `NullInt32`, `NullInt64`, `NullTime`, `TimeOrZero`, `MarshalJSONB`, `UnmarshalJSONB`)
- Replaced duplicated `queryBuilder`/`evalQueryBuilder` structs and nullable helpers in `internal/session/providers/postgres/provider.go`, `eval_store.go`, `reencryption.go`, and `ee/pkg/audit/logger.go` with imports from the shared package
- New package has 100% test coverage

Closes #527

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/pgutil/... -count=1` -- 100% coverage
- [x] `go test ./internal/session/providers/postgres/... -count=1` -- passes
- [x] `go test ./ee/pkg/audit/... -count=1` -- passes
- [x] `golangci-lint run ./internal/pgutil/... ./internal/session/providers/postgres/...` -- 0 issues
- [x] `golangci-lint run ./ee/pkg/audit/...` -- only pre-existing `lll` issue in `handler_test.go`