### PR TITLE
refactor: deduplicate enterprise controller code

### DIFF
--- a/ee/internal/controller/arenajob_controller_test.go
+++ b/ee/internal/controller/arenajob_controller_test.go
@@ -2007,7 +2007,7 @@ spec:
 			reconciler := &ArenaJobReconciler{
 				Client: nil,
 			}
-			result := reconciler.getWorkspaceForNamespace(ctx, "test-namespace")
+			result := GetWorkspaceForNamespace(ctx, reconciler.Client, "test-namespace")
 			Expect(result).To(Equal("test-namespace"))
 		})
 
@@ -2030,7 +2030,7 @@ spec:
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
-			result := reconciler.getWorkspaceForNamespace(ctx, "ns-with-workspace-label")
+			result := GetWorkspaceForNamespace(ctx, reconciler.Client, "ns-with-workspace-label")
 			Expect(result).To(Equal("my-workspace"))
 		})
 
@@ -2050,7 +2050,7 @@ spec:
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
-			result := reconciler.getWorkspaceForNamespace(ctx, "ns-without-workspace-label")
+			result := GetWorkspaceForNamespace(ctx, reconciler.Client, "ns-without-workspace-label")
 			Expect(result).To(Equal("ns-without-workspace-label"))
 		})
 
@@ -2060,7 +2060,7 @@ spec:
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
-			result := reconciler.getWorkspaceForNamespace(ctx, "non-existent-namespace")
+			result := GetWorkspaceForNamespace(ctx, reconciler.Client, "non-existent-namespace")
 			Expect(result).To(Equal("non-existent-namespace"))
 		})
 	})

--- a/ee/internal/controller/arenasource_controller.go
+++ b/ee/internal/controller/arenasource_controller.go
@@ -13,11 +13,8 @@ package controller
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
-	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -209,7 +206,7 @@ func (r *ArenaSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		}
 
 		// Store the artifact (sync to filesystem)
-		contentPath, version, artifactURL, err := r.storeArtifact(source, result.artifact)
+		contentPath, version, err := r.storeArtifact(ctx, source, result.artifact)
 		if err != nil {
 			log.Error(err, "Failed to store artifact")
 			r.handleFetchError(ctx, source, err)
@@ -228,7 +225,7 @@ func (r *ArenaSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		// Update status with artifact info
 		source.Status.Artifact = &omniav1alpha1.Artifact{
 			Revision:       result.artifact.Revision,
-			URL:            artifactURL, // Legacy: tar.gz URL (empty for filesystem mode)
+			URL:            "",          // Legacy: tar.gz URL (empty for filesystem mode)
 			ContentPath:    contentPath, // New: filesystem path
 			Version:        version,     // New: content-addressable hash
 			Checksum:       result.artifact.Checksum,
@@ -244,7 +241,7 @@ func (r *ArenaSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 			source.Status.HeadVersion = version
 			// Count versions
 			if r.WorkspaceContentPath != "" {
-				workspaceName := r.getWorkspaceForNamespace(ctx, source.Namespace)
+				workspaceName := GetWorkspaceForNamespace(ctx, r.Client, source.Namespace)
 				targetPath := source.Spec.TargetPath
 				if targetPath == "" {
 					targetPath = fmt.Sprintf("arena/%s", source.Name)
@@ -459,7 +456,7 @@ func (r *ArenaSourceReconciler) createGitFetcher(ctx context.Context, source *om
 
 	// Load credentials if specified
 	if source.Spec.Git.SecretRef != nil {
-		creds, err := r.loadGitCredentials(ctx, source.Namespace, source.Spec.Git.SecretRef.Name)
+		creds, err := LoadGitCredentials(ctx, r.Client, source.Namespace, source.Spec.Git.SecretRef.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load git credentials: %w", err)
 		}
@@ -483,7 +480,7 @@ func (r *ArenaSourceReconciler) createOCIFetcher(ctx context.Context, source *om
 
 	// Load credentials if specified
 	if source.Spec.OCI.SecretRef != nil {
-		creds, err := r.loadOCICredentials(ctx, source.Namespace, source.Spec.OCI.SecretRef.Name)
+		creds, err := LoadOCICredentials(ctx, r.Client, source.Namespace, source.Spec.OCI.SecretRef.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to load oci credentials: %w", err)
 		}
@@ -508,336 +505,39 @@ func (r *ArenaSourceReconciler) createConfigMapFetcher(source *omniav1alpha1.Are
 	return fetcher.NewConfigMapFetcher(config, r.Client), nil
 }
 
-// loadGitCredentials loads Git credentials from a Secret.
-func (r *ArenaSourceReconciler) loadGitCredentials(ctx context.Context, namespace, secretName string) (*fetcher.GitCredentials, error) {
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-		return nil, err
-	}
-
-	creds := &fetcher.GitCredentials{}
-
-	// HTTPS credentials
-	if username, ok := secret.Data["username"]; ok {
-		creds.Username = string(username)
-	}
-	if password, ok := secret.Data["password"]; ok {
-		creds.Password = string(password)
-	}
-
-	// SSH credentials
-	if identity, ok := secret.Data["identity"]; ok {
-		creds.PrivateKey = identity
-	}
-	if knownHosts, ok := secret.Data["known_hosts"]; ok {
-		creds.KnownHosts = knownHosts
-	}
-
-	return creds, nil
-}
-
-// loadOCICredentials loads OCI credentials from a Secret.
-func (r *ArenaSourceReconciler) loadOCICredentials(ctx context.Context, namespace, secretName string) (*fetcher.OCICredentials, error) {
-	secret := &corev1.Secret{}
-	if err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
-		return nil, err
-	}
-
-	creds := &fetcher.OCICredentials{}
-
-	// Basic auth credentials
-	if username, ok := secret.Data["username"]; ok {
-		creds.Username = string(username)
-	}
-	if password, ok := secret.Data["password"]; ok {
-		creds.Password = string(password)
-	}
-
-	// Docker config
-	if dockerConfig, ok := secret.Data[".dockerconfigjson"]; ok {
-		creds.DockerConfig = dockerConfig
-	}
-
-	return creds, nil
-}
-
 // storeArtifact stores the fetched artifact by syncing to the workspace content filesystem.
 // Returns contentPath, version, url (url is always empty for filesystem mode).
-func (r *ArenaSourceReconciler) storeArtifact(source *omniav1alpha1.ArenaSource, artifact *fetcher.Artifact) (contentPath, version, url string, err error) {
+func (r *ArenaSourceReconciler) storeArtifact(ctx context.Context, source *omniav1alpha1.ArenaSource, artifact *fetcher.Artifact) (contentPath, version string, err error) {
 	// If artifact has no path (no-change result), return existing values
 	if artifact.Path == "" && source.Status.Artifact != nil {
 		return source.Status.Artifact.ContentPath,
 			source.Status.Artifact.Version,
-			"",
 			nil
 	}
 
 	// WorkspaceContentPath is required
 	if r.WorkspaceContentPath == "" {
-		return "", "", "", fmt.Errorf("WorkspaceContentPath is required for storing artifacts")
+		return "", "", fmt.Errorf("WorkspaceContentPath is required for storing artifacts")
 	}
 
-	return r.syncToFilesystem(source, artifact)
-}
-
-// syncToFilesystem copies the artifact directory to the workspace content filesystem
-// and creates a content-addressable version.
-func (r *ArenaSourceReconciler) syncToFilesystem(source *omniav1alpha1.ArenaSource, artifact *fetcher.Artifact) (contentPath, version, url string, err error) {
-	ctx := context.Background()
-	log := logf.FromContext(ctx).WithValues(
-		"source", source.Name,
-		"namespace", source.Namespace,
-	)
-
-	// Get workspace name from namespace label (allows future multi-namespace workspaces)
-	workspaceName := r.getWorkspaceForNamespace(ctx, source.Namespace)
-
-	// Ensure workspace PVC exists (lazy creation)
-	if r.StorageManager != nil {
-		if _, pvcErr := r.StorageManager.EnsureWorkspacePVC(ctx, workspaceName); pvcErr != nil {
-			log.Error(pvcErr, "failed to ensure workspace PVC exists", "workspace", workspaceName)
-			return "", "", "", fmt.Errorf("failed to ensure workspace PVC: %w", pvcErr)
-		}
-		log.V(1).Info("workspace PVC ensured", "workspace", workspaceName)
-	}
-
-	// Determine target path within workspace content
+	workspaceName := GetWorkspaceForNamespace(ctx, r.Client, source.Namespace)
 	targetPath := source.Spec.TargetPath
 	if targetPath == "" {
 		targetPath = fmt.Sprintf("arena/%s", source.Name)
 	}
 
-	// Workspace content structure: {base}/{workspace}/{namespace}/{targetPath}
-	// This structure supports future multi-namespace workspaces
-	workspacePath := filepath.Join(r.WorkspaceContentPath, workspaceName, source.Namespace, targetPath)
-
-	// Use the checksum from the artifact (already calculated by fetcher)
-	// Extract the hash part from "sha256:<hash>"
-	contentHash := strings.TrimPrefix(artifact.Checksum, "sha256:")
-	if contentHash == "" || contentHash == artifact.Checksum || len(contentHash) < 12 {
-		// Fallback: calculate hash if checksum format is unexpected or too short
-		var err error
-		contentHash, err = fetcher.CalculateDirectoryHash(artifact.Path)
-		if err != nil {
-			return "", "", "", fmt.Errorf("failed to calculate content hash: %w", err)
-		}
+	syncer := &FilesystemSyncer{
+		WorkspaceContentPath: r.WorkspaceContentPath,
+		MaxVersionsPerSource: r.MaxVersionsPerSource,
+		StorageManager:       r.StorageManager,
 	}
 
-	// Short version for display (first 12 chars of SHA256)
-	version = contentHash[:12]
-
-	// Check if this version already exists
-	versionDir := filepath.Join(workspacePath, ".arena", "versions", version)
-	if _, err := os.Stat(versionDir); err == nil {
-		log.V(1).Info("Version already exists, skipping sync", "version", version)
-		// Version already exists, just update HEAD
-		contentPath = filepath.Join(targetPath, ".arena", "versions", version)
-		if err := r.updateHEAD(workspacePath, version); err != nil {
-			return "", "", "", fmt.Errorf("failed to update HEAD: %w", err)
-		}
-		return contentPath, version, "", nil
-	}
-
-	// Create version directory
-	if err := os.MkdirAll(versionDir, 0755); err != nil {
-		return "", "", "", fmt.Errorf("failed to create version directory: %w", err)
-	}
-
-	// Try os.Rename first (atomic, same filesystem), fallback to copy
-	if err := os.Rename(artifact.Path, versionDir); err != nil {
-		// Rename failed (likely cross-filesystem), copy instead
-		// First remove the empty versionDir we just created
-		_ = os.RemoveAll(versionDir)
-		if err := os.MkdirAll(versionDir, 0755); err != nil {
-			return "", "", "", fmt.Errorf("failed to create version directory: %w", err)
-		}
-		if err := copyDirectory(artifact.Path, versionDir); err != nil {
-			// Clean up on failure
-			_ = os.RemoveAll(versionDir)
-			return "", "", "", fmt.Errorf("failed to copy content to version directory: %w", err)
-		}
-	}
-
-	// Update HEAD pointer atomically
-	if err := r.updateHEAD(workspacePath, version); err != nil {
-		return "", "", "", fmt.Errorf("failed to update HEAD: %w", err)
-	}
-
-	// Garbage collect old versions
-	if err := r.gcOldVersions(workspacePath); err != nil {
-		// Log but don't fail on GC errors
-		log.Error(err, "Failed to garbage collect old versions")
-	}
-
-	log.Info("Successfully synced content to filesystem",
-		"version", version,
-		"path", versionDir,
-	)
-
-	contentPath = filepath.Join(targetPath, ".arena", "versions", version)
-	return contentPath, version, "", nil
-}
-
-// getWorkspaceForNamespace looks up the workspace name from a namespace's labels.
-// Returns the namespace name as fallback if workspace label is not found.
-func (r *ArenaSourceReconciler) getWorkspaceForNamespace(ctx context.Context, namespace string) string {
-	// Handle nil client (e.g., in tests that don't set up the client)
-	if r.Client == nil {
-		return namespace
-	}
-	ns := &corev1.Namespace{}
-	if err := r.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
-		// Fallback to namespace name if we can't look it up
-		return namespace
-	}
-	if wsName, ok := ns.Labels[labelWorkspace]; ok && wsName != "" {
-		return wsName
-	}
-	// Fallback to namespace name
-	return namespace
-}
-
-// updateHEAD atomically updates the HEAD pointer to the given version.
-func (r *ArenaSourceReconciler) updateHEAD(workspacePath, version string) error {
-	arenaDir := filepath.Join(workspacePath, ".arena")
-	if err := os.MkdirAll(arenaDir, 0755); err != nil {
-		return err
-	}
-
-	headPath := filepath.Join(arenaDir, "HEAD")
-	tempPath := headPath + ".tmp"
-
-	// Write to temp file first
-	if err := os.WriteFile(tempPath, []byte(version), 0644); err != nil {
-		return err
-	}
-
-	// Atomic rename
-	return os.Rename(tempPath, headPath)
-}
-
-// gcOldVersions removes old versions exceeding MaxVersionsPerSource.
-func (r *ArenaSourceReconciler) gcOldVersions(workspacePath string) error {
-	versionsDir := filepath.Join(workspacePath, ".arena", "versions")
-
-	entries, err := os.ReadDir(versionsDir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil
-		}
-		return err
-	}
-
-	maxVersions := r.MaxVersionsPerSource
-	if maxVersions <= 0 {
-		maxVersions = 10 // Default
-	}
-
-	if len(entries) <= maxVersions {
-		return nil
-	}
-
-	// Get version directories with their mod times
-	type versionInfo struct {
-		name    string
-		modTime time.Time
-	}
-	versions := make([]versionInfo, 0, len(entries))
-	for _, entry := range entries {
-		if !entry.IsDir() {
-			continue
-		}
-		info, err := entry.Info()
-		if err != nil {
-			continue
-		}
-		versions = append(versions, versionInfo{
-			name:    entry.Name(),
-			modTime: info.ModTime(),
-		})
-	}
-
-	// Sort by mod time (oldest first)
-	sort.Slice(versions, func(i, j int) bool {
-		return versions[i].modTime.Before(versions[j].modTime)
+	return syncer.SyncToFilesystem(ctx, SyncParams{
+		WorkspaceName: workspaceName,
+		Namespace:     source.Namespace,
+		TargetPath:    targetPath,
+		Artifact:      artifact,
 	})
-
-	// Remove oldest versions
-	for i := 0; i < len(versions)-maxVersions; i++ {
-		versionPath := filepath.Join(versionsDir, versions[i].name)
-		if err := os.RemoveAll(versionPath); err != nil {
-			return fmt.Errorf("failed to remove old version %s: %w", versions[i].name, err)
-		}
-	}
-
-	return nil
-}
-
-// copyDirectory recursively copies a directory.
-func copyDirectory(src, dst string) error {
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-
-		// Get relative path
-		relPath, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-
-		targetPath := filepath.Join(dst, relPath)
-
-		if info.IsDir() {
-			return os.MkdirAll(targetPath, info.Mode())
-		}
-
-		// Handle symlinks
-		if info.Mode()&os.ModeSymlink != 0 {
-			link, err := os.Readlink(path)
-			if err != nil {
-				return err
-			}
-			return os.Symlink(link, targetPath)
-		}
-
-		// Copy file
-		return copyFileWithMode(path, targetPath, info.Mode())
-	})
-}
-
-// copyFileWithMode copies a file preserving its mode.
-func copyFileWithMode(src, dst string, mode os.FileMode) error {
-	sourceFile, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		if err := sourceFile.Close(); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close source file %s: %v\n", src, err)
-		}
-	}()
-
-	destFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
-	if err != nil {
-		return err
-	}
-
-	if _, err := io.Copy(destFile, sourceFile); err != nil {
-		if closeErr := destFile.Close(); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close dest file %s after copy error: %v\n", dst, closeErr)
-		}
-		return err
-	}
-
-	if err := destFile.Sync(); err != nil {
-		if closeErr := destFile.Close(); closeErr != nil {
-			fmt.Fprintf(os.Stderr, "Warning: failed to close dest file %s after sync error: %v\n", dst, closeErr)
-		}
-		return err
-	}
-
-	return destFile.Close()
 }
 
 // handleFetchError handles errors during fetch operations.

--- a/ee/internal/controller/credentials.go
+++ b/ee/internal/controller/credentials.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/fetcher"
+)
+
+// LoadGitCredentials loads Git credentials from a Kubernetes Secret.
+// It supports both HTTPS (username/password) and SSH (identity/known_hosts) credentials.
+func LoadGitCredentials(ctx context.Context, c client.Reader, namespace, secretName string) (*fetcher.GitCredentials, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+		return nil, err
+	}
+
+	creds := &fetcher.GitCredentials{}
+
+	// HTTPS credentials
+	if username, ok := secret.Data["username"]; ok {
+		creds.Username = string(username)
+	}
+	if password, ok := secret.Data["password"]; ok {
+		creds.Password = string(password)
+	}
+
+	// SSH credentials
+	if identity, ok := secret.Data["identity"]; ok {
+		creds.PrivateKey = identity
+	}
+	if knownHosts, ok := secret.Data["known_hosts"]; ok {
+		creds.KnownHosts = knownHosts
+	}
+
+	return creds, nil
+}
+
+// LoadOCICredentials loads OCI registry credentials from a Kubernetes Secret.
+// It supports basic auth (username/password) and Docker config (.dockerconfigjson) credentials.
+func LoadOCICredentials(ctx context.Context, c client.Reader, namespace, secretName string) (*fetcher.OCICredentials, error) {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret); err != nil {
+		return nil, err
+	}
+
+	creds := &fetcher.OCICredentials{}
+
+	// Basic auth credentials
+	if username, ok := secret.Data["username"]; ok {
+		creds.Username = string(username)
+	}
+	if password, ok := secret.Data["password"]; ok {
+		creds.Password = string(password)
+	}
+
+	// Docker config
+	if dockerConfig, ok := secret.Data[".dockerconfigjson"]; ok {
+		creds.DockerConfig = dockerConfig
+	}
+
+	return creds, nil
+}

--- a/ee/internal/controller/credentials_test.go
+++ b/ee/internal/controller/credentials_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Credentials", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Describe("LoadGitCredentials", func() {
+		It("should load HTTPS credentials from a secret", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "git-https-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username": []byte("my-user"),
+					"password": []byte("my-pass"),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadGitCredentials(ctx, fakeClient, "default", "git-https-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.Username).To(Equal("my-user"))
+			Expect(creds.Password).To(Equal("my-pass"))
+			Expect(creds.PrivateKey).To(BeNil())
+			Expect(creds.KnownHosts).To(BeNil())
+		})
+
+		It("should load SSH credentials from a secret", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "git-ssh-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"identity":    []byte("ssh-private-key-data"),
+					"known_hosts": []byte("github.com ssh-rsa AAAA..."),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadGitCredentials(ctx, fakeClient, "default", "git-ssh-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.PrivateKey).To(Equal([]byte("ssh-private-key-data")))
+			Expect(creds.KnownHosts).To(Equal([]byte("github.com ssh-rsa AAAA...")))
+			Expect(creds.Username).To(BeEmpty())
+			Expect(creds.Password).To(BeEmpty())
+		})
+
+		It("should load combined HTTPS and SSH credentials", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "git-combined-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username":    []byte("my-user"),
+					"password":    []byte("my-pass"),
+					"identity":    []byte("ssh-key"),
+					"known_hosts": []byte("hosts"),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadGitCredentials(ctx, fakeClient, "default", "git-combined-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.Username).To(Equal("my-user"))
+			Expect(creds.Password).To(Equal("my-pass"))
+			Expect(creds.PrivateKey).To(Equal([]byte("ssh-key")))
+			Expect(creds.KnownHosts).To(Equal([]byte("hosts")))
+		})
+
+		It("should return error when secret does not exist", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			_, err := LoadGitCredentials(ctx, fakeClient, "default", "nonexistent-secret")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return empty credentials for secret with no relevant keys", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"unrelated-key": []byte("some-value"),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadGitCredentials(ctx, fakeClient, "default", "empty-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.Username).To(BeEmpty())
+			Expect(creds.Password).To(BeEmpty())
+			Expect(creds.PrivateKey).To(BeNil())
+			Expect(creds.KnownHosts).To(BeNil())
+		})
+	})
+
+	Describe("LoadOCICredentials", func() {
+		It("should load basic auth credentials from a secret", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oci-basic-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username": []byte("registry-user"),
+					"password": []byte("registry-pass"),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadOCICredentials(ctx, fakeClient, "default", "oci-basic-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.Username).To(Equal("registry-user"))
+			Expect(creds.Password).To(Equal("registry-pass"))
+			Expect(creds.DockerConfig).To(BeNil())
+		})
+
+		It("should load Docker config credentials from a secret", func() {
+			dockerConfig := []byte(`{"auths":{"registry.example.com":{"auth":"base64encoded"}}}`)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oci-docker-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					".dockerconfigjson": dockerConfig,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadOCICredentials(ctx, fakeClient, "default", "oci-docker-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.DockerConfig).To(Equal(dockerConfig))
+			Expect(creds.Username).To(BeEmpty())
+			Expect(creds.Password).To(BeEmpty())
+		})
+
+		It("should return error when secret does not exist", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			_, err := LoadOCICredentials(ctx, fakeClient, "default", "nonexistent-secret")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return empty credentials for secret with no relevant keys", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "empty-oci-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"unrelated-key": []byte("some-value"),
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadOCICredentials(ctx, fakeClient, "default", "empty-oci-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.Username).To(BeEmpty())
+			Expect(creds.Password).To(BeEmpty())
+			Expect(creds.DockerConfig).To(BeNil())
+		})
+
+		It("should load combined basic auth and Docker config credentials", func() {
+			dockerConfig := []byte(`{"auths":{}}`)
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "oci-combined-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"username":          []byte("user"),
+					"password":          []byte("pass"),
+					".dockerconfigjson": dockerConfig,
+				},
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+			creds, err := LoadOCICredentials(ctx, fakeClient, "default", "oci-combined-secret")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(creds.Username).To(Equal("user"))
+			Expect(creds.Password).To(Equal("pass"))
+			Expect(creds.DockerConfig).To(Equal(dockerConfig))
+		})
+	})
+})

--- a/ee/internal/controller/fssync.go
+++ b/ee/internal/controller/fssync.go
@@ -1,0 +1,310 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/fetcher"
+	"github.com/altairalabs/omnia/ee/pkg/workspace"
+)
+
+// FilesystemSyncer manages content-addressable filesystem sync for arena sources.
+// It provides the shared pipeline: hash calculation, version storage, HEAD pointer update,
+// and garbage collection of old versions.
+type FilesystemSyncer struct {
+	// WorkspaceContentPath is the base path for workspace content volumes.
+	WorkspaceContentPath string
+
+	// MaxVersionsPerSource is the maximum number of versions to retain per source.
+	// Default is 10 if not set.
+	MaxVersionsPerSource int
+
+	// StorageManager handles lazy workspace PVC creation.
+	StorageManager *workspace.StorageManager
+}
+
+// SyncParams contains the parameters for a filesystem sync operation.
+type SyncParams struct {
+	// WorkspaceName is the resolved workspace name for the namespace.
+	WorkspaceName string
+
+	// Namespace is the Kubernetes namespace of the source.
+	Namespace string
+
+	// TargetPath is the relative path within the workspace content directory.
+	TargetPath string
+
+	// Artifact is the fetched artifact to sync.
+	Artifact *fetcher.Artifact
+}
+
+// SyncToFilesystem copies the artifact directory to the workspace content filesystem
+// and creates a content-addressable version. It returns the relative content path and the version hash.
+func (s *FilesystemSyncer) SyncToFilesystem(ctx context.Context, params SyncParams) (contentPath, version string, err error) {
+	log := logf.FromContext(ctx).WithValues(
+		"workspace", params.WorkspaceName,
+		"namespace", params.Namespace,
+		"targetPath", params.TargetPath,
+	)
+
+	if err := s.ensureWorkspacePVC(ctx, params.WorkspaceName); err != nil {
+		return "", "", err
+	}
+
+	// Workspace content structure: {base}/{workspace}/{namespace}/{targetPath}
+	workspacePath := filepath.Join(s.WorkspaceContentPath, params.WorkspaceName, params.Namespace, params.TargetPath)
+
+	version, err = calculateVersion(params.Artifact)
+	if err != nil {
+		return "", "", err
+	}
+
+	// Check if this version already exists
+	versionDir := filepath.Join(workspacePath, ".arena", "versions", version)
+	if _, statErr := os.Stat(versionDir); statErr == nil {
+		log.V(1).Info("Version already exists, skipping sync", "version", version)
+		contentPath = filepath.Join(params.TargetPath, ".arena", "versions", version)
+		if headErr := UpdateHEAD(workspacePath, version); headErr != nil {
+			return "", "", fmt.Errorf("failed to update HEAD: %w", headErr)
+		}
+		return contentPath, version, nil
+	}
+
+	if err := storeVersion(params.Artifact.Path, versionDir); err != nil {
+		return "", "", err
+	}
+
+	// Update HEAD pointer atomically
+	if err := UpdateHEAD(workspacePath, version); err != nil {
+		return "", "", fmt.Errorf("failed to update HEAD: %w", err)
+	}
+
+	// Garbage collect old versions
+	if err := GCOldVersions(workspacePath, s.MaxVersionsPerSource); err != nil {
+		// Log but don't fail on GC errors
+		log.Error(err, "Failed to garbage collect old versions")
+	}
+
+	log.Info("Successfully synced content to filesystem",
+		"version", version,
+		"path", versionDir,
+	)
+
+	contentPath = filepath.Join(params.TargetPath, ".arena", "versions", version)
+	return contentPath, version, nil
+}
+
+// ensureWorkspacePVC ensures the workspace PVC exists if a StorageManager is configured.
+func (s *FilesystemSyncer) ensureWorkspacePVC(ctx context.Context, workspaceName string) error {
+	if s.StorageManager == nil {
+		return nil
+	}
+	log := logf.FromContext(ctx).WithValues("workspace", workspaceName)
+	if _, err := s.StorageManager.EnsureWorkspacePVC(ctx, workspaceName); err != nil {
+		log.Error(err, "failed to ensure workspace PVC exists")
+		return fmt.Errorf("failed to ensure workspace PVC: %w", err)
+	}
+	log.V(1).Info("workspace PVC ensured")
+	return nil
+}
+
+// calculateVersion computes a short content-addressable version string from the artifact checksum.
+func calculateVersion(artifact *fetcher.Artifact) (string, error) {
+	contentHash := strings.TrimPrefix(artifact.Checksum, "sha256:")
+	if contentHash == "" || contentHash == artifact.Checksum || len(contentHash) < 12 {
+		var err error
+		contentHash, err = fetcher.CalculateDirectoryHash(artifact.Path)
+		if err != nil {
+			return "", fmt.Errorf("failed to calculate content hash: %w", err)
+		}
+	}
+	// Short version for display (first 12 chars of SHA256)
+	return contentHash[:12], nil
+}
+
+// storeVersion creates the version directory and moves/copies the artifact content into it.
+func storeVersion(artifactPath, versionDir string) error {
+	if err := os.MkdirAll(versionDir, 0755); err != nil {
+		return fmt.Errorf("failed to create version directory: %w", err)
+	}
+
+	// Try os.Rename first (atomic, same filesystem), fallback to copy
+	if err := os.Rename(artifactPath, versionDir); err != nil {
+		// Rename failed (likely cross-filesystem), copy instead
+		_ = os.RemoveAll(versionDir)
+		if mkErr := os.MkdirAll(versionDir, 0755); mkErr != nil {
+			return fmt.Errorf("failed to create version directory: %w", mkErr)
+		}
+		if cpErr := copyDirectory(artifactPath, versionDir); cpErr != nil {
+			_ = os.RemoveAll(versionDir)
+			return fmt.Errorf("failed to copy content to version directory: %w", cpErr)
+		}
+	}
+	return nil
+}
+
+// UpdateHEAD atomically updates the HEAD pointer to the given version.
+func UpdateHEAD(workspacePath, version string) error {
+	arenaDir := filepath.Join(workspacePath, ".arena")
+	if err := os.MkdirAll(arenaDir, 0755); err != nil {
+		return err
+	}
+
+	headPath := filepath.Join(arenaDir, "HEAD")
+	tempPath := headPath + ".tmp"
+
+	// Write to temp file first
+	if err := os.WriteFile(tempPath, []byte(version), 0644); err != nil {
+		return err
+	}
+
+	// Atomic rename
+	return os.Rename(tempPath, headPath)
+}
+
+// GCOldVersions removes old versions exceeding maxVersions.
+// If maxVersions is <= 0, defaults to 10.
+func GCOldVersions(workspacePath string, maxVersions int) error {
+	versionsDir := filepath.Join(workspacePath, ".arena", "versions")
+
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	if maxVersions <= 0 {
+		maxVersions = 10 // Default
+	}
+
+	if len(entries) <= maxVersions {
+		return nil
+	}
+
+	versions := collectVersionInfos(entries)
+
+	// Sort by mod time (oldest first)
+	sort.Slice(versions, func(i, j int) bool {
+		return versions[i].modTime.Before(versions[j].modTime)
+	})
+
+	// Remove oldest versions
+	for i := 0; i < len(versions)-maxVersions; i++ {
+		versionPath := filepath.Join(versionsDir, versions[i].name)
+		if err := os.RemoveAll(versionPath); err != nil {
+			return fmt.Errorf("failed to remove old version %s: %w", versions[i].name, err)
+		}
+	}
+
+	return nil
+}
+
+// versionInfo holds directory name and modification time for GC sorting.
+type versionInfo struct {
+	name    string
+	modTime time.Time
+}
+
+// collectVersionInfos reads directory entries and returns versionInfo for directories only.
+func collectVersionInfos(entries []os.DirEntry) []versionInfo {
+	versions := make([]versionInfo, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		versions = append(versions, versionInfo{
+			name:    entry.Name(),
+			modTime: info.ModTime(),
+		})
+	}
+	return versions
+}
+
+// copyDirectory recursively copies a directory.
+func copyDirectory(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Get relative path
+		relPath, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+
+		targetPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode())
+		}
+
+		// Handle symlinks
+		if info.Mode()&os.ModeSymlink != 0 {
+			link, err := os.Readlink(path)
+			if err != nil {
+				return err
+			}
+			return os.Symlink(link, targetPath)
+		}
+
+		// Copy file
+		return copyFileWithMode(path, targetPath, info.Mode())
+	})
+}
+
+// copyFileWithMode copies a file preserving its mode.
+func copyFileWithMode(src, dst string, mode os.FileMode) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := sourceFile.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close source file %s: %v\n", src, err)
+		}
+	}()
+
+	destFile, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(destFile, sourceFile); err != nil {
+		if closeErr := destFile.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close dest file %s after copy error: %v\n", dst, closeErr)
+		}
+		return err
+	}
+
+	if err := destFile.Sync(); err != nil {
+		if closeErr := destFile.Close(); closeErr != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to close dest file %s after sync error: %v\n", dst, closeErr)
+		}
+		return err
+	}
+
+	return destFile.Close()
+}

--- a/ee/internal/controller/fssync_test.go
+++ b/ee/internal/controller/fssync_test.go
@@ -1,0 +1,433 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/fetcher"
+)
+
+var _ = Describe("FilesystemSyncer", func() {
+	var (
+		ctx     context.Context
+		tmpDir  string
+		syncer  *FilesystemSyncer
+		srcDir  string
+		srcFile string
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		var err error
+		tmpDir, err = os.MkdirTemp("", "fssync-test-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		syncer = &FilesystemSyncer{
+			WorkspaceContentPath: tmpDir,
+			MaxVersionsPerSource: 3,
+		}
+
+		// Create artifact source directory with a file
+		srcDir, err = os.MkdirTemp("", "fssync-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		srcFile = filepath.Join(srcDir, "test.txt")
+		Expect(os.WriteFile(srcFile, []byte("hello world"), 0644)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tmpDir)
+		_ = os.RemoveAll(srcDir)
+	})
+
+	Describe("SyncToFilesystem", func() {
+		It("should sync a new artifact to the filesystem", func() {
+			artifact := &fetcher.Artifact{
+				Path:     srcDir,
+				Checksum: "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+				Revision: "v1.0.0",
+			}
+
+			contentPath, version, err := syncer.SyncToFilesystem(ctx, SyncParams{
+				WorkspaceName: "ws1",
+				Namespace:     "ns1",
+				TargetPath:    "arena/my-source",
+				Artifact:      artifact,
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(version).To(Equal("abcdef123456"))
+			Expect(contentPath).To(Equal("arena/my-source/.arena/versions/abcdef123456"))
+
+			// Verify HEAD file
+			headContent, err := os.ReadFile(filepath.Join(tmpDir, "ws1", "ns1", "arena/my-source", ".arena", "HEAD"))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(headContent)).To(Equal("abcdef123456"))
+		})
+
+		It("should skip sync when version already exists", func() {
+			artifact := &fetcher.Artifact{
+				Path:     srcDir,
+				Checksum: "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+				Revision: "v1.0.0",
+			}
+
+			// First sync
+			contentPath1, version1, err := syncer.SyncToFilesystem(ctx, SyncParams{
+				WorkspaceName: "ws1",
+				Namespace:     "ns1",
+				TargetPath:    "arena/my-source",
+				Artifact:      artifact,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create new source dir for second sync (original was moved)
+			srcDir2, err := os.MkdirTemp("", "fssync-src2-*")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = os.RemoveAll(srcDir2) }()
+			Expect(os.WriteFile(filepath.Join(srcDir2, "test.txt"), []byte("hello world"), 0644)).To(Succeed())
+
+			artifact2 := &fetcher.Artifact{
+				Path:     srcDir2,
+				Checksum: "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+				Revision: "v1.0.0",
+			}
+
+			// Second sync with same checksum
+			contentPath2, version2, err := syncer.SyncToFilesystem(ctx, SyncParams{
+				WorkspaceName: "ws1",
+				Namespace:     "ns1",
+				TargetPath:    "arena/my-source",
+				Artifact:      artifact2,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(contentPath2).To(Equal(contentPath1))
+			Expect(version2).To(Equal(version1))
+		})
+
+		It("should handle nil StorageManager", func() {
+			syncer.StorageManager = nil
+			artifact := &fetcher.Artifact{
+				Path:     srcDir,
+				Checksum: "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+				Revision: "v1.0.0",
+			}
+
+			_, _, err := syncer.SyncToFilesystem(ctx, SyncParams{
+				WorkspaceName: "ws1",
+				Namespace:     "ns1",
+				TargetPath:    "arena/my-source",
+				Artifact:      artifact,
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("UpdateHEAD", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "head-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tmpDir)
+	})
+
+	It("should create HEAD file with version content", func() {
+		err := UpdateHEAD(tmpDir, "v1.0.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		content, err := os.ReadFile(filepath.Join(tmpDir, ".arena", "HEAD"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal("v1.0.0"))
+	})
+
+	It("should overwrite existing HEAD file", func() {
+		Expect(UpdateHEAD(tmpDir, "v1.0.0")).To(Succeed())
+		Expect(UpdateHEAD(tmpDir, "v2.0.0")).To(Succeed())
+
+		content, err := os.ReadFile(filepath.Join(tmpDir, ".arena", "HEAD"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content)).To(Equal("v2.0.0"))
+	})
+
+	It("should create .arena directory if it does not exist", func() {
+		err := UpdateHEAD(tmpDir, "v1.0.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		info, err := os.Stat(filepath.Join(tmpDir, ".arena"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue())
+	})
+})
+
+var _ = Describe("GCOldVersions", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "gc-test-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tmpDir)
+	})
+
+	It("should not error when versions directory does not exist", func() {
+		err := GCOldVersions(tmpDir, 3)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not remove versions when under the limit", func() {
+		versionsDir := filepath.Join(tmpDir, ".arena", "versions")
+		Expect(os.MkdirAll(versionsDir, 0755)).To(Succeed())
+
+		for i := 0; i < 3; i++ {
+			Expect(os.MkdirAll(filepath.Join(versionsDir, "v"+string(rune('a'+i))), 0755)).To(Succeed())
+		}
+
+		err := GCOldVersions(tmpDir, 3)
+		Expect(err).NotTo(HaveOccurred())
+
+		entries, err := os.ReadDir(versionsDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(3))
+	})
+
+	It("should remove oldest versions when over the limit", func() {
+		versionsDir := filepath.Join(tmpDir, ".arena", "versions")
+		Expect(os.MkdirAll(versionsDir, 0755)).To(Succeed())
+
+		// Create 5 version dirs with staggered mod times
+		versions := []string{"oldest", "old", "mid", "new", "newest"}
+		for i, name := range versions {
+			dir := filepath.Join(versionsDir, name)
+			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			// Set modification times with 1-second intervals
+			modTime := time.Now().Add(time.Duration(i-5) * time.Second)
+			Expect(os.Chtimes(dir, modTime, modTime)).To(Succeed())
+		}
+
+		err := GCOldVersions(tmpDir, 3)
+		Expect(err).NotTo(HaveOccurred())
+
+		entries, err := os.ReadDir(versionsDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(3))
+
+		// Verify oldest two were removed
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		Expect(names).NotTo(ContainElement("oldest"))
+		Expect(names).NotTo(ContainElement("old"))
+		Expect(names).To(ContainElement("mid"))
+		Expect(names).To(ContainElement("new"))
+		Expect(names).To(ContainElement("newest"))
+	})
+
+	It("should default to 10 when maxVersions is 0", func() {
+		versionsDir := filepath.Join(tmpDir, ".arena", "versions")
+		Expect(os.MkdirAll(versionsDir, 0755)).To(Succeed())
+
+		// Create 11 versions
+		for i := 0; i < 11; i++ {
+			dir := filepath.Join(versionsDir, "v"+string(rune('a'+i)))
+			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			modTime := time.Now().Add(time.Duration(i-11) * time.Second)
+			Expect(os.Chtimes(dir, modTime, modTime)).To(Succeed())
+		}
+
+		err := GCOldVersions(tmpDir, 0) // Should default to 10
+		Expect(err).NotTo(HaveOccurred())
+
+		entries, err := os.ReadDir(versionsDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(10))
+	})
+
+	It("should skip non-directory entries", func() {
+		versionsDir := filepath.Join(tmpDir, ".arena", "versions")
+		Expect(os.MkdirAll(versionsDir, 0755)).To(Succeed())
+
+		// Create directories and a file
+		for i := 0; i < 4; i++ {
+			dir := filepath.Join(versionsDir, "v"+string(rune('a'+i)))
+			Expect(os.MkdirAll(dir, 0755)).To(Succeed())
+			modTime := time.Now().Add(time.Duration(i-4) * time.Second)
+			Expect(os.Chtimes(dir, modTime, modTime)).To(Succeed())
+		}
+		Expect(os.WriteFile(filepath.Join(versionsDir, "not-a-dir.txt"), []byte("data"), 0644)).To(Succeed())
+
+		err := GCOldVersions(tmpDir, 3)
+		Expect(err).NotTo(HaveOccurred())
+
+		entries, err := os.ReadDir(versionsDir)
+		Expect(err).NotTo(HaveOccurred())
+		// 3 dirs remaining + 1 file = 4 total entries
+		Expect(entries).To(HaveLen(4))
+	})
+})
+
+var _ = Describe("copyDirectory", func() {
+	var srcDir string
+	var dstDir string
+
+	BeforeEach(func() {
+		var err error
+		srcDir, err = os.MkdirTemp("", "copy-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		dstDir, err = os.MkdirTemp("", "copy-dst-*")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(srcDir)
+		_ = os.RemoveAll(dstDir)
+	})
+
+	It("should copy files and subdirectories", func() {
+		// Create source structure
+		Expect(os.MkdirAll(filepath.Join(srcDir, "subdir"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(srcDir, "file1.txt"), []byte("content1"), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(srcDir, "subdir", "file2.txt"), []byte("content2"), 0644)).To(Succeed())
+
+		err := copyDirectory(srcDir, dstDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify copied files
+		content1, err := os.ReadFile(filepath.Join(dstDir, "file1.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content1)).To(Equal("content1"))
+
+		content2, err := os.ReadFile(filepath.Join(dstDir, "subdir", "file2.txt"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(content2)).To(Equal("content2"))
+	})
+
+	It("should return error for non-existent source", func() {
+		err := copyDirectory("/nonexistent/path", dstDir)
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("calculateVersion", func() {
+	It("should extract version from sha256 checksum", func() {
+		artifact := &fetcher.Artifact{
+			Checksum: "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+		}
+
+		version, err := calculateVersion(artifact)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(Equal("abcdef123456"))
+	})
+
+	It("should calculate hash when checksum is empty", func() {
+		tmpDir, err := os.MkdirTemp("", "calc-version-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		Expect(os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("test data"), 0644)).To(Succeed())
+
+		artifact := &fetcher.Artifact{
+			Path:     tmpDir,
+			Checksum: "",
+		}
+
+		version, err := calculateVersion(artifact)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(HaveLen(12))
+	})
+
+	It("should calculate hash when checksum has wrong prefix", func() {
+		tmpDir, err := os.MkdirTemp("", "calc-version-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		Expect(os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("test data"), 0644)).To(Succeed())
+
+		artifact := &fetcher.Artifact{
+			Path:     tmpDir,
+			Checksum: "md5:abcdef",
+		}
+
+		version, err := calculateVersion(artifact)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(HaveLen(12))
+	})
+
+	It("should calculate hash when checksum hash part is too short", func() {
+		tmpDir, err := os.MkdirTemp("", "calc-version-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		Expect(os.WriteFile(filepath.Join(tmpDir, "test.txt"), []byte("test data"), 0644)).To(Succeed())
+
+		artifact := &fetcher.Artifact{
+			Path:     tmpDir,
+			Checksum: "sha256:short",
+		}
+
+		version, err := calculateVersion(artifact)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(version).To(HaveLen(12))
+	})
+})
+
+var _ = Describe("storeVersion", func() {
+	It("should move artifact to version directory", func() {
+		srcDir, err := os.MkdirTemp("", "store-src-*")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(srcDir, "test.txt"), []byte("data"), 0644)).To(Succeed())
+
+		dstDir := filepath.Join(os.TempDir(), "store-dst-test-"+time.Now().Format("20060102150405"))
+		defer func() { _ = os.RemoveAll(dstDir) }()
+
+		err = storeVersion(srcDir, dstDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Verify content was stored
+		entries, err := os.ReadDir(dstDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).NotTo(BeEmpty())
+	})
+})
+
+var _ = Describe("collectVersionInfos", func() {
+	It("should collect directory entries only", func() {
+		tmpDir, err := os.MkdirTemp("", "collect-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = os.RemoveAll(tmpDir) }()
+
+		Expect(os.MkdirAll(filepath.Join(tmpDir, "dir1"), 0755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(tmpDir, "dir2"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tmpDir, "file.txt"), []byte("data"), 0644)).To(Succeed())
+
+		entries, err := os.ReadDir(tmpDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		versions := collectVersionInfos(entries)
+		Expect(versions).To(HaveLen(2))
+		names := []string{versions[0].name, versions[1].name}
+		Expect(names).To(ContainElement("dir1"))
+		Expect(names).To(ContainElement("dir2"))
+	})
+})

--- a/ee/internal/controller/helpers.go
+++ b/ee/internal/controller/helpers.go
@@ -9,8 +9,13 @@ Functional Source License. See ee/LICENSE for details.
 package controller
 
 import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // SetCondition sets a status condition on the given conditions slice.
@@ -27,4 +32,23 @@ func SetCondition(conditions *[]metav1.Condition, generation int64, condType str
 // ptr is a helper function for creating pointers to values.
 func ptr[T any](v T) *T {
 	return &v
+}
+
+// GetWorkspaceForNamespace looks up the workspace name from a namespace's labels.
+// Returns the namespace name as fallback if the workspace label is not found or
+// if the client is nil.
+func GetWorkspaceForNamespace(ctx context.Context, c client.Reader, namespace string) string {
+	if c == nil {
+		return namespace
+	}
+	ns := &corev1.Namespace{}
+	if err := c.Get(ctx, types.NamespacedName{Name: namespace}, ns); err != nil {
+		// Fallback to namespace name if we can't look it up
+		return namespace
+	}
+	if wsName, ok := ns.Labels[labelWorkspace]; ok && wsName != "" {
+		return wsName
+	}
+	// Fallback to namespace name
+	return namespace
 }

--- a/ee/internal/controller/helpers_test.go
+++ b/ee/internal/controller/helpers_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("GetWorkspaceForNamespace", func() {
+	var (
+		ctx    context.Context
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	It("should return workspace name from namespace label", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "my-namespace",
+				Labels: map[string]string{
+					labelWorkspace: "my-workspace",
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+		result := GetWorkspaceForNamespace(ctx, fakeClient, "my-namespace")
+		Expect(result).To(Equal("my-workspace"))
+	})
+
+	It("should fallback to namespace name when label is missing", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   "no-label-ns",
+				Labels: map[string]string{},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+		result := GetWorkspaceForNamespace(ctx, fakeClient, "no-label-ns")
+		Expect(result).To(Equal("no-label-ns"))
+	})
+
+	It("should fallback to namespace name when namespace does not exist", func() {
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		result := GetWorkspaceForNamespace(ctx, fakeClient, "nonexistent-ns")
+		Expect(result).To(Equal("nonexistent-ns"))
+	})
+
+	It("should fallback to namespace name when client is nil", func() {
+		result := GetWorkspaceForNamespace(ctx, nil, "any-namespace")
+		Expect(result).To(Equal("any-namespace"))
+	})
+
+	It("should fallback when workspace label is empty string", func() {
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "empty-label-ns",
+				Labels: map[string]string{
+					labelWorkspace: "",
+				},
+			},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+
+		result := GetWorkspaceForNamespace(ctx, fakeClient, "empty-label-ns")
+		Expect(result).To(Equal("empty-label-ns"))
+	})
+})


### PR DESCRIPTION
## Summary

Resolves #533.

- Extract ~400 lines of duplicated filesystem sync pipeline (`syncToFilesystem`, `updateHEAD`, `gcOldVersions`, `storeVersion`, `copyDirectory`, `copyFileWithMode`) from ArenaSource and ArenaTemplateSource controllers into a shared `FilesystemSyncer` in `ee/internal/controller/fssync.go`
- Extract duplicated credential loading (`loadGitCredentials`, `loadOCICredentials`) into shared package-level functions in `ee/internal/controller/credentials.go`
- Move `getWorkspaceForNamespace` (copied 3 times across ArenaJob, ArenaSource, ArenaTemplateSource controllers) to `ee/internal/controller/helpers.go` as `GetWorkspaceForNamespace`
- Fix O(n^2) bubble sort in ArenaTemplateSource `gcOldVersions` — now uses `sort.Slice` via the shared implementation
- Remove always-empty `url` return from `ArenaSourceReconciler.storeArtifact` (flagged by `unparam`)
- Add comprehensive tests for all shared functions (`fssync_test.go`, `credentials_test.go`, `helpers_test.go`)

### Files changed

| File | Change |
|------|--------|
| `ee/internal/controller/fssync.go` | **New** — shared `FilesystemSyncer`, `UpdateHEAD`, `GCOldVersions`, `copyDirectory`, `copyFileWithMode` |
| `ee/internal/controller/credentials.go` | **New** — shared `LoadGitCredentials`, `LoadOCICredentials` |
| `ee/internal/controller/helpers.go` | Added `GetWorkspaceForNamespace` |
| `ee/internal/controller/arenasource_controller.go` | Removed duplicated methods, delegates to shared code |
| `ee/internal/controller/arenatemplatesource_controller.go` | Removed duplicated methods, delegates to shared code |
| `ee/internal/controller/arenajob_controller.go` | Removed duplicated `getWorkspaceForNamespace`, uses shared function |
| `ee/internal/controller/*_test.go` | Updated existing tests, added new test files |

### Net impact

~600 lines removed from controllers, ~400 lines of shared code added (including tests). The bubble sort fix changes ArenaTemplateSource GC from O(n^2) to O(n log n).

## Test plan

- [ ] Verify `go build ./...` passes
- [ ] Verify `go vet ./ee/internal/controller/` passes
- [ ] Verify `golangci-lint run ./ee/internal/controller/...` has no new issues
- [ ] Verify all existing controller tests pass in CI (requires envtest)
- [ ] Verify new `fssync_test.go`, `credentials_test.go`, `helpers_test.go` pass in CI
- [ ] Verify coverage >= 80% on new files in CI