### PR TITLE
fix: resolve race condition and deadlock in client tool execution

### DIFF
--- a/internal/agent/echo_handler_test.go
+++ b/internal/agent/echo_handler_test.go
@@ -34,6 +34,10 @@ type mockResponseWriter struct {
 	mediaChunks []*facade.MediaChunkInfo
 	errors      []struct{ code, message string }
 	err         error
+
+	// toolCallCh is an optional channel that signals when a tool call is received.
+	// Tests that read toolCalls concurrently should use this for synchronization.
+	toolCallCh chan *facade.ToolCallInfo
 }
 
 func (m *mockResponseWriter) WriteChunk(content string) error {
@@ -73,6 +77,9 @@ func (m *mockResponseWriter) WriteToolCall(info *facade.ToolCallInfo) error {
 		return m.err
 	}
 	m.toolCalls = append(m.toolCalls, info)
+	if m.toolCallCh != nil {
+		m.toolCallCh <- info
+	}
 	return nil
 }
 

--- a/internal/agent/runtime_handler.go
+++ b/internal/agent/runtime_handler.go
@@ -204,8 +204,19 @@ func (h *RuntimeHandler) handleRecvResult(
 		return h.handleClientToolCall(ctx, stream, writer, result.resp, toolResultCh)
 	}
 
+	// Check if this is a Done message — the conversation turn is complete.
+	// Without this, both sides block on Recv() (deadlock): the runtime loops
+	// back to read the next client message while the facade waits for more
+	// server messages. The old code avoided this by calling CloseSend()
+	// before reading, but the client-tool flow needs the stream open.
+	_, isDone := result.resp.Message.(*runtimev1.ServerMessage_Done)
+
 	if err := h.forwardResponse(result.resp, writer); err != nil {
 		return fmt.Errorf("error forwarding response: %w", err)
+	}
+
+	if isDone {
+		return errStreamDone
 	}
 	return nil
 }
@@ -354,11 +365,14 @@ func (h *RuntimeHandler) forwardToolCall(tc *runtimev1.ToolCall, writer facade.R
 		Arguments: args,
 	}
 
-	// Add client tool fields
+	// Add client tool fields — copy Categories to avoid sharing the proto slice.
 	if tc.Execution == runtimev1.ToolExecution_TOOL_EXECUTION_CLIENT {
 		info.Execution = "client"
 		info.ConsentMessage = tc.ConsentMessage
-		info.Categories = tc.Categories
+		if len(tc.Categories) > 0 {
+			info.Categories = make([]string, len(tc.Categories))
+			copy(info.Categories, tc.Categories)
+		}
 	}
 
 	return writer.WriteToolCall(info)

--- a/internal/agent/runtime_handler_test.go
+++ b/internal/agent/runtime_handler_test.go
@@ -713,7 +713,8 @@ func TestRuntimeHandler_ClientToolCall(t *testing.T) {
 	t.Cleanup(func() { _ = client.Close() })
 
 	handler := NewRuntimeHandler(client)
-	writer := &mockResponseWriter{}
+	toolCallCh := make(chan *facade.ToolCallInfo, 1)
+	writer := &mockResponseWriter{toolCallCh: toolCallCh}
 	sessionID := "session-ct-1"
 
 	// Start HandleMessage in a goroutine — it will block waiting for the tool result
@@ -724,16 +725,20 @@ func TestRuntimeHandler_ClientToolCall(t *testing.T) {
 		}, writer)
 	}()
 
-	// Give the handler time to receive and forward the tool call
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the tool call to be forwarded to the writer
+	var tc *facade.ToolCallInfo
+	select {
+	case tc = <-toolCallCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for tool call")
+	}
 
-	// Verify the tool call was forwarded to the writer
-	require.Len(t, writer.toolCalls, 1)
-	assert.Equal(t, "ct-1", writer.toolCalls[0].ID)
-	assert.Equal(t, "get_location", writer.toolCalls[0].Name)
-	assert.Equal(t, "client", writer.toolCalls[0].Execution)
-	assert.Equal(t, "Allow location access?", writer.toolCalls[0].ConsentMessage)
-	assert.Equal(t, []string{"location"}, writer.toolCalls[0].Categories)
+	// Verify the tool call fields
+	assert.Equal(t, "ct-1", tc.ID)
+	assert.Equal(t, "get_location", tc.Name)
+	assert.Equal(t, "client", tc.Execution)
+	assert.Equal(t, "Allow location access?", tc.ConsentMessage)
+	assert.Equal(t, []string{"location"}, tc.Categories)
 
 	// Send tool result via the ClientToolRouter interface
 	routed := handler.SendToolResult(sessionID, &facade.ClientToolResultInfo{
@@ -784,7 +789,8 @@ func TestRuntimeHandler_ClientToolCall_Rejected(t *testing.T) {
 	t.Cleanup(func() { _ = client.Close() })
 
 	handler := NewRuntimeHandler(client)
-	writer := &mockResponseWriter{}
+	toolCallCh := make(chan *facade.ToolCallInfo, 1)
+	writer := &mockResponseWriter{toolCallCh: toolCallCh}
 	sessionID := "session-ct-2"
 
 	errCh := make(chan error, 1)
@@ -794,7 +800,12 @@ func TestRuntimeHandler_ClientToolCall_Rejected(t *testing.T) {
 		}, writer)
 	}()
 
-	time.Sleep(200 * time.Millisecond)
+	// Wait for the tool call to arrive
+	select {
+	case <-toolCallCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for tool call")
+	}
 
 	// Reject the tool call
 	routed := handler.SendToolResult(sessionID, &facade.ClientToolResultInfo{


### PR DESCRIPTION
## Summary
- Fix deadlock where facade and runtime both blocked on `Recv()` after a `Done` message — caused by deferring `CloseSend()` instead of closing on `Done`
- Fix data race in `TestRuntimeHandler_ClientToolCall` — replace `time.Sleep` with channel-based synchronization and copy proto slice to avoid shared memory

## Root Cause
PR #617 changed `CloseSend()` from being called immediately after sending to being deferred, which is needed for client tool flows but deadlocks normal conversations. The fix detects `ServerMessage_Done` and exits the receive loop.

## Test plan
- [x] `go test ./internal/agent/... -race` passes with no races
- [x] Pre-commit hooks pass (lint, vet, coverage 89.1%)
- [ ] CI + SonarCloud pass