### PR TITLE
feat: per-agent Quality tab and default TTL for arena jobs

### DIFF
--- a/dashboard/src/app/agents/[name]/page.tsx
+++ b/dashboard/src/app/agents/[name]/page.tsx
@@ -3,10 +3,10 @@
 import { use, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, FileText, MessageSquare, Activity } from "lucide-react";
+import { ArrowLeft, FileText, MessageSquare, Activity, ShieldCheck } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Header } from "@/components/layout";
-import { StatusBadge, ScaleControl, AgentMetricsPanel, EventsPanel, EvalConfigPanel } from "@/components/agents";
+import { StatusBadge, ScaleControl, AgentMetricsPanel, EventsPanel, EvalConfigPanel, AgentQualityTab } from "@/components/agents";
 import { AgentConsole } from "@/components/console";
 import { LogViewer } from "@/components/logs";
 import { useDataService } from "@/lib/data";
@@ -130,6 +130,10 @@ export default function AgentDetailPage({ params }: Readonly<AgentDetailPageProp
             <TabsTrigger value="metrics" className="gap-1.5">
               <Activity className="h-4 w-4" />
               Metrics
+            </TabsTrigger>
+            <TabsTrigger value="quality" className="gap-1.5">
+              <ShieldCheck className="h-4 w-4" />
+              Quality
             </TabsTrigger>
             <TabsTrigger value="config">Configuration</TabsTrigger>
             <TabsTrigger value="events">Events</TabsTrigger>
@@ -388,6 +392,10 @@ export default function AgentDetailPage({ params }: Readonly<AgentDetailPageProp
               agentName={metadata.name}
               namespace={metadata.namespace || "default"}
             />
+          </TabsContent>
+
+          <TabsContent value="quality" className="mt-4">
+            <AgentQualityTab agentName={metadata.name} />
           </TabsContent>
 
           <TabsContent value="config" className="mt-4">

--- a/dashboard/src/components/agents/agent-quality-tab.test.tsx
+++ b/dashboard/src/components/agents/agent-quality-tab.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { AgentQualityTab } from "./agent-quality-tab";
+
+// Mock eval hooks
+const mockUseEvalSummary = vi.fn();
+vi.mock("@/hooks", () => ({
+  useEvalSummary: (...args: unknown[]) => mockUseEvalSummary(...args),
+}));
+
+// Mock quality components to isolate unit tests
+vi.mock("@/components/quality/assertion-type-breakdown", () => ({
+  AssertionTypeBreakdown: ({ filter }: { filter?: { agent?: string } }) => (
+    <div data-testid="assertion-breakdown" data-agent={filter?.agent} />
+  ),
+}));
+
+vi.mock("@/components/quality/pass-rate-trend-chart", () => ({
+  PassRateTrendChart: ({ filter, timeRange }: { filter?: { agent?: string }; timeRange?: string }) => (
+    <div data-testid="trend-chart" data-agent={filter?.agent} data-range={timeRange} />
+  ),
+}));
+
+vi.mock("@/components/quality/failing-sessions-table", () => ({
+  FailingSessionsTable: ({ agentName }: { agentName?: string }) => (
+    <div data-testid="failing-sessions" data-agent={agentName} />
+  ),
+}));
+
+function renderTab(agentName = "my-agent") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentQualityTab agentName={agentName} />
+    </QueryClientProvider>
+  );
+}
+
+describe("AgentQualityTab", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseEvalSummary.mockReturnValue({ data: [], isLoading: false });
+  });
+
+  it("renders summary cards", () => {
+    renderTab();
+    expect(screen.getByText("Active Evals")).toBeInTheDocument();
+    expect(screen.getByText("Avg Pass Rate")).toBeInTheDocument();
+    expect(screen.getByText("Passing")).toBeInTheDocument();
+    expect(screen.getByText("Failing")).toBeInTheDocument();
+  });
+
+  it("passes agent filter to child components", () => {
+    renderTab("test-agent");
+    expect(screen.getByTestId("assertion-breakdown")).toHaveAttribute("data-agent", "test-agent");
+    expect(screen.getByTestId("trend-chart")).toHaveAttribute("data-agent", "test-agent");
+    expect(screen.getByTestId("failing-sessions")).toHaveAttribute("data-agent", "test-agent");
+  });
+
+  it("passes agent filter to useEvalSummary", () => {
+    renderTab("test-agent");
+    expect(mockUseEvalSummary).toHaveBeenCalledWith({ agent: "test-agent" });
+  });
+
+  it("computes stats from summaries", () => {
+    mockUseEvalSummary.mockReturnValue({
+      data: [
+        { evalId: "a", passRate: 95, metricType: "gauge" },
+        { evalId: "b", passRate: 60, metricType: "gauge" },
+        { evalId: "c", passRate: 80, metricType: "gauge" },
+        { evalId: "d", passRate: 100, metricType: "counter" },
+      ],
+      isLoading: false,
+    });
+    renderTab();
+    // 4 total evals
+    expect(screen.getByText("4")).toBeInTheDocument();
+    // avg pass rate of gauges: (95+60+80)/3 = 78.3%
+    expect(screen.getByText("78.3%")).toBeInTheDocument();
+    // 1 passing (>=90) and 1 failing (<70) — both render "1"
+    const ones = screen.getAllByText("1");
+    expect(ones).toHaveLength(2);
+  });
+
+  it("shows loading skeletons", () => {
+    mockUseEvalSummary.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = renderTab();
+    // Should have skeleton elements for the 4 summary cards
+    const skeletons = container.querySelectorAll("[class*='skeleton' i], [data-slot='skeleton']");
+    expect(skeletons.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("changes time range on button click", () => {
+    renderTab();
+    // Default is 24h
+    expect(screen.getByTestId("trend-chart")).toHaveAttribute("data-range", "24h");
+    // Click 7d
+    fireEvent.click(screen.getByText("7d"));
+    expect(screen.getByTestId("trend-chart")).toHaveAttribute("data-range", "7d");
+  });
+
+  it("handles empty summaries gracefully", () => {
+    mockUseEvalSummary.mockReturnValue({ data: [], isLoading: false });
+    renderTab();
+    expect(screen.getByText("0.0%")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/agents/agent-quality-tab.tsx
+++ b/dashboard/src/components/agents/agent-quality-tab.tsx
@@ -1,0 +1,147 @@
+/**
+ * Per-agent quality tab showing eval metrics scoped to a single agent.
+ *
+ * Reuses the shared quality components (breakdown, trends, failing sessions)
+ * with an agent-scoped EvalFilter so only metrics for this agent are shown.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import { useState, useMemo } from "react";
+import { CheckCircle, XCircle, Activity, TrendingUp } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AssertionTypeBreakdown } from "@/components/quality/assertion-type-breakdown";
+import { PassRateTrendChart } from "@/components/quality/pass-rate-trend-chart";
+import { FailingSessionsTable } from "@/components/quality/failing-sessions-table";
+import { useEvalSummary, type EvalTrendRange } from "@/hooks";
+import type { EvalFilter } from "@/lib/prometheus-queries";
+
+const TIME_RANGES: { label: string; value: EvalTrendRange }[] = [
+  { label: "1h", value: "1h" },
+  { label: "6h", value: "6h" },
+  { label: "24h", value: "24h" },
+  { label: "7d", value: "7d" },
+  { label: "30d", value: "30d" },
+];
+
+interface AgentQualityTabProps {
+  agentName: string;
+}
+
+export function AgentQualityTab({ agentName }: Readonly<AgentQualityTabProps>) {
+  const [activeMetric, setActiveMetric] = useState<string>();
+  const [timeRange, setTimeRange] = useState<EvalTrendRange>("24h");
+
+  const filter: EvalFilter = useMemo(() => ({ agent: agentName }), [agentName]);
+  const { data: summaries, isLoading } = useEvalSummary(filter);
+
+  const stats = useMemo(() => {
+    if (!summaries || summaries.length === 0) {
+      return { total: 0, passing: 0, failing: 0, avgPassRate: 0 };
+    }
+    const gauges = summaries.filter((s) => s.metricType === "gauge");
+    const passing = gauges.filter((s) => s.passRate >= 90).length;
+    const failing = gauges.filter((s) => s.passRate < 70).length;
+    const avgPassRate =
+      gauges.length > 0
+        ? gauges.reduce((sum, s) => sum + s.passRate, 0) / gauges.length
+        : 0;
+    return { total: summaries.length, passing, failing, avgPassRate };
+  }, [summaries]);
+
+  return (
+    <div className="space-y-4">
+      {/* Summary cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <SummaryCard
+          title="Active Evals"
+          value={stats.total}
+          icon={<Activity className="h-4 w-4 text-muted-foreground" />}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          title="Avg Pass Rate"
+          value={`${stats.avgPassRate.toFixed(1)}%`}
+          icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          title="Passing"
+          value={stats.passing}
+          icon={<CheckCircle className="h-4 w-4 text-green-500" />}
+          isLoading={isLoading}
+        />
+        <SummaryCard
+          title="Failing"
+          value={stats.failing}
+          icon={<XCircle className="h-4 w-4 text-red-500" />}
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Time range selector + trend chart */}
+      <div className="flex items-center gap-2">
+        {TIME_RANGES.map((r) => (
+          <button
+            key={r.value}
+            onClick={() => setTimeRange(r.value)}
+            className={`px-3 py-1 text-sm rounded-md transition-colors ${
+              timeRange === r.value
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:bg-muted/80"
+            }`}
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+
+      <PassRateTrendChart timeRange={timeRange} filter={filter} height={300} />
+
+      {/* Metrics breakdown + failing sessions */}
+      <div className="grid md:grid-cols-2 gap-4">
+        <AssertionTypeBreakdown
+          activeMetric={activeMetric}
+          onSelectMetric={setActiveMetric}
+          filter={filter}
+        />
+        <FailingSessionsTable
+          evalType={activeMetric}
+          agentName={agentName}
+        />
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({
+  title,
+  value,
+  icon,
+  isLoading,
+}: Readonly<{
+  title: string;
+  value: string | number;
+  icon: React.ReactNode;
+  isLoading: boolean;
+}>) {
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+        <CardTitle className="text-sm font-medium">{title}</CardTitle>
+        {icon}
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <Skeleton className="h-7 w-16" />
+        ) : (
+          <div className="text-2xl font-bold">{value}</div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dashboard/src/components/agents/index.ts
+++ b/dashboard/src/components/agents/index.ts
@@ -7,3 +7,4 @@ export { ScaleControl } from "./scale-control";
 export { AgentMetricsPanel } from "./agent-metrics-panel";
 export { EventsPanel } from "./events-panel";
 export { EvalConfigPanel } from "./eval-config-panel";
+export { AgentQualityTab } from "./agent-quality-tab";

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -1124,9 +1124,12 @@ func (r *ArenaJobReconciler) createWorkerJob(ctx context.Context, arenaJob *omni
 		log.Info("setting worker ServiceAccountName for workload identity", "serviceAccount", saName)
 	}
 
-	// Set TTL if specified
+	// Set TTL for automatic cleanup after completion (default: 1 hour)
 	if arenaJob.Spec.TTLSecondsAfterFinished != nil {
 		job.Spec.TTLSecondsAfterFinished = arenaJob.Spec.TTLSecondsAfterFinished
+	} else {
+		defaultTTL := int32(3600)
+		job.Spec.TTLSecondsAfterFinished = &defaultTTL
 	}
 
 	// Set owner reference

--- a/ee/internal/controller/arenajob_controller_test.go
+++ b/ee/internal/controller/arenajob_controller_test.go
@@ -816,6 +816,113 @@ var _ = Describe("ArenaJob Controller", func() {
 		})
 	})
 
+	Context("When ArenaJob does not specify TTL", func() {
+		var (
+			arenaJob    *omniav1alpha1.ArenaJob
+			arenaSource *omniav1alpha1.ArenaSource
+		)
+
+		BeforeEach(func() {
+			By("creating the ArenaSource in Ready state")
+			arenaSource = &omniav1alpha1.ArenaSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-ttl-source",
+					Namespace: arenaJobNamespace,
+				},
+				Spec: omniav1alpha1.ArenaSourceSpec{
+					Type:     omniav1alpha1.ArenaSourceTypeConfigMap,
+					Interval: "5m",
+					ConfigMap: &omniav1alpha1.ConfigMapSource{
+						Name: "test-configmap",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaSource)).To(Succeed())
+
+			arenaSource.Status.Phase = omniav1alpha1.ArenaSourcePhaseReady
+			arenaSource.Status.Artifact = &omniav1alpha1.Artifact{
+				Revision:       "v1.0.0",
+				Checksum:       "sha256:abc123",
+				LastUpdateTime: metav1.Now(),
+			}
+			Expect(k8sClient.Status().Update(ctx, arenaSource)).To(Succeed())
+
+			By("creating the ArenaJob without TTL")
+			arenaJob = &omniav1alpha1.ArenaJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "default-ttl-job",
+					Namespace: arenaJobNamespace,
+				},
+				Spec: omniav1alpha1.ArenaJobSpec{
+					SourceRef: corev1alpha1.LocalObjectReference{
+						Name: "default-ttl-source",
+					},
+					Type: omniav1alpha1.ArenaJobTypeLoadTest,
+				},
+			}
+			Expect(k8sClient.Create(ctx, arenaJob)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			By("cleaning up resources")
+			job := &omniav1alpha1.ArenaJob{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "default-ttl-job",
+				Namespace: arenaJobNamespace,
+			}, job)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, job)).To(Succeed())
+			}
+
+			k8sJob := &batchv1.Job{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "default-ttl-job-worker",
+				Namespace: arenaJobNamespace,
+			}, k8sJob)
+			if err == nil {
+				propagation := metav1.DeletePropagationBackground
+				Expect(k8sClient.Delete(ctx, k8sJob, &client.DeleteOptions{
+					PropagationPolicy: &propagation,
+				})).To(Succeed())
+			}
+
+			source := &omniav1alpha1.ArenaSource{}
+			err = k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "default-ttl-source",
+				Namespace: arenaJobNamespace,
+			}, source)
+			if err == nil {
+				Expect(k8sClient.Delete(ctx, source)).To(Succeed())
+			}
+		})
+
+		It("should default to 1 hour TTL", func() {
+			By("reconciling the ArenaJob")
+			reconciler := &ArenaJobReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      "default-ttl-job",
+					Namespace: arenaJobNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the K8s Job has default TTL of 3600 seconds")
+			k8sJob := &batchv1.Job{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "default-ttl-job-worker",
+				Namespace: arenaJobNamespace,
+			}, k8sJob)).To(Succeed())
+
+			Expect(k8sJob.Spec.TTLSecondsAfterFinished).NotTo(BeNil())
+			Expect(*k8sJob.Spec.TTLSecondsAfterFinished).To(Equal(int32(3600)))
+		})
+	})
+
 	Context("When testing SetupWithManager", func() {
 		It("should return error with nil manager", func() {
 			reconciler := &ArenaJobReconciler{


### PR DESCRIPTION
## Summary

- **Per-agent Quality tab**: Adds a Quality tab to the agent detail page showing eval metrics scoped to a single agent. Reuses existing quality components (`AssertionTypeBreakdown`, `PassRateTrendChart`, `FailingSessionsTable`) with an agent-scoped `EvalFilter`. Includes summary cards (Active Evals, Avg Pass Rate, Passing, Failing) and a configurable time range selector.
- **Default ArenaJob TTL**: When `TTLSecondsAfterFinished` is not set on an ArenaJob, defaults to 3600s (1 hour) so completed K8s Jobs are automatically cleaned up instead of accumulating.

## Test plan

- [x] `AgentQualityTab` unit tests (7 tests) verify summary card rendering, agent filter propagation, stats computation, loading state, and time range switching
- [x] Ginkgo integration test verifies default 1-hour TTL when ArenaJob omits `TTLSecondsAfterFinished`
- [x] Existing TTL test still passes (explicit TTL=300s honored)
- [x] Dashboard typecheck and ESLint pass
- [x] All pre-commit hooks pass

Closes #520
