### PR TITLE
fix: improve Arena E2E debug output to capture worker pod logs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -164,7 +164,16 @@ jobs:
           kubectl logs -n omnia-system -l control-plane=controller-manager --tail=100 || true
           echo ""
           echo "=== Arena controller logs ==="
-          kubectl logs -n omnia-system -l control-plane=arena-controller-manager --tail=100 || true
+          kubectl logs -n omnia-system -l app.kubernetes.io/component=arena-controller --tail=100 || true
+          echo ""
+          echo "=== Events in test-arena ==="
+          kubectl get events -n test-arena --sort-by=.lastTimestamp | tail -30 || true
+          echo ""
+          echo "=== Worker pod logs ==="
+          for pod in $(kubectl get pods -n test-arena -l app.kubernetes.io/component=worker -o jsonpath='{.items[*].metadata.name}' 2>/dev/null); do
+            echo "--- $pod ---"
+            kubectl logs -n test-arena "$pod" --tail=30 || true
+          done
           echo ""
           echo "=== Redis logs ==="
           kubectl logs -n omnia-system omnia-redis-master-0 --tail=50 || true

--- a/test/e2e/arena_e2e_test.go
+++ b/test/e2e/arena_e2e_test.go
@@ -136,11 +136,21 @@ var _ = Describe("Arena Fleet", Ordered, Label("arena"), func() {
 		output, _ = utils.Run(cmd)
 		_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n%s\n", output)
 
-		// Get arena controller logs
+		// Get arena controller logs (use component label, not control-plane)
 		cmd = exec.Command("kubectl", "logs", "-n", namespace,
-			"-l", "control-plane=arena-controller-manager", "--tail=100")
+			"-l", "app.kubernetes.io/component=arena-controller", "--tail=100")
 		output, _ = utils.Run(cmd)
 		_, _ = fmt.Fprintf(GinkgoWriter, "Arena controller logs:\n%s\n", output)
+
+		// Get worker pod logs (from the arena test namespace)
+		cmd = exec.Command("kubectl", "get", "pods", "-n", arenaNamespace,
+			"-l", "app.kubernetes.io/component=worker", "-o", "jsonpath={.items[*].metadata.name}")
+		podNames, _ := utils.Run(cmd)
+		for _, podName := range strings.Fields(podNames) {
+			cmd = exec.Command("kubectl", "logs", "-n", arenaNamespace, podName, "--tail=50")
+			output, _ = utils.Run(cmd)
+			_, _ = fmt.Fprintf(GinkgoWriter, "Worker pod %s logs:\n%s\n", podName, output)
+		}
 	}
 
 	// After each test, check for failures and dump debug info


### PR DESCRIPTION
## Summary
- Fix arena controller label selector in debug dumps (`control-plane=arena-controller-manager` → `app.kubernetes.io/component=arena-controller`)
- Add worker pod log capture in test AfterEach debug dump
- Add test-arena namespace events to CI debug step
- Add worker pod log iteration to CI debug step

## Context
Arena E2E is failing on main (run 22924493508) with all worker pods in Error status. The debug output was missing:
1. Arena controller logs (wrong label selector returned "No resources found")
2. Worker pod logs (never captured)
3. Events from the test-arena namespace

This PR fixes the debug output so the next failure will show the actual worker error message.

## Test plan
- [ ] Arena E2E runs and debug output now captures worker pod logs on failure
- [ ] Arena controller logs appear in debug output