### PR TITLE
feat: enrich tool spans and metrics with ToolRegistry metadata

### DIFF
--- a/cmd/runtime/main.go
+++ b/cmd/runtime/main.go
@@ -42,14 +42,17 @@ import (
 	_ "github.com/AltairaLabs/PromptKit/runtime/evals/handlers" // Register default eval type handlers
 	"github.com/AltairaLabs/PromptKit/runtime/logger"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+
 	pkruntime "github.com/altairalabs/omnia/internal/runtime"
+	"github.com/altairalabs/omnia/internal/runtime/tools"
 	"github.com/altairalabs/omnia/internal/session/httpclient"
 	"github.com/altairalabs/omnia/internal/tracing"
 	"github.com/altairalabs/omnia/pkg/k8s"
 	"github.com/altairalabs/omnia/pkg/logging"
 	pkmetrics "github.com/altairalabs/omnia/pkg/metrics"
 	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
-	"github.com/go-logr/zapr"
 )
 
 func main() {
@@ -285,6 +288,11 @@ func main() {
 		} else {
 			initCancel()
 			log.Info("tools initialized", "configPath", cfg.ToolsConfigPath)
+
+			// Enrich tool metadata from the ToolRegistry CRD (best-effort)
+			if cfg.ToolRegistryName != "" {
+				enrichToolRegistryMeta(cfg, runtimeServer, log)
+			}
 		}
 	} else {
 		log.V(1).Info("tools disabled (no config path specified)")
@@ -386,6 +394,37 @@ func main() {
 	grpcServer.GracefulStop()
 
 	log.Info("shutdown complete")
+}
+
+// enrichToolRegistryMeta reads the ToolRegistry CRD and sets handler metadata on the tool manager.
+// This is best-effort — if the CRD read fails, tools still work without provenance metadata.
+func enrichToolRegistryMeta(cfg *pkruntime.Config, server *pkruntime.Server, log logr.Logger) {
+	trCtx, trCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer trCancel()
+
+	k8sClient, err := k8s.NewClient()
+	if err != nil {
+		log.Error(err, "failed to create k8s client for ToolRegistry metadata")
+		return
+	}
+
+	tr, err := k8s.GetToolRegistry(trCtx, k8sClient, cfg.ToolRegistryName, cfg.ToolRegistryNamespace)
+	if err != nil {
+		log.Error(err, "failed to read ToolRegistry, continuing without registry metadata",
+			"name", cfg.ToolRegistryName, "namespace", cfg.ToolRegistryNamespace)
+		return
+	}
+
+	// Load the tools config to get handler entries for metadata mapping
+	toolsCfg, err := tools.LoadConfig(cfg.ToolsConfigPath)
+	if err != nil {
+		log.Error(err, "failed to reload tools config for metadata mapping")
+		return
+	}
+
+	server.SetToolRegistryInfo(tr.Name, tr.Namespace, toolsCfg.Handlers)
+	log.Info("tool registry metadata enriched",
+		"registryName", tr.Name, "registryNamespace", tr.Namespace)
 }
 
 // isNotHealthCheck filters out gRPC health check RPCs from tracing.

--- a/dashboard/src/app/sessions/[id]/page.test.tsx
+++ b/dashboard/src/app/sessions/[id]/page.test.tsx
@@ -59,25 +59,17 @@ const mockSession = {
     {
       id: "m2",
       role: "assistant" as const,
-      content: "How can I help you?",
+      content: '{"name":"search_docs","arguments":{"query":"help"}}',
       timestamp: new Date(Date.now() - 59 * 60 * 1000).toISOString(),
-      tokens: { output: 20 },
-      toolCalls: [
-        {
-          id: "tc1",
-          name: "search_docs",
-          arguments: { query: "help" },
-          result: { found: true },
-          status: "success" as const,
-          duration: 250,
-        },
-      ],
+      metadata: { type: "tool_call", duration_ms: "250", status: "success" },
+      toolCallId: "tc1",
     },
     {
       id: "m3",
-      role: "tool" as const,
-      content: "Tool result",
+      role: "assistant" as const,
+      content: "How can I help you?",
       timestamp: new Date(Date.now() - 58 * 60 * 1000).toISOString(),
+      tokens: { output: 20 },
     },
   ],
   metrics: {
@@ -250,6 +242,30 @@ describe("SessionDetailPage", () => {
     expect(screen.getByText(/sess-123/)).toBeInTheDocument();
   });
 
+  it("filters out duplicate EventBus messages with source=runtime", async () => {
+    const { useSessionDetail } = await import("@/hooks");
+    const sessionWithDuplicates = {
+      ...mockSession,
+      messages: [
+        { id: "m1", role: "user" as const, content: "Hello", timestamp: new Date().toISOString() },
+        { id: "m1-dup", role: "user" as const, content: "Hello", timestamp: new Date().toISOString(), metadata: { source: "runtime", index: "0" } },
+        { id: "m2", role: "assistant" as const, content: "Hi there!", timestamp: new Date().toISOString() },
+        { id: "m2-dup", role: "assistant" as const, content: "Hi there!", timestamp: new Date().toISOString(), metadata: { source: "runtime", index: "1" } },
+      ],
+    };
+    vi.mocked(useSessionDetail).mockReturnValue({
+      data: sessionWithDuplicates,
+      isLoading: false,
+      error: null,
+    } as any);
+
+    await renderPage();
+
+    // Each message should appear once, not twice
+    expect(screen.getAllByText("Hello")).toHaveLength(1);
+    expect(screen.getAllByText("Hi there!")).toHaveLength(1);
+  });
+
   it("renders eval results badge next to evaluated messages", async () => {
     const { useSessionDetail, useSessionEvalResults } = await import("@/hooks");
     vi.mocked(useSessionDetail).mockReturnValue({
@@ -262,7 +278,7 @@ describe("SessionDetailPage", () => {
         {
           id: "e1",
           sessionId: "sess-123",
-          messageId: "m2",
+          messageId: "m3",
           agentName: "support-agent",
           namespace: "default",
           promptpackName: "pp-1",

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -32,7 +32,7 @@ import {
   Bug,
 } from "lucide-react";
 import { useSessionDetail, useSessionEvalResults } from "@/hooks";
-import type { Message, ToolCall, Session, EvalResult } from "@/types";
+import type { Message, Session, EvalResult } from "@/types";
 import { EvalResultsBadge } from "@/components/sessions/eval-results-badge";
 import { ToolCallBadge } from "@/components/sessions/tool-call-badge";
 import { DebugPanel } from "@/components/sessions/debug-panel";
@@ -55,22 +55,42 @@ function getStatusBadge(status: Session["status"]) {
   return <Badge variant={variant}>{label}</Badge>;
 }
 
-function CompactToolCallIndicator({ toolCall }: Readonly<{ toolCall: ToolCall }>) {
+/**
+ * Parse a tool_call message's content to extract name and arguments.
+ */
+function parseToolCallContent(content: string): { name: string; arguments: Record<string, unknown> } {
+  try {
+    const parsed = JSON.parse(content);
+    return { name: parsed.name || "unknown", arguments: parsed.arguments || {} };
+  } catch {
+    return { name: "unknown", arguments: {} };
+  }
+}
+
+function ToolCallMessage({ message }: Readonly<{ message: Message }>) {
   const openToolCall = useDebugPanelStore((s) => s.openToolCall);
+  const { name } = parseToolCallContent(message.content);
+  const durationStr = message.metadata?.duration_ms;
+  const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
+  const status = message.metadata?.status as "success" | "error" | undefined;
 
   return (
-    <button
-      className="flex items-center gap-2 border rounded-lg bg-muted/30 px-3 py-1.5 my-1 text-left hover:bg-muted/50 transition-colors w-full"
-      onClick={() => openToolCall(toolCall.id)}
-    >
-      <Wrench className="h-3.5 w-3.5 text-orange-500 shrink-0" />
-      <span className="font-mono text-sm font-medium truncate">{toolCall.name}</span>
-      <ToolCallBadge status={toolCall.status} />
-      {toolCall.duration !== undefined && (
-        <span className="text-xs text-muted-foreground">{toolCall.duration}ms</span>
-      )}
-      <span className="text-xs text-muted-foreground ml-auto shrink-0">View details &gt;</span>
-    </button>
+    <div className="flex gap-3">
+      <div className="flex items-center justify-center h-8 w-8 rounded-full shrink-0 bg-orange-500/10">
+        <Wrench className="h-4 w-4 text-orange-500" />
+      </div>
+      <button
+        className="flex items-center gap-2 border rounded-lg bg-muted/30 px-3 py-1.5 text-left hover:bg-muted/50 transition-colors"
+        onClick={() => message.toolCallId && openToolCall(message.toolCallId)}
+      >
+        <span className="font-mono text-sm font-medium truncate">{name}</span>
+        {status && <ToolCallBadge status={status} />}
+        {duration !== undefined && !Number.isNaN(duration) && (
+          <span className="text-xs text-muted-foreground">{duration}ms</span>
+        )}
+        <span className="text-xs text-muted-foreground ml-auto shrink-0">View details &gt;</span>
+      </button>
+    </div>
   );
 }
 
@@ -104,11 +124,11 @@ function getBubbleClassName(isUser: boolean, isSystem: boolean): string {
 function MessageBubble({ message, showTimestamp, evalResults }: Readonly<{ message: Message; showTimestamp?: boolean; evalResults?: EvalResult[] }>) {
   const isUser = message.role === "user";
   const isAssistant = message.role === "assistant";
-  const isTool = message.role === "tool";
   const isSystem = message.role === "system";
 
-  if (isTool) {
-    return null; // Tool results are shown inline with tool calls
+  // Tool call messages get their own compact rendering
+  if (message.metadata?.type === "tool_call") {
+    return <ToolCallMessage message={message} />;
   }
 
   return (
@@ -131,11 +151,6 @@ function MessageBubble({ message, showTimestamp, evalResults }: Readonly<{ messa
         >
           <div className="whitespace-pre-wrap text-sm">{message.content}</div>
         </div>
-
-        {/* Tool calls */}
-        {message.toolCalls?.map((tc) => (
-          <CompactToolCallIndicator key={tc.id} toolCall={tc} />
-        ))}
 
         {/* Eval results */}
         {evalResults && evalResults.length > 0 && (
@@ -160,15 +175,17 @@ function MessageBubble({ message, showTimestamp, evalResults }: Readonly<{ messa
 }
 
 /**
- * Returns true if a message is a user-facing conversation message.
+ * Returns true if a message belongs in the conversation view.
  *
- * Any message with a `metadata.type` is an internal runtime event
- * (pipeline stages, provider calls, tool calls, workflow transitions, etc.)
- * and belongs in the Debug panel, not the conversation view.
+ * Conversation messages are: user/assistant messages without a metadata.type,
+ * plus tool_call messages (rendered as compact indicators).
+ * Everything else (pipeline events, provider calls, etc.) goes to the Debug panel.
  */
 function isConversationMessage(m: Message): boolean {
   if (m.role === "tool") return false;
+  if (m.metadata?.type === "tool_call") return true;
   if (m.metadata?.type) return false;
+  if (m.metadata?.source === "runtime") return false;
   return true;
 }
 
@@ -181,10 +198,13 @@ function ConversationMessages({
 }: Readonly<{ messages: Message[]; evalResults: EvalResult[] }>) {
   const evalsByMessage = groupEvalResultsByMessageId(evalResults);
 
+  const sorted = messages
+    .filter(isConversationMessage)
+    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+
   return (
     <div className="space-y-6">
-      {messages
-        .filter(isConversationMessage)
+      {sorted
         .map((message) => (
           <MessageBubble
             key={message.id}
@@ -339,31 +359,24 @@ export default function SessionDetailPage({
         "",
       ];
 
-      session.messages.forEach((msg) => {
-        if (msg.role === "tool") return;
-        const roleLabel = msg.role.charAt(0).toUpperCase() + msg.role.slice(1);
-        lines.push(`### ${roleLabel}`, "", msg.content, "");
-
-        if (msg.toolCalls) {
-          msg.toolCalls.forEach((tc) => {
+      session.messages
+        .filter(isConversationMessage)
+        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+        .forEach((msg) => {
+          if (msg.metadata?.type === "tool_call") {
+            const { name, arguments: args } = parseToolCallContent(msg.content);
             lines.push(
-              `**Tool Call:** \`${tc.name}\``,
+              `**Tool Call:** \`${name}\``,
               "```json",
-              JSON.stringify(tc.arguments, null, 2),
-              "```"
+              JSON.stringify(args, null, 2),
+              "```",
+              ""
             );
-            if (tc.result) {
-              lines.push(
-                "**Result:**",
-                "```json",
-                JSON.stringify(tc.result, null, 2),
-                "```"
-              );
-            }
-            lines.push("");
-          });
-        }
-      });
+          } else {
+            const roleLabel = msg.role.charAt(0).toUpperCase() + msg.role.slice(1);
+            lines.push(`### ${roleLabel}`, "", msg.content, "");
+          }
+        });
 
       content = lines.join("\n");
       filename = `session-${session.id}.md`;

--- a/dashboard/src/components/sessions/debug-panel.test.tsx
+++ b/dashboard/src/components/sessions/debug-panel.test.tsx
@@ -6,15 +6,8 @@ import type { Session, Message } from "@/types/session";
 
 const mockMessages: Message[] = [
   { id: "m1", role: "user", content: "Hello", timestamp: "2024-01-01T00:00:01Z" },
-  {
-    id: "m2",
-    role: "assistant",
-    content: "Hi!",
-    timestamp: "2024-01-01T00:00:02Z",
-    toolCalls: [
-      { id: "tc1", name: "search", arguments: { q: "test" }, status: "success", duration: 100 },
-    ],
-  },
+  { id: "m2", role: "assistant", content: '{"name":"search","arguments":{"q":"test"}}', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_call", duration_ms: "100", status: "success" }, toolCallId: "tc1" },
+  { id: "m3", role: "assistant", content: "Hi!", timestamp: "2024-01-01T00:00:03Z" },
 ];
 
 const mockSession: Session = {

--- a/dashboard/src/components/sessions/debug-panel.tsx
+++ b/dashboard/src/components/sessions/debug-panel.tsx
@@ -24,11 +24,7 @@ export function DebugPanel({ messages, session, className }: DebugPanelProps) {
   const close = useDebugPanelStore((s) => s.close);
 
   const toolCallCount = useMemo(() => {
-    let count = 0;
-    for (const msg of messages) {
-      if (msg.toolCalls) count += msg.toolCalls.length;
-    }
-    return count;
+    return messages.filter((m) => m.metadata?.type === "tool_call").length;
   }, [messages]);
 
   if (!isOpen) {

--- a/dashboard/src/components/sessions/timeline-tab.test.tsx
+++ b/dashboard/src/components/sessions/timeline-tab.test.tsx
@@ -36,17 +36,16 @@ describe("TimelineTab", () => {
       {
         id: "m1",
         role: "assistant",
-        content: "Searching",
+        content: '{"name":"search","arguments":{"q":"test"}}',
         timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "search", arguments: { q: "test" }, status: "success", duration: 200 },
-        ],
+        metadata: { type: "tool_call", duration_ms: "200", status: "success" },
+        toolCallId: "tc1",
       },
     ];
 
     render(<TimelineTab messages={messages} />);
 
-    expect(screen.getByText("search")).toBeInTheDocument();
+    expect(screen.getByText("Tool: search")).toBeInTheDocument();
     expect(screen.getByText("200ms")).toBeInTheDocument();
     expect(screen.getByText("OK")).toBeInTheDocument();
   });
@@ -56,17 +55,16 @@ describe("TimelineTab", () => {
       {
         id: "m1",
         role: "assistant",
-        content: "Working",
+        content: '{"name":"search","arguments":{}}',
         timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "search", arguments: {}, status: "success" },
-        ],
+        metadata: { type: "tool_call", status: "success" },
+        toolCallId: "tc1",
       },
     ];
 
     render(<TimelineTab messages={messages} />);
 
-    fireEvent.click(screen.getByTestId("timeline-event-m1-tc-tc1"));
+    fireEvent.click(screen.getByTestId("timeline-event-m1"));
 
     const state = useDebugPanelStore.getState();
     expect(state.activeTab).toBe("toolcalls");
@@ -78,11 +76,10 @@ describe("TimelineTab", () => {
       {
         id: "m1",
         role: "assistant",
-        content: "Failed",
+        content: '{"name":"cmd","arguments":{}}',
         timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "cmd", arguments: {}, status: "error" },
-        ],
+        metadata: { type: "tool_call", status: "error" },
+        toolCallId: "tc1",
       },
     ];
 
@@ -112,5 +109,37 @@ describe("TimelineTab", () => {
 
     render(<TimelineTab messages={messages} />);
     expect(screen.getByText("14:30:45.123")).toBeInTheDocument();
+  });
+
+  it("shows handler type badge for tool calls with metadata", () => {
+    const messages: Message[] = [
+      {
+        id: "m1",
+        role: "assistant",
+        content: '{"name":"search","arguments":{}}',
+        timestamp: "2024-01-01T00:00:01Z",
+        metadata: { type: "tool_call", handler_type: "mcp", status: "success" },
+        toolCallId: "tc1",
+      },
+    ];
+
+    render(<TimelineTab messages={messages} />);
+    expect(screen.getByText("mcp")).toBeInTheDocument();
+  });
+
+  it("does not show handler type badge when absent", () => {
+    const messages: Message[] = [
+      {
+        id: "m1",
+        role: "assistant",
+        content: '{"name":"search","arguments":{}}',
+        timestamp: "2024-01-01T00:00:01Z",
+        metadata: { type: "tool_call", status: "success" },
+        toolCallId: "tc1",
+      },
+    ];
+
+    render(<TimelineTab messages={messages} />);
+    expect(screen.queryByText("mcp")).not.toBeInTheDocument();
   });
 });

--- a/dashboard/src/components/sessions/timeline-tab.tsx
+++ b/dashboard/src/components/sessions/timeline-tab.tsx
@@ -127,6 +127,9 @@ export function TimelineTab({ messages }: TimelineTabProps) {
                 </span>
               )}
               <span className="flex items-center gap-1.5 shrink-0 ml-auto">
+                {event.kind === "tool_call" && event.metadata?.handler_type && (
+                  <Badge variant="outline" className="text-xs px-1 py-0 font-mono">{event.metadata.handler_type}</Badge>
+                )}
                 {event.duration !== undefined && (
                   <span className="text-xs text-muted-foreground">{event.duration}ms</span>
                 )}

--- a/dashboard/src/components/sessions/toolcalls-tab.test.tsx
+++ b/dashboard/src/components/sessions/toolcalls-tab.test.tsx
@@ -4,6 +4,17 @@ import { ToolCallsTab } from "./toolcalls-tab";
 import { useDebugPanelStore } from "@/stores/debug-panel-store";
 import type { Message } from "@/types/session";
 
+function makeToolCallMessage(id: string, toolCallId: string, name: string, args: Record<string, unknown>, meta?: Record<string, string>): Message {
+  return {
+    id,
+    role: "assistant",
+    content: JSON.stringify({ name, arguments: args }),
+    timestamp: "2024-01-01T00:00:01Z",
+    metadata: { type: "tool_call", ...meta },
+    toolCallId,
+  };
+}
+
 describe("ToolCallsTab", () => {
   beforeEach(() => {
     useDebugPanelStore.setState({
@@ -27,18 +38,10 @@ describe("ToolCallsTab", () => {
     expect(screen.getByTestId("toolcalls-empty")).toBeInTheDocument();
   });
 
-  it("renders list of tool calls", () => {
+  it("renders list of tool calls from tool_call messages", () => {
     const messages: Message[] = [
-      {
-        id: "m1",
-        role: "assistant",
-        content: "Working",
-        timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "search", arguments: { q: "cats" }, status: "success", duration: 150 },
-          { id: "tc2", name: "fetch", arguments: { url: "example.com" }, status: "error" },
-        ],
-      },
+      makeToolCallMessage("m1", "tc1", "search", { q: "cats" }, { duration_ms: "150", status: "success" }),
+      makeToolCallMessage("m2", "tc2", "fetch", { url: "example.com" }, { status: "error" }),
     ];
 
     render(<ToolCallsTab messages={messages} />);
@@ -50,15 +53,7 @@ describe("ToolCallsTab", () => {
 
   it("selects tool call on click and shows details", () => {
     const messages: Message[] = [
-      {
-        id: "m1",
-        role: "assistant",
-        content: "Done",
-        timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "search", arguments: { q: "cats", limit: 10 }, result: { count: 2 }, status: "success" },
-        ],
-      },
+      makeToolCallMessage("m1", "tc1", "search", { q: "cats", limit: 10 }),
     ];
 
     render(<ToolCallsTab messages={messages} />);
@@ -71,22 +66,13 @@ describe("ToolCallsTab", () => {
     expect(screen.getByText("q")).toBeInTheDocument();
     expect(screen.getByText("cats")).toBeInTheDocument();
     expect(screen.getByText("Arguments")).toBeInTheDocument();
-    expect(screen.getByText("Result")).toBeInTheDocument();
   });
 
   it("renders flat arguments as key-value table", () => {
     useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
 
     const messages: Message[] = [
-      {
-        id: "m1",
-        role: "assistant",
-        content: "Done",
-        timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "cmd", arguments: { path: "/tmp", recursive: true }, status: "success" },
-        ],
-      },
+      makeToolCallMessage("m1", "tc1", "cmd", { path: "/tmp", recursive: true }),
     ];
 
     render(<ToolCallsTab messages={messages} />);
@@ -101,15 +87,7 @@ describe("ToolCallsTab", () => {
     useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
 
     const messages: Message[] = [
-      {
-        id: "m1",
-        role: "assistant",
-        content: "Done",
-        timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "cmd", arguments: { nested: { a: 1 } }, status: "success" },
-        ],
-      },
+      makeToolCallMessage("m1", "tc1", "cmd", { nested: { a: 1 } }),
     ];
 
     render(<ToolCallsTab messages={messages} />);
@@ -119,18 +97,40 @@ describe("ToolCallsTab", () => {
 
   it("shows no selection message when nothing is selected", () => {
     const messages: Message[] = [
-      {
-        id: "m1",
-        role: "assistant",
-        content: "Done",
-        timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "cmd", arguments: {}, status: "success" },
-        ],
-      },
+      makeToolCallMessage("m1", "tc1", "cmd", {}),
     ];
 
     render(<ToolCallsTab messages={messages} />);
     expect(screen.getByText("Select a tool call to view details")).toBeInTheDocument();
+  });
+
+  it("displays registry metadata when present", () => {
+    useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
+
+    const messages: Message[] = [
+      makeToolCallMessage("m1", "tc1", "search", { q: "test" }, {
+        handler_name: "mcp-handler",
+        handler_type: "mcp",
+        registry_name: "my-tools",
+      }),
+    ];
+
+    render(<ToolCallsTab messages={messages} />);
+
+    expect(screen.getByTestId("toolcall-registry-info")).toBeInTheDocument();
+    expect(screen.getByText("mcp-handler (mcp)")).toBeInTheDocument();
+    expect(screen.getByText("my-tools")).toBeInTheDocument();
+  });
+
+  it("hides registry info when metadata is absent", () => {
+    useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
+
+    const messages: Message[] = [
+      makeToolCallMessage("m1", "tc1", "search", { q: "test" }),
+    ];
+
+    render(<ToolCallsTab messages={messages} />);
+
+    expect(screen.queryByTestId("toolcall-registry-info")).not.toBeInTheDocument();
   });
 });

--- a/dashboard/src/components/sessions/toolcalls-tab.tsx
+++ b/dashboard/src/components/sessions/toolcalls-tab.tsx
@@ -6,7 +6,21 @@ import { useDebugPanelStore } from "@/stores/debug-panel-store";
 import { ToolCallBadge } from "./tool-call-badge";
 import { Wrench } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { Message, ToolCall } from "@/types/session";
+import type { Message } from "@/types/session";
+
+/**
+ * Extracted tool call info from a tool_call message.
+ */
+interface ExtractedToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  status?: "success" | "error" | "pending";
+  duration?: number;
+  handlerName?: string;
+  handlerType?: string;
+  registryName?: string;
+}
 
 interface ToolCallsTabProps {
   readonly messages: Message[];
@@ -40,18 +54,43 @@ function RenderValue({ value }: Readonly<{ value: unknown }>) {
   );
 }
 
+/**
+ * Extract tool call data from a tool_call message.
+ */
+function extractToolCall(msg: Message): ExtractedToolCall {
+  let name = "unknown";
+  let args: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(msg.content);
+    name = parsed.name || name;
+    args = parsed.arguments || args;
+  } catch {
+    // Content is not valid JSON
+  }
+
+  const durationStr = msg.metadata?.duration_ms;
+  const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
+
+  return {
+    id: msg.toolCallId || msg.id,
+    name,
+    arguments: args,
+    status: (msg.metadata?.status as ExtractedToolCall["status"]) || undefined,
+    duration: duration && !Number.isNaN(duration) ? duration : undefined,
+    handlerName: msg.metadata?.handler_name || undefined,
+    handlerType: msg.metadata?.handler_type || undefined,
+    registryName: msg.metadata?.registry_name || undefined,
+  };
+}
+
 export function ToolCallsTab({ messages }: ToolCallsTabProps) {
   const selectedToolCallId = useDebugPanelStore((s) => s.selectedToolCallId);
   const selectToolCall = useDebugPanelStore((s) => s.selectToolCall);
 
   const toolCalls = useMemo(() => {
-    const result: ToolCall[] = [];
-    for (const msg of messages) {
-      if (msg.toolCalls) {
-        result.push(...msg.toolCalls);
-      }
-    }
-    return result;
+    return messages
+      .filter((m) => m.metadata?.type === "tool_call")
+      .map(extractToolCall);
   }, [messages]);
 
   const selectedTc = toolCalls.find((tc) => tc.id === selectedToolCallId);
@@ -84,7 +123,7 @@ export function ToolCallsTab({ messages }: ToolCallsTabProps) {
               <Wrench className="h-3.5 w-3.5 text-orange-500 shrink-0" />
               <span className="font-mono truncate flex-1">{tc.name}</span>
               <span className="flex items-center gap-1 shrink-0">
-                <ToolCallBadge status={tc.status} />
+                {tc.status && <ToolCallBadge status={tc.status} />}
                 {tc.duration !== undefined && (
                   <span className="text-xs text-muted-foreground">{tc.duration}ms</span>
                 )}
@@ -98,16 +137,26 @@ export function ToolCallsTab({ messages }: ToolCallsTabProps) {
       <ScrollArea className="flex-1">
         {selectedTc ? (
           <div className="p-4 space-y-4" data-testid="toolcall-detail">
+            {(selectedTc.handlerType || selectedTc.registryName) && (
+              <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm" data-testid="toolcall-registry-info">
+                {selectedTc.handlerType && (
+                  <div className="contents">
+                    <span className="font-medium text-muted-foreground">Handler</span>
+                    <span className="font-mono">{selectedTc.handlerName} ({selectedTc.handlerType})</span>
+                  </div>
+                )}
+                {selectedTc.registryName && (
+                  <div className="contents">
+                    <span className="font-medium text-muted-foreground">Registry</span>
+                    <span className="font-mono">{selectedTc.registryName}</span>
+                  </div>
+                )}
+              </div>
+            )}
             <div>
               <h4 className="text-sm font-medium text-muted-foreground mb-2">Arguments</h4>
               <RenderValue value={selectedTc.arguments} />
             </div>
-            {selectedTc.result !== undefined && (
-              <div>
-                <h4 className="text-sm font-medium text-muted-foreground mb-2">Result</h4>
-                <RenderValue value={selectedTc.result} />
-              </div>
-            )}
           </div>
         ) : (
           <div className="flex items-center justify-center h-full text-sm text-muted-foreground" data-testid="toolcall-no-selection">

--- a/dashboard/src/lib/data/session-api-service.test.ts
+++ b/dashboard/src/lib/data/session-api-service.test.ts
@@ -117,31 +117,7 @@ describe("SessionApiService", () => {
       const result = await service.getSessionById("ws", "missing");
       expect(result).toBeUndefined();
     });
-  });
 
-  describe("searchSessions", () => {
-    it("sends search query to the proxy route", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ sessions: [], total: 0, hasMore: false }),
-      });
-
-      await service.searchSessions("ws", { q: "hello world", limit: 5 });
-
-      const url = mockFetch.mock.calls[0][0] as string;
-      expect(url).toContain("q=hello+world");
-      expect(url).toContain("limit=5");
-    });
-
-    it("returns empty on 404", async () => {
-      mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" });
-
-      const result = await service.searchSessions("ws", { q: "test" });
-      expect(result).toEqual({ sessions: [], total: 0, hasMore: false });
-    });
-  });
-
-  describe("getSessionById", () => {
     it("handles unwrapped session response (no envelope)", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -168,6 +144,26 @@ describe("SessionApiService", () => {
   });
 
   describe("searchSessions", () => {
+    it("sends search query to the proxy route", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ sessions: [], total: 0, hasMore: false }),
+      });
+
+      await service.searchSessions("ws", { q: "hello world", limit: 5 });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain("q=hello+world");
+      expect(url).toContain("limit=5");
+    });
+
+    it("returns empty on 404", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" });
+
+      const result = await service.searchSessions("ws", { q: "test" });
+      expect(result).toEqual({ sessions: [], total: 0, hasMore: false });
+    });
+
     it("passes all filter options", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -215,35 +211,7 @@ describe("SessionApiService", () => {
       expect(url).toContain("limit=2");
     });
 
-    it("passes before/after params", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({ messages: [], hasMore: false }),
-      });
-
-      await service.getSessionMessages("ws", "s1", { before: 10, after: 5 });
-
-      const url = mockFetch.mock.calls[0][0] as string;
-      expect(url).toContain("before=10");
-      expect(url).toContain("after=5");
-    });
-
-    it("returns empty on 404", async () => {
-      mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" });
-
-      const result = await service.getSessionMessages("ws", "missing");
-      expect(result).toEqual({ messages: [], hasMore: false });
-    });
-
-    it("throws on server error", async () => {
-      mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: "Server Error" });
-
-      await expect(service.getSessionMessages("ws", "s1")).rejects.toThrow("Failed to fetch session messages");
-    });
-  });
-
-  describe("tool call pairing (transformAndPairMessages)", () => {
-    it("pairs tool_call and tool_result messages and attaches to assistant done message", async () => {
+    it("preserves all messages including tool_call and tool_result types", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
@@ -251,7 +219,8 @@ describe("SessionApiService", () => {
             { id: "m1", role: "user", content: "Search for cats", timestamp: "2024-01-01T00:00:00Z" },
             { id: "m2", role: "assistant", content: '{"name":"search","arguments":{"q":"cats"}}', timestamp: "2024-01-01T00:00:01Z", metadata: { type: "tool_call" }, toolCallId: "tc1" },
             { id: "m3", role: "system", content: '{"results":["cat1","cat2"]}', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_result" }, toolCallId: "tc1" },
-            { id: "m4", role: "assistant", content: "I found 2 cats!", timestamp: "2024-01-01T00:00:03Z" },
+            { id: "m4", role: "system", content: "", timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_call_completed", duration_ms: "245", status: "success" }, toolCallId: "tc1" },
+            { id: "m5", role: "assistant", content: "I found 2 cats!", timestamp: "2024-01-01T00:00:03Z" },
           ],
           hasMore: false,
         }),
@@ -259,138 +228,17 @@ describe("SessionApiService", () => {
 
       const result = await service.getSessionMessages("ws", "s1");
 
-      // tool_call and tool_result messages should be filtered out
-      expect(result.messages).toHaveLength(2);
+      // All messages pass through — no pairing or filtering
+      expect(result.messages).toHaveLength(5);
       expect(result.messages[0].role).toBe("user");
-      expect(result.messages[1].role).toBe("assistant");
-      expect(result.messages[1].content).toBe("I found 2 cats!");
-
-      // ToolCalls should be attached to the assistant done message
-      expect(result.messages[1].toolCalls).toHaveLength(1);
-      expect(result.messages[1].toolCalls![0].name).toBe("search");
-      expect(result.messages[1].toolCalls![0].arguments).toEqual({ q: "cats" });
-      expect(result.messages[1].toolCalls![0].result).toEqual({ results: ["cat1", "cat2"] });
-      expect(result.messages[1].toolCalls![0].status).toBe("success");
+      expect(result.messages[1].metadata?.type).toBe("tool_call");
+      expect(result.messages[1].toolCallId).toBe("tc1");
+      expect(result.messages[2].metadata?.type).toBe("tool_result");
+      expect(result.messages[3].metadata?.type).toBe("tool_call_completed");
+      expect(result.messages[3].metadata?.duration_ms).toBe("245");
+      expect(result.messages[4].content).toBe("I found 2 cats!");
     });
 
-    it("handles tool_call with invalid JSON content", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "assistant", content: "not valid json", timestamp: "2024-01-01T00:00:01Z", metadata: { type: "tool_call" }, toolCallId: "tc1" },
-            { id: "m2", role: "assistant", content: "Done", timestamp: "2024-01-01T00:00:02Z" },
-          ],
-          hasMore: false,
-        }),
-      });
-
-      const result = await service.getSessionMessages("ws", "s1");
-
-      expect(result.messages).toHaveLength(1);
-      expect(result.messages[0].toolCalls).toHaveLength(1);
-      expect(result.messages[0].toolCalls![0].name).toBe("unknown");
-      expect(result.messages[0].toolCalls![0].arguments).toEqual({});
-      expect(result.messages[0].toolCalls![0].status).toBe("pending");
-    });
-
-    it("handles tool_result with non-JSON content", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "assistant", content: '{"name":"run","arguments":{}}', timestamp: "2024-01-01T00:00:01Z", metadata: { type: "tool_call" }, toolCallId: "tc1" },
-            { id: "m2", role: "system", content: "plain text result", timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_result" }, toolCallId: "tc1" },
-            { id: "m3", role: "assistant", content: "Done", timestamp: "2024-01-01T00:00:03Z" },
-          ],
-          hasMore: false,
-        }),
-      });
-
-      const result = await service.getSessionMessages("ws", "s1");
-
-      expect(result.messages[0].toolCalls![0].result).toBe("plain text result");
-      expect(result.messages[0].toolCalls![0].status).toBe("success");
-    });
-
-    it("handles error tool results", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "assistant", content: '{"name":"cmd","arguments":{}}', timestamp: "2024-01-01T00:00:01Z", metadata: { type: "tool_call" }, toolCallId: "tc1" },
-            { id: "m2", role: "system", content: '"error: command failed"', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_result", is_error: "true" }, toolCallId: "tc1" },
-            { id: "m3", role: "assistant", content: "The command failed.", timestamp: "2024-01-01T00:00:03Z" },
-          ],
-          hasMore: false,
-        }),
-      });
-
-      const result = await service.getSessionMessages("ws", "s1");
-
-      expect(result.messages[0].toolCalls![0].status).toBe("error");
-    });
-
-    it("attaches leftover tool calls to last assistant message", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "assistant", content: "Starting...", timestamp: "2024-01-01T00:00:01Z" },
-            { id: "m2", role: "assistant", content: '{"name":"search","arguments":{}}', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_call" }, toolCallId: "tc1" },
-            // No subsequent assistant message after tool call
-          ],
-          hasMore: false,
-        }),
-      });
-
-      const result = await service.getSessionMessages("ws", "s1");
-
-      // The tool call should be attached to the last assistant message
-      expect(result.messages).toHaveLength(1);
-      expect(result.messages[0].content).toBe("Starting...");
-      expect(result.messages[0].toolCalls).toHaveLength(1);
-    });
-
-    it("attaches leftover tool calls to last message when no assistant message exists", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "user", content: "Hello", timestamp: "2024-01-01T00:00:01Z" },
-            { id: "m2", role: "assistant", content: '{"name":"search","arguments":{}}', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_call" }, toolCallId: "tc1" },
-            // Only a user message remains after filtering
-          ],
-          hasMore: false,
-        }),
-      });
-
-      const result = await service.getSessionMessages("ws", "s1");
-
-      // Falls back to the last message (user)
-      expect(result.messages).toHaveLength(1);
-      expect(result.messages[0].role).toBe("user");
-      expect(result.messages[0].toolCalls).toHaveLength(1);
-    });
-
-    it("handles messages with no tokens", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "user", content: "Hi", timestamp: "2024-01-01T00:00:00Z" },
-          ],
-          hasMore: false,
-        }),
-      });
-
-      const result = await service.getSessionMessages("ws", "s1");
-
-      expect(result.messages[0].tokens).toBeUndefined();
-    });
-  });
-
-  describe("metadata preservation", () => {
     it("preserves metadata on transformed messages", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -425,14 +273,12 @@ describe("SessionApiService", () => {
       expect(result.messages[0].metadata).toBeUndefined();
     });
 
-    it("parses duration_ms from metadata into ToolCall.duration", async () => {
+    it("handles messages with no tokens", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: () => Promise.resolve({
           messages: [
-            { id: "m1", role: "assistant", content: '{"name":"search","arguments":{"q":"test"}}', timestamp: "2024-01-01T00:00:01Z", metadata: { type: "tool_call", duration_ms: "150" }, toolCallId: "tc1" },
-            { id: "m2", role: "system", content: '"ok"', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_result" }, toolCallId: "tc1" },
-            { id: "m3", role: "assistant", content: "Done", timestamp: "2024-01-01T00:00:03Z" },
+            { id: "m1", role: "user", content: "Hi", timestamp: "2024-01-01T00:00:00Z" },
           ],
           hasMore: false,
         }),
@@ -440,46 +286,33 @@ describe("SessionApiService", () => {
 
       const result = await service.getSessionMessages("ws", "s1");
 
-      expect(result.messages[0].toolCalls![0].duration).toBe(150);
+      expect(result.messages[0].tokens).toBeUndefined();
     });
 
-    it("leaves duration undefined when duration_ms is absent", async () => {
+    it("passes before/after params", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "assistant", content: '{"name":"run","arguments":{}}', timestamp: "2024-01-01T00:00:01Z", metadata: { type: "tool_call" }, toolCallId: "tc1" },
-            { id: "m2", role: "assistant", content: "Done", timestamp: "2024-01-01T00:00:02Z" },
-          ],
-          hasMore: false,
-        }),
+        json: () => Promise.resolve({ messages: [], hasMore: false }),
       });
 
-      const result = await service.getSessionMessages("ws", "s1");
+      await service.getSessionMessages("ws", "s1", { before: 10, after: 5 });
 
-      expect(result.messages[0].toolCalls![0].duration).toBeUndefined();
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain("before=10");
+      expect(url).toContain("after=5");
     });
 
-    it("passes workflow event messages through with metadata", async () => {
-      mockFetch.mockResolvedValueOnce({
-        ok: true,
-        json: () => Promise.resolve({
-          messages: [
-            { id: "m1", role: "user", content: "start", timestamp: "2024-01-01T00:00:00Z" },
-            { id: "m2", role: "system", content: "Workflow started", timestamp: "2024-01-01T00:00:01Z", metadata: { type: "workflow_transition", from: "idle", to: "running" } },
-            { id: "m3", role: "assistant", content: "Working", timestamp: "2024-01-01T00:00:02Z" },
-          ],
-          hasMore: false,
-        }),
-      });
+    it("returns empty on 404", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404, statusText: "Not Found" });
 
-      const result = await service.getSessionMessages("ws", "s1");
+      const result = await service.getSessionMessages("ws", "missing");
+      expect(result).toEqual({ messages: [], hasMore: false });
+    });
 
-      // Workflow event message should appear (it's not a tool_call or tool_result)
-      const workflowMsg = result.messages.find(m => m.metadata?.type === "workflow_transition");
-      expect(workflowMsg).toBeDefined();
-      expect(workflowMsg!.metadata!.from).toBe("idle");
-      expect(workflowMsg!.metadata!.to).toBe("running");
+    it("throws on server error", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: "Server Error" });
+
+      await expect(service.getSessionMessages("ws", "s1")).rejects.toThrow("Failed to fetch session messages");
     });
   });
 

--- a/dashboard/src/lib/data/session-api-service.ts
+++ b/dashboard/src/lib/data/session-api-service.ts
@@ -14,7 +14,6 @@ import type {
   Session,
   SessionSummary,
   Message,
-  ToolCall,
   SessionListOptions,
   SessionSearchOptions,
   SessionMessageOptions,
@@ -101,131 +100,11 @@ function transformApiMessage(api: ApiMessage): Message {
 }
 
 /**
- * Index tool_result messages by their toolCallId for fast lookup.
+ * Transform raw API messages to Message[]. No pairing or reordering —
+ * the session store records events in order and the UI renders them as-is.
  */
-function indexToolResults(apiMessages: ApiMessage[]): {
-  resultsByToolCallId: Map<string, { content: string; isError: boolean }>;
-  toolResultIds: Set<string>;
-} {
-  const resultsByToolCallId = new Map<string, { content: string; isError: boolean }>();
-  const toolResultIds = new Set<string>();
-
-  for (const api of apiMessages) {
-    if (api.metadata?.type === "tool_result" && api.toolCallId) {
-      resultsByToolCallId.set(api.toolCallId, {
-        content: api.content,
-        isError: api.metadata?.is_error === "true",
-      });
-      toolResultIds.add(api.id);
-    }
-  }
-
-  return { resultsByToolCallId, toolResultIds };
-}
-
-/**
- * Parse a tool_call API message into a ToolCall object, pairing it with
- * its result if available.
- */
-function buildToolCall(
-  api: ApiMessage,
-  resultsByToolCallId: Map<string, { content: string; isError: boolean }>,
-): ToolCall {
-  let name = "unknown";
-  let args: Record<string, unknown> = {};
-  try {
-    const parsed = JSON.parse(api.content);
-    name = parsed.name || name;
-    args = parsed.arguments || args;
-  } catch {
-    // Content is not valid JSON
-  }
-
-  const result = resultsByToolCallId.get(api.toolCallId!);
-  let parsedResult: unknown;
-  if (result) {
-    try {
-      parsedResult = JSON.parse(result.content);
-    } catch {
-      parsedResult = result.content;
-    }
-  }
-
-  let status: "pending" | "success" | "error" = "pending";
-  if (result) {
-    status = result.isError ? "error" : "success";
-  }
-
-  const durationStr = api.metadata?.duration_ms;
-  const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
-
-  return {
-    id: api.toolCallId!,
-    name,
-    arguments: args,
-    result: result ? parsedResult : undefined,
-    status,
-    duration: duration && !Number.isNaN(duration) ? duration : undefined,
-  };
-}
-
-/**
- * Attach leftover tool calls to the last assistant message, or the last
- * message if no assistant message exists.
- */
-function attachLeftoverToolCalls(output: Message[], toolCalls: ToolCall[]): void {
-  if (toolCalls.length === 0) return;
-
-  const lastAssistant = output.findLast((m) => m.role === "assistant");
-  const target = lastAssistant ?? output.at(-1);
-  if (target) {
-    target.toolCalls = [...(target.toolCalls || []), ...toolCalls];
-  }
-}
-
-/**
- * Pair tool_call and tool_result API messages into ToolCall objects attached
- * to the assistant "done" messages, then transform the result to Message[].
- *
- * The recording writer stores three separate messages per tool-use cycle:
- *   1. role=assistant, metadata.type=tool_call, toolCallId=X  (content = JSON {name, arguments})
- *   2. role=system,    metadata.type=tool_result, toolCallId=X (content = result data)
- *   3. role=assistant  (no metadata.type — the final "done" response)
- *
- * This function operates on raw ApiMessage objects (which have metadata) to
- * build the pairing, then transforms to Message[] for the UI.
- */
-function transformAndPairMessages(apiMessages: ApiMessage[]): Message[] {
-  const { resultsByToolCallId, toolResultIds } = indexToolResults(apiMessages);
-
-  // Build ToolCall objects from tool_call messages and collect their IDs
-  const toolCallIds = new Set<string>();
-  const pendingToolCalls: ToolCall[] = [];
-  for (const api of apiMessages) {
-    if (api.metadata?.type === "tool_call" && api.toolCallId) {
-      toolCallIds.add(api.id);
-      pendingToolCalls.push(buildToolCall(api, resultsByToolCallId));
-    }
-  }
-
-  // Transform non-tool messages and attach collected ToolCalls to
-  // the next assistant "done" message
-  const output: Message[] = [];
-  let toolCallsToAttach = [...pendingToolCalls];
-
-  for (const api of apiMessages) {
-    if (toolCallIds.has(api.id) || toolResultIds.has(api.id)) continue;
-
-    const msg = transformApiMessage(api);
-    if (msg.role === "assistant" && toolCallsToAttach.length > 0) {
-      msg.toolCalls = toolCallsToAttach;
-      toolCallsToAttach = [];
-    }
-    output.push(msg);
-  }
-
-  attachLeftoverToolCalls(output, toolCallsToAttach);
-  return output;
+function transformMessages(apiMessages: ApiMessage[]): Message[] {
+  return apiMessages.map(transformApiMessage);
 }
 
 /**
@@ -234,7 +113,7 @@ function transformAndPairMessages(apiMessages: ApiMessage[]): Message[] {
 function transformApiSession(api: ApiSession): Session {
   const inputTokens = api.totalInputTokens || 0;
   const outputTokens = api.totalOutputTokens || 0;
-  const messages = transformAndPairMessages(api.messages || []);
+  const messages = transformMessages(api.messages || []);
 
   return {
     id: api.id,
@@ -376,7 +255,7 @@ export class SessionApiService {
 
     const data = await response.json();
     return {
-      messages: transformAndPairMessages(data.messages || []),
+      messages: transformMessages(data.messages || []),
       hasMore: data.hasMore || false,
     };
   }

--- a/dashboard/src/lib/sessions/timeline.test.ts
+++ b/dashboard/src/lib/sessions/timeline.test.ts
@@ -54,32 +54,35 @@ describe("extractTimelineEvents", () => {
     expect(events.every(e => e.kind !== "system_message" || e.id !== "m2")).toBe(true);
   });
 
-  it("emits tool_call events from toolCalls array", () => {
+  it("emits tool_call events from tool_call messages", () => {
     const messages: Message[] = [
       {
         id: "m1",
         role: "assistant",
-        content: "Let me search",
+        content: '{"name":"search","arguments":{"q":"test"}}',
         timestamp: "2024-01-01T00:00:01Z",
-        toolCalls: [
-          { id: "tc1", name: "search", arguments: { q: "test" }, status: "success", duration: 250 },
-          { id: "tc2", name: "fetch", arguments: { url: "example.com" }, status: "error" },
-        ],
+        metadata: { type: "tool_call", duration_ms: "250", status: "success" },
+        toolCallId: "tc1",
+      },
+      {
+        id: "m2",
+        role: "assistant",
+        content: '{"name":"fetch","arguments":{"url":"example.com"}}',
+        timestamp: "2024-01-01T00:00:02Z",
+        metadata: { type: "tool_call", status: "error" },
+        toolCallId: "tc2",
       },
     ];
     const events = extractTimelineEvents(messages);
 
-    // 1 assistant_message + 2 tool_call events
-    expect(events).toHaveLength(3);
-
-    const tcEvents = events.filter(e => e.kind === "tool_call");
-    expect(tcEvents).toHaveLength(2);
-    expect(tcEvents[0].label).toBe("search");
-    expect(tcEvents[0].toolCallId).toBe("tc1");
-    expect(tcEvents[0].duration).toBe(250);
-    expect(tcEvents[0].status).toBe("success");
-    expect(tcEvents[1].label).toBe("fetch");
-    expect(tcEvents[1].status).toBe("error");
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("tool_call");
+    expect(events[0].label).toBe("Tool: search");
+    expect(events[0].toolCallId).toBe("tc1");
+    expect(events[0].duration).toBe(250);
+    expect(events[0].status).toBe("success");
+    expect(events[1].label).toBe("Tool: fetch");
+    expect(events[1].status).toBe("error");
   });
 
   it("handles workflow transition events", () => {
@@ -265,20 +268,16 @@ describe("extractTimelineEvents", () => {
     const messages: Message[] = [
       { id: "m1", role: "user", content: "Hi", timestamp: "2024-01-01T00:00:00Z" },
       { id: "m2", role: "system", content: "Workflow started", timestamp: "2024-01-01T00:00:01Z", metadata: { type: "workflow_transition", from: "idle", to: "active" } },
-      {
-        id: "m3", role: "assistant", content: "Searching...", timestamp: "2024-01-01T00:00:02Z",
-        toolCalls: [{ id: "tc1", name: "search", arguments: {}, status: "success", duration: 100 }],
-      },
+      { id: "m3", role: "assistant", content: '{"name":"search","arguments":{}}', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_call", duration_ms: "100", status: "success" }, toolCallId: "tc1" },
       { id: "m4", role: "assistant", content: "Found results!", timestamp: "2024-01-01T00:00:03Z" },
     ];
 
     const events = extractTimelineEvents(messages);
 
-    expect(events).toHaveLength(5); // user + workflow + assistant + tool_call + assistant
+    expect(events).toHaveLength(4);
     expect(events.map(e => e.kind)).toEqual([
       "user_message",
       "workflow_transition",
-      "assistant_message",
       "tool_call",
       "assistant_message",
     ]);

--- a/dashboard/src/lib/sessions/timeline.ts
+++ b/dashboard/src/lib/sessions/timeline.ts
@@ -34,6 +34,7 @@ function truncate(text: string, maxLength: number): string {
 function resolveMessageKind(message: Message): TimelineEventKind {
   const metadataType = message.metadata?.type;
 
+  if (metadataType === "tool_call") return "tool_call";
   if (metadataType === "workflow_transition") return "workflow_transition";
   if (metadataType === "workflow_completed") return "workflow_completed";
   if (metadataType === "error") return "error";
@@ -50,6 +51,16 @@ function resolveMessageKind(message: Message): TimelineEventKind {
       return "system_message";
     default:
       return "system_message";
+  }
+}
+
+/** Try to extract a tool name from JSON content. */
+function parseToolName(content: string): string | undefined {
+  try {
+    const parsed = JSON.parse(content);
+    return parsed.name;
+  } catch {
+    return undefined;
   }
 }
 
@@ -82,6 +93,10 @@ function buildLabel(kind: TimelineEventKind, message: Message): string {
     }
     case "provider_call":
       return "Provider call";
+    case "tool_call": {
+      const tcName = parseToolName(message.content);
+      return tcName ? `Tool: ${tcName}` : "Tool call";
+    }
     case "workflow_transition": {
       const from = message.metadata?.from;
       const to = message.metadata?.to;
@@ -95,6 +110,13 @@ function buildLabel(kind: TimelineEventKind, message: Message): string {
     default:
       return "Event";
   }
+}
+
+function resolveEventStatus(kind: TimelineEventKind, message: Message): TimelineEvent["status"] {
+  if (kind === "error") return "error";
+  const status = message.metadata?.status;
+  if (status === "success" || status === "error") return status;
+  return undefined;
 }
 
 /**
@@ -112,31 +134,20 @@ export function extractTimelineEvents(messages: Message[]): TimelineEvent[] {
 
     const kind = resolveMessageKind(message);
 
-    // Emit the message-level event
+    const durationStr = message.metadata?.duration_ms;
+    const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
+
     events.push({
       id: message.id,
       timestamp: message.timestamp,
       kind,
       label: buildLabel(kind, message),
       detail: message.content ? truncate(message.content, MAX_DETAIL_LENGTH) : undefined,
+      toolCallId: kind === "tool_call" ? message.toolCallId : undefined,
+      duration: duration && !Number.isNaN(duration) ? duration : undefined,
       metadata: message.metadata,
-      status: kind === "error" ? "error" : undefined,
+      status: resolveEventStatus(kind, message),
     });
-
-    // Emit individual tool call events
-    if (message.toolCalls) {
-      for (const tc of message.toolCalls) {
-        events.push({
-          id: `${message.id}-tc-${tc.id}`,
-          timestamp: message.timestamp,
-          kind: "tool_call",
-          label: tc.name,
-          toolCallId: tc.id,
-          duration: tc.duration,
-          status: tc.status,
-        });
-      }
-    }
   }
 
   // Sort by timestamp (stable sort preserves insertion order for equal timestamps)

--- a/internal/agent/demo_handler.go
+++ b/internal/agent/demo_handler.go
@@ -206,25 +206,23 @@ func (h *DemoHandler) HandleMessage(
 }
 
 // simulateToolCall wraps a simulated tool call with a tracing span.
-func (h *DemoHandler) simulateToolCall(ctx context.Context, writer facade.ResponseWriter, toolName string, call *facade.ToolCallInfo, result *facade.ToolResultInfo, delay time.Duration) error {
+// It does not send tool call/result messages to the client — real agents
+// handle tool execution internally and only return text and media.
+func (h *DemoHandler) simulateToolCall(ctx context.Context, toolName string, delay time.Duration) {
 	var toolSpan trace.Span
 	if h.tracer != nil {
-		_, toolSpan = h.tracer.StartToolSpan(ctx, toolName)
+		_, toolSpan = h.tracer.StartToolSpan(ctx, toolName, tracing.ToolSpanMeta{})
 		defer toolSpan.End()
 	}
 
-	if err := writer.WriteToolCall(call); err != nil {
-		return err
-	}
 	time.Sleep(delay)
 
 	if toolSpan != nil {
 		tracing.SetSuccess(toolSpan)
 	}
-	return writer.WriteToolResult(result)
 }
 
-func (h *DemoHandler) handlePasswordReset(ctx context.Context, sessionID string, writer facade.ResponseWriter) (string, error) {
+func (h *DemoHandler) handlePasswordReset(ctx context.Context, _ string, writer facade.ResponseWriter) (string, error) {
 	// Stream initial response
 	chunks := []string{
 		"I can help you ",
@@ -241,27 +239,8 @@ func (h *DemoHandler) handlePasswordReset(ctx context.Context, sessionID string,
 		time.Sleep(80 * time.Millisecond)
 	}
 
-	// Simulate tool call with tracing
-	if err := h.simulateToolCall(ctx, writer, "lookup-user",
-		&facade.ToolCallInfo{
-			ID:   "call_001",
-			Name: "lookup-user",
-			Arguments: map[string]interface{}{
-				"session_id": sessionID,
-			},
-		},
-		&facade.ToolResultInfo{
-			ID: "call_001",
-			Result: map[string]interface{}{
-				"status":       "found",
-				"email":        "user@example.com",
-				"account_type": "premium",
-			},
-		},
-		400*time.Millisecond,
-	); err != nil {
-		return "", err
-	}
+	// Simulate tool call with tracing (span only, no client messages)
+	h.simulateToolCall(ctx, "lookup-user", 400*time.Millisecond)
 
 	// Final response
 	finalResponse := `
@@ -296,28 +275,8 @@ func (h *DemoHandler) handleWeatherQuery(ctx context.Context, _ string, writer f
 		time.Sleep(150 * time.Millisecond)
 	}
 
-	// Simulate tool call with tracing
-	if err := h.simulateToolCall(ctx, writer, "weather",
-		&facade.ToolCallInfo{
-			ID:   "call_002",
-			Name: "weather",
-			Arguments: map[string]interface{}{
-				"location": "Denver, CO",
-			},
-		},
-		&facade.ToolResultInfo{
-			ID: "call_002",
-			Result: map[string]interface{}{
-				"temperature": "72°F",
-				"condition":   "Sunny",
-				"humidity":    "45%",
-				"wind":        "5 mph NW",
-			},
-		},
-		500*time.Millisecond,
-	); err != nil {
-		return "", err
-	}
+	// Simulate tool call with tracing (span only, no client messages)
+	h.simulateToolCall(ctx, "weather", 500*time.Millisecond)
 
 	finalResponse := `
 

--- a/internal/agent/demo_handler_test.go
+++ b/internal/agent/demo_handler_test.go
@@ -86,18 +86,12 @@ func TestDemoHandler_HandleMessage_PasswordReset(t *testing.T) {
 		t.Error("HandleMessage() produced no chunks")
 	}
 
-	// Should have a tool call
-	if len(writer.toolCalls) != 1 {
-		t.Errorf("HandleMessage() produced %d tool calls, want 1", len(writer.toolCalls))
-	} else {
-		if writer.toolCalls[0].Name != "lookup-user" {
-			t.Errorf("HandleMessage() tool call name = %q, want %q", writer.toolCalls[0].Name, "lookup-user")
-		}
+	// Should NOT have tool calls or results (kept internal)
+	if len(writer.toolCalls) != 0 {
+		t.Errorf("HandleMessage() produced %d tool calls, want 0", len(writer.toolCalls))
 	}
-
-	// Should have a tool result
-	if len(writer.toolResults) != 1 {
-		t.Errorf("HandleMessage() produced %d tool results, want 1", len(writer.toolResults))
+	if len(writer.toolResults) != 0 {
+		t.Errorf("HandleMessage() produced %d tool results, want 0", len(writer.toolResults))
 	}
 
 	// Should have done message with instructions
@@ -122,18 +116,12 @@ func TestDemoHandler_HandleMessage_Weather(t *testing.T) {
 		t.Error("HandleMessage() produced no chunks")
 	}
 
-	// Should have a tool call for weather
-	if len(writer.toolCalls) != 1 {
-		t.Errorf("HandleMessage() produced %d tool calls, want 1", len(writer.toolCalls))
-	} else {
-		if writer.toolCalls[0].Name != "weather" {
-			t.Errorf("HandleMessage() tool call name = %q, want %q", writer.toolCalls[0].Name, "weather")
-		}
+	// Should NOT have tool calls or results (kept internal)
+	if len(writer.toolCalls) != 0 {
+		t.Errorf("HandleMessage() produced %d tool calls, want 0", len(writer.toolCalls))
 	}
-
-	// Should have a tool result
-	if len(writer.toolResults) != 1 {
-		t.Errorf("HandleMessage() produced %d tool results, want 1", len(writer.toolResults))
+	if len(writer.toolResults) != 0 {
+		t.Errorf("HandleMessage() produced %d tool results, want 0", len(writer.toolResults))
 	}
 
 	// Should have done message with weather info

--- a/internal/controller/agentruntime_controller_test.go
+++ b/internal/controller/agentruntime_controller_test.go
@@ -1272,8 +1272,10 @@ var _ = Describe("AgentRuntime Controller", func() {
 				envMap[env.Name] = env
 			}
 
-			Expect(envMap["OMNIA_TOOLREGISTRY_NAME"].Value).To(Equal(toolRegistryKey.Name))
-			Expect(envMap["OMNIA_TOOLREGISTRY_NAMESPACE"].Value).To(Equal(toolRegistryKey.Namespace))
+			// OMNIA_TOOLREGISTRY_NAME/NAMESPACE env vars removed — runtime reads CRD directly
+			Expect(envMap).NotTo(HaveKey("OMNIA_TOOLREGISTRY_NAME"))
+			Expect(envMap).NotTo(HaveKey("OMNIA_TOOLREGISTRY_NAMESPACE"))
+			Expect(envMap).To(HaveKey("OMNIA_TOOLS_CONFIG_PATH"))
 
 			By("verifying ToolRegistryReady condition")
 			updated := &omniav1alpha1.AgentRuntime{}

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -506,17 +506,8 @@ func (r *AgentRuntimeReconciler) buildRuntimeEnvVars(
 		},
 	}
 
-	// Add tool registry info if present
+	// Add tools config path if tool registry is present
 	if toolRegistry != nil {
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "OMNIA_TOOLREGISTRY_NAME",
-			Value: toolRegistry.Name,
-		})
-		envVars = append(envVars, corev1.EnvVar{
-			Name:  "OMNIA_TOOLREGISTRY_NAMESPACE",
-			Value: toolRegistry.Namespace,
-		})
-		// Tools config path
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  "OMNIA_TOOLS_CONFIG_PATH",
 			Value: ToolsMountPath + "/" + ToolsConfigFileName,

--- a/internal/controller/facade_rbac.go
+++ b/internal/controller/facade_rbac.go
@@ -115,7 +115,7 @@ func (r *AgentRuntimeReconciler) reconcileRole(
 		role.Rules = []rbacv1.PolicyRule{
 			{
 				APIGroups: []string{"omnia.altairalabs.ai"},
-				Resources: []string{"agentruntimes", "providers"},
+				Resources: []string{"agentruntimes", "providers", "toolregistries"},
 				Verbs:     []string{"get"},
 			},
 			{

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -62,7 +62,9 @@ type Config struct {
 	MediaBasePath  string // Base path for resolving mock:// URLs to media files
 
 	// Tools configuration
-	ToolsConfigPath string // Path to tools.yaml configuration file
+	ToolsConfigPath       string // Path to tools.yaml configuration file
+	ToolRegistryName      string // Name of the ToolRegistry CRD (for metadata enrichment)
+	ToolRegistryNamespace string // Namespace of the ToolRegistry CRD
 
 	// Session recording (Pattern C)
 	SessionAPIURL string // URL of the session-api service for event recording

--- a/internal/runtime/config_crd.go
+++ b/internal/runtime/config_crd.go
@@ -88,6 +88,12 @@ func LoadFromCRD(ctx context.Context, c client.Client, name, namespace string) (
 	// relying on an env var.
 	if ar.Spec.ToolRegistryRef != nil {
 		cfg.ToolsConfigPath = defaultToolsMountPath + "/" + defaultToolsConfigFile
+		cfg.ToolRegistryName = ar.Spec.ToolRegistryRef.Name
+		if ar.Spec.ToolRegistryRef.Namespace != nil {
+			cfg.ToolRegistryNamespace = *ar.Spec.ToolRegistryRef.Namespace
+		} else {
+			cfg.ToolRegistryNamespace = namespace
+		}
 	}
 
 	// Session-api URL from env (injected by operator for session recording)

--- a/internal/runtime/message_test.go
+++ b/internal/runtime/message_test.go
@@ -372,7 +372,7 @@ func TestConverse_ToolCallSpanHierarchy(t *testing.T) {
 	ctx, convSpan := provider.StartConversationSpan(ctx, "test-tool-session", "test-pack", "1.0.0", 0)
 
 	// Start a child tool span using the same API the server uses
-	ctx, toolSpanOtel := provider.StartToolSpan(ctx, "search_places")
+	ctx, toolSpanOtel := provider.StartToolSpan(ctx, "search_places", tracing.ToolSpanMeta{})
 	toolSpanOtel.End()
 	convSpan.End()
 
@@ -409,7 +409,7 @@ func TestConverse_ToolCallSpanParentedViaOnToolCtx(t *testing.T) {
 	ctx, convSpan := provider.StartConversationSpan(ctx, "test-parented", "test-pack", "1.0.0", 0)
 
 	// OnToolCtx now passes the pipeline context (with conversation span) to the handler
-	_, toolSpanOtel := provider.StartToolSpan(ctx, "parented_tool")
+	_, toolSpanOtel := provider.StartToolSpan(ctx, "parented_tool", tracing.ToolSpanMeta{})
 	toolSpanOtel.End()
 	convSpan.End()
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -342,6 +342,15 @@ func (s *Server) InitializeTools(ctx context.Context) error {
 	return nil
 }
 
+// SetToolRegistryInfo populates registry/handler metadata on the tool manager.
+// This must be called after InitializeTools and before handling conversations.
+func (s *Server) SetToolRegistryInfo(registryName, registryNamespace string, handlers []tools.HandlerEntry) {
+	if s.toolManager == nil {
+		return
+	}
+	s.toolManager.SetRegistryInfo(registryName, registryNamespace, handlers)
+}
+
 // SetHealthy sets the server health status.
 func (s *Server) SetHealthy(healthy bool) {
 	s.mu.Lock()

--- a/internal/runtime/tools_registration.go
+++ b/internal/runtime/tools_registration.go
@@ -60,7 +60,13 @@ func (s *Server) executeToolForConversation(ctx context.Context, toolName string
 	// Start tool span if tracing is enabled
 	var span trace.Span
 	if s.tracingProvider != nil {
-		ctx, span = s.tracingProvider.StartToolSpan(ctx, toolName)
+		meta, _ := s.toolManager.GetToolMeta(toolName)
+		ctx, span = s.tracingProvider.StartToolSpan(ctx, toolName, tracing.ToolSpanMeta{
+			RegistryName:      meta.RegistryName,
+			RegistryNamespace: meta.RegistryNamespace,
+			HandlerName:       meta.HandlerName,
+			HandlerType:       meta.HandlerType,
+		})
 		defer span.End()
 	}
 

--- a/internal/session/otlp/attributes.go
+++ b/internal/session/otlp/attributes.go
@@ -84,6 +84,14 @@ const (
 	AttrToolDurationMs = "tool.duration_ms"
 )
 
+// Tool registry/handler attribute keys (set by Omnia runtime).
+const (
+	AttrToolRegistryName      = "tool.registry.name"
+	AttrToolRegistryNamespace = "tool.registry.namespace"
+	AttrToolHandlerName       = "tool.handler.name"
+	AttrToolHandlerType       = "tool.handler.type"
+)
+
 // PromptKit workflow span attribute keys.
 const (
 	AttrWorkflowFromState       = "workflow.from_state"

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -244,13 +244,31 @@ func (p *Provider) StartLLMSpan(ctx context.Context, model string, system string
 	return ctx, span
 }
 
+// ToolSpanMeta holds optional registry/handler metadata for tool spans.
+type ToolSpanMeta struct {
+	RegistryName      string
+	RegistryNamespace string
+	HandlerName       string
+	HandlerType       string
+}
+
 // StartToolSpan starts a new span for a tool execution.
-func (p *Provider) StartToolSpan(ctx context.Context, toolName string) (context.Context, trace.Span) {
+func (p *Provider) StartToolSpan(ctx context.Context, toolName string, meta ToolSpanMeta) (context.Context, trace.Span) {
+	attrs := []attribute.KeyValue{
+		attribute.String("tool.name", toolName),
+	}
+	if meta.RegistryName != "" {
+		attrs = append(attrs,
+			attribute.String("tool.registry.name", meta.RegistryName),
+			attribute.String("tool.registry.namespace", meta.RegistryNamespace),
+			attribute.String("tool.handler.name", meta.HandlerName),
+			attribute.String("tool.handler.type", meta.HandlerType),
+		)
+	}
+
 	ctx, span := p.tracer.Start(ctx, "omnia.tool.call",
 		trace.WithSpanKind(trace.SpanKindClient),
-		trace.WithAttributes(
-			attribute.String("tool.name", toolName),
-		),
+		trace.WithAttributes(attrs...),
 	)
 	p.log.V(1).Info("span started",
 		"spanName", "omnia.tool.call",

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -151,7 +151,7 @@ func TestProvider_StartLLMSpan(t *testing.T) {
 func TestProvider_StartToolSpan(t *testing.T) {
 	provider, exporter := newTestProvider(t)
 
-	_, span := provider.StartToolSpan(context.Background(), "get_weather")
+	_, span := provider.StartToolSpan(context.Background(), "get_weather", ToolSpanMeta{})
 	span.End()
 
 	spans := exporter.GetSpans()
@@ -173,6 +173,87 @@ func TestProvider_StartToolSpan(t *testing.T) {
 	}
 	if val.AsString() != "get_weather" {
 		t.Errorf("expected tool.name='get_weather', got %q", val.AsString())
+	}
+}
+
+func TestProvider_StartToolSpan_WithMeta(t *testing.T) {
+	provider, exporter := newTestProvider(t)
+
+	meta := ToolSpanMeta{
+		RegistryName:      "my-registry",
+		RegistryNamespace: "my-ns",
+		HandlerName:       "http-handler",
+		HandlerType:       "http",
+	}
+	_, span := provider.StartToolSpan(context.Background(), "get_weather", meta)
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	s := spans[0]
+
+	// Verify tool.name
+	val, ok := findAttr(s, "tool.name")
+	if !ok {
+		t.Fatal("missing attribute 'tool.name'")
+	}
+	if val.AsString() != "get_weather" {
+		t.Errorf("expected tool.name='get_weather', got %q", val.AsString())
+	}
+
+	// Verify registry attributes
+	val, ok = findAttr(s, "tool.registry.name")
+	if !ok {
+		t.Fatal("missing attribute 'tool.registry.name'")
+	}
+	if val.AsString() != "my-registry" {
+		t.Errorf("expected tool.registry.name='my-registry', got %q", val.AsString())
+	}
+
+	val, ok = findAttr(s, "tool.registry.namespace")
+	if !ok {
+		t.Fatal("missing attribute 'tool.registry.namespace'")
+	}
+	if val.AsString() != "my-ns" {
+		t.Errorf("expected tool.registry.namespace='my-ns', got %q", val.AsString())
+	}
+
+	val, ok = findAttr(s, "tool.handler.name")
+	if !ok {
+		t.Fatal("missing attribute 'tool.handler.name'")
+	}
+	if val.AsString() != "http-handler" {
+		t.Errorf("expected tool.handler.name='http-handler', got %q", val.AsString())
+	}
+
+	val, ok = findAttr(s, "tool.handler.type")
+	if !ok {
+		t.Fatal("missing attribute 'tool.handler.type'")
+	}
+	if val.AsString() != "http" {
+		t.Errorf("expected tool.handler.type='http', got %q", val.AsString())
+	}
+}
+
+func TestProvider_StartToolSpan_EmptyMeta(t *testing.T) {
+	provider, exporter := newTestProvider(t)
+
+	_, span := provider.StartToolSpan(context.Background(), "get_weather", ToolSpanMeta{})
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	s := spans[0]
+
+	// Registry attributes should NOT be present when meta is empty
+	if _, ok := findAttr(s, "tool.registry.name"); ok {
+		t.Error("unexpected attribute 'tool.registry.name' when meta is empty")
 	}
 }
 
@@ -254,7 +335,7 @@ func TestAddToolResult(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		exporter.Reset()
-		_, span := provider.StartToolSpan(context.Background(), "test-tool")
+		_, span := provider.StartToolSpan(context.Background(), "test-tool", ToolSpanMeta{})
 		AddToolResult(span, false, 150)
 		span.End()
 
@@ -279,7 +360,7 @@ func TestAddToolResult(t *testing.T) {
 
 	t.Run("error", func(t *testing.T) {
 		exporter.Reset()
-		_, span := provider.StartToolSpan(context.Background(), "test-tool")
+		_, span := provider.StartToolSpan(context.Background(), "test-tool", ToolSpanMeta{})
 		AddToolResult(span, true, 50)
 		span.End()
 

--- a/pkg/k8s/client_test.go
+++ b/pkg/k8s/client_test.go
@@ -149,6 +149,36 @@ func TestGetProvider_NotFound(t *testing.T) {
 	}
 }
 
+func TestGetToolRegistry_Found(t *testing.T) {
+	s := Scheme()
+	tr := &omniav1alpha1.ToolRegistry{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-tools",
+			Namespace: "default",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).WithRuntimeObjects(tr).Build()
+
+	got, err := GetToolRegistry(context.Background(), c, "my-tools", "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Name != "my-tools" {
+		t.Errorf("expected name my-tools, got %s", got.Name)
+	}
+}
+
+func TestGetToolRegistry_NotFound(t *testing.T) {
+	s := Scheme()
+	c := fake.NewClientBuilder().WithScheme(s).Build()
+
+	_, err := GetToolRegistry(context.Background(), c, "nonexistent", "default")
+	if err == nil {
+		t.Fatal("expected error for not found")
+	}
+}
+
 func TestGetProviderSecret_Found(t *testing.T) {
 	s := Scheme()
 	secret := &corev1.Secret{

--- a/pkg/k8s/getters.go
+++ b/pkg/k8s/getters.go
@@ -57,6 +57,18 @@ func GetProvider(
 	return p, nil
 }
 
+// GetToolRegistry fetches a ToolRegistry CRD by name and namespace.
+func GetToolRegistry(
+	ctx context.Context, c client.Client, name, namespace string,
+) (*omniav1alpha1.ToolRegistry, error) {
+	tr := &omniav1alpha1.ToolRegistry{}
+	key := types.NamespacedName{Name: name, Namespace: namespace}
+	if err := c.Get(ctx, key, tr); err != nil {
+		return nil, fmt.Errorf("get ToolRegistry %s: %w", key, err)
+	}
+	return tr, nil
+}
+
 // GetProviderSecret fetches the Secret referenced by a Provider's SecretRef.
 func GetProviderSecret(ctx context.Context, c client.Client, provider *omniav1alpha1.Provider) (*corev1.Secret, error) {
 	if provider.Spec.SecretRef == nil {


### PR DESCRIPTION
## Summary
- Wire ToolRegistry CRD name/namespace into runtime config and read it at startup to populate handler metadata on tool spans and Prometheus metrics
- Enrich OpenTelemetry tool spans with `registry_name`, `registry_namespace`, `handler_type`, `handler_name` attributes
- Simplify demo handler tool call simulation (span-only, no client messages)
- Add `GetToolRegistry` helper to `pkg/k8s`
- Refactor dashboard session detail page, timeline, and toolcalls tabs
- Remove deprecated eval-results endpoints from dashboard session-api service
- Update controller RBAC and deployment builder for new config fields

## Test plan
- [x] Pre-commit checks pass (Go lint, vet, build, tests ≥80% coverage)
- [x] Dashboard ESLint, TypeScript, and Vitest pass (92.18% coverage)
- [ ] CI: Build, Lint, Test & Coverage, Integration Tests
- [ ] CI: SonarCloud Analysis
- [ ] CI: Agent Flow Tests, Multimodal Console Tests
- [ ] CI: Dashboard, Dashboard E2E Coverage