### PR TITLE
feat: PDB, topology spread, pre-stop hook, Redis cap, body limit

### DIFF
--- a/charts/omnia/templates/clusterrole.yaml
+++ b/charts/omnia/templates/clusterrole.yaml
@@ -321,6 +321,19 @@ rules:
       - patch
       - update
       - watch
+  # PodDisruptionBudgets for agent pod availability
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
   # KEDA ScaledObjects for advanced autoscaling
   - apiGroups:
       - keda.sh

--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -365,7 +365,8 @@ func buildAPIMux(pool *pgxpool.Pool, registry *providers.Registry, f *flags, log
 	svcCfg.EventPublisher = initEventPublisher(registry, log, httpMetrics)
 
 	sessionService := api.NewSessionService(registry, svcCfg, log)
-	handler := api.NewHandler(sessionService, log)
+	maxBody := int64(envInt32("MAX_BODY_SIZE", int32(api.DefaultMaxBodySize)))
+	handler := api.NewHandler(sessionService, log, maxBody)
 
 	mux := http.NewServeMux()
 	handler.RegisterRoutes(mux)
@@ -437,6 +438,7 @@ func initProviders(ctx context.Context, f *flags, pool *pgxpool.Pool, log logr.L
 	if f.redisAddrs != "" {
 		redisCfg := redis.DefaultConfig()
 		redisCfg.Addrs = strings.Split(f.redisAddrs, ",")
+		redisCfg.MaxMessagesPerSession = int(envInt32("REDIS_MAX_MESSAGES", int32(redisCfg.MaxMessagesPerSession)))
 		hotProvider, err := redis.New(redisCfg)
 		if err != nil {
 			return nil, nil, fmt.Errorf("creating redis provider: %w", err)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -143,6 +143,18 @@ rules:
   verbs:
   - get
 - apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - rolebindings

--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -69,6 +69,7 @@ type AgentRuntimeReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=keda.sh,resources=scaledobjects,verbs=get;list;watch;create;update;patch;delete
 
 // reconcileReferences fetches and validates all referenced resources.
@@ -224,6 +225,11 @@ func (r *AgentRuntimeReconciler) reconcileResources(
 	}
 	SetCondition(&agentRuntime.Status.Conditions, agentRuntime.Generation, ConditionTypeServiceReady, metav1.ConditionTrue,
 		"ServiceCreated", "Service created/updated successfully")
+
+	// Reconcile PDB (only meaningful when replicas > 1)
+	if err := r.reconcilePDB(ctx, agentRuntime); err != nil {
+		log.Error(err, "Failed to reconcile PDB")
+	}
 
 	return deployment, nil
 }

--- a/internal/controller/agentruntime_controller_test.go
+++ b/internal/controller/agentruntime_controller_test.go
@@ -25,6 +25,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -228,6 +229,16 @@ var _ = Describe("AgentRuntime Controller", func() {
 			Expect(runtimeContainer.Image).To(Equal("test-runtime:v1.0.0"))
 			Expect(runtimeContainer.Ports).To(HaveLen(2)) // gRPC port + health port
 			Expect(runtimeContainer.Ports[0].ContainerPort).To(Equal(int32(DefaultRuntimeGRPCPort)))
+
+			By("verifying pre-stop lifecycle hook on facade container")
+			Expect(facadeContainer.Lifecycle).NotTo(BeNil())
+			Expect(facadeContainer.Lifecycle.PreStop).NotTo(BeNil())
+			Expect(facadeContainer.Lifecycle.PreStop.Exec).NotTo(BeNil())
+			Expect(facadeContainer.Lifecycle.PreStop.Exec.Command).To(Equal([]string{"/bin/sh", "-c", "sleep 5"}))
+
+			By("verifying termination grace period")
+			Expect(deployment.Spec.Template.Spec.TerminationGracePeriodSeconds).NotTo(BeNil())
+			Expect(*deployment.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(int64(45)))
 
 			By("verifying the Service was created")
 			service := &corev1.Service{}
@@ -1988,6 +1999,141 @@ var _ = Describe("AgentRuntime Controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, agentRuntimeKey, hpa)
 			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should create PDB and topology spread when replicas > 1", func() {
+			By("creating a PromptPack")
+			promptPack := &omniav1alpha1.PromptPack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      promptPackKey.Name,
+					Namespace: promptPackKey.Namespace,
+				},
+				Spec: omniav1alpha1.PromptPackSpec{
+					Version: "1.0.0",
+					Source: omniav1alpha1.PromptPackSource{
+						Type: omniav1alpha1.PromptPackSourceTypeConfigMap,
+					},
+					Rollout: omniav1alpha1.RolloutStrategy{
+						Type: omniav1alpha1.RolloutStrategyImmediate,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, promptPack)).To(Succeed())
+
+			By("creating an AgentRuntime with 3 replicas")
+			replicas := int32(3)
+			agentRuntime := &omniav1alpha1.AgentRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentRuntimeKey.Name,
+					Namespace: agentRuntimeKey.Namespace,
+				},
+				Spec: omniav1alpha1.AgentRuntimeSpec{
+					PromptPackRef: omniav1alpha1.PromptPackRef{
+						Name: promptPackKey.Name,
+					},
+					Facade: omniav1alpha1.FacadeConfig{
+						Type: omniav1alpha1.FacadeTypeWebSocket,
+					},
+					Provider: &omniav1alpha1.ProviderConfig{
+						Type: omniav1alpha1.ProviderTypeClaude,
+						SecretRef: &corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+					},
+					Runtime: &omniav1alpha1.RuntimeConfig{
+						Replicas: &replicas,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agentRuntime)).To(Succeed())
+
+			By("reconciling the AgentRuntime")
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: agentRuntimeKey})
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: agentRuntimeKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying PDB was created")
+			pdb := &policyv1.PodDisruptionBudget{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, agentRuntimeKey, pdb)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(pdb.Spec.MinAvailable).NotTo(BeNil())
+			Expect(pdb.Spec.MinAvailable.IntValue()).To(Equal(1))
+			Expect(pdb.OwnerReferences).To(HaveLen(1))
+			Expect(pdb.OwnerReferences[0].Name).To(Equal(agentRuntimeKey.Name))
+
+			By("verifying topology spread constraints on deployment")
+			deployment := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, agentRuntimeKey, deployment)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(deployment.Spec.Template.Spec.TopologySpreadConstraints).To(HaveLen(1))
+			tsc := deployment.Spec.Template.Spec.TopologySpreadConstraints[0]
+			Expect(tsc.MaxSkew).To(Equal(int32(1)))
+			Expect(tsc.TopologyKey).To(Equal("topology.kubernetes.io/zone"))
+			Expect(tsc.WhenUnsatisfiable).To(Equal(corev1.ScheduleAnyway))
+		})
+
+		It("should not create PDB when replicas is 1", func() {
+			By("creating a PromptPack")
+			promptPack := &omniav1alpha1.PromptPack{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      promptPackKey.Name,
+					Namespace: promptPackKey.Namespace,
+				},
+				Spec: omniav1alpha1.PromptPackSpec{
+					Version: "1.0.0",
+					Source: omniav1alpha1.PromptPackSource{
+						Type: omniav1alpha1.PromptPackSourceTypeConfigMap,
+					},
+					Rollout: omniav1alpha1.RolloutStrategy{
+						Type: omniav1alpha1.RolloutStrategyImmediate,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, promptPack)).To(Succeed())
+
+			By("creating an AgentRuntime with 1 replica (default)")
+			agentRuntime := &omniav1alpha1.AgentRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      agentRuntimeKey.Name,
+					Namespace: agentRuntimeKey.Namespace,
+				},
+				Spec: omniav1alpha1.AgentRuntimeSpec{
+					PromptPackRef: omniav1alpha1.PromptPackRef{
+						Name: promptPackKey.Name,
+					},
+					Facade: omniav1alpha1.FacadeConfig{
+						Type: omniav1alpha1.FacadeTypeWebSocket,
+					},
+					Provider: &omniav1alpha1.ProviderConfig{
+						Type: omniav1alpha1.ProviderTypeClaude,
+						SecretRef: &corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agentRuntime)).To(Succeed())
+
+			By("reconciling the AgentRuntime")
+			_, _ = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: agentRuntimeKey})
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: agentRuntimeKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying no PDB was created")
+			pdb := &policyv1.PodDisruptionBudget{}
+			err = k8sClient.Get(ctx, agentRuntimeKey, pdb)
+			Expect(errors.IsNotFound(err)).To(BeTrue())
+
+			By("verifying no topology spread constraints on single-replica deployment")
+			deployment := &appsv1.Deployment{}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, agentRuntimeKey, deployment)
+			}, timeout, interval).Should(Succeed())
+			Expect(deployment.Spec.Template.Spec.TopologySpreadConstraints).To(BeEmpty())
 		})
 
 		It("should return early when AgentRuntime is not found", func() {

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -173,6 +174,10 @@ func (r *AgentRuntimeReconciler) buildDeploymentSpec(
 		Volumes:            volumes,
 	}
 
+	// Termination grace period: 45s allows the 30s shutdown timeout to complete
+	// plus headroom for the pre-stop hook and connection draining.
+	podSpec.TerminationGracePeriodSeconds = ptr.To(int64(45))
+
 	// Add scheduling constraints if specified
 	if agentRuntime.Spec.Runtime != nil {
 		if agentRuntime.Spec.Runtime.NodeSelector != nil {
@@ -183,6 +188,21 @@ func (r *AgentRuntimeReconciler) buildDeploymentSpec(
 		}
 		if agentRuntime.Spec.Runtime.Affinity != nil {
 			podSpec.Affinity = agentRuntime.Spec.Runtime.Affinity
+		}
+	}
+
+	// Default topology spread: distribute agent pods across zones when replicas > 1.
+	// Users can override via CRD affinity rules.
+	if replicas > 1 && podSpec.Affinity == nil {
+		podSpec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				TopologyKey:       "topology.kubernetes.io/zone",
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: labels,
+				},
+			},
 		}
 	}
 
@@ -284,6 +304,15 @@ func (r *AgentRuntimeReconciler) buildFacadeContainer(
 			},
 			InitialDelaySeconds: 15,
 			PeriodSeconds:       20,
+		},
+		// Pre-stop hook: sleep 5s to let the load balancer stop routing traffic
+		// before SIGTERM triggers the 30s graceful shutdown in the facade process.
+		Lifecycle: &corev1.Lifecycle{
+			PreStop: &corev1.LifecycleHandler{
+				Exec: &corev1.ExecAction{
+					Command: []string{"/bin/sh", "-c", "sleep 5"},
+				},
+			},
 		},
 	}
 

--- a/internal/controller/pdb.go
+++ b/internal/controller/pdb.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	policyv1 "k8s.io/api/policy/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// reconcilePDB creates or updates a PodDisruptionBudget for agent pods.
+// PDB is only created when replicas > 1 (single-replica PDB is meaningless).
+// When replicas <= 1, any existing PDB is cleaned up.
+func (r *AgentRuntimeReconciler) reconcilePDB(
+	ctx context.Context,
+	agentRuntime *omniav1alpha1.AgentRuntime,
+) error {
+	log := logf.FromContext(ctx)
+
+	replicas := int32(1)
+	if agentRuntime.Spec.Runtime != nil && agentRuntime.Spec.Runtime.Replicas != nil {
+		replicas = *agentRuntime.Spec.Runtime.Replicas
+	}
+
+	pdb := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentRuntime.Name,
+			Namespace: agentRuntime.Namespace,
+		},
+	}
+
+	// Clean up PDB when replicas <= 1
+	if replicas <= 1 {
+		if err := r.Delete(ctx, pdb); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete PDB: %w", err)
+		}
+		return nil
+	}
+
+	labels := map[string]string{
+		labelAppName:      labelValueOmniaAgent,
+		labelAppInstance:  agentRuntime.Name,
+		labelAppManagedBy: labelValueOmniaOperator,
+		labelOmniaComp:    "agent",
+	}
+
+	minAvailable := intstr.FromInt32(1)
+
+	result, err := controllerutil.CreateOrUpdate(ctx, r.Client, pdb, func() error {
+		if err := controllerutil.SetControllerReference(agentRuntime, pdb, r.Scheme); err != nil {
+			return err
+		}
+
+		pdb.Labels = labels
+		pdb.Spec = policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvailable,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+		}
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to reconcile PDB: %w", err)
+	}
+
+	log.Info("PDB reconciled", "result", result)
+	return nil
+}

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -42,8 +42,9 @@ const (
 	maxSearchQueryLen   = 500
 	maxOffsetLimit      = 10000
 
-	// DefaultMaxBodySize is the maximum allowed request body size (10 MB).
-	DefaultMaxBodySize int64 = 10 << 20
+	// DefaultMaxBodySize is the maximum allowed request body size (16 MB).
+	// Aligned with WebSocket and gRPC max message sizes across the pipeline.
+	DefaultMaxBodySize int64 = 16 << 20
 )
 
 // SessionListResponse is the JSON response for session list/search endpoints.

--- a/internal/session/providers/redis/config.go
+++ b/internal/session/providers/redis/config.go
@@ -22,8 +22,9 @@ import (
 )
 
 const (
-	defaultKeyPrefix  = "hot:"
-	defaultMaxRetries = 3
+	defaultKeyPrefix             = "hot:"
+	defaultMaxRetries            = 3
+	defaultMaxMessagesPerSession = 1000
 )
 
 // Config holds connection and behaviour settings for the Redis hot cache provider.
@@ -60,8 +61,9 @@ type Config struct {
 // set at least one address in Addrs.
 func DefaultConfig() Config {
 	return Config{
-		KeyPrefix:  defaultKeyPrefix,
-		MaxRetries: defaultMaxRetries,
+		KeyPrefix:             defaultKeyPrefix,
+		MaxRetries:            defaultMaxRetries,
+		MaxMessagesPerSession: defaultMaxMessagesPerSession,
 	}
 }
 
@@ -76,6 +78,7 @@ type Options struct {
 // DefaultOptions returns Options with sensible defaults.
 func DefaultOptions() Options {
 	return Options{
-		KeyPrefix: defaultKeyPrefix,
+		KeyPrefix:             defaultKeyPrefix,
+		MaxMessagesPerSession: defaultMaxMessagesPerSession,
 	}
 }

--- a/internal/session/providers/redis/provider_test.go
+++ b/internal/session/providers/redis/provider_test.go
@@ -571,6 +571,9 @@ func TestDefaultConfig(t *testing.T) {
 	if cfg.MaxRetries != defaultMaxRetries {
 		t.Errorf("MaxRetries = %d, want %d", cfg.MaxRetries, defaultMaxRetries)
 	}
+	if cfg.MaxMessagesPerSession != defaultMaxMessagesPerSession {
+		t.Errorf("MaxMessagesPerSession = %d, want %d", cfg.MaxMessagesPerSession, defaultMaxMessagesPerSession)
+	}
 }
 
 func TestDefaultOptions(t *testing.T) {
@@ -578,8 +581,8 @@ func TestDefaultOptions(t *testing.T) {
 	if opts.KeyPrefix != defaultKeyPrefix {
 		t.Errorf("KeyPrefix = %q, want %q", opts.KeyPrefix, defaultKeyPrefix)
 	}
-	if opts.MaxMessagesPerSession != 0 {
-		t.Errorf("MaxMessagesPerSession = %d, want 0", opts.MaxMessagesPerSession)
+	if opts.MaxMessagesPerSession != defaultMaxMessagesPerSession {
+		t.Errorf("MaxMessagesPerSession = %d, want %d", opts.MaxMessagesPerSession, defaultMaxMessagesPerSession)
 	}
 }
 


### PR DESCRIPTION
## Summary

Third batch of scalability improvements from the March scalability review. Follows #578 (timeouts, worker pool) and #579 (circuit breaker, pool sizing, query optimization).

- **PodDisruptionBudget** (S-K8S-7): Automatically reconciled for every agent deployment with `replicas > 1`. Sets `minAvailable: 1` with owner reference for garbage collection. Cleaned up when replicas drop to 1.
- **Topology spread constraints** (S-K8S-10): Default `topologySpreadConstraints` with `maxSkew: 1` across zones when `replicas > 1` and no custom affinity is set. Uses `ScheduleAnyway` to avoid blocking scheduling.
- **Pre-stop lifecycle hook** (S-K8S-9): Facade container gets a `preStop: exec: sleep 5` hook. This gives the load balancer time to stop routing traffic before SIGTERM triggers the 30s graceful shutdown.
- **Termination grace period**: Set to 45s (5s pre-stop + 30s shutdown + 10s headroom).
- **Redis message list cap** (S-CONV-2): `MaxMessagesPerSession` defaults to 1000 (was unlimited/0). Prevents unbounded Redis memory growth. Configurable via `REDIS_MAX_MESSAGES` env var.
- **Session-API body limit** (S-MSG-1): `DefaultMaxBodySize` raised from 10 MB to 16 MB to align with WebSocket/gRPC pipeline limits. Configurable via `MAX_BODY_SIZE` env var.
- **RBAC**: Added `policy/poddisruptionbudgets` permissions to operator ClusterRole and Helm chart.

## Test plan

- [x] Controller tests: PDB created for replicas > 1, not created for replicas = 1
- [x] Controller tests: topology spread constraints verified on multi-replica deployment
- [x] Controller tests: pre-stop lifecycle hook and terminationGracePeriodSeconds verified
- [x] Redis provider tests: DefaultConfig and DefaultOptions assert MaxMessagesPerSession=1000
- [x] Session-API handler tests: DefaultMaxBodySize passes (uses constant)
- [x] Full controller suite (244 tests pass)
- [x] Pre-commit: lint, vet, coverage (all changed files >= 80%), Helm validation
- [ ] CI pipeline