### PR TITLE
refactor: extract shared helpers and eliminate duplication

### DIFF
--- a/ee/cmd/omnia-arena-controller/api/server.go
+++ b/ee/cmd/omnia-arena-controller/api/server.go
@@ -18,12 +18,7 @@ import (
 	"github.com/go-logr/logr"
 
 	"github.com/altairalabs/omnia/ee/pkg/license"
-)
-
-// HTTP header and content type constants.
-const (
-	headerContentType = "Content-Type"
-	contentTypeJSON   = "application/json"
+	"github.com/altairalabs/omnia/internal/httputil"
 )
 
 // Server provides HTTP API endpoints for arena operations.
@@ -128,7 +123,7 @@ func (s *Server) handleRenderTemplate(w http.ResponseWriter, r *http.Request) {
 		s.log.Error(err, "failed to render template",
 			"templatePath", req.TemplatePath,
 			"outputPath", req.OutputPath)
-		w.Header().Set(headerContentType, contentTypeJSON)
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(RenderTemplateResponse{
 			Success: false,
@@ -137,7 +132,7 @@ func (s *Server) handleRenderTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		s.log.Error(err, "failed to encode response")
 	}
@@ -195,7 +190,7 @@ func (s *Server) handlePreviewTemplate(w http.ResponseWriter, r *http.Request) {
 	result, err := PreviewTemplate(req.TemplatePath, req.ProjectName, req.Variables)
 	if err != nil {
 		s.log.Error(err, "failed to preview template", "templatePath", req.TemplatePath)
-		w.Header().Set(headerContentType, contentTypeJSON)
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(PreviewTemplateResponse{
 			Errors: []string{err.Error()},
@@ -203,7 +198,7 @@ func (s *Server) handlePreviewTemplate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	if err := json.NewEncoder(w).Encode(result); err != nil {
 		s.log.Error(err, "failed to encode response")
 	}
@@ -249,7 +244,7 @@ func (s *Server) handleGetLicense(w http.ResponseWriter, r *http.Request) {
 		lic = license.OpenCoreLicense()
 	}
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	if err := json.NewEncoder(w).Encode(toLicenseResponse(lic)); err != nil {
 		s.log.Error(err, "failed to encode license response")
 	}

--- a/ee/internal/controller/arenadevsession_controller.go
+++ b/ee/internal/controller/arenadevsession_controller.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -599,11 +600,11 @@ func (r *ArenaDevSessionReconciler) reconcileDeployment(ctx context.Context, ses
 							},
 							Resources: r.getResources(session),
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr[bool](false),
+								AllowPrivilegeEscalation: ptr.To(false),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
-								RunAsNonRoot: ptr[bool](true),
+								RunAsNonRoot: ptr.To(true),
 								SeccompProfile: &corev1.SeccompProfile{
 									Type: corev1.SeccompProfileTypeRuntimeDefault,
 								},

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -1005,9 +1006,9 @@ func (r *ArenaJobReconciler) createWorkerJob(ctx context.Context, arenaJob *omni
 				Spec: corev1.PodSpec{
 					RestartPolicy: corev1.RestartPolicyNever,
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsNonRoot: ptr(true),
-						RunAsUser:    ptr(int64(65532)), // nonroot user
-						FSGroup:      ptr(int64(65532)),
+						RunAsNonRoot: ptr.To(true),
+						RunAsUser:    ptr.To(int64(65532)), // nonroot user
+						FSGroup:      ptr.To(int64(65532)),
 						SeccompProfile: &corev1.SeccompProfile{
 							Type: corev1.SeccompProfileTypeRuntimeDefault,
 						},
@@ -1020,9 +1021,9 @@ func (r *ArenaJobReconciler) createWorkerJob(ctx context.Context, arenaJob *omni
 							ImagePullPolicy: r.getWorkerImagePullPolicy(),
 							Env:             env,
 							SecurityContext: &corev1.SecurityContext{
-								AllowPrivilegeEscalation: ptr(false),
-								ReadOnlyRootFilesystem:   ptr(true),
-								RunAsNonRoot:             ptr(true),
+								AllowPrivilegeEscalation: ptr.To(false),
+								ReadOnlyRootFilesystem:   ptr.To(true),
+								RunAsNonRoot:             ptr.To(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},

--- a/ee/internal/controller/helpers.go
+++ b/ee/internal/controller/helpers.go
@@ -29,11 +29,6 @@ func SetCondition(conditions *[]metav1.Condition, generation int64, condType str
 	})
 }
 
-// ptr is a helper function for creating pointers to values.
-func ptr[T any](v T) *T {
-	return &v
-}
-
 // GetWorkspaceForNamespace looks up the workspace name from a namespace's labels.
 // Returns the namespace name as fallback if the workspace label is not found or
 // if the client is nil.

--- a/ee/internal/controller/keyrotation_controller_test.go
+++ b/ee/internal/controller/keyrotation_controller_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -510,7 +511,7 @@ func TestKeyRotation_InvalidCronSchedule(t *testing.T) {
 
 func TestKeyRotation_CustomBatchSize(t *testing.T) {
 	policy := newKeyRotationPolicy()
-	policy.Spec.Encryption.KeyRotation.BatchSize = ptr[int32](50)
+	policy.Spec.Encryption.KeyRotation.BatchSize = ptr.To(int32(50))
 
 	reconciler, _, _ := setupKeyRotationTest(t, policy, newEncryptionSecret())
 	assert.Equal(t, 50, reconciler.getBatchSize(policy))

--- a/ee/internal/controller/sessionanalyticssync_controller_test.go
+++ b/ee/internal/controller/sessionanalyticssync_controller_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -411,8 +412,8 @@ func TestIsSyncEnabled(t *testing.T) {
 		want    bool
 	}{
 		{"nil means enabled", nil, true},
-		{"explicit true", ptr(true), true},
-		{"explicit false", ptr(false), false},
+		{"explicit true", ptr.To(true), true},
+		{"explicit false", ptr.To(false), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/ee/pkg/evals/webhook_dispatcher.go
+++ b/ee/pkg/evals/webhook_dispatcher.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/altairalabs/omnia/internal/httputil"
 	"github.com/altairalabs/omnia/internal/session/api"
 )
 
@@ -28,8 +29,6 @@ const (
 	maxRetries          = 3
 	initialRetryBackoff = 1 * time.Second
 	backoffMultiplier   = 2
-	contentTypeJSON     = "application/json"
-	contentTypeHeader   = "Content-Type"
 )
 
 // WebhookDispatcher evaluates recent eval results against configured
@@ -211,7 +210,7 @@ func (d *WebhookDispatcher) doPost(
 		return fmt.Errorf("create request: %w", err)
 	}
 
-	req.Header.Set(contentTypeHeader, contentTypeJSON)
+	req.Header.Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	for k, v := range cfg.Headers {
 		req.Header.Set(k, v)
 	}

--- a/ee/pkg/evals/webhook_dispatcher_test.go
+++ b/ee/pkg/evals/webhook_dispatcher_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/altairalabs/omnia/internal/httputil"
 	"github.com/altairalabs/omnia/internal/session/api"
 )
 
@@ -309,8 +310,9 @@ func TestCheckAndFire_CustomHeaders(t *testing.T) {
 	if receivedHeaders.Get("X-Custom") != "custom-value" {
 		t.Errorf("expected X-Custom header, got %q", receivedHeaders.Get("X-Custom"))
 	}
-	if receivedHeaders.Get(contentTypeHeader) != contentTypeJSON {
-		t.Errorf("expected Content-Type %q, got %q", contentTypeJSON, receivedHeaders.Get(contentTypeHeader))
+	if receivedHeaders.Get(httputil.HeaderContentType) != httputil.ContentTypeJSON {
+		got := receivedHeaders.Get(httputil.HeaderContentType)
+		t.Errorf("expected Content-Type %q, got %q", httputil.ContentTypeJSON, got)
 	}
 }
 

--- a/ee/pkg/streaming/helpers.go
+++ b/ee/pkg/streaming/helpers.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package streaming
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// Common error messages used by streaming publishers.
+const (
+	ErrMsgNilEvent    = "event must not be nil"
+	ErrMsgMarshalFail = "failed to marshal event"
+)
+
+// marshalEvent validates and marshals a SessionEvent to JSON bytes.
+// Returns an error if the event is nil or cannot be marshalled.
+func marshalEvent(event *SessionEvent) ([]byte, error) {
+	if event == nil {
+		return nil, fmt.Errorf("%s", ErrMsgNilEvent)
+	}
+
+	data, err := json.Marshal(event)
+	if err != nil {
+		return nil, fmt.Errorf("%s: %w", ErrMsgMarshalFail, err)
+	}
+
+	return data, nil
+}
+
+// publishFunc is a function that sends serialised event data to a backend.
+type publishFunc func(ctx context.Context, event *SessionEvent) error
+
+// defaultPublishBatch iterates over events and publishes each one using the
+// supplied publish function. It stops on the first error.
+func defaultPublishBatch(ctx context.Context, events []*SessionEvent, publish publishFunc) error {
+	for i, event := range events {
+		if err := publish(ctx, event); err != nil {
+			return fmt.Errorf("failed to publish event at index %d: %w", i, err)
+		}
+	}
+	return nil
+}

--- a/ee/pkg/streaming/helpers_test.go
+++ b/ee/pkg/streaming/helpers_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package streaming
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestMarshalEvent_NilEvent(t *testing.T) {
+	data, err := marshalEvent(nil)
+	if err == nil {
+		t.Fatal("expected error for nil event")
+	}
+	if data != nil {
+		t.Errorf("expected nil data, got %v", data)
+	}
+	if !strings.Contains(err.Error(), ErrMsgNilEvent) {
+		t.Errorf("expected error to contain %q, got %q", ErrMsgNilEvent, err.Error())
+	}
+}
+
+func TestMarshalEvent_Success(t *testing.T) {
+	event := newTestEvent("evt-1", "sess-1")
+	data, err := marshalEvent(event)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty data")
+	}
+	if !strings.Contains(string(data), "evt-1") {
+		t.Errorf("expected data to contain event ID, got %s", string(data))
+	}
+}
+
+func TestDefaultPublishBatch_Success(t *testing.T) {
+	var published []*SessionEvent
+	pub := func(_ context.Context, event *SessionEvent) error {
+		published = append(published, event)
+		return nil
+	}
+
+	events := []*SessionEvent{
+		newTestEvent("evt-1", "sess-1"),
+		newTestEvent("evt-2", "sess-2"),
+	}
+
+	err := defaultPublishBatch(context.Background(), events, pub)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(published) != 2 {
+		t.Errorf("expected 2 published events, got %d", len(published))
+	}
+}
+
+func TestDefaultPublishBatch_Empty(t *testing.T) {
+	callCount := 0
+	pub := func(_ context.Context, _ *SessionEvent) error {
+		callCount++
+		return nil
+	}
+
+	err := defaultPublishBatch(context.Background(), nil, pub)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callCount != 0 {
+		t.Errorf("expected no calls, got %d", callCount)
+	}
+}
+
+func TestDefaultPublishBatch_ErrorMidBatch(t *testing.T) {
+	callCount := 0
+	pub := func(_ context.Context, _ *SessionEvent) error {
+		callCount++
+		if callCount == 2 {
+			return fmt.Errorf("publish error")
+		}
+		return nil
+	}
+
+	events := []*SessionEvent{
+		newTestEvent("evt-1", "sess-1"),
+		newTestEvent("evt-2", "sess-2"),
+		newTestEvent("evt-3", "sess-3"),
+	}
+
+	err := defaultPublishBatch(context.Background(), events, pub)
+	if err == nil {
+		t.Fatal("expected error from batch publish")
+	}
+	if !strings.Contains(err.Error(), "index 1") {
+		t.Errorf("expected error to reference index 1, got %q", err.Error())
+	}
+}
+
+func TestDefaultPublishBatch_NilEventPropagatesError(t *testing.T) {
+	pub := func(_ context.Context, event *SessionEvent) error {
+		if event == nil {
+			return fmt.Errorf("nil event")
+		}
+		return nil
+	}
+
+	events := []*SessionEvent{newTestEvent("evt-1", "sess-1"), nil}
+	err := defaultPublishBatch(context.Background(), events, pub)
+	if err == nil {
+		t.Fatal("expected error for nil event")
+	}
+}

--- a/ee/pkg/streaming/kafka.go
+++ b/ee/pkg/streaming/kafka.go
@@ -22,12 +22,8 @@ import (
 	"github.com/IBM/sarama"
 )
 
-// Error messages used by the Kafka publisher.
-const (
-	errMsgPublisherClosed = "publisher is closed"
-	errMsgNilEvent        = "event must not be nil"
-	errMsgMarshalFailed   = "failed to marshal event"
-)
+// errMsgPublisherClosed is a Kafka-specific error message.
+const errMsgPublisherClosed = "publisher is closed"
 
 // saramaProducer abstracts the sarama.AsyncProducer for testing.
 type saramaProducer interface {
@@ -91,7 +87,7 @@ func newKafkaPublisherWithProducer(
 // Publish sends a single session event to Kafka. It is non-blocking.
 func (kp *KafkaPublisher) Publish(_ context.Context, event *SessionEvent) error {
 	if event == nil {
-		return errors.New(errMsgNilEvent)
+		return errors.New(ErrMsgNilEvent)
 	}
 
 	kp.mu.RLock()
@@ -156,7 +152,7 @@ func (kp *KafkaPublisher) Close() error {
 func (kp *KafkaPublisher) buildMessage(event *SessionEvent) (*sarama.ProducerMessage, error) {
 	data, err := json.Marshal(event)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", errMsgMarshalFailed, err)
+		return nil, fmt.Errorf("%s: %w", ErrMsgMarshalFail, err)
 	}
 
 	msg := &sarama.ProducerMessage{

--- a/ee/pkg/streaming/kafka_test.go
+++ b/ee/pkg/streaming/kafka_test.go
@@ -134,8 +134,8 @@ func TestKafkaPublisher_PublishNilEvent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for nil event")
 	}
-	if err.Error() != errMsgNilEvent {
-		t.Errorf("expected error %q, got %q", errMsgNilEvent, err.Error())
+	if err.Error() != ErrMsgNilEvent {
+		t.Errorf("expected error %q, got %q", ErrMsgNilEvent, err.Error())
 	}
 
 	if err := pub.Close(); err != nil {

--- a/ee/pkg/streaming/memory.go
+++ b/ee/pkg/streaming/memory.go
@@ -37,7 +37,7 @@ func NewMemoryPublisher() *MemoryPublisher {
 // Publish stores an event in memory.
 func (m *MemoryPublisher) Publish(_ context.Context, event *SessionEvent) error {
 	if event == nil {
-		return errors.New(errMsgNilEvent)
+		return errors.New(ErrMsgNilEvent)
 	}
 
 	m.mu.Lock()

--- a/ee/pkg/workspace/storage_test.go
+++ b/ee/pkg/workspace/storage_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -28,10 +29,6 @@ func newFakeClient(objs ...client.Object) client.Client {
 		WithScheme(newTestScheme()).
 		WithObjects(objs...).
 		Build()
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }
 
 func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
@@ -57,7 +54,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(true),
+						Enabled: ptr.To(true),
 						Size:    "5Gi",
 					},
 				},
@@ -77,7 +74,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled:      ptr(true),
+						Enabled:      ptr.To(true),
 						StorageClass: "custom-nfs",
 					},
 				},
@@ -98,7 +95,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(true),
+						Enabled: ptr.To(true),
 					},
 				},
 			},
@@ -119,7 +116,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(false),
+						Enabled: ptr.To(false),
 					},
 				},
 			},
@@ -155,7 +152,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(true),
+						Enabled: ptr.To(true),
 					},
 				},
 			},
@@ -203,7 +200,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled:     ptr(true),
+						Enabled:     ptr.To(true),
 						AccessModes: []string{"ReadWriteOnce", "ReadOnlyMany"},
 					},
 				},
@@ -223,7 +220,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(true),
+						Enabled: ptr.To(true),
 						Size:    "invalid-size",
 					},
 				},
@@ -243,7 +240,7 @@ func TestStorageManager_EnsureWorkspacePVC(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(true),
+						Enabled: ptr.To(true),
 					},
 				},
 			},
@@ -356,7 +353,7 @@ func TestStorageManager_GetWorkspacePVCName(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(true),
+						Enabled: ptr.To(true),
 					},
 				},
 			},
@@ -374,7 +371,7 @@ func TestStorageManager_GetWorkspacePVCName(t *testing.T) {
 						Name: "test-ns",
 					},
 					Storage: &omniav1alpha1.WorkspaceStorageConfig{
-						Enabled: ptr(false),
+						Enabled: ptr.To(false),
 					},
 				},
 			},
@@ -435,7 +432,7 @@ func TestStorageManager_PVCExists(t *testing.T) {
 				Name: "test-ns",
 			},
 			Storage: &omniav1alpha1.WorkspaceStorageConfig{
-				Enabled: ptr(true),
+				Enabled: ptr.To(true),
 			},
 		},
 	}

--- a/internal/controller/agentruntime_controller_test.go
+++ b/internal/controller/agentruntime_controller_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -2677,21 +2678,21 @@ var _ = Describe("AgentRuntime Controller Unit Tests", func() {
 	Describe("ptr helper function", func() {
 		It("should return a pointer to an int32 value", func() {
 			val := int32(42)
-			result := ptr(val)
+			result := ptr.To(val)
 			Expect(result).NotTo(BeNil())
 			Expect(*result).To(Equal(int32(42)))
 		})
 
 		It("should return a pointer to a bool value", func() {
 			val := true
-			result := ptr(val)
+			result := ptr.To(val)
 			Expect(result).NotTo(BeNil())
 			Expect(*result).To(BeTrue())
 		})
 
 		It("should return a pointer to a string value", func() {
 			val := "test"
-			result := ptr(val)
+			result := ptr.To(val)
 			Expect(result).NotTo(BeNil())
 			Expect(*result).To(Equal("test"))
 		})
@@ -2699,19 +2700,19 @@ var _ = Describe("AgentRuntime Controller Unit Tests", func() {
 
 	Describe("ptrSelectPolicy helper function", func() {
 		It("should return a pointer to MaxChangePolicySelect", func() {
-			result := ptrSelectPolicy(autoscalingv2.MaxChangePolicySelect)
+			result := ptr.To(autoscalingv2.MaxChangePolicySelect)
 			Expect(result).NotTo(BeNil())
 			Expect(*result).To(Equal(autoscalingv2.MaxChangePolicySelect))
 		})
 
 		It("should return a pointer to MinChangePolicySelect", func() {
-			result := ptrSelectPolicy(autoscalingv2.MinChangePolicySelect)
+			result := ptr.To(autoscalingv2.MinChangePolicySelect)
 			Expect(result).NotTo(BeNil())
 			Expect(*result).To(Equal(autoscalingv2.MinChangePolicySelect))
 		})
 
 		It("should return a pointer to DisabledPolicySelect", func() {
-			result := ptrSelectPolicy(autoscalingv2.DisabledPolicySelect)
+			result := ptr.To(autoscalingv2.DisabledPolicySelect)
 			Expect(result).NotTo(BeNil())
 			Expect(*result).To(Equal(autoscalingv2.DisabledPolicySelect))
 		})
@@ -2844,8 +2845,8 @@ var _ = Describe("AgentRuntime Controller Unit Tests", func() {
 							Enabled: true,
 							Type:    omniav1alpha1.AutoscalerTypeKEDA,
 							KEDA: &omniav1alpha1.KEDAConfig{
-								PollingInterval: ptr(int32(15)),
-								CooldownPeriod:  ptr(int32(60)),
+								PollingInterval: ptr.To(int32(15)),
+								CooldownPeriod:  ptr.To(int32(60)),
 								Triggers: []omniav1alpha1.KEDATrigger{
 									{
 										Type: "cpu",
@@ -2881,7 +2882,7 @@ var _ = Describe("AgentRuntime Controller Unit Tests", func() {
 							Enabled: true,
 							Type:    omniav1alpha1.AutoscalerTypeKEDA,
 							KEDA: &omniav1alpha1.KEDAConfig{
-								PollingInterval: ptr(int32(15)),
+								PollingInterval: ptr.To(int32(15)),
 								Triggers:        []omniav1alpha1.KEDATrigger{}, // Empty list
 							},
 						},

--- a/internal/controller/autoscaling.go
+++ b/internal/controller/autoscaling.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -133,8 +134,8 @@ func (r *AgentRuntimeReconciler) reconcileKEDA(
 		Kind:               agentRuntime.Kind,
 		Name:               agentRuntime.Name,
 		UID:                agentRuntime.UID,
-		Controller:         ptr(true),
-		BlockOwnerDeletion: ptr(true),
+		Controller:         ptr.To(true),
+		BlockOwnerDeletion: ptr.To(true),
 	}
 	scaledObject.SetOwnerReferences([]metav1.OwnerReference{ownerRef})
 
@@ -365,7 +366,7 @@ func (r *AgentRuntimeReconciler) reconcileHPA(
 				},
 				ScaleUp: &autoscalingv2.HPAScalingRules{
 					// Scale up faster than scale down (responsive to load)
-					StabilizationWindowSeconds: ptr(int32(0)),
+					StabilizationWindowSeconds: ptr.To(int32(0)),
 					Policies: []autoscalingv2.HPAScalingPolicy{
 						{
 							Type:          autoscalingv2.PercentScalingPolicy,
@@ -378,7 +379,7 @@ func (r *AgentRuntimeReconciler) reconcileHPA(
 							PeriodSeconds: 15,
 						},
 					},
-					SelectPolicy: ptrSelectPolicy(autoscalingv2.MaxChangePolicySelect),
+					SelectPolicy: ptr.To(autoscalingv2.MaxChangePolicySelect),
 				},
 			},
 		}

--- a/internal/controller/environment.go
+++ b/internal/controller/environment.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 )
@@ -178,7 +179,7 @@ func buildSecretKeyEnvVar(secretRef *corev1.LocalObjectReference, envName, secre
 			SecretKeyRef: &corev1.SecretKeySelector{
 				LocalObjectReference: *secretRef,
 				Key:                  secretKey,
-				Optional:             boolPtr(true),
+				Optional:             ptr.To(true),
 			},
 		},
 	}

--- a/internal/controller/eval_env_test.go
+++ b/internal/controller/eval_env_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+
+	"k8s.io/utils/ptr"
 )
 
 func TestBuildEvalEnvVars(t *testing.T) {
@@ -69,8 +71,8 @@ func TestBuildEvalEnvVars(t *testing.T) {
 			evalConfig: &omniav1alpha1.EvalConfig{
 				Enabled: true,
 				Sampling: &omniav1alpha1.EvalSampling{
-					DefaultRate:  ptr(int32(50)),
-					LLMJudgeRate: ptr(int32(5)),
+					DefaultRate:  ptr.To(int32(50)),
+					LLMJudgeRate: ptr.To(int32(5)),
 				},
 			},
 			wantLen:  3,
@@ -109,8 +111,8 @@ func TestBuildEvalEnvVars_Values(t *testing.T) {
 			},
 		},
 		Sampling: &omniav1alpha1.EvalSampling{
-			DefaultRate:  ptr(int32(75)),
-			LLMJudgeRate: ptr(int32(20)),
+			DefaultRate:  ptr.To(int32(75)),
+			LLMJudgeRate: ptr.To(int32(20)),
 		},
 	}
 

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controller
 
 import (
-	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -33,19 +32,6 @@ func SetCondition(conditions *[]metav1.Condition, generation int64, condType str
 		Reason:             reason,
 		Message:            message,
 	})
-}
-
-// Helper functions for creating pointers
-func ptr[T any](v T) *T {
-	return &v
-}
-
-func ptrSelectPolicy(p autoscalingv2.ScalingPolicySelect) *autoscalingv2.ScalingPolicySelect {
-	return &p
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 // providerKeyMapping maps provider types to their expected API key env var names.

--- a/internal/httputil/constants.go
+++ b/internal/httputil/constants.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package httputil provides shared HTTP constants and helpers.
+package httputil
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// Common HTTP header names and content types.
+const (
+	HeaderContentType = "Content-Type"
+	ContentTypeJSON   = "application/json"
+)
+
+// WriteJSON serialises v as JSON and writes it to w with the given status code.
+// The Content-Type header is set to application/json.
+func WriteJSON(w http.ResponseWriter, statusCode int, v any) error {
+	w.Header().Set(HeaderContentType, ContentTypeJSON)
+	w.WriteHeader(statusCode)
+	return json.NewEncoder(w).Encode(v)
+}

--- a/internal/httputil/constants_test.go
+++ b/internal/httputil/constants_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httputil
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestConstants(t *testing.T) {
+	if HeaderContentType != "Content-Type" {
+		t.Errorf("expected HeaderContentType to be %q, got %q", "Content-Type", HeaderContentType)
+	}
+	if ContentTypeJSON != "application/json" {
+		t.Errorf("expected ContentTypeJSON to be %q, got %q", "application/json", ContentTypeJSON)
+	}
+}
+
+func TestWriteJSON_Success(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	payload := map[string]string{"key": "value"}
+	err := WriteJSON(w, http.StatusOK, payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if ct != ContentTypeJSON {
+		t.Errorf("expected Content-Type %q, got %q", ContentTypeJSON, ct)
+	}
+
+	var result map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if result["key"] != "value" {
+		t.Errorf("expected key=value, got key=%s", result["key"])
+	}
+}
+
+func TestWriteJSON_CustomStatusCode(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	payload := map[string]string{"error": "not found"}
+	err := WriteJSON(w, http.StatusNotFound, payload)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected status %d, got %d", http.StatusNotFound, w.Code)
+	}
+}
+
+func TestWriteJSON_NilPayload(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	err := WriteJSON(w, http.StatusNoContent, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected status %d, got %d", http.StatusNoContent, w.Code)
+	}
+}
+
+func TestWriteJSON_Struct(t *testing.T) {
+	type response struct {
+		Name  string `json:"name"`
+		Count int    `json:"count"`
+	}
+
+	w := httptest.NewRecorder()
+
+	err := WriteJSON(w, http.StatusCreated, response{Name: "test", Count: 42})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if w.Code != http.StatusCreated {
+		t.Errorf("expected status %d, got %d", http.StatusCreated, w.Code)
+	}
+
+	var result response
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if result.Name != "test" || result.Count != 42 {
+		t.Errorf("expected {test, 42}, got {%s, %d}", result.Name, result.Count)
+	}
+}
+
+func TestWriteJSON_UnmarshalableValue(t *testing.T) {
+	w := httptest.NewRecorder()
+
+	// channels cannot be marshalled to JSON
+	err := WriteJSON(w, http.StatusOK, make(chan int))
+	if err == nil {
+		t.Fatal("expected error for unmarshalable value")
+	}
+}

--- a/internal/media/handler.go
+++ b/internal/media/handler.go
@@ -26,6 +26,8 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+
+	"github.com/altairalabs/omnia/internal/httputil"
 )
 
 // HTTP handler constants to avoid string duplication.
@@ -33,8 +35,6 @@ const (
 	errMethodNotAllowed = "method not allowed"
 	errInvalidPath      = "invalid path"
 	errFailedToEncode   = "failed to encode response"
-	contentTypeJSON     = "application/json"
-	headerContentType   = "Content-Type"
 	pathMediaDownload   = "/media/download/"
 )
 
@@ -169,7 +169,7 @@ func (h *Handler) handleRequestUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	if err := json.NewEncoder(w).Encode(creds); err != nil {
 		h.log.Error(err, errFailedToEncode)
 	}
@@ -337,7 +337,7 @@ func (h *Handler) handleConfirmUpload(w http.ResponseWriter, r *http.Request) {
 	h.metrics.UploadCompleted(info.SizeBytes, duration)
 	h.log.Info("upload confirmed", "uploadID", uploadID, "bytes", info.SizeBytes)
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	if err := json.NewEncoder(w).Encode(info); err != nil {
 		h.log.Error(err, errFailedToEncode)
 	}
@@ -394,7 +394,7 @@ func (h *Handler) handleInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	if err := json.NewEncoder(w).Encode(info); err != nil {
 		h.log.Error(err, errFailedToEncode)
 	}

--- a/internal/session/api/eval_handler.go
+++ b/internal/session/api/eval_handler.go
@@ -25,6 +25,8 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+
+	"github.com/altairalabs/omnia/internal/httputil"
 )
 
 // EvalResultListResponse is the JSON response for eval result list endpoints.
@@ -234,15 +236,15 @@ func writeEvalError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrMissingEvalResults),
 		errors.Is(err, ErrMissingEvalDefinition):
-		w.Header().Set(headerContentType, contentTypeJSON)
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 		w.WriteHeader(http.StatusBadRequest)
 		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: err.Error()})
 	case errors.Is(err, ErrNoMessages):
-		w.Header().Set(headerContentType, contentTypeJSON)
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 		w.WriteHeader(http.StatusUnprocessableEntity)
 		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: err.Error()})
 	case errors.Is(err, ErrMissingEvalStore):
-		w.Header().Set(headerContentType, contentTypeJSON)
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "eval store not configured"})
 	default:

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -27,15 +27,13 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/altairalabs/omnia/internal/httputil"
 	"github.com/altairalabs/omnia/internal/session"
 	"github.com/altairalabs/omnia/internal/session/providers"
 )
 
 // Handler constants.
 const (
-	contentTypeJSON   = "application/json"
-	headerContentType = "Content-Type"
-
 	defaultListLimit    = 20
 	maxListLimit        = 100
 	defaultMessageLimit = 50
@@ -304,7 +302,7 @@ func (h *Handler) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	w.WriteHeader(http.StatusCreated)
 	_ = json.NewEncoder(w).Encode(SessionResponse{Session: sess})
 }
@@ -462,7 +460,7 @@ func parseTimeParam(s string) (time.Time, error) {
 
 // writeJSON writes a JSON 200 OK response.
 func writeJSON(w http.ResponseWriter, data any) {
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	if err := json.NewEncoder(w).Encode(data); err != nil {
 		// Response is already partially written; log but don't try to write another error.
 		_ = err
@@ -504,7 +502,7 @@ func writeError(w http.ResponseWriter, err error) {
 		}
 	}
 
-	w.Header().Set(headerContentType, contentTypeJSON)
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	w.WriteHeader(status)
 	_ = json.NewEncoder(w).Encode(ErrorResponse{Error: msg})
 }


### PR DESCRIPTION
## Summary
- Replace all local `ptr[T]`, `boolPtr`, and `ptrSelectPolicy` helpers with `k8s.io/utils/ptr.To()` across 15+ files
- Extract shared `marshalEvent` and `defaultPublishBatch` helpers in `ee/pkg/streaming/helpers.go`, reducing duplication across NATS, Kinesis, and Pulsar publishers
- Introduce `internal/httputil/constants.go` with `HeaderContentType`, `ContentTypeJSON`, and `WriteJSON()` helper; migrate 5 packages to use it
- Export error constants (`ErrMsgNilEvent`, `ErrMsgMarshalFail`) in streaming package for consistent error messages across Kafka, NATS, Kinesis, Pulsar, and Memory publishers

Closes #536

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./ee/pkg/streaming/... -count=1` — all 67 tests pass
- [x] `go test ./internal/httputil/... -count=1` — 100% coverage
- [x] `go test ./ee/pkg/workspace/... -count=1` — all pass
- [x] `go test ./ee/pkg/evals/... -count=1` — all pass
- [x] `golangci-lint run` — no new issues (only pre-existing complexity warnings)
- [x] New helper files have >80% coverage (httputil: 100%, streaming/helpers: 90%)
- [ ] CI controller tests (require envtest) — will validate in CI