### PR TITLE
fix: restore tool call/result messages in demo handler

### DIFF
--- a/internal/agent/demo_handler.go
+++ b/internal/agent/demo_handler.go
@@ -205,21 +205,32 @@ func (h *DemoHandler) HandleMessage(
 	return err
 }
 
-// simulateToolCall wraps a simulated tool call with a tracing span.
-// It does not send tool call/result messages to the client — real agents
-// handle tool execution internally and only return text and media.
-func (h *DemoHandler) simulateToolCall(ctx context.Context, toolName string, delay time.Duration) {
+// simulateToolCall wraps a simulated tool call with a tracing span and sends
+// tool_call / tool_result messages to the client so E2E tests can verify the
+// full message flow.
+func (h *DemoHandler) simulateToolCall(
+	ctx context.Context,
+	writer facade.ResponseWriter,
+	toolName string,
+	call *facade.ToolCallInfo,
+	result *facade.ToolResultInfo,
+	delay time.Duration,
+) error {
 	var toolSpan trace.Span
 	if h.tracer != nil {
 		_, toolSpan = h.tracer.StartToolSpan(ctx, toolName, tracing.ToolSpanMeta{})
 		defer toolSpan.End()
 	}
 
+	if err := writer.WriteToolCall(call); err != nil {
+		return err
+	}
 	time.Sleep(delay)
 
 	if toolSpan != nil {
 		tracing.SetSuccess(toolSpan)
 	}
+	return writer.WriteToolResult(result)
 }
 
 func (h *DemoHandler) handlePasswordReset(ctx context.Context, _ string, writer facade.ResponseWriter) (string, error) {
@@ -239,8 +250,26 @@ func (h *DemoHandler) handlePasswordReset(ctx context.Context, _ string, writer 
 		time.Sleep(80 * time.Millisecond)
 	}
 
-	// Simulate tool call with tracing (span only, no client messages)
-	h.simulateToolCall(ctx, "lookup-user", 400*time.Millisecond)
+	// Simulate tool call with tracing and client messages
+	if err := h.simulateToolCall(ctx, writer, "lookup-user",
+		&facade.ToolCallInfo{
+			ID:   "call_001",
+			Name: "lookup-user",
+			Arguments: map[string]interface{}{
+				"email": "user@example.com",
+			},
+		},
+		&facade.ToolResultInfo{
+			ID: "call_001",
+			Result: map[string]interface{}{
+				"found": true,
+				"email": "user@example.com",
+			},
+		},
+		400*time.Millisecond,
+	); err != nil {
+		return "", err
+	}
 
 	// Final response
 	finalResponse := `
@@ -275,8 +304,28 @@ func (h *DemoHandler) handleWeatherQuery(ctx context.Context, _ string, writer f
 		time.Sleep(150 * time.Millisecond)
 	}
 
-	// Simulate tool call with tracing (span only, no client messages)
-	h.simulateToolCall(ctx, "weather", 500*time.Millisecond)
+	// Simulate tool call with tracing and client messages
+	if err := h.simulateToolCall(ctx, writer, "weather",
+		&facade.ToolCallInfo{
+			ID:   "call_002",
+			Name: "weather",
+			Arguments: map[string]interface{}{
+				"location": "Denver, CO",
+			},
+		},
+		&facade.ToolResultInfo{
+			ID: "call_002",
+			Result: map[string]interface{}{
+				"temperature": "72°F",
+				"condition":   "Sunny",
+				"humidity":    "45%",
+				"wind":        "5 mph NW",
+			},
+		},
+		500*time.Millisecond,
+	); err != nil {
+		return "", err
+	}
 
 	finalResponse := `
 

--- a/internal/agent/demo_handler_test.go
+++ b/internal/agent/demo_handler_test.go
@@ -86,12 +86,14 @@ func TestDemoHandler_HandleMessage_PasswordReset(t *testing.T) {
 		t.Error("HandleMessage() produced no chunks")
 	}
 
-	// Should NOT have tool calls or results (kept internal)
-	if len(writer.toolCalls) != 0 {
-		t.Errorf("HandleMessage() produced %d tool calls, want 0", len(writer.toolCalls))
+	// Should have tool call and result for lookup-user
+	if len(writer.toolCalls) != 1 {
+		t.Errorf("HandleMessage() produced %d tool calls, want 1", len(writer.toolCalls))
+	} else if writer.toolCalls[0].Name != "lookup-user" {
+		t.Errorf("HandleMessage() tool call name = %q, want %q", writer.toolCalls[0].Name, "lookup-user")
 	}
-	if len(writer.toolResults) != 0 {
-		t.Errorf("HandleMessage() produced %d tool results, want 0", len(writer.toolResults))
+	if len(writer.toolResults) != 1 {
+		t.Errorf("HandleMessage() produced %d tool results, want 1", len(writer.toolResults))
 	}
 
 	// Should have done message with instructions
@@ -116,12 +118,14 @@ func TestDemoHandler_HandleMessage_Weather(t *testing.T) {
 		t.Error("HandleMessage() produced no chunks")
 	}
 
-	// Should NOT have tool calls or results (kept internal)
-	if len(writer.toolCalls) != 0 {
-		t.Errorf("HandleMessage() produced %d tool calls, want 0", len(writer.toolCalls))
+	// Should have tool call and result for weather
+	if len(writer.toolCalls) != 1 {
+		t.Errorf("HandleMessage() produced %d tool calls, want 1", len(writer.toolCalls))
+	} else if writer.toolCalls[0].Name != "weather" {
+		t.Errorf("HandleMessage() tool call name = %q, want %q", writer.toolCalls[0].Name, "weather")
 	}
-	if len(writer.toolResults) != 0 {
-		t.Errorf("HandleMessage() produced %d tool results, want 0", len(writer.toolResults))
+	if len(writer.toolResults) != 1 {
+		t.Errorf("HandleMessage() produced %d tool results, want 1", len(writer.toolResults))
 	}
 
 	// Should have done message with weather info


### PR DESCRIPTION
## Summary

- The demo handler's `simulateToolCall` was refactored in 79ccbcd to only create tracing spans, removing the `WriteToolCall`/`WriteToolResult` messages to the client
- This broke the E2E `should handle tool calls via demo handler` test which expects `tool_call` and `tool_result` WebSocket messages
- Core E2E has been failing on main since March 2 due to this regression

## Changes

- Restore `simulateToolCall` to send `tool_call` and `tool_result` messages via the `ResponseWriter` (in addition to creating tracing spans)
- Update `handleWeatherQuery` and `handlePasswordReset` to pass tool call/result info to `simulateToolCall`
- Update unit tests to expect 1 tool call and 1 tool result for weather and password-reset flows

## Test plan

- [x] `go test ./internal/agent/... -count=1` — all demo handler tests pass
- [x] `golangci-lint run ./internal/agent/...` — 0 issues
- [x] Pre-commit hooks pass (coverage 80.6%)
- [ ] Core E2E should now pass the `should handle tool calls via demo handler` test