### PR TITLE
feat: dashboard reads from first-class tables, remove dual-write

### DIFF
--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Session provider calls proxy route.
+ *
+ * GET /api/workspaces/{name}/sessions/{sessionId}/provider-calls
+ *   → SESSION_API_URL/api/v1/sessions/{sessionId}/provider-calls
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+
+const SESSION_API_URL = process.env.SESSION_API_URL;
+
+type Params = { name: string; sessionId: string };
+
+export const GET = withWorkspaceAccess<Params>(
+  "viewer",
+  async (
+    _request: NextRequest,
+    context: WorkspaceRouteContext<Params>,
+    _access: WorkspaceAccess,
+    _user: User
+  ): Promise<NextResponse> => {
+    const { sessionId } = await context.params;
+
+    if (!SESSION_API_URL) {
+      return NextResponse.json(
+        { error: "Session API not configured", providerCalls: [] },
+        { status: 503 }
+      );
+    }
+
+    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
+    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/provider-calls`;
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { Accept: "application/json" },
+      });
+
+      const data = await response.json();
+      return NextResponse.json(data, { status: response.status });
+    } catch (error) {
+      console.error("Session API proxy error:", error);
+      return NextResponse.json(
+        {
+          error: "Failed to connect to Session API",
+          details: error instanceof Error ? error.message : String(error),
+          providerCalls: [],
+        },
+        { status: 502 }
+      );
+    }
+  }
+);

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/route.ts
@@ -1,0 +1,56 @@
+/**
+ * Session tool calls proxy route.
+ *
+ * GET /api/workspaces/{name}/sessions/{sessionId}/tool-calls
+ *   → SESSION_API_URL/api/v1/sessions/{sessionId}/tool-calls
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+
+const SESSION_API_URL = process.env.SESSION_API_URL;
+
+type Params = { name: string; sessionId: string };
+
+export const GET = withWorkspaceAccess<Params>(
+  "viewer",
+  async (
+    _request: NextRequest,
+    context: WorkspaceRouteContext<Params>,
+    _access: WorkspaceAccess,
+    _user: User
+  ): Promise<NextResponse> => {
+    const { sessionId } = await context.params;
+
+    if (!SESSION_API_URL) {
+      return NextResponse.json(
+        { error: "Session API not configured", toolCalls: [] },
+        { status: 503 }
+      );
+    }
+
+    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
+    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/tool-calls`;
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { Accept: "application/json" },
+      });
+
+      const data = await response.json();
+      return NextResponse.json(data, { status: response.status });
+    } catch (error) {
+      console.error("Session API proxy error:", error);
+      return NextResponse.json(
+        {
+          error: "Failed to connect to Session API",
+          details: error instanceof Error ? error.message : String(error),
+          toolCalls: [],
+        },
+        { status: 502 }
+      );
+    }
+  }
+);

--- a/dashboard/src/app/sessions/[id]/page.test.tsx
+++ b/dashboard/src/app/sessions/[id]/page.test.tsx
@@ -12,6 +12,8 @@ import SessionDetailPage from "./page";
 vi.mock("@/hooks", () => ({
   useSessionDetail: vi.fn(),
   useSessionEvalResults: vi.fn(),
+  useSessionToolCalls: vi.fn(() => ({ data: [] })),
+  useSessionProviderCalls: vi.fn(() => ({ data: [] })),
   useSessionAllMessages: vi.fn(() => ({
     messages: [],
     totalLoaded: 0,
@@ -112,9 +114,19 @@ async function renderPage(id = "sess-123") {
 describe("SessionDetailPage", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
-    // Default mock for useSessionEvalResults to avoid errors in tests that don't set it
-    const { useSessionEvalResults } = await import("@/hooks");
+    // Default mocks to avoid errors in tests that don't set them
+    const { useSessionEvalResults, useSessionToolCalls, useSessionProviderCalls } = await import("@/hooks");
     vi.mocked(useSessionEvalResults).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useSessionToolCalls).mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useSessionProviderCalls).mockReturnValue({
       data: [],
       isLoading: false,
       error: null,
@@ -210,10 +222,26 @@ describe("SessionDetailPage", () => {
     expect(screen.getByText("Export JSON")).toBeInTheDocument();
   });
 
-  it("renders tool call card in assistant message", async () => {
-    const { useSessionDetail } = await import("@/hooks");
+  it("renders tool call indicator from first-class tool calls", async () => {
+    const { useSessionDetail, useSessionToolCalls } = await import("@/hooks");
     vi.mocked(useSessionDetail).mockReturnValue({
       data: mockSession,
+      isLoading: false,
+      error: null,
+    } as any);
+    vi.mocked(useSessionToolCalls).mockReturnValue({
+      data: [
+        {
+          id: "tc1",
+          callId: "call-1",
+          sessionId: "sess-123",
+          name: "search_docs",
+          arguments: { query: "help" },
+          status: "success" as const,
+          durationMs: 250,
+          createdAt: new Date(Date.now() - 59 * 60 * 1000).toISOString(),
+        },
+      ],
       isLoading: false,
       error: null,
     } as any);

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -42,8 +42,8 @@ import {
   XCircle,
   Shield,
 } from "lucide-react";
-import { useSessionDetail, useSessionAllMessages, useSessionEvalResults } from "@/hooks";
-import type { Message, Session, EvalResult } from "@/types";
+import { useSessionDetail, useSessionAllMessages, useSessionEvalResults, useSessionToolCalls, useSessionProviderCalls } from "@/hooks";
+import type { Message, Session, ToolCall, ProviderCall, EvalResult } from "@/types";
 import { EvalResultsBadge } from "@/components/sessions/eval-results-badge";
 import { ToolCallBadge } from "@/components/sessions/tool-call-badge";
 import { DebugPanel } from "@/components/sessions/debug-panel";
@@ -66,24 +66,9 @@ function getStatusBadge(status: Session["status"]) {
   return <Badge variant={variant}>{label}</Badge>;
 }
 
-/**
- * Parse a tool_call message's content to extract name and arguments.
- */
-function parseToolCallContent(content: string): { name: string; arguments: Record<string, unknown> } {
-  try {
-    const parsed = JSON.parse(content);
-    return { name: parsed.name || "unknown", arguments: parsed.arguments || {} };
-  } catch {
-    return { name: "unknown", arguments: {} };
-  }
-}
-
-function ToolCallMessage({ message }: Readonly<{ message: Message }>) {
+/** Inline tool call indicator rendered from a first-class ToolCall record. */
+function ToolCallIndicator({ toolCall }: Readonly<{ toolCall: ToolCall }>) {
   const openToolCall = useDebugPanelStore((s) => s.openToolCall);
-  const { name } = parseToolCallContent(message.content);
-  const durationStr = message.metadata?.duration_ms;
-  const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
-  const status = message.metadata?.status as "success" | "error" | undefined;
 
   return (
     <div className="flex gap-3">
@@ -92,12 +77,12 @@ function ToolCallMessage({ message }: Readonly<{ message: Message }>) {
       </div>
       <button
         className="flex items-center gap-2 border rounded-lg bg-muted/30 px-3 py-1.5 text-left hover:bg-muted/50 transition-colors"
-        onClick={() => message.toolCallId && openToolCall(message.toolCallId)}
+        onClick={() => openToolCall(toolCall.callId || toolCall.id)}
       >
-        <span className="font-mono text-sm font-medium truncate">{name}</span>
-        {status && <ToolCallBadge status={status} />}
-        {duration !== undefined && !Number.isNaN(duration) && (
-          <span className="text-xs text-muted-foreground">{duration}ms</span>
+        <span className="font-mono text-sm font-medium truncate">{toolCall.name}</span>
+        {toolCall.status && <ToolCallBadge status={toolCall.status} />}
+        {toolCall.durationMs !== undefined && (
+          <span className="text-xs text-muted-foreground">{toolCall.durationMs}ms</span>
         )}
         <span className="text-xs text-muted-foreground ml-auto shrink-0">View details &gt;</span>
       </button>
@@ -193,11 +178,6 @@ function MessageBubble({ message, showTimestamp, evalResults, inlineEvals }: Rea
   const isAssistant = message.role === "assistant";
   const isSystem = message.role === "system";
 
-  // Tool call messages get their own compact rendering
-  if (message.metadata?.type === "tool_call") {
-    return <ToolCallMessage message={message} />;
-  }
-
   return (
     <div className={cn("flex gap-3", isUser ? "flex-row-reverse" : "flex-row")}>
       <div
@@ -257,13 +237,11 @@ function isEvalMessage(m: Message): boolean {
 /**
  * Returns true if a message belongs in the conversation view.
  *
- * Conversation messages are: user/assistant messages without a metadata.type,
- * plus tool_call messages (rendered as compact indicators).
- * Everything else (pipeline events, eval events, provider calls, etc.) goes to the Debug panel.
+ * Conversation messages are: user/assistant messages without a metadata.type.
+ * Everything else (pipeline events, eval events, provider calls, tool events, etc.) goes to the Debug panel.
  */
 function isConversationMessage(m: Message): boolean {
   if (m.role === "tool") return false;
-  if (m.metadata?.type === "tool_call") return true;
   if (m.metadata?.type) return false;
   if (m.metadata?.source === "runtime") return false;
   return true;
@@ -325,15 +303,22 @@ const INITIAL_MESSAGE_WINDOW = 50;
  * Uses windowed rendering for the visible portion, plus server-side pagination
  * via "Load more" to fetch additional pages from the API.
  */
+/** A unified item for interleaving messages and tool calls by timestamp. */
+type ConversationItem =
+  | { kind: "message"; message: Message; id: string; timestamp: string }
+  | { kind: "toolCall"; toolCall: ToolCall; id: string; timestamp: string };
+
 function ConversationMessages({
   messages,
   evalResults,
+  toolCalls,
   hasMore,
   isFetchingMore,
   onLoadMore,
 }: Readonly<{
   messages: Message[];
   evalResults: EvalResult[];
+  toolCalls: ToolCall[];
   hasMore?: boolean;
   isFetchingMore?: boolean;
   onLoadMore?: () => void;
@@ -342,13 +327,19 @@ function ConversationMessages({
   const evalsByMessage = groupEvalResultsByMessageId(evalResults);
   const inlineEvalsByMessage = collectEvalsForAssistantMessages(messages);
 
-  const sorted = messages
-    .filter(isConversationMessage)
-    .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
+  // Merge messages and tool calls into a single timeline
+  const items: ConversationItem[] = [];
+  for (const m of messages.filter(isConversationMessage)) {
+    items.push({ kind: "message", message: m, id: m.id, timestamp: m.timestamp });
+  }
+  for (const tc of toolCalls) {
+    items.push({ kind: "toolCall", toolCall: tc, id: `tc-${tc.id}`, timestamp: tc.createdAt });
+  }
+  items.sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
-  const total = sorted.length;
+  const total = items.length;
   const startIndex = Math.max(0, total - visibleCount);
-  const visible = sorted.slice(startIndex);
+  const visible = items.slice(startIndex);
   const remaining = startIndex;
 
   return (
@@ -378,15 +369,19 @@ function ConversationMessages({
           </Button>
         </div>
       )}
-      {visible.map((message) => (
-        <MessageBubble
-          key={message.id}
-          message={message}
-          showTimestamp
-          evalResults={evalsByMessage.get(message.id)}
-          inlineEvals={inlineEvalsByMessage.get(message.id)}
-        />
-      ))}
+      {visible.map((item) =>
+        item.kind === "message" ? (
+          <MessageBubble
+            key={item.id}
+            message={item.message}
+            showTimestamp
+            evalResults={evalsByMessage.get(item.message.id)}
+            inlineEvals={inlineEvalsByMessage.get(item.message.id)}
+          />
+        ) : (
+          <ToolCallIndicator key={item.id} toolCall={item.toolCall} />
+        )
+      )}
     </div>
   );
 }
@@ -449,6 +444,8 @@ export default function SessionDetailPage({
   const defaultTab = searchParams.get("tab") ?? "conversation";
   const { data: session, isLoading, error } = useSessionDetail(id);
   const { data: evalResults } = useSessionEvalResults(id);
+  const { data: toolCalls } = useSessionToolCalls(id);
+  const { data: providerCalls } = useSessionProviderCalls(id);
   const grafana = useGrafana();
   const sessionDashboardUrl = grafana.enabled && session
     ? buildSessionDashboardUrl(grafana, id, session.agentName, session.agentNamespace)
@@ -521,24 +518,34 @@ export default function SessionDetailPage({
         "",
       ];
 
-      session.messages
-        .filter(isConversationMessage)
-        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
-        .forEach((msg) => {
-          if (msg.metadata?.type === "tool_call") {
-            const { name, arguments: args } = parseToolCallContent(msg.content);
+      // Interleave messages and tool calls for export
+      const exportItems: { timestamp: string; render: () => void }[] = [];
+      for (const msg of session.messages.filter(isConversationMessage)) {
+        exportItems.push({
+          timestamp: msg.timestamp,
+          render: () => {
+            const roleLabel = msg.role.charAt(0).toUpperCase() + msg.role.slice(1);
+            lines.push(`### ${roleLabel}`, "", msg.content, "");
+          },
+        });
+      }
+      for (const tc of toolCalls || []) {
+        exportItems.push({
+          timestamp: tc.createdAt,
+          render: () => {
             lines.push(
-              `**Tool Call:** \`${name}\``,
+              `**Tool Call:** \`${tc.name}\``,
               "```json",
-              JSON.stringify(args, null, 2),
+              JSON.stringify(tc.arguments, null, 2),
               "```",
               ""
             );
-          } else {
-            const roleLabel = msg.role.charAt(0).toUpperCase() + msg.role.slice(1);
-            lines.push(`### ${roleLabel}`, "", msg.content, "");
-          }
+          },
         });
+      }
+      exportItems
+        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+        .forEach((item) => item.render());
 
       content = lines.join("\n");
       filename = `session-${session.id}.md`;
@@ -641,7 +648,7 @@ export default function SessionDetailPage({
           </TabsList>
 
           <TabsContent value="conversation" className="flex-1 min-h-0 mt-4">
-            <ConversationWithDebugPanel session={session} evalResults={evalResults || []} />
+            <ConversationWithDebugPanel session={session} evalResults={evalResults || []} toolCalls={toolCalls || []} providerCalls={providerCalls || []} />
           </TabsContent>
 
           <TabsContent value="evals" className="mt-4">
@@ -1042,7 +1049,9 @@ function AggregatedEvalRow({ eval_ }: Readonly<{ eval_: AggregatedEval }>) {
 function ConversationWithDebugPanel({
   session,
   evalResults,
-}: Readonly<{ session: Session; evalResults: EvalResult[] }>) {
+  toolCalls,
+  providerCalls,
+}: Readonly<{ session: Session; evalResults: EvalResult[]; toolCalls: ToolCall[]; providerCalls: ProviderCall[] }>) {
   const debugOpen = useDebugPanelStore((s) => s.isOpen);
 
   // Use paginated message loading. Falls back to session.messages while loading.
@@ -1060,6 +1069,7 @@ function ConversationWithDebugPanel({
     <ConversationMessages
       messages={messages}
       evalResults={evalResults}
+      toolCalls={toolCalls}
       hasMore={hasMore}
       isFetchingMore={isFetchingMore}
       onLoadMore={fetchMore}
@@ -1074,7 +1084,7 @@ function ConversationWithDebugPanel({
             {conversationContent}
           </ScrollArea>
         </Card>
-        <DebugPanel messages={messages} session={session} />
+        <DebugPanel messages={messages} session={session} toolCalls={toolCalls} providerCalls={providerCalls} />
       </div>
     );
   }
@@ -1090,7 +1100,7 @@ function ConversationWithDebugPanel({
       </ResizablePanel>
       <ResizableHandle withHandle />
       <ResizablePanel defaultSize={30} minSize={15}>
-        <DebugPanel messages={messages} session={session} />
+        <DebugPanel messages={messages} session={session} toolCalls={toolCalls} providerCalls={providerCalls} />
       </ResizablePanel>
     </ResizablePanelGroup>
   );

--- a/dashboard/src/components/sessions/debug-panel.test.tsx
+++ b/dashboard/src/components/sessions/debug-panel.test.tsx
@@ -2,12 +2,25 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { DebugPanel } from "./debug-panel";
 import { useDebugPanelStore } from "@/stores/debug-panel-store";
-import type { Session, Message } from "@/types/session";
+import type { Session, Message, ToolCall } from "@/types/session";
 
 const mockMessages: Message[] = [
   { id: "m1", role: "user", content: "Hello", timestamp: "2024-01-01T00:00:01Z" },
   { id: "m2", role: "assistant", content: '{"name":"search","arguments":{"q":"test"}}', timestamp: "2024-01-01T00:00:02Z", metadata: { type: "tool_call", duration_ms: "100", status: "success" }, toolCallId: "tc1" },
   { id: "m3", role: "assistant", content: "Hi!", timestamp: "2024-01-01T00:00:03Z" },
+];
+
+const mockToolCalls: ToolCall[] = [
+  {
+    id: "tc1",
+    callId: "call-1",
+    sessionId: "s1",
+    name: "search",
+    arguments: { q: "test" },
+    status: "success",
+    durationMs: 100,
+    createdAt: "2024-01-01T00:00:02Z",
+  },
 ];
 
 const mockSession: Session = {
@@ -67,7 +80,7 @@ describe("DebugPanel", () => {
 
   it("shows tool calls tab content when selected", () => {
     useDebugPanelStore.setState({ isOpen: true, activeTab: "toolcalls" });
-    render(<DebugPanel messages={mockMessages} session={mockSession} />);
+    render(<DebugPanel messages={mockMessages} session={mockSession} toolCalls={mockToolCalls} />);
 
     expect(screen.getByTestId("toolcalls-tab")).toBeInTheDocument();
   });
@@ -97,7 +110,7 @@ describe("DebugPanel", () => {
 
   it("displays tool call count badge", () => {
     useDebugPanelStore.setState({ isOpen: true });
-    render(<DebugPanel messages={mockMessages} session={mockSession} />);
+    render(<DebugPanel messages={mockMessages} session={mockSession} toolCalls={mockToolCalls} />);
 
     expect(screen.getByText("1")).toBeInTheDocument();
   });

--- a/dashboard/src/components/sessions/debug-panel.tsx
+++ b/dashboard/src/components/sessions/debug-panel.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useMemo } from "react";
 import { useDebugPanelStore } from "@/stores/debug-panel-store";
 import { DebugPanelTabs } from "./debug-panel-tabs";
 import { TimelineTab } from "./timeline-tab";
@@ -9,23 +8,23 @@ import { RawTab } from "./raw-tab";
 import { Button } from "@/components/ui/button";
 import { ChevronUp, ChevronDown, X } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { Message, Session } from "@/types/session";
+import type { Message, Session, ToolCall, ProviderCall } from "@/types/session";
 
 interface DebugPanelProps {
   readonly messages: Message[];
   readonly session: Session;
+  readonly toolCalls?: ToolCall[];
+  readonly providerCalls?: ProviderCall[];
   readonly className?: string;
 }
 
-export function DebugPanel({ messages, session, className }: DebugPanelProps) {
+export function DebugPanel({ messages, session, toolCalls, providerCalls, className }: DebugPanelProps) {
   const isOpen = useDebugPanelStore((s) => s.isOpen);
   const activeTab = useDebugPanelStore((s) => s.activeTab);
   const toggle = useDebugPanelStore((s) => s.toggle);
   const close = useDebugPanelStore((s) => s.close);
 
-  const toolCallCount = useMemo(() => {
-    return messages.filter((m) => m.metadata?.type === "tool_call").length;
-  }, [messages]);
+  const toolCallCount = toolCalls?.length ?? 0;
 
   if (!isOpen) {
     return (
@@ -63,8 +62,8 @@ export function DebugPanel({ messages, session, className }: DebugPanelProps) {
         </div>
       </div>
       <div className="flex-1 min-h-0">
-        {activeTab === "timeline" && <TimelineTab messages={messages} />}
-        {activeTab === "toolcalls" && <ToolCallsTab messages={messages} />}
+        {activeTab === "timeline" && <TimelineTab messages={messages} toolCalls={toolCalls} providerCalls={providerCalls} />}
+        {activeTab === "toolcalls" && <ToolCallsTab toolCalls={toolCalls || []} />}
         {activeTab === "raw" && <RawTab session={session} />}
       </div>
     </div>

--- a/dashboard/src/components/sessions/timeline-tab.tsx
+++ b/dashboard/src/components/sessions/timeline-tab.tsx
@@ -22,10 +22,12 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { Message } from "@/types/session";
+import type { Message, ToolCall, ProviderCall } from "@/types/session";
 
 interface TimelineTabProps {
   readonly messages: Message[];
+  readonly toolCalls?: ToolCall[];
+  readonly providerCalls?: ProviderCall[];
 }
 
 const KIND_CONFIG: Record<TimelineEventKind, {
@@ -362,9 +364,9 @@ function EvalGroupSection({ group, openToolCall }: {
   );
 }
 
-export function TimelineTab({ messages }: TimelineTabProps) {
+export function TimelineTab({ messages, toolCalls, providerCalls }: TimelineTabProps) {
   const openToolCall = useDebugPanelStore((s) => s.openToolCall);
-  const events = extractTimelineEvents(messages);
+  const events = extractTimelineEvents(messages, toolCalls, providerCalls);
 
   if (events.length === 0) {
     return (

--- a/dashboard/src/components/sessions/toolcalls-tab.test.tsx
+++ b/dashboard/src/components/sessions/toolcalls-tab.test.tsx
@@ -2,16 +2,15 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { ToolCallsTab } from "./toolcalls-tab";
 import { useDebugPanelStore } from "@/stores/debug-panel-store";
-import type { Message } from "@/types/session";
+import type { ToolCall } from "@/types/session";
 
-function makeToolCallMessage(id: string, toolCallId: string, name: string, args: Record<string, unknown>, meta?: Record<string, string>): Message {
+function makeToolCall(overrides: Partial<ToolCall> & { id: string; callId: string; name: string }): ToolCall {
   return {
-    id,
-    role: "assistant",
-    content: JSON.stringify({ name, arguments: args }),
-    timestamp: "2024-01-01T00:00:01Z",
-    metadata: { type: "tool_call", ...meta },
-    toolCallId,
+    sessionId: "sess-1",
+    arguments: {},
+    status: "pending",
+    createdAt: "2024-01-01T00:00:01Z",
+    ...overrides,
   };
 }
 
@@ -26,25 +25,17 @@ describe("ToolCallsTab", () => {
   });
 
   it("renders empty state when no tool calls", () => {
-    render(<ToolCallsTab messages={[]} />);
+    render(<ToolCallsTab toolCalls={[]} />);
     expect(screen.getByText("No tool calls in this session")).toBeInTheDocument();
   });
 
-  it("renders empty state when messages have no tool calls", () => {
-    const messages: Message[] = [
-      { id: "m1", role: "user", content: "Hi", timestamp: "2024-01-01T00:00:00Z" },
-    ];
-    render(<ToolCallsTab messages={messages} />);
-    expect(screen.getByTestId("toolcalls-empty")).toBeInTheDocument();
-  });
-
-  it("renders list of tool calls from tool_call messages", () => {
-    const messages: Message[] = [
-      makeToolCallMessage("m1", "tc1", "search", { q: "cats" }, { duration_ms: "150", status: "success" }),
-      makeToolCallMessage("m2", "tc2", "fetch", { url: "example.com" }, { status: "error" }),
+  it("renders list of tool calls", () => {
+    const toolCalls: ToolCall[] = [
+      makeToolCall({ id: "tc1", callId: "call-1", name: "search", durationMs: 150, status: "success" }),
+      makeToolCall({ id: "tc2", callId: "call-2", name: "fetch", status: "error" }),
     ];
 
-    render(<ToolCallsTab messages={messages} />);
+    render(<ToolCallsTab toolCalls={toolCalls} />);
 
     expect(screen.getByText("search")).toBeInTheDocument();
     expect(screen.getByText("fetch")).toBeInTheDocument();
@@ -52,33 +43,31 @@ describe("ToolCallsTab", () => {
   });
 
   it("selects tool call on click and shows details", () => {
-    const messages: Message[] = [
-      makeToolCallMessage("m1", "tc1", "search", { q: "cats", limit: 10 }),
+    const toolCalls: ToolCall[] = [
+      makeToolCall({ id: "tc1", callId: "call-1", name: "search", arguments: { q: "cats", limit: 10 } }),
     ];
 
-    render(<ToolCallsTab messages={messages} />);
+    render(<ToolCallsTab toolCalls={toolCalls} />);
 
-    fireEvent.click(screen.getByTestId("toolcall-item-tc1"));
+    fireEvent.click(screen.getByTestId("toolcall-item-call-1"));
 
-    expect(useDebugPanelStore.getState().selectedToolCallId).toBe("tc1");
+    expect(useDebugPanelStore.getState().selectedToolCallId).toBe("call-1");
 
-    // Detail pane should show arguments in collapsible JSON viewer
     expect(screen.getByText("Arguments")).toBeInTheDocument();
     expect(screen.getByTestId("json-block")).toBeInTheDocument();
   });
 
   it("renders arguments in collapsible JSON viewer", () => {
-    useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
+    useDebugPanelStore.setState({ selectedToolCallId: "call-1" });
 
-    const messages: Message[] = [
-      makeToolCallMessage("m1", "tc1", "cmd", { path: "/tmp", recursive: true }),
+    const toolCalls: ToolCall[] = [
+      makeToolCall({ id: "tc1", callId: "call-1", name: "cmd", arguments: { path: "/tmp", recursive: true } }),
     ];
 
-    render(<ToolCallsTab messages={messages} />);
+    render(<ToolCallsTab toolCalls={toolCalls} />);
 
     const jsonBlock = screen.getByTestId("json-block");
     expect(jsonBlock).toBeInTheDocument();
-    // Values are rendered with syntax highlighting in separate elements
     expect(jsonBlock.textContent).toContain("path");
     expect(jsonBlock.textContent).toContain("/tmp");
     expect(jsonBlock.textContent).toContain("recursive");
@@ -86,52 +75,58 @@ describe("ToolCallsTab", () => {
   });
 
   it("renders nested arguments as JSON", () => {
-    useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
+    useDebugPanelStore.setState({ selectedToolCallId: "call-1" });
 
-    const messages: Message[] = [
-      makeToolCallMessage("m1", "tc1", "cmd", { nested: { a: 1 } }),
+    const toolCalls: ToolCall[] = [
+      makeToolCall({ id: "tc1", callId: "call-1", name: "cmd", arguments: { nested: { a: 1 } } }),
     ];
 
-    render(<ToolCallsTab messages={messages} />);
+    render(<ToolCallsTab toolCalls={toolCalls} />);
 
     expect(screen.getByTestId("json-block")).toBeInTheDocument();
   });
 
   it("shows no selection message when nothing is selected", () => {
-    const messages: Message[] = [
-      makeToolCallMessage("m1", "tc1", "cmd", {}),
+    const toolCalls: ToolCall[] = [
+      makeToolCall({ id: "tc1", callId: "call-1", name: "cmd" }),
     ];
 
-    render(<ToolCallsTab messages={messages} />);
+    render(<ToolCallsTab toolCalls={toolCalls} />);
     expect(screen.getByText("Select a tool call to view details")).toBeInTheDocument();
   });
 
-  it("displays registry metadata when present", () => {
-    useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
+  it("displays registry metadata from labels when present", () => {
+    useDebugPanelStore.setState({ selectedToolCallId: "call-1" });
 
-    const messages: Message[] = [
-      makeToolCallMessage("m1", "tc1", "search", { q: "test" }, {
-        handler_name: "mcp-handler",
-        handler_type: "mcp",
-        registry_name: "my-tools",
+    const toolCalls: ToolCall[] = [
+      makeToolCall({
+        id: "tc1",
+        callId: "call-1",
+        name: "search",
+        arguments: { q: "test" },
+        labels: {
+          handler_name: "mcp-handler",
+          handler_type: "mcp",
+          registry_name: "my-tools",
+        },
       }),
     ];
 
-    render(<ToolCallsTab messages={messages} />);
+    render(<ToolCallsTab toolCalls={toolCalls} />);
 
     expect(screen.getByTestId("toolcall-registry-info")).toBeInTheDocument();
     expect(screen.getByText("mcp-handler (mcp)")).toBeInTheDocument();
     expect(screen.getByText("my-tools")).toBeInTheDocument();
   });
 
-  it("hides registry info when metadata is absent", () => {
-    useDebugPanelStore.setState({ selectedToolCallId: "tc1" });
+  it("hides registry info when labels are absent", () => {
+    useDebugPanelStore.setState({ selectedToolCallId: "call-1" });
 
-    const messages: Message[] = [
-      makeToolCallMessage("m1", "tc1", "search", { q: "test" }),
+    const toolCalls: ToolCall[] = [
+      makeToolCall({ id: "tc1", callId: "call-1", name: "search", arguments: { q: "test" } }),
     ];
 
-    render(<ToolCallsTab messages={messages} />);
+    render(<ToolCallsTab toolCalls={toolCalls} />);
 
     expect(screen.queryByTestId("toolcall-registry-info")).not.toBeInTheDocument();
   });

--- a/dashboard/src/components/sessions/toolcalls-tab.tsx
+++ b/dashboard/src/components/sessions/toolcalls-tab.tsx
@@ -1,32 +1,15 @@
 "use client";
 
-import { useMemo } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useDebugPanelStore } from "@/stores/debug-panel-store";
 import { ToolCallBadge } from "./tool-call-badge";
 import { JsonBlock } from "@/components/ui/json-block";
 import { Wrench } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { Message } from "@/types/session";
-
-/**
- * Extracted tool call info from a tool_call message, paired with its result.
- */
-interface ExtractedToolCall {
-  id: string;
-  name: string;
-  arguments: Record<string, unknown>;
-  result?: string;
-  resultIsError?: boolean;
-  status?: "success" | "error" | "pending";
-  duration?: number;
-  handlerName?: string;
-  handlerType?: string;
-  registryName?: string;
-}
+import type { ToolCall } from "@/types/session";
 
 interface ToolCallsTabProps {
-  readonly messages: Message[];
+  readonly toolCalls: ToolCall[];
 }
 
 function RenderValue({ value }: Readonly<{ value: unknown }>) {
@@ -41,66 +24,11 @@ function tryParseJSON(text: string): unknown {
   }
 }
 
-/**
- * Extract tool call data from a tool_call message.
- */
-function extractToolCall(msg: Message): ExtractedToolCall {
-  let name = "unknown";
-  let args: Record<string, unknown> = {};
-  try {
-    const parsed = JSON.parse(msg.content);
-    name = parsed.name || name;
-    args = parsed.arguments || args;
-  } catch {
-    // Content is not valid JSON
-  }
-
-  const durationStr = msg.metadata?.duration_ms;
-  const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
-
-  return {
-    id: msg.toolCallId || msg.id,
-    name,
-    arguments: args,
-    status: (msg.metadata?.status as ExtractedToolCall["status"]) || undefined,
-    duration: duration && !Number.isNaN(duration) ? duration : undefined,
-    handlerName: msg.metadata?.handler_name || undefined,
-    handlerType: msg.metadata?.handler_type || undefined,
-    registryName: msg.metadata?.registry_name || undefined,
-  };
-}
-
-export function ToolCallsTab({ messages }: ToolCallsTabProps) {
+export function ToolCallsTab({ toolCalls }: ToolCallsTabProps) {
   const selectedToolCallId = useDebugPanelStore((s) => s.selectedToolCallId);
   const selectToolCall = useDebugPanelStore((s) => s.selectToolCall);
 
-  const toolCalls = useMemo(() => {
-    // Build a map of toolCallId → result content from tool_result messages.
-    const resultsByCallId = new Map<string, { content: string; isError: boolean }>();
-    for (const m of messages) {
-      const mType = m.metadata?.type;
-      if ((mType === "tool_result" || mType === "tool_call_completed" || m.role === "tool") && m.toolCallId) {
-        resultsByCallId.set(m.toolCallId, {
-          content: m.content,
-          isError: m.metadata?.is_error === "true" || m.metadata?.status === "error",
-        });
-      }
-    }
-
-    return messages
-      .filter((m) => m.metadata?.type === "tool_call")
-      .map((m) => {
-        const tc = extractToolCall(m);
-        const result = resultsByCallId.get(tc.id);
-        if (result) {
-          tc.result = result.content;
-          tc.resultIsError = result.isError;
-        }
-        return tc;
-      });
-  }, [messages]);
-
-  const selectedTc = toolCalls.find((tc) => tc.id === selectedToolCallId);
+  const selectedTc = toolCalls.find((tc) => tc.callId === selectedToolCallId || tc.id === selectedToolCallId);
 
   if (toolCalls.length === 0) {
     return (
@@ -119,20 +47,20 @@ export function ToolCallsTab({ messages }: ToolCallsTabProps) {
             <button
               key={tc.id}
               type="button"
-              onClick={() => selectToolCall(tc.id)}
+              onClick={() => selectToolCall(tc.callId || tc.id)}
               className={cn(
                 "flex items-center gap-2 w-full text-left px-3 py-2 rounded text-sm transition-colors",
                 "hover:bg-muted/50",
-                selectedToolCallId === tc.id && "bg-muted"
+                (selectedToolCallId === tc.callId || selectedToolCallId === tc.id) && "bg-muted"
               )}
-              data-testid={`toolcall-item-${tc.id}`}
+              data-testid={`toolcall-item-${tc.callId || tc.id}`}
             >
               <Wrench className="h-3.5 w-3.5 text-orange-500 shrink-0" />
               <span className="font-mono truncate flex-1">{tc.name}</span>
               <span className="flex items-center gap-1 shrink-0">
                 {tc.status && <ToolCallBadge status={tc.status} />}
-                {tc.duration !== undefined && (
-                  <span className="text-xs text-muted-foreground">{tc.duration}ms</span>
+                {tc.durationMs !== undefined && (
+                  <span className="text-xs text-muted-foreground">{tc.durationMs}ms</span>
                 )}
               </span>
             </button>
@@ -144,18 +72,18 @@ export function ToolCallsTab({ messages }: ToolCallsTabProps) {
       <div className="flex-1 flex flex-col min-h-0">
         {selectedTc ? (
           <div className="flex flex-col h-full p-4 gap-4" data-testid="toolcall-detail">
-            {(selectedTc.handlerType || selectedTc.registryName) && (
+            {(selectedTc.labels?.handler_type || selectedTc.labels?.registry_name) && (
               <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 text-sm shrink-0" data-testid="toolcall-registry-info">
-                {selectedTc.handlerType && (
+                {selectedTc.labels?.handler_type && (
                   <div className="contents">
                     <span className="font-medium text-muted-foreground">Handler</span>
-                    <span className="font-mono">{selectedTc.handlerName} ({selectedTc.handlerType})</span>
+                    <span className="font-mono">{selectedTc.labels.handler_name} ({selectedTc.labels.handler_type})</span>
                   </div>
                 )}
-                {selectedTc.registryName && (
+                {selectedTc.labels?.registry_name && (
                   <div className="contents">
                     <span className="font-medium text-muted-foreground">Registry</span>
-                    <span className="font-mono">{selectedTc.registryName}</span>
+                    <span className="font-mono">{selectedTc.labels.registry_name}</span>
                   </div>
                 )}
               </div>
@@ -171,12 +99,20 @@ export function ToolCallsTab({ messages }: ToolCallsTabProps) {
                 <div className="min-w-0 flex flex-col">
                   <h4 className={cn(
                     "text-sm font-medium mb-2 shrink-0",
-                    selectedTc.resultIsError ? "text-destructive" : "text-muted-foreground"
+                    selectedTc.errorMessage ? "text-destructive" : "text-muted-foreground"
                   )}>
-                    {selectedTc.resultIsError ? "Error" : "Result"}
+                    {selectedTc.errorMessage ? "Error" : "Result"}
                   </h4>
                   <div className="flex-1 min-h-0 overflow-auto rounded border bg-white dark:bg-zinc-950">
-                    <RenderValue value={tryParseJSON(selectedTc.result)} />
+                    <RenderValue value={typeof selectedTc.result === "string" ? tryParseJSON(selectedTc.result) : selectedTc.result} />
+                  </div>
+                </div>
+              )}
+              {!selectedTc.result && selectedTc.errorMessage && (
+                <div className="min-w-0 flex flex-col">
+                  <h4 className="text-sm font-medium mb-2 shrink-0 text-destructive">Error</h4>
+                  <div className="flex-1 min-h-0 overflow-auto rounded border bg-white dark:bg-zinc-950">
+                    <RenderValue value={selectedTc.errorMessage} />
                   </div>
                 </div>
               )}

--- a/dashboard/src/hooks/index.ts
+++ b/dashboard/src/hooks/index.ts
@@ -86,7 +86,7 @@ export { useProviderPreview } from "./use-provider-preview";
 export { useToolRegistryPreview } from "./use-tool-registry-preview";
 export type { ProviderPreviewResult } from "./use-provider-preview";
 export type { ToolRegistryPreviewResult } from "./use-tool-registry-preview";
-export { useSessions, useSessionDetail, useSessionSearch, useSessionMessages, useSessionAllMessages, useSessionEvalResults } from "./use-sessions";
+export { useSessions, useSessionDetail, useSessionSearch, useSessionMessages, useSessionAllMessages, useSessionToolCalls, useSessionProviderCalls, useSessionEvalResults } from "./use-sessions";
 export { useEvalSummary } from "./use-eval-quality";
 export type { EvalScoreSummary } from "./use-eval-quality";
 export { useEvalScoreTrends, useEvalMetrics, EVAL_TREND_RANGES } from "./use-eval-trends";

--- a/dashboard/src/hooks/use-sessions.test.ts
+++ b/dashboard/src/hooks/use-sessions.test.ts
@@ -9,8 +9,12 @@ const mockGetSessionById = vi.fn();
 const mockSearchSessions = vi.fn();
 const mockGetSessionMessages = vi.fn();
 
-const { mockGetSessionEvalResults } = vi.hoisted(() => {
-  return { mockGetSessionEvalResults: vi.fn() };
+const { mockGetSessionEvalResults, mockGetToolCalls, mockGetProviderCalls } = vi.hoisted(() => {
+  return {
+    mockGetSessionEvalResults: vi.fn(),
+    mockGetToolCalls: vi.fn(),
+    mockGetProviderCalls: vi.fn(),
+  };
 });
 
 vi.mock("@/lib/data", () => ({
@@ -32,11 +36,13 @@ vi.mock("@/contexts/workspace-context", () => ({
 vi.mock("@/lib/data/session-api-service", () => ({
   SessionApiService: class MockSessionApiService {
     getSessionEvalResults = mockGetSessionEvalResults;
+    getToolCalls = mockGetToolCalls;
+    getProviderCalls = mockGetProviderCalls;
   },
 }));
 
 // Import after mocks
-import { useSessions, useSessionDetail, useSessionSearch, useSessionMessages, useSessionAllMessages, useSessionEvalResults } from "./use-sessions";
+import { useSessions, useSessionDetail, useSessionSearch, useSessionMessages, useSessionAllMessages, useSessionToolCalls, useSessionProviderCalls, useSessionEvalResults } from "./use-sessions";
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -258,6 +264,60 @@ describe("useSessionEvalResults", () => {
 
   it("is disabled when sessionId is empty", () => {
     const { result } = renderHook(() => useSessionEvalResults(""), { wrapper: createWrapper() });
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+describe("useSessionToolCalls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetToolCalls.mockResolvedValue([
+      { id: "tc1", callId: "call-1", sessionId: "s1", name: "search", status: "success", createdAt: "2024-01-01T00:00:00Z" },
+    ]);
+  });
+
+  it("fetches tool calls for a session", async () => {
+    const { result } = renderHook(() => useSessionToolCalls("s1"), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(mockGetToolCalls).toHaveBeenCalledWith("test-workspace", "s1");
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].name).toBe("search");
+  });
+
+  it("is disabled when sessionId is empty", () => {
+    const { result } = renderHook(() => useSessionToolCalls(""), { wrapper: createWrapper() });
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+});
+
+describe("useSessionProviderCalls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProviderCalls.mockResolvedValue([
+      { id: "pc1", sessionId: "s1", provider: "claude", model: "sonnet", status: "completed", createdAt: "2024-01-01T00:00:00Z" },
+    ]);
+  });
+
+  it("fetches provider calls for a session", async () => {
+    const { result } = renderHook(() => useSessionProviderCalls("s1"), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isPending).toBe(false);
+    });
+
+    expect(result.current.isSuccess).toBe(true);
+    expect(mockGetProviderCalls).toHaveBeenCalledWith("test-workspace", "s1");
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data![0].provider).toBe("claude");
+  });
+
+  it("is disabled when sessionId is empty", () => {
+    const { result } = renderHook(() => useSessionProviderCalls(""), { wrapper: createWrapper() });
     expect(result.current.fetchStatus).toBe("idle");
   });
 });

--- a/dashboard/src/hooks/use-sessions.ts
+++ b/dashboard/src/hooks/use-sessions.ts
@@ -10,6 +10,8 @@ import type {
   SessionSearchOptions,
   SessionMessageOptions,
   Message,
+  ToolCall,
+  ProviderCall,
 } from "@/types/session";
 
 /**
@@ -190,6 +192,42 @@ export function useSessionAllMessages(sessionId: string, enabled = true) {
     fetchMore: query.fetchNextPage,
     error: query.error,
   };
+}
+
+/**
+ * Fetch tool calls for a session from the first-class tool_calls table.
+ */
+export function useSessionToolCalls(sessionId: string) {
+  const { currentWorkspace } = useWorkspace();
+
+  return useQuery({
+    queryKey: ["session-tool-calls", currentWorkspace?.name, sessionId],
+    queryFn: async (): Promise<ToolCall[]> => {
+      if (!currentWorkspace) return [];
+      const service = new SessionApiService();
+      return service.getToolCalls(currentWorkspace.name, sessionId);
+    },
+    enabled: !!currentWorkspace && !!sessionId,
+    staleTime: 10000,
+  });
+}
+
+/**
+ * Fetch provider calls for a session from the first-class provider_calls table.
+ */
+export function useSessionProviderCalls(sessionId: string) {
+  const { currentWorkspace } = useWorkspace();
+
+  return useQuery({
+    queryKey: ["session-provider-calls", currentWorkspace?.name, sessionId],
+    queryFn: async (): Promise<ProviderCall[]> => {
+      if (!currentWorkspace) return [];
+      const service = new SessionApiService();
+      return service.getProviderCalls(currentWorkspace.name, sessionId);
+    },
+    enabled: !!currentWorkspace && !!sessionId,
+    staleTime: 10000,
+  });
 }
 
 /**

--- a/dashboard/src/lib/data/session-api-service.ts
+++ b/dashboard/src/lib/data/session-api-service.ts
@@ -14,6 +14,8 @@ import type {
   Session,
   SessionSummary,
   Message,
+  ToolCall,
+  ProviderCall,
   SessionListOptions,
   SessionSearchOptions,
   SessionMessageOptions,
@@ -259,6 +261,40 @@ export class SessionApiService {
       messages: transformMessages(data.messages || []),
       hasMore: data.hasMore || false,
     };
+  }
+
+  async getToolCalls(
+    workspace: string,
+    sessionId: string
+  ): Promise<ToolCall[]> {
+    const response = await fetch(
+      `${SESSION_API_BASE}/${encodeURIComponent(workspace)}/sessions/${encodeURIComponent(sessionId)}/tool-calls`
+    );
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403 || response.status === 404) {
+        return [];
+      }
+      throw new Error(`Failed to fetch tool calls: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data || [];
+  }
+
+  async getProviderCalls(
+    workspace: string,
+    sessionId: string
+  ): Promise<ProviderCall[]> {
+    const response = await fetch(
+      `${SESSION_API_BASE}/${encodeURIComponent(workspace)}/sessions/${encodeURIComponent(sessionId)}/provider-calls`
+    );
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403 || response.status === 404) {
+        return [];
+      }
+      throw new Error(`Failed to fetch provider calls: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return data || [];
   }
 
   async getSessionEvalResults(

--- a/dashboard/src/lib/sessions/timeline.test.ts
+++ b/dashboard/src/lib/sessions/timeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { extractTimelineEvents } from "./timeline";
-import type { Message } from "@/types/session";
+import { extractTimelineEvents, toolCallsToTimelineEvents, providerCallsToTimelineEvents } from "./timeline";
+import type { Message, ToolCall, ProviderCall } from "@/types/session";
 
 function makeMessage(overrides: Partial<Message> & { id: string }): Message {
   return {
@@ -293,5 +293,122 @@ describe("extractTimelineEvents", () => {
       "tool_call",
       "assistant_message",
     ]);
+  });
+
+  it("merges first-class tool calls into timeline", () => {
+    const messages: Message[] = [
+      makeMessage({ id: "m1", role: "user", content: "Hi", timestamp: "2024-01-01T00:00:00Z" }),
+      makeMessage({ id: "m2", role: "assistant", content: "Hello!", timestamp: "2024-01-01T00:00:03Z" }),
+    ];
+    const toolCalls: ToolCall[] = [
+      {
+        id: "tc1", callId: "call-1", sessionId: "s1", name: "search",
+        arguments: { q: "test" }, status: "success", durationMs: 100,
+        createdAt: "2024-01-01T00:00:01Z",
+      },
+    ];
+
+    const events = extractTimelineEvents(messages, toolCalls);
+
+    expect(events).toHaveLength(3);
+    expect(events[1].kind).toBe("tool_call");
+    expect(events[1].label).toBe("Tool: search");
+    expect(events[1].status).toBe("success");
+  });
+
+  it("merges first-class provider calls into timeline", () => {
+    const messages: Message[] = [
+      makeMessage({ id: "m1", role: "user", content: "Hi", timestamp: "2024-01-01T00:00:00Z" }),
+    ];
+    const providerCalls: ProviderCall[] = [
+      {
+        id: "pc1", sessionId: "s1", provider: "claude", model: "sonnet",
+        status: "completed", durationMs: 500, createdAt: "2024-01-01T00:00:01Z",
+      },
+    ];
+
+    const events = extractTimelineEvents(messages, undefined, providerCalls);
+
+    expect(events).toHaveLength(2);
+    expect(events[1].kind).toBe("provider_call");
+    expect(events[1].label).toBe("Provider: claude/sonnet");
+    expect(events[1].status).toBe("success");
+  });
+
+  it("skips message-based tool events when first-class records provided", () => {
+    const messages: Message[] = [
+      makeMessage({ id: "m1", role: "user", content: "Hi", timestamp: "2024-01-01T00:00:00Z" }),
+      {
+        id: "m2", role: "assistant",
+        content: '{"name":"search","arguments":{}}',
+        timestamp: "2024-01-01T00:00:01Z",
+        metadata: { type: "tool_call" }, toolCallId: "tc1",
+      },
+    ];
+    const toolCalls: ToolCall[] = [
+      {
+        id: "tc1", callId: "call-1", sessionId: "s1", name: "search",
+        arguments: {}, status: "success", createdAt: "2024-01-01T00:00:01Z",
+      },
+    ];
+
+    const events = extractTimelineEvents(messages, toolCalls);
+
+    // Should have user message + first-class tool call, not the message-based one
+    expect(events).toHaveLength(2);
+    expect(events[1].kind).toBe("tool_call");
+    expect(events[1].id).toBe("tc-tc1");
+  });
+});
+
+describe("toolCallsToTimelineEvents", () => {
+  it("converts tool calls to timeline events", () => {
+    const toolCalls: ToolCall[] = [
+      {
+        id: "tc1", callId: "call-1", sessionId: "s1", name: "search",
+        arguments: { q: "test" }, status: "success", durationMs: 100,
+        createdAt: "2024-01-01T00:00:01Z",
+      },
+      {
+        id: "tc2", callId: "call-2", sessionId: "s1", name: "fetch",
+        arguments: {}, status: "error", errorMessage: "timeout",
+        createdAt: "2024-01-01T00:00:02Z",
+      },
+    ];
+
+    const events = toolCallsToTimelineEvents(toolCalls);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("tool_call");
+    expect(events[0].label).toBe("Tool: search");
+    expect(events[0].status).toBe("success");
+    expect(events[0].duration).toBe(100);
+    expect(events[1].status).toBe("error");
+  });
+});
+
+describe("providerCallsToTimelineEvents", () => {
+  it("converts provider calls to timeline events", () => {
+    const providerCalls: ProviderCall[] = [
+      {
+        id: "pc1", sessionId: "s1", provider: "claude", model: "sonnet",
+        status: "completed", durationMs: 2000,
+        createdAt: "2024-01-01T00:00:01Z",
+      },
+      {
+        id: "pc2", sessionId: "s1", provider: "claude", model: "sonnet",
+        status: "failed", errorMessage: "rate limited",
+        createdAt: "2024-01-01T00:00:02Z",
+      },
+    ];
+
+    const events = providerCallsToTimelineEvents(providerCalls);
+
+    expect(events).toHaveLength(2);
+    expect(events[0].kind).toBe("provider_call");
+    expect(events[0].label).toBe("Provider: claude/sonnet");
+    expect(events[0].status).toBe("success");
+    expect(events[0].duration).toBe(2000);
+    expect(events[1].status).toBe("error");
   });
 });

--- a/dashboard/src/lib/sessions/timeline.ts
+++ b/dashboard/src/lib/sessions/timeline.ts
@@ -1,4 +1,4 @@
-import type { Message } from "@/types/session";
+import type { Message, ToolCall, ProviderCall } from "@/types/session";
 
 export type TimelineEventKind =
   | "user_message"
@@ -149,30 +149,96 @@ function resolveEventStatus(kind: TimelineEventKind, message: Message): Timeline
   return undefined;
 }
 
+function resolveToolCallStatus(status: string): TimelineEvent["status"] {
+  if (status === "error") return "error";
+  if (status === "success") return "success";
+  return undefined;
+}
+
+function resolveProviderCallStatus(status: string): TimelineEvent["status"] {
+  if (status === "failed") return "error";
+  if (status === "completed") return "success";
+  return undefined;
+}
+
+/** Convert first-class ToolCall records to timeline events. */
+export function toolCallsToTimelineEvents(toolCalls: ToolCall[]): TimelineEvent[] {
+  return toolCalls.map((tc) => ({
+    id: `tc-${tc.id}`,
+    timestamp: tc.createdAt,
+    kind: "tool_call" as TimelineEventKind,
+    label: `Tool: ${tc.name}`,
+    detail: tc.arguments ? truncate(JSON.stringify(tc.arguments), MAX_DETAIL_LENGTH) : undefined,
+    toolCallId: tc.callId || tc.id,
+    duration: tc.durationMs,
+    status: resolveToolCallStatus(tc.status),
+  }));
+}
+
+/** Convert first-class ProviderCall records to timeline events. */
+export function providerCallsToTimelineEvents(providerCalls: ProviderCall[]): TimelineEvent[] {
+  return providerCalls.map((pc) => ({
+    id: `pc-${pc.id}`,
+    timestamp: pc.createdAt,
+    kind: "provider_call" as TimelineEventKind,
+    label: `Provider: ${pc.provider}/${pc.model}`,
+    detail: pc.durationMs ? `${pc.durationMs}ms` : undefined,
+    duration: pc.durationMs,
+    status: resolveProviderCallStatus(pc.status),
+  }));
+}
+
+/** Check whether a message-based event should be skipped because first-class records replace it. */
+function shouldSkipMessageEvent(
+  kind: TimelineEventKind,
+  hasToolCalls: boolean,
+  hasProviderCalls: boolean,
+): boolean {
+  if (hasToolCalls && (kind === "tool_call" || kind === "tool_result")) return true;
+  if (hasProviderCalls && kind === "provider_call") return true;
+  return false;
+}
+
+/** Convert a single message to a TimelineEvent. */
+function messageToTimelineEvent(message: Message, kind: TimelineEventKind): TimelineEvent {
+  const durationStr = message.metadata?.duration_ms;
+  const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
+
+  return {
+    id: message.id,
+    timestamp: message.timestamp,
+    kind,
+    label: buildLabel(kind, message),
+    detail: message.content ? truncate(message.content, MAX_DETAIL_LENGTH) : undefined,
+    toolCallId: (kind === "tool_call" || kind === "tool_result") ? message.toolCallId : undefined,
+    duration: duration && !Number.isNaN(duration) ? duration : undefined,
+    metadata: message.metadata,
+    status: resolveEventStatus(kind, message),
+  };
+}
+
 /**
- * Extract a flat, chronologically sorted list of timeline events from session messages.
+ * Extract a flat, chronologically sorted list of timeline events from session messages,
+ * optionally merging first-class tool call and provider call records.
  */
-export function extractTimelineEvents(messages: Message[]): TimelineEvent[] {
+export function extractTimelineEvents(
+  messages: Message[],
+  toolCalls?: ToolCall[],
+  providerCalls?: ProviderCall[],
+): TimelineEvent[] {
+  const hasToolCalls = (toolCalls?.length ?? 0) > 0;
+  const hasProviderCalls = (providerCalls?.length ?? 0) > 0;
   const events: TimelineEvent[] = [];
 
   for (const message of messages) {
     const kind = resolveMessageKind(message);
-
-    const durationStr = message.metadata?.duration_ms;
-    const duration = durationStr ? Number.parseInt(durationStr, 10) : undefined;
-
-    events.push({
-      id: message.id,
-      timestamp: message.timestamp,
-      kind,
-      label: buildLabel(kind, message),
-      detail: message.content ? truncate(message.content, MAX_DETAIL_LENGTH) : undefined,
-      toolCallId: (kind === "tool_call" || kind === "tool_result") ? message.toolCallId : undefined,
-      duration: duration && !Number.isNaN(duration) ? duration : undefined,
-      metadata: message.metadata,
-      status: resolveEventStatus(kind, message),
-    });
+    if (shouldSkipMessageEvent(kind, hasToolCalls, hasProviderCalls)) continue;
+    events.push(messageToTimelineEvent(message, kind));
   }
+
+  // Merge first-class records
+  if (toolCalls) events.push(...toolCallsToTimelineEvents(toolCalls));
+  if (providerCalls) events.push(...providerCallsToTimelineEvents(providerCalls));
 
   // Sort by timestamp (stable sort preserves insertion order for equal timestamps)
   events.sort((a, b) => a.timestamp.localeCompare(b.timestamp));

--- a/dashboard/src/types/session.ts
+++ b/dashboard/src/types/session.ts
@@ -2,11 +2,46 @@
 
 export interface ToolCall {
   id: string;
+  callId: string;
+  sessionId: string;
   name: string;
   arguments: Record<string, unknown>;
   result?: unknown;
   status: "pending" | "success" | "error";
+  durationMs?: number;
+  execution?: "server" | "client";
+  errorMessage?: string;
+  labels?: Record<string, string>;
+  createdAt: string;
+}
+
+export interface ProviderCall {
+  id: string;
+  sessionId: string;
+  provider: string;
+  model: string;
+  status: "pending" | "completed" | "failed";
+  inputTokens?: number;
+  outputTokens?: number;
+  cachedTokens?: number;
+  costUsd?: number;
+  durationMs?: number;
+  finishReason?: string;
+  toolCallCount?: number;
+  errorMessage?: string;
+  labels?: Record<string, string>;
+  createdAt: string;
+}
+
+/** Inline tool call embedded in a message (live console WebSocket path). */
+export interface MessageToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  result?: unknown;
+  status: string;
   duration?: number; // ms
+  error?: string;
 }
 
 export interface Message {
@@ -14,7 +49,7 @@ export interface Message {
   role: "user" | "assistant" | "system" | "tool";
   content: string;
   timestamp: string; // ISO date string
-  toolCalls?: ToolCall[];
+  toolCalls?: MessageToolCall[];
   toolCallId?: string; // for tool response messages
   metadata?: Record<string, string>;
   tokens?: {

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -88,6 +88,10 @@ export default defineConfig({
         "src/app/api/workspaces/[name]/arena/projects/**",
         "src/app/api/workspaces/[name]/arena/sources/[sourceName]/file/**",
 
+        // Session sub-route proxies — simple pass-through to session-api
+        "src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/**",
+        "src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/**",
+
         // Other API routes that require K8s infrastructure
         "src/app/api/workspaces/[name]/agents/**",
         "src/app/api/workspaces/[name]/costs/**",

--- a/hack/pre-commit
+++ b/hack/pre-commit
@@ -214,6 +214,8 @@ if [ -n "$STAGED_DASHBOARD_FILES" ]; then
                    [[ "$REL_FILE" == src/app/api/workspaces/\[name\]/stats/* ]] || \
                    [[ "$REL_FILE" == src/app/api/workspaces/\[name\]/arena/projects/* ]] || \
                    [[ "$REL_FILE" == src/app/api/workspaces/\[name\]/arena/sources/* ]] || \
+                   [[ "$REL_FILE" == src/app/api/workspaces/\[name\]/sessions/\[sessionId\]/tool-calls/* ]] || \
+                   [[ "$REL_FILE" == src/app/api/workspaces/\[name\]/sessions/\[sessionId\]/provider-calls/* ]] || \
                    [[ "$REL_FILE" == src/app/api/workspaces/\[name\]/route.ts ]] || \
                    [[ "$REL_FILE" == src/app/api/workspaces/route.ts ]] || \
                    [[ "$REL_FILE" == src/app/api/providers/* ]] || \

--- a/internal/runtime/event_store.go
+++ b/internal/runtime/event_store.go
@@ -35,8 +35,8 @@ import (
 )
 
 // eventAction holds the outputs of converting a single PromptKit event.
-// The message field is always set (backward compatibility); toolCall and
-// providerCall are set only for tool/provider events (dual-write path).
+// For tool/provider events, only the first-class record is set (no legacy message).
+// For other events, the message field carries the data.
 type eventAction struct {
 	message      *session.Message
 	toolCall     *session.ToolCall
@@ -273,22 +273,14 @@ func (s *OmniaEventStore) convertMessageCreated(event *events.Event) (eventActio
 		"index":       strconv.Itoa(data.Index),
 	}
 
-	// Enrich with tool call data if present on assistant messages
+	// Tool calls on assistant messages are recorded via the first-class tool_calls table
+	// (EventToolCallStarted events), so we only count them in stats here.
 	if len(data.ToolCalls) > 0 {
-		metadata[metaKeyType] = "tool_call"
-		toolCallJSON, err := json.Marshal(data.ToolCalls)
-		if err == nil {
-			metadata["tool_calls"] = string(toolCallJSON)
-		}
-		// Use the first tool call ID for linking
-		if data.ToolCalls[0].ID != "" {
-			msg := s.buildMessage(role, content, event.Timestamp, metadata)
-			msg.ToolCallID = data.ToolCalls[0].ID
-			return eventAction{
-				message: &msg,
-				stats:   session.SessionStatsUpdate{AddMessages: 1, AddToolCalls: int32(len(data.ToolCalls))},
-			}, true
-		}
+		msg := s.buildMessage(role, content, event.Timestamp, metadata)
+		return eventAction{
+			message: &msg,
+			stats:   session.SessionStatsUpdate{AddMessages: 1, AddToolCalls: int32(len(data.ToolCalls))},
+		}, true
 	}
 
 	// Enrich with tool result data if present on tool messages
@@ -452,47 +444,14 @@ const (
 	metaKeyRegistryNamespace = "registry_namespace"
 )
 
-// enrichToolMeta adds registry/handler metadata to the map if available.
-func (s *OmniaEventStore) enrichToolMeta(metadata map[string]string, toolName string) {
-	if s.toolMetaFn == nil {
-		return
-	}
-	meta, ok := s.toolMetaFn(toolName)
-	if !ok {
-		return
-	}
-	metadata[metaKeyHandlerName] = meta.HandlerName
-	metadata[metaKeyHandlerType] = meta.HandlerType
-	metadata[metaKeyRegistryName] = meta.RegistryName
-	metadata[metaKeyRegistryNamespace] = meta.RegistryNamespace
-}
-
 // --- Tool call events ---
 
-// convertToolCallStarted creates a tool_call message AND a ToolCall record (dual-write).
+// convertToolCallStarted creates a first-class ToolCall record.
 func (s *OmniaEventStore) convertToolCallStarted(event *events.Event) (eventAction, bool) {
 	data, ok := asPtr[events.ToolCallStartedData](event.Data)
 	if !ok {
 		return eventAction{}, false
 	}
-
-	content, err := json.Marshal(map[string]interface{}{
-		"name":      data.ToolName,
-		"arguments": data.Args,
-	})
-	if err != nil {
-		s.log.Error(err, "failed to marshal tool call")
-		return eventAction{}, false
-	}
-
-	metadata := map[string]string{
-		metaKeyType:   "tool_call",
-		metaKeySource: metaValueSource,
-	}
-	s.enrichToolMeta(metadata, data.ToolName)
-
-	msg := s.buildMessage(session.RoleAssistant, string(content), event.Timestamp, metadata)
-	msg.ToolCallID = data.CallID
 
 	// Build first-class ToolCall record.
 	tcID := uuid.New().String()
@@ -511,14 +470,11 @@ func (s *OmniaEventStore) convertToolCallStarted(event *events.Event) (eventActi
 	s.toolCallKeys.Store(data.CallID, callKey{id: tcID, createdAt: event.Timestamp})
 
 	return eventAction{
-		message:  &msg,
 		toolCall: &tc,
-		// No AddToolCalls in stats — RecordToolCall handles the session counter.
-		stats: session.SessionStatsUpdate{},
 	}, true
 }
 
-// convertToolCallCompleted creates a tool_result message AND an updated ToolCall record.
+// convertToolCallCompleted creates an updated ToolCall record (upsert).
 func (s *OmniaEventStore) convertToolCallCompleted(event *events.Event) (eventAction, bool) {
 	data, ok := asPtr[events.ToolCallCompletedData](event.Data)
 	if !ok {
@@ -526,29 +482,6 @@ func (s *OmniaEventStore) convertToolCallCompleted(event *events.Event) (eventAc
 	}
 
 	resultBody := textFromParts(data.Parts)
-
-	payload := map[string]interface{}{
-		"toolName":   data.ToolName,
-		"callID":     data.CallID,
-		"status":     data.Status,
-		"durationMs": data.Duration.Milliseconds(),
-	}
-	if resultBody != "" {
-		payload["result"] = resultBody
-	}
-	content, _ := json.Marshal(payload)
-
-	metadata := map[string]string{
-		metaKeyType:       "tool_call_completed",
-		metaKeySource:     metaValueSource,
-		metaKeyToolName:   data.ToolName,
-		metaKeyDurationMs: strconv.FormatInt(data.Duration.Milliseconds(), 10),
-		"status":          data.Status,
-	}
-	s.enrichToolMeta(metadata, data.ToolName)
-
-	msg := s.buildMessage(session.RoleSystem, string(content), event.Timestamp, metadata)
-	msg.ToolCallID = data.CallID
 
 	// Build ToolCall upsert — reuse the ID from the started event.
 	tc := s.buildToolCallUpsert(data.CallID, data.ToolName, event.Timestamp)
@@ -558,10 +491,10 @@ func (s *OmniaEventStore) convertToolCallCompleted(event *events.Event) (eventAc
 		tc.Result = resultBody
 	}
 
-	return eventAction{message: &msg, toolCall: &tc}, true
+	return eventAction{toolCall: &tc}, true
 }
 
-// convertToolCallFailed creates a tool_result message AND an errored ToolCall record.
+// convertToolCallFailed creates an errored ToolCall record.
 func (s *OmniaEventStore) convertToolCallFailed(event *events.Event) (eventAction, bool) {
 	data, ok := asPtr[events.ToolCallFailedData](event.Data)
 	if !ok {
@@ -573,54 +506,22 @@ func (s *OmniaEventStore) convertToolCallFailed(event *events.Event) (eventActio
 		errMsg = data.Error.Error()
 	}
 
-	metadata := map[string]string{
-		metaKeyType:       "tool_result",
-		metaKeyIsError:    "true",
-		metaKeySource:     metaValueSource,
-		metaKeyToolName:   data.ToolName,
-		metaKeyDurationMs: strconv.FormatInt(data.Duration.Milliseconds(), 10),
-	}
-	s.enrichToolMeta(metadata, data.ToolName)
-
-	msg := s.buildMessage(session.RoleSystem, errMsg, event.Timestamp, metadata)
-	msg.ToolCallID = data.CallID
-
 	tc := s.buildToolCallUpsert(data.CallID, data.ToolName, event.Timestamp)
 	tc.Status = session.ToolCallStatusError
 	tc.DurationMs = data.Duration.Milliseconds()
 	tc.ErrorMessage = errMsg
 
-	return eventAction{message: &msg, toolCall: &tc}, true
+	return eventAction{toolCall: &tc}, true
 }
 
 // --- Client tool events ---
 
-// convertClientToolRequest records a client-side tool request (dual-write).
+// convertClientToolRequest records a client-side tool request as a first-class ToolCall.
 func (s *OmniaEventStore) convertClientToolRequest(event *events.Event) (eventAction, bool) {
 	data, ok := asPtr[events.ClientToolRequestData](event.Data)
 	if !ok {
 		return eventAction{}, false
 	}
-
-	content, err := json.Marshal(map[string]interface{}{
-		"name":      data.ToolName,
-		"arguments": data.Args,
-		"execution": "client",
-	})
-	if err != nil {
-		s.log.Error(err, "failed to marshal client tool request")
-		return eventAction{}, false
-	}
-
-	metadata := map[string]string{
-		metaKeyType:   "tool_call",
-		metaKeySource: metaValueSource,
-		"execution":   "client",
-	}
-	s.enrichToolMeta(metadata, data.ToolName)
-
-	msg := s.buildMessage(session.RoleAssistant, string(content), event.Timestamp, metadata)
-	msg.ToolCallID = data.CallID
 
 	tcID := uuid.New().String()
 	tc := session.ToolCall{
@@ -635,7 +536,7 @@ func (s *OmniaEventStore) convertClientToolRequest(event *events.Event) (eventAc
 	s.enrichToolCallLabels(&tc, data.ToolName)
 	s.toolCallKeys.Store(data.CallID, callKey{id: tcID, createdAt: event.Timestamp})
 
-	return eventAction{message: &msg, toolCall: &tc}, true
+	return eventAction{toolCall: &tc}, true
 }
 
 // NOTE: convertClientToolResolved will be added when the published PromptKit SDK
@@ -643,26 +544,12 @@ func (s *OmniaEventStore) convertClientToolRequest(event *events.Event) (eventAc
 
 // --- Provider call events ---
 
-// convertProviderCallStarted records the start of a provider call (dual-write).
+// convertProviderCallStarted records the start of a provider call.
 func (s *OmniaEventStore) convertProviderCallStarted(event *events.Event) (eventAction, bool) {
 	data, ok := asPtr[events.ProviderCallStartedData](event.Data)
 	if !ok {
 		return eventAction{}, false
 	}
-
-	content, _ := json.Marshal(map[string]interface{}{
-		"provider":     data.Provider,
-		"model":        data.Model,
-		"messageCount": data.MessageCount,
-		"toolCount":    data.ToolCount,
-	})
-
-	msg := s.buildMessage(session.RoleSystem, string(content), event.Timestamp, map[string]string{
-		metaKeyType:   "provider_call_started",
-		metaKeySource: metaValueSource,
-		"provider":    data.Provider,
-		"model":       data.Model,
-	})
 
 	pcID := uuid.New().String()
 	pc := session.ProviderCall{
@@ -678,37 +565,15 @@ func (s *OmniaEventStore) convertProviderCallStarted(event *events.Event) (event
 	key := data.Provider + ":" + data.Model + ":" + event.Timestamp.Format(time.RFC3339Nano)
 	s.providerCallKeys.Store(key, callKey{id: pcID, createdAt: event.Timestamp})
 
-	return eventAction{message: &msg, providerCall: &pc}, true
+	return eventAction{providerCall: &pc}, true
 }
 
-// convertProviderCallCompleted records provider call completion (dual-write).
+// convertProviderCallCompleted records provider call completion.
 func (s *OmniaEventStore) convertProviderCallCompleted(event *events.Event) (eventAction, bool) {
 	data, ok := asPtr[events.ProviderCallCompletedData](event.Data)
 	if !ok {
 		return eventAction{}, false
 	}
-
-	content, err := json.Marshal(map[string]interface{}{
-		"provider":     data.Provider,
-		"model":        data.Model,
-		"inputTokens":  data.InputTokens,
-		"outputTokens": data.OutputTokens,
-		"cachedTokens": data.CachedTokens,
-		"cost":         data.Cost,
-		"finishReason": data.FinishReason,
-		"durationMs":   data.Duration.Milliseconds(),
-	})
-	if err != nil {
-		s.log.Error(err, "failed to marshal provider call data")
-		return eventAction{}, false
-	}
-
-	msg := s.buildMessage(session.RoleSystem, string(content), event.Timestamp, map[string]string{
-		metaKeyType:   "provider_call",
-		metaKeySource: metaValueSource,
-	})
-	msg.InputTokens = int32(data.InputTokens)
-	msg.OutputTokens = int32(data.OutputTokens)
 
 	pc := s.buildProviderCallUpsert(data.Provider, data.Model, event.Timestamp)
 	pc.Status = session.ProviderCallStatusCompleted
@@ -720,9 +585,8 @@ func (s *OmniaEventStore) convertProviderCallCompleted(event *events.Event) (eve
 	pc.FinishReason = data.FinishReason
 
 	return eventAction{
-		message:      &msg,
 		providerCall: &pc,
-		// Keep stats on message path for backward compat during dual-write.
+		// Stats still needed — session counters for tokens/cost.
 		stats: session.SessionStatsUpdate{
 			AddInputTokens:  int32(data.InputTokens),
 			AddOutputTokens: int32(data.OutputTokens),
@@ -731,7 +595,7 @@ func (s *OmniaEventStore) convertProviderCallCompleted(event *events.Event) (eve
 	}, true
 }
 
-// convertProviderCallFailed records a provider call failure (dual-write).
+// convertProviderCallFailed records a provider call failure.
 func (s *OmniaEventStore) convertProviderCallFailed(event *events.Event) (eventAction, bool) {
 	data, ok := asPtr[events.ProviderCallFailedData](event.Data)
 	if !ok {
@@ -743,27 +607,12 @@ func (s *OmniaEventStore) convertProviderCallFailed(event *events.Event) (eventA
 		errMsg = data.Error.Error()
 	}
 
-	content, _ := json.Marshal(map[string]interface{}{
-		"provider":   data.Provider,
-		"model":      data.Model,
-		"error":      errMsg,
-		"durationMs": data.Duration.Milliseconds(),
-	})
-
-	msg := s.buildMessage(session.RoleSystem, string(content), event.Timestamp, map[string]string{
-		metaKeyType:    "provider_call_failed",
-		metaKeyIsError: "true",
-		metaKeySource:  metaValueSource,
-		"provider":     data.Provider,
-		"model":        data.Model,
-	})
-
 	pc := s.buildProviderCallUpsert(data.Provider, data.Model, event.Timestamp)
 	pc.Status = session.ProviderCallStatusFailed
 	pc.DurationMs = data.Duration.Milliseconds()
 	pc.ErrorMessage = errMsg
 
-	return eventAction{message: &msg, providerCall: &pc}, true
+	return eventAction{providerCall: &pc}, true
 }
 
 // --- Eval events ---
@@ -856,8 +705,8 @@ func (s *OmniaEventStore) buildMessage(
 	}
 }
 
-// writeAction persists an eventAction to session-api: the legacy message (backward
-// compat) plus optional first-class tool/provider call records (dual-write).
+// writeAction persists an eventAction to session-api: the message (for non-tool/provider events)
+// and/or first-class tool/provider call records.
 // Errors are logged but never propagated, matching the facade's fire-and-forget pattern.
 func (s *OmniaEventStore) writeAction(traceCtx context.Context, sessionID string, action eventAction) {
 	if s.sessionStore == nil {
@@ -893,7 +742,7 @@ func (s *OmniaEventStore) writeAction(traceCtx context.Context, sessionID string
 		}
 	}
 
-	// Write legacy message (backward compat).
+	// Write message (for non-tool/provider events).
 	if action.message != nil {
 		if err := s.sessionStore.AppendMessage(ctx, sessionID, *action.message); err != nil {
 			log.Error(err, "failed to append event message",
@@ -902,7 +751,7 @@ func (s *OmniaEventStore) writeAction(traceCtx context.Context, sessionID string
 		}
 	}
 
-	// Update session stats (tokens, cost, etc.) — still needed for backward compat.
+	// Update session stats (tokens, cost, message counts, etc.).
 	if err := s.sessionStore.UpdateSessionStats(ctx, sessionID, action.stats); err != nil {
 		log.Error(err, "failed to update session stats",
 			"sessionID", sessionID, "messageType", msgType)

--- a/internal/runtime/event_store_test.go
+++ b/internal/runtime/event_store_test.go
@@ -243,35 +243,19 @@ func TestOmniaEventStore_AppendToolCallStarted(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Role != session.RoleAssistant {
-		t.Errorf("expected role assistant, got %s", msg.Role)
-	}
-	if msg.ToolCallID != "call-123" {
-		t.Errorf("expected toolCallID call-123, got %s", msg.ToolCallID)
-	}
-	if msg.Metadata["type"] != "tool_call" {
-		t.Errorf("expected metadata type tool_call, got %s", msg.Metadata["type"])
-	}
-	if msg.Metadata["source"] != "runtime" {
-		t.Errorf("expected metadata source runtime, got %s", msg.Metadata["source"])
-	}
-
-	var content map[string]interface{}
-	if err := json.Unmarshal([]byte(msg.Content), &content); err != nil {
-		t.Fatalf("failed to unmarshal content: %v", err)
-	}
-	if content["name"] != "weather" {
-		t.Errorf("expected tool name weather, got %v", content["name"])
-	}
-
-	// Tool call counter is now handled by RecordToolCall, not stats.
+	// No legacy message — only first-class tool call record.
 	store.waitForToolCalls(t, 1)
+	msgs := store.getMessages()
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages for tool call started, got %d", len(msgs))
+	}
+
 	tcs := store.getToolCalls()
 	if tcs[0].Name != "weather" {
 		t.Errorf("expected tool call name weather, got %s", tcs[0].Name)
+	}
+	if tcs[0].CallID != "call-123" {
+		t.Errorf("expected callID call-123, got %s", tcs[0].CallID)
 	}
 	if tcs[0].Status != session.ToolCallStatusPending {
 		t.Errorf("expected tool call status pending, got %s", tcs[0].Status)
@@ -301,32 +285,22 @@ func TestOmniaEventStore_AppendToolCallCompleted(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Role != session.RoleSystem {
-		t.Errorf("expected role system, got %s", msg.Role)
-	}
-	if msg.ToolCallID != "call-123" {
-		t.Errorf("expected toolCallID call-123, got %s", msg.ToolCallID)
-	}
-	if msg.Metadata["type"] != "tool_call_completed" {
-		t.Errorf("expected metadata type tool_call_completed, got %s", msg.Metadata["type"])
-	}
-	if msg.Metadata["status"] != "success" {
-		t.Errorf("expected status=success, got %s", msg.Metadata["status"])
-	}
-	if msg.Metadata["duration_ms"] != "500" {
-		t.Errorf("expected duration_ms=500, got %s", msg.Metadata["duration_ms"])
+	// No legacy message — only first-class tool call record.
+	store.waitForToolCalls(t, 1)
+	msgs := store.getMessages()
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages for tool call completed, got %d", len(msgs))
 	}
 
-	// Verify content has structured data
-	var content map[string]interface{}
-	if err := json.Unmarshal([]byte(msg.Content), &content); err != nil {
-		t.Fatalf("failed to unmarshal content: %v", err)
+	tcs := store.getToolCalls()
+	if tcs[0].Name != "weather" {
+		t.Errorf("expected tool call name weather, got %s", tcs[0].Name)
 	}
-	if content["toolName"] != "weather" {
-		t.Errorf("expected toolName=weather, got %v", content["toolName"])
+	if tcs[0].Status != session.ToolCallStatusSuccess {
+		t.Errorf("expected status success, got %s", tcs[0].Status)
+	}
+	if tcs[0].DurationMs != 500 {
+		t.Errorf("expected durationMs=500, got %d", tcs[0].DurationMs)
 	}
 }
 
@@ -351,19 +325,13 @@ func TestOmniaEventStore_ToolCallCompletedWithResultBody(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	var content map[string]interface{}
-	if err := json.Unmarshal([]byte(msg.Content), &content); err != nil {
-		t.Fatalf("failed to unmarshal content: %v", err)
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].Result != "91" {
+		t.Errorf("expected result=91, got %v", tcs[0].Result)
 	}
-
-	if content["result"] != "91" {
-		t.Errorf("expected result=91, got %v", content["result"])
-	}
-	if content["toolName"] != "calculate" {
-		t.Errorf("expected toolName=calculate, got %v", content["toolName"])
+	if tcs[0].Name != "calculate" {
+		t.Errorf("expected name=calculate, got %s", tcs[0].Name)
 	}
 }
 
@@ -387,16 +355,10 @@ func TestOmniaEventStore_ToolCallCompletedWithoutParts(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	var content map[string]interface{}
-	if err := json.Unmarshal([]byte(msg.Content), &content); err != nil {
-		t.Fatalf("failed to unmarshal content: %v", err)
-	}
-
-	if _, exists := content["result"]; exists {
-		t.Errorf("expected no result key when Parts is empty, got %v", content["result"])
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].Result != nil {
+		t.Errorf("expected no result when Parts is empty, got %v", tcs[0].Result)
 	}
 }
 
@@ -420,17 +382,22 @@ func TestOmniaEventStore_AppendToolCallFailed(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
+	// No legacy message — only first-class tool call record.
+	store.waitForToolCalls(t, 1)
+	msgs := store.getMessages()
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages for tool call failed, got %d", len(msgs))
+	}
 
-	if msg.Metadata["is_error"] != "true" {
-		t.Errorf("expected is_error=true, got %s", msg.Metadata["is_error"])
+	tcs := store.getToolCalls()
+	if tcs[0].Status != session.ToolCallStatusError {
+		t.Errorf("expected status error, got %s", tcs[0].Status)
 	}
-	if msg.Content != "API timeout" {
-		t.Errorf("expected content 'API timeout', got %s", msg.Content)
+	if tcs[0].ErrorMessage != "API timeout" {
+		t.Errorf("expected errorMessage 'API timeout', got %s", tcs[0].ErrorMessage)
 	}
-	if msg.ToolCallID != "call-456" {
-		t.Errorf("expected toolCallID call-456, got %s", msg.ToolCallID)
+	if tcs[0].CallID != "call-456" {
+		t.Errorf("expected callID call-456, got %s", tcs[0].CallID)
 	}
 }
 
@@ -453,9 +420,10 @@ func TestOmniaEventStore_ToolCallFailedNilError(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	if store.getMessages()[0].Content != "unknown error" {
-		t.Errorf("expected 'unknown error' for nil error, got %s", store.getMessages()[0].Content)
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].ErrorMessage != "unknown error" {
+		t.Errorf("expected 'unknown error' for nil error, got %s", tcs[0].ErrorMessage)
 	}
 }
 
@@ -481,14 +449,22 @@ func TestOmniaEventStore_AppendProviderCallStarted(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["type"] != "provider_call_started" {
-		t.Errorf("expected type provider_call_started, got %s", msg.Metadata["type"])
+	// No legacy message — only first-class provider call record.
+	store.waitForProviderCalls(t, 1)
+	msgs := store.getMessages()
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages for provider call started, got %d", len(msgs))
 	}
-	if msg.Metadata["provider"] != "claude" {
-		t.Errorf("expected provider=claude, got %s", msg.Metadata["provider"])
+
+	pcs := store.getProviderCalls()
+	if pcs[0].Provider != "claude" {
+		t.Errorf("expected provider=claude, got %s", pcs[0].Provider)
+	}
+	if pcs[0].Model != "claude-3-sonnet" {
+		t.Errorf("expected model=claude-3-sonnet, got %s", pcs[0].Model)
+	}
+	if pcs[0].Status != session.ProviderCallStatusPending {
+		t.Errorf("expected status pending, got %s", pcs[0].Status)
 	}
 }
 
@@ -516,19 +492,31 @@ func TestOmniaEventStore_AppendProviderCallCompleted(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["type"] != "provider_call" {
-		t.Errorf("expected type provider_call, got %s", msg.Metadata["type"])
-	}
-	if msg.InputTokens != 100 {
-		t.Errorf("expected inputTokens=100, got %d", msg.InputTokens)
-	}
-	if msg.OutputTokens != 200 {
-		t.Errorf("expected outputTokens=200, got %d", msg.OutputTokens)
+	// No legacy message — only first-class provider call record.
+	store.waitForProviderCalls(t, 1)
+	msgs := store.getMessages()
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages for provider call completed, got %d", len(msgs))
 	}
 
+	pcs := store.getProviderCalls()
+	if pcs[0].Status != session.ProviderCallStatusCompleted {
+		t.Errorf("expected status completed, got %s", pcs[0].Status)
+	}
+	if pcs[0].InputTokens != 100 {
+		t.Errorf("expected inputTokens=100, got %d", pcs[0].InputTokens)
+	}
+	if pcs[0].OutputTokens != 200 {
+		t.Errorf("expected outputTokens=200, got %d", pcs[0].OutputTokens)
+	}
+	if pcs[0].CostUSD != 0.005 {
+		t.Errorf("expected costUSD=0.005, got %f", pcs[0].CostUSD)
+	}
+	if pcs[0].FinishReason != "end_turn" {
+		t.Errorf("expected finishReason=end_turn, got %s", pcs[0].FinishReason)
+	}
+
+	// Stats should still be updated for session counters.
 	store.waitForStats(t, 1)
 	stats := store.getStats()
 	if stats[0].AddInputTokens != 100 {
@@ -559,14 +547,19 @@ func TestOmniaEventStore_AppendProviderCallFailed(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["type"] != "provider_call_failed" {
-		t.Errorf("expected type provider_call_failed, got %s", msg.Metadata["type"])
+	// No legacy message — only first-class provider call record.
+	store.waitForProviderCalls(t, 1)
+	msgs := store.getMessages()
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages for provider call failed, got %d", len(msgs))
 	}
-	if msg.Metadata["is_error"] != "true" {
-		t.Errorf("expected is_error=true, got %s", msg.Metadata["is_error"])
+
+	pcs := store.getProviderCalls()
+	if pcs[0].Status != session.ProviderCallStatusFailed {
+		t.Errorf("expected status failed, got %s", pcs[0].Status)
+	}
+	if pcs[0].ErrorMessage != "rate limited" {
+		t.Errorf("expected errorMessage 'rate limited', got %s", pcs[0].ErrorMessage)
 	}
 }
 
@@ -661,26 +654,15 @@ func TestOmniaEventStore_AppendMessageCreated_WithToolCalls(t *testing.T) {
 	store.waitForMessages(t, 1)
 	msg := store.getMessages()[0]
 
-	if msg.Metadata["type"] != "tool_call" {
-		t.Errorf("expected type=tool_call, got %s", msg.Metadata["type"])
+	// Message should NOT have tool_call metadata — tool calls are first-class records now.
+	if msg.Metadata["type"] == "tool_call" {
+		t.Error("expected no tool_call type metadata on message")
 	}
-	if msg.ToolCallID != "tc-1" {
-		t.Errorf("expected toolCallID=tc-1, got %s", msg.ToolCallID)
-	}
-	if msg.Metadata["tool_calls"] == "" {
-		t.Error("expected tool_calls metadata to be set")
+	if msg.Metadata["tool_calls"] != "" {
+		t.Error("expected no tool_calls metadata on message")
 	}
 
-	// Verify tool_calls contains both calls
-	var toolCalls []events.MessageToolCall
-	if err := json.Unmarshal([]byte(msg.Metadata["tool_calls"]), &toolCalls); err != nil {
-		t.Fatalf("failed to unmarshal tool_calls: %v", err)
-	}
-	if len(toolCalls) != 2 {
-		t.Errorf("expected 2 tool calls, got %d", len(toolCalls))
-	}
-
-	// Stats should count both tool calls
+	// Stats should still count tool calls.
 	store.waitForStats(t, 1)
 	stats := store.getStats()
 	if stats[0].AddToolCalls != 2 {
@@ -1285,8 +1267,8 @@ func TestOmniaEventStore_AppendEmptySessionID(t *testing.T) {
 	}
 
 	time.Sleep(50 * time.Millisecond)
-	if len(store.getMessages()) != 0 {
-		t.Error("expected no messages for empty sessionID")
+	if len(store.getToolCalls()) != 0 {
+		t.Error("expected no tool calls for empty sessionID")
 	}
 }
 
@@ -1479,14 +1461,13 @@ func TestOmniaEventStore_ValueTypeToolCall(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["type"] != "tool_call" {
-		t.Errorf("expected type=tool_call, got %s", msg.Metadata["type"])
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].Name != "get_weather" {
+		t.Errorf("expected name=get_weather, got %s", tcs[0].Name)
 	}
-	if msg.ToolCallID != "call-val-1" {
-		t.Errorf("expected ToolCallID=call-val-1, got %s", msg.ToolCallID)
+	if tcs[0].CallID != "call-val-1" {
+		t.Errorf("expected callID=call-val-1, got %s", tcs[0].CallID)
 	}
 }
 
@@ -1512,14 +1493,13 @@ func TestOmniaEventStore_ValueTypeToolCallCompleted(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["type"] != "tool_call_completed" {
-		t.Errorf("expected type=tool_call_completed, got %s", msg.Metadata["type"])
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].Name != "get_weather" {
+		t.Errorf("expected name=get_weather, got %s", tcs[0].Name)
 	}
-	if msg.Metadata["duration_ms"] != "500" {
-		t.Errorf("expected duration_ms=500, got %s", msg.Metadata["duration_ms"])
+	if tcs[0].DurationMs != 500 {
+		t.Errorf("expected durationMs=500, got %d", tcs[0].DurationMs)
 	}
 }
 
@@ -1545,11 +1525,10 @@ func TestOmniaEventStore_ValueTypeProviderCallStarted(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["type"] != "provider_call_started" {
-		t.Errorf("expected type=provider_call_started, got %s", msg.Metadata["type"])
+	store.waitForProviderCalls(t, 1)
+	pcs := store.getProviderCalls()
+	if pcs[0].Provider != "ollama" {
+		t.Errorf("expected provider=ollama, got %s", pcs[0].Provider)
 	}
 }
 
@@ -1574,16 +1553,18 @@ func TestOmniaEventStore_ValueTypeProviderCallFailed(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["type"] != "provider_call_failed" {
-		t.Errorf("expected type=provider_call_failed, got %s", msg.Metadata["type"])
+	store.waitForProviderCalls(t, 1)
+	pcs := store.getProviderCalls()
+	if pcs[0].Status != session.ProviderCallStatusFailed {
+		t.Errorf("expected status=failed, got %s", pcs[0].Status)
+	}
+	if pcs[0].ErrorMessage != "timeout" {
+		t.Errorf("expected errorMessage=timeout, got %s", pcs[0].ErrorMessage)
 	}
 }
 
-// TestOmniaEventStore_ToolCallWithRegistryMeta verifies that tool call messages
-// are enriched with registry/handler metadata when toolMetaFn is set.
+// TestOmniaEventStore_ToolCallWithRegistryMeta verifies that tool call records
+// are enriched with registry/handler labels when toolMetaFn is set.
 func TestOmniaEventStore_ToolCallWithRegistryMeta(t *testing.T) {
 	store := &mockSessionStore{}
 	es := NewOmniaEventStore(store, logr.Discard())
@@ -1615,24 +1596,23 @@ func TestOmniaEventStore_ToolCallWithRegistryMeta(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["handler_name"] != "mcp-handler" {
-		t.Errorf("expected handler_name=mcp-handler, got %s", msg.Metadata["handler_name"])
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].Labels["handler_name"] != "mcp-handler" {
+		t.Errorf("expected label handler_name=mcp-handler, got %s", tcs[0].Labels["handler_name"])
 	}
-	if msg.Metadata["handler_type"] != "mcp" {
-		t.Errorf("expected handler_type=mcp, got %s", msg.Metadata["handler_type"])
+	if tcs[0].Labels["handler_type"] != "mcp" {
+		t.Errorf("expected label handler_type=mcp, got %s", tcs[0].Labels["handler_type"])
 	}
-	if msg.Metadata["registry_name"] != "my-registry" {
-		t.Errorf("expected registry_name=my-registry, got %s", msg.Metadata["registry_name"])
+	if tcs[0].Labels["registry_name"] != "my-registry" {
+		t.Errorf("expected label registry_name=my-registry, got %s", tcs[0].Labels["registry_name"])
 	}
-	if msg.Metadata["registry_namespace"] != "my-ns" {
-		t.Errorf("expected registry_namespace=my-ns, got %s", msg.Metadata["registry_namespace"])
+	if tcs[0].Labels["registry_namespace"] != "my-ns" {
+		t.Errorf("expected label registry_namespace=my-ns, got %s", tcs[0].Labels["registry_namespace"])
 	}
 }
 
-// TestOmniaEventStore_ToolCallCompletedWithRegistryMeta verifies completed events get metadata.
+// TestOmniaEventStore_ToolCallCompletedWithRegistryMeta verifies completed events get labels.
 func TestOmniaEventStore_ToolCallCompletedWithRegistryMeta(t *testing.T) {
 	store := &mockSessionStore{}
 	es := NewOmniaEventStore(store, logr.Discard())
@@ -1660,14 +1640,13 @@ func TestOmniaEventStore_ToolCallCompletedWithRegistryMeta(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if msg.Metadata["handler_type"] != "http" {
-		t.Errorf("expected handler_type=http, got %s", msg.Metadata["handler_type"])
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].Labels["handler_type"] != "http" {
+		t.Errorf("expected label handler_type=http, got %s", tcs[0].Labels["handler_type"])
 	}
-	if msg.Metadata["registry_name"] != "reg" {
-		t.Errorf("expected registry_name=reg, got %s", msg.Metadata["registry_name"])
+	if tcs[0].Labels["registry_name"] != "reg" {
+		t.Errorf("expected label registry_name=reg, got %s", tcs[0].Labels["registry_name"])
 	}
 }
 
@@ -1692,11 +1671,12 @@ func TestOmniaEventStore_ToolCallWithoutMetaFn(t *testing.T) {
 		t.Fatalf("Append() error = %v", err)
 	}
 
-	store.waitForMessages(t, 1)
-	msg := store.getMessages()[0]
-
-	if _, ok := msg.Metadata["handler_name"]; ok {
-		t.Error("expected no handler_name when toolMetaFn is nil")
+	store.waitForToolCalls(t, 1)
+	tcs := store.getToolCalls()
+	if tcs[0].Labels != nil {
+		if _, ok := tcs[0].Labels["handler_name"]; ok {
+			t.Error("expected no handler_name label when toolMetaFn is nil")
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes Phase 1b of the tool/provider call migration. The dashboard now reads tool and provider data from the first-class `tool_calls` and `provider_calls` tables (added in #624) instead of parsing legacy system messages. The runtime event store no longer creates messages for tool/provider events — only first-class records.

- **Types**: Add `ProviderCall` interface, extend `ToolCall` with `callId`, `sessionId`, `execution`, `errorMessage`, `labels`, `createdAt`; add `MessageToolCall` for live console path
- **Proxy routes**: New `GET /api/workspaces/{name}/sessions/{sessionId}/tool-calls` and `/provider-calls` pass-through proxies
- **Service layer**: `SessionApiService.getToolCalls()` / `getProviderCalls()` + `useSessionToolCalls` / `useSessionProviderCalls` hooks
- **ToolCallsTab**: Rewrote to read from `ToolCall[]` directly — removed JSON content parsing and message result-pairing logic
- **Conversation view**: Tool call indicators now interleaved from first-class records by timestamp; `isConversationMessage` no longer includes `tool_call` messages
- **Timeline**: New `toolCallsToTimelineEvents()` / `providerCallsToTimelineEvents()` converters; `extractTimelineEvents()` merges first-class records and skips legacy message-based events
- **Runtime event store**: Removed message creation from all 7 tool/provider converters (`convertToolCallStarted`, `convertToolCallCompleted`, `convertToolCallFailed`, `convertClientToolRequest`, `convertProviderCallStarted`, `convertProviderCallCompleted`, `convertProviderCallFailed`); removed `enrichToolMeta` (metadata now in `ToolCall.Labels`); removed tool_call metadata embedding from `convertMessageCreated`
- **Tests**: Updated all Go and TS tests — tool/provider events assert no message, only first-class records; new timeline merge tests; new hook tests

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/runtime/... -count=1` — all pass
- [x] `npm run lint` — 0 errors
- [x] `npm run typecheck` — passes
- [x] Dashboard tests — 3357 tests, 230 files pass
- [x] Pre-commit hook passes (ESLint, TypeScript, coverage ≥80%, Go vet, lint, build, generated code)