### PR TITLE
fix: security hardening for WebSocket origins, arena controller, and Redis credentials

### DIFF
--- a/charts/omnia/templates/arena-controller-deployment.yaml
+++ b/charts/omnia/templates/arena-controller-deployment.yaml
@@ -29,9 +29,11 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "omnia.serviceAccountName" . }}
       securityContext:
-        # Run as root to write to shared workspace-content PVC
-        runAsNonRoot: false
-        runAsUser: 0
+        runAsNonRoot: {{ .Values.enterprise.arena.controller.podSecurityContext.runAsNonRoot | default true }}
+        runAsUser: {{ .Values.enterprise.arena.controller.podSecurityContext.runAsUser | default 65532 }}
+        fsGroup: {{ .Values.enterprise.arena.controller.podSecurityContext.fsGroup | default 65532 }}
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: manager
           image: {{ .Values.enterprise.arena.controller.image.repository | default "ghcr.io/altairalabs/omnia-arena-controller" }}:{{ .Values.enterprise.arena.controller.image.tag | default .Chart.AppVersion }}
@@ -51,6 +53,9 @@ spec:
             - --redis-addr={{ include "omnia.fullname" . }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.enterprise.arena.queue.redis.port | default 6379 }}
             {{- else if .Values.enterprise.arena.queue.redis.host }}
             - --redis-addr={{ .Values.enterprise.arena.queue.redis.host }}:{{ .Values.enterprise.arena.queue.redis.port | default 6379 }}
+            {{- end }}
+            {{- if .Values.enterprise.arena.queue.redis.passwordSecret }}
+            - --redis-password-secret={{ .Values.enterprise.arena.queue.redis.passwordSecret }}
             {{- end }}
             {{- end }}
             {{- if and (or .Values.nfs.server.enabled .Values.nfs.external.server) (not .Values.nfs.csiDriver.enabled) }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -66,6 +66,14 @@ enterprise:
         pullPolicy: IfNotPresent
       # -- Resource limits for arena controller
       resources: {}
+      # -- Pod security context for arena controller
+      podSecurityContext:
+        # -- Run as non-root user
+        runAsNonRoot: true
+        # -- User ID (65532 = nonroot distroless user)
+        runAsUser: 65532
+        # -- Group ID for volume ownership
+        fsGroup: 65532
 
     # Worker configuration for ArenaJob execution
     worker:
@@ -106,6 +114,9 @@ enterprise:
         host: ""
         # -- Redis port
         port: 6379
+        # -- Name of Kubernetes Secret containing Redis password (key: "redis-password").
+        # When set, worker pods receive the password via secretKeyRef instead of plain text.
+        passwordSecret: ""
 
     # Dev console for interactive agent testing
     # Dev console image settings used by ArenaDevSession controller to create

--- a/ee/cmd/omnia-arena-controller/main.go
+++ b/ee/cmd/omnia-arena-controller/main.go
@@ -76,6 +76,7 @@ func main() {
 	var nfsPath string
 	var redisAddr string
 	var redisPassword string
+	var redisPasswordSecret string
 	var redisDB int
 	var workerServiceAccountName string
 	var enableWebhooks bool
@@ -103,7 +104,10 @@ func main() {
 	flag.StringVar(&redisAddr, "redis-addr", "",
 		"Redis server address for Arena work queue.")
 	flag.StringVar(&redisPassword, "redis-password", "",
-		"Redis password for Arena work queue.")
+		"Redis password for Arena work queue (deprecated: use --redis-password-secret instead).")
+	flag.StringVar(&redisPasswordSecret, "redis-password-secret", "",
+		"Name of Kubernetes Secret containing Redis password (key: redis-password). "+
+			"When set, workers receive the password via secretKeyRef instead of plain text.")
 	flag.IntVar(&redisDB, "redis-db", 0,
 		"Redis database number for Arena work queue.")
 	flag.StringVar(&workerServiceAccountName, "worker-service-account-name", "",
@@ -265,6 +269,7 @@ func main() {
 		Aggregator:               arenaAggregator,
 		RedisAddr:                redisAddr,
 		RedisPassword:            redisPassword,
+		RedisPasswordSecret:      redisPasswordSecret,
 		RedisDB:                  redisDB,
 		WorkspaceContentPath:     workspaceContentPath,
 		NFSServer:                nfsServer,

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -85,6 +85,10 @@ type ArenaJobReconciler struct {
 	RedisAddr     string
 	RedisPassword string
 	RedisDB       int
+	// RedisPasswordSecret is the name of the Kubernetes Secret containing the Redis password.
+	// When set, worker pods receive the password via a secretKeyRef instead of a plain-text env var.
+	// The secret must have a key named "redis-password".
+	RedisPasswordSecret string
 	// WorkspaceContentPath is the base path for workspace content volumes.
 	// When set, workers mount the workspace content PVC and access content directly.
 	// Structure: {WorkspaceContentPath}/{workspace}/{namespace}/{contentPath}
@@ -299,6 +303,35 @@ func (r *ArenaJobReconciler) getExistingJob(ctx context.Context, arenaJob *omnia
 		return nil, err
 	}
 	return job, nil
+}
+
+// redisPasswordSecretKey is the key within the Kubernetes Secret that holds the Redis password.
+const redisPasswordSecretKey = "redis-password"
+
+// buildRedisPasswordEnvVar returns the REDIS_PASSWORD env var for worker pods.
+// When RedisPasswordSecret is set, uses a secretKeyRef for secure injection.
+// Falls back to plain-text value from RedisPassword for backward compatibility.
+func (r *ArenaJobReconciler) buildRedisPasswordEnvVar() []corev1.EnvVar {
+	if r.RedisPasswordSecret != "" {
+		return []corev1.EnvVar{{
+			Name: "REDIS_PASSWORD",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: r.RedisPasswordSecret,
+					},
+					Key: redisPasswordSecretKey,
+				},
+			},
+		}}
+	}
+	if r.RedisPassword != "" {
+		return []corev1.EnvVar{{
+			Name:  "REDIS_PASSWORD",
+			Value: r.RedisPassword,
+		}}
+	}
+	return nil
 }
 
 // getJobName returns the name for the K8s Job.
@@ -819,12 +852,7 @@ func (r *ArenaJobReconciler) createWorkerJob(ctx context.Context, arenaJob *omni
 			Value: r.RedisAddr,
 		})
 	}
-	if r.RedisPassword != "" {
-		env = append(env, corev1.EnvVar{
-			Name:  "REDIS_PASSWORD",
-			Value: r.RedisPassword,
-		})
-	}
+	env = append(env, r.buildRedisPasswordEnvVar()...)
 
 	// Add verbose flag for debug logging
 	if arenaJob.Spec.Verbose {


### PR DESCRIPTION
## Summary

Addresses three security issues identified in #525:

- **WebSocket origin validation (HIGH):** Replace the permissive `CheckOrigin` that allowed all origins with a configurable allowlist via `OMNIA_ALLOWED_ORIGINS` env var or `WithAllowedOrigins` server option. When no allowlist is configured, defaults to the standard same-origin policy (Origin host must match Host header).

- **Arena controller runs as non-root (HIGH):** Change the arena controller pod security context from `runAsUser: 0` (root) to `runAsUser: 65532` (nonroot distroless user) with `fsGroup: 65532` and `seccompProfile: RuntimeDefault`. Helm values added for overriding UID/GID.

- **Redis password via secretKeyRef (MEDIUM):** Add `--redis-password-secret` flag and `RedisPasswordSecret` field so worker pods receive the Redis password through a Kubernetes Secret reference (`secretKeyRef`) instead of a plain-text env var. Falls back to the existing `--redis-password` flag for backward compatibility. Helm value `enterprise.arena.queue.redis.passwordSecret` added to configure the secret name.

## Test plan

- [x] Origin validation unit tests pass locally (`TestParseAllowedOrigins`, `TestServerCheckOrigin_*`, `TestServerWithAllowedOrigins`)
- [x] Full facade test suite passes (94.8% coverage on server.go)
- [x] `buildRedisPasswordEnvVar` Ginkgo tests added (require envtest in CI)
- [x] `golangci-lint` passes on all changed packages (no new issues)
- [x] `helm lint charts/omnia` passes
- [ ] CI runs full test suite including envtest-based controller tests

Closes #525