### PR TITLE
fix: critical security fixes across runtime, privacy, and dashboard

### DIFF
--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/eval-results/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/eval-results/route.test.ts
@@ -16,6 +16,10 @@ vi.mock("@/lib/auth/workspace-authz", () => ({
   checkWorkspaceAccess: vi.fn(),
 }));
 
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
 const mockUser = {
   id: "testuser-id",
   provider: "oauth" as const,
@@ -42,6 +46,13 @@ function createMockContext() {
   return { params: Promise.resolve({ name: "test-ws", sessionId: "sess-123" }) };
 }
 
+function mockWorkspace(namespace = "test-ns") {
+  return {
+    metadata: { name: "test-ws" },
+    spec: { namespace: { name: namespace } },
+  };
+}
+
 describe("GET /api/workspaces/[name]/sessions/[sessionId]/eval-results", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -56,12 +67,21 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/eval-results", () => {
   it("proxies eval-results request to backend", async () => {
     const { getUser } = await import("@/lib/auth");
     const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({
       granted: true,
       role: "viewer",
       permissions: viewerPermissions,
+    });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
+
+    // Namespace guard
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
     });
 
     const results = [
@@ -80,7 +100,7 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/eval-results", () => {
     const body = await response.json();
     expect(body.results).toHaveLength(1);
 
-    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    const fetchUrl = mockFetch.mock.calls[1][0] as string;
     expect(fetchUrl).toContain("/api/v1/sessions/sess-123/eval-results");
   });
 
@@ -105,6 +125,7 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/eval-results", () => {
   it("returns 502 on fetch error", async () => {
     const { getUser } = await import("@/lib/auth");
     const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({
@@ -112,7 +133,14 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/eval-results", () => {
       role: "viewer",
       permissions: viewerPermissions,
     });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
 
+    // Namespace guard succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
     mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
 
     const { GET } = await import("./route");
@@ -136,5 +164,34 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/eval-results", () => {
     const response = await GET(createMockRequest(), createMockContext());
 
     expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when session belongs to a different namespace (IDOR prevention)", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace("namespace-a") as Awaited<ReturnType<typeof getWorkspace>>);
+
+    // Session belongs to namespace-b
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "namespace-b" } }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Session not found");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/eval-results/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/eval-results/route.ts
@@ -2,7 +2,10 @@
  * Session eval-results proxy route.
  *
  * GET /api/workspaces/{name}/sessions/{sessionId}/eval-results
- *   → SESSION_API_URL/api/v1/sessions/{sessionId}/eval-results
+ *   -> SESSION_API_URL/api/v1/sessions/{sessionId}/eval-results
+ *
+ * Verifies the session belongs to the workspace's namespace before
+ * returning data (prevents cross-workspace IDOR).
  *
  * Copyright 2026 Altaira Labs.
  * SPDX-License-Identifier: Apache-2.0
@@ -10,10 +13,9 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { verifySessionNamespace } from "../../session-namespace-guard";
 import type { WorkspaceAccess } from "@/types/workspace";
 import type { User } from "@/lib/auth/types";
-
-const SESSION_API_URL = process.env.SESSION_API_URL;
 
 type Params = { name: string; sessionId: string };
 
@@ -25,17 +27,12 @@ export const GET = withWorkspaceAccess<Params>(
     _access: WorkspaceAccess,
     _user: User
   ): Promise<NextResponse> => {
-    const { sessionId } = await context.params;
+    const { name, sessionId } = await context.params;
 
-    if (!SESSION_API_URL) {
-      return NextResponse.json(
-        { error: "Session API not configured", results: [] },
-        { status: 503 }
-      );
-    }
+    const guard = await verifySessionNamespace(name, sessionId);
+    if (!guard.ok) return guard.response;
 
-    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
-    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/eval-results`;
+    const targetUrl = `${guard.baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/eval-results`;
 
     try {
       const response = await fetch(targetUrl, {

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/events/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/events/route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for session events proxy route.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/workspace-authz", () => ({
+  checkWorkspaceAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+const mockUser = {
+  id: "testuser-id",
+  provider: "oauth" as const,
+  username: "testuser",
+  email: "test@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+const noPermissions = { read: false, write: false, delete: false, manageMembers: false };
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function createMockRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost:3000/api/workspaces/test-ws/sessions/sess-123/events",
+    { method: "GET" }
+  );
+}
+
+function createMockContext() {
+  return { params: Promise.resolve({ name: "test-ws", sessionId: "sess-123" }) };
+}
+
+function mockWorkspace(namespace = "test-ns") {
+  return {
+    metadata: { name: "test-ws" },
+    spec: { namespace: { name: namespace } },
+  };
+}
+
+describe("GET /api/workspaces/[name]/sessions/[sessionId]/events", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("SESSION_API_URL", "https://session-api:8080");
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("proxies events request to backend", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ events: [{ type: "stream.start" }] }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.events).toHaveLength(1);
+
+    const fetchUrl = mockFetch.mock.calls[1][0] as string;
+    expect(fetchUrl).toContain("/api/v1/sessions/sess-123/events");
+  });
+
+  it("returns 404 when session belongs to a different namespace (IDOR prevention)", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace("namespace-a") as Awaited<ReturnType<typeof getWorkspace>>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "namespace-b" } }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Session not found");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 when SESSION_API_URL is not set", async () => {
+    vi.stubEnv("SESSION_API_URL", "");
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 403 when user lacks workspace access", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: false, role: null, permissions: noPermissions });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/events/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/events/route.ts
@@ -2,15 +2,17 @@
  * Session runtime events proxy route.
  *
  * GET /api/workspaces/{name}/sessions/{sessionId}/events
- *   → SESSION_API_URL/api/v1/sessions/{sessionId}/events
+ *   -> SESSION_API_URL/api/v1/sessions/{sessionId}/events
+ *
+ * Verifies the session belongs to the workspace's namespace before
+ * returning data (prevents cross-workspace IDOR).
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { verifySessionNamespace } from "../../session-namespace-guard";
 import type { WorkspaceAccess } from "@/types/workspace";
 import type { User } from "@/lib/auth/types";
-
-const SESSION_API_URL = process.env.SESSION_API_URL;
 
 type Params = { name: string; sessionId: string };
 
@@ -22,17 +24,12 @@ export const GET = withWorkspaceAccess<Params>(
     _access: WorkspaceAccess,
     _user: User
   ): Promise<NextResponse> => {
-    const { sessionId } = await context.params;
+    const { name, sessionId } = await context.params;
 
-    if (!SESSION_API_URL) {
-      return NextResponse.json(
-        { error: "Session API not configured", events: [] },
-        { status: 503 }
-      );
-    }
+    const guard = await verifySessionNamespace(name, sessionId);
+    if (!guard.ok) return guard.response;
 
-    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
-    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/events`;
+    const targetUrl = `${guard.baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/events`;
 
     try {
       const response = await fetch(targetUrl, {

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/messages/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/messages/route.test.ts
@@ -13,6 +13,10 @@ vi.mock("@/lib/auth/workspace-authz", () => ({
   checkWorkspaceAccess: vi.fn(),
 }));
 
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
 const mockUser = {
   id: "testuser-id",
   provider: "oauth" as const,
@@ -36,6 +40,24 @@ function createMockContext() {
   return { params: Promise.resolve({ name: "test-ws", sessionId: "sess-123" }) };
 }
 
+function mockWorkspace(namespace = "test-ns") {
+  return {
+    metadata: { name: "test-ws" },
+    spec: { namespace: { name: namespace } },
+  };
+}
+
+/** Set up auth + workspace mocks for a standard successful flow. */
+async function setupAuthorizedMocks(namespace = "test-ns") {
+  const { getUser } = await import("@/lib/auth");
+  const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+  const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+  vi.mocked(getUser).mockResolvedValue(mockUser);
+  vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+  vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace(namespace) as Awaited<ReturnType<typeof getWorkspace>>);
+}
+
 describe("GET /api/workspaces/[name]/sessions/[sessionId]/messages", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -48,12 +70,15 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/messages", () => {
   });
 
   it("proxies messages request to backend", async () => {
-    const { getUser } = await import("@/lib/auth");
-    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    await setupAuthorizedMocks();
 
-    vi.mocked(getUser).mockResolvedValue(mockUser);
-    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
-
+    // Namespace guard
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
+    // Actual messages request
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -67,17 +92,18 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/messages", () => {
     const body = await response.json();
     expect(body.messages).toHaveLength(1);
 
-    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    const fetchUrl = mockFetch.mock.calls[1][0] as string;
     expect(fetchUrl).toContain("/api/v1/sessions/sess-123/messages");
   });
 
   it("forwards pagination query params", async () => {
-    const { getUser } = await import("@/lib/auth");
-    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    await setupAuthorizedMocks();
 
-    vi.mocked(getUser).mockResolvedValue(mockUser);
-    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
-
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -87,7 +113,7 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/messages", () => {
     const { GET } = await import("./route");
     await GET(createMockRequest("?limit=50&before=100&after=10"), createMockContext());
 
-    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    const fetchUrl = mockFetch.mock.calls[1][0] as string;
     expect(fetchUrl).toContain("limit=50");
     expect(fetchUrl).toContain("before=100");
     expect(fetchUrl).toContain("after=10");
@@ -108,12 +134,13 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/messages", () => {
   });
 
   it("returns 502 on fetch error", async () => {
-    const { getUser } = await import("@/lib/auth");
-    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    await setupAuthorizedMocks();
 
-    vi.mocked(getUser).mockResolvedValue(mockUser);
-    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
-
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
     mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
 
     const { GET } = await import("./route");
@@ -133,5 +160,26 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]/messages", () => {
     const response = await GET(createMockRequest(), createMockContext());
 
     expect(response.status).toBe(403);
+  });
+
+  it("returns 404 when session belongs to a different namespace (IDOR prevention)", async () => {
+    await setupAuthorizedMocks("namespace-a");
+
+    // Session belongs to namespace-b
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "namespace-b" } }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Session not found");
+
+    // Should NOT make a second fetch for messages
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/messages/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/messages/route.ts
@@ -2,15 +2,17 @@
  * Session messages proxy route.
  *
  * GET /api/workspaces/{name}/sessions/{sessionId}/messages
- *   → SESSION_API_URL/api/v1/sessions/{sessionId}/messages?limit=&before=&after=
+ *   -> SESSION_API_URL/api/v1/sessions/{sessionId}/messages?limit=&before=&after=
+ *
+ * Verifies the session belongs to the workspace's namespace before
+ * returning data (prevents cross-workspace IDOR).
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { verifySessionNamespace } from "../../session-namespace-guard";
 import type { WorkspaceAccess } from "@/types/workspace";
 import type { User } from "@/lib/auth/types";
-
-const SESSION_API_URL = process.env.SESSION_API_URL;
 
 type Params = { name: string; sessionId: string };
 
@@ -22,14 +24,10 @@ export const GET = withWorkspaceAccess<Params>(
     _access: WorkspaceAccess,
     _user: User
   ): Promise<NextResponse> => {
-    const { sessionId } = await context.params;
+    const { name, sessionId } = await context.params;
 
-    if (!SESSION_API_URL) {
-      return NextResponse.json(
-        { error: "Session API not configured", messages: [], hasMore: false },
-        { status: 503 }
-      );
-    }
+    const guard = await verifySessionNamespace(name, sessionId);
+    if (!guard.ok) return guard.response;
 
     const params = new URLSearchParams();
     const forwardParams = ["limit", "before", "after"];
@@ -41,8 +39,7 @@ export const GET = withWorkspaceAccess<Params>(
     const queryString = params.toString();
     const suffix = queryString ? `?${queryString}` : "";
 
-    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
-    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/messages${suffix}`;
+    const targetUrl = `${guard.baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/messages${suffix}`;
 
     try {
       const response = await fetch(targetUrl, {

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for session provider-calls proxy route.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/workspace-authz", () => ({
+  checkWorkspaceAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+const mockUser = {
+  id: "testuser-id",
+  provider: "oauth" as const,
+  username: "testuser",
+  email: "test@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+const noPermissions = { read: false, write: false, delete: false, manageMembers: false };
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function createMockRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost:3000/api/workspaces/test-ws/sessions/sess-123/provider-calls",
+    { method: "GET" }
+  );
+}
+
+function createMockContext() {
+  return { params: Promise.resolve({ name: "test-ws", sessionId: "sess-123" }) };
+}
+
+function mockWorkspace(namespace = "test-ns") {
+  return {
+    metadata: { name: "test-ws" },
+    spec: { namespace: { name: namespace } },
+  };
+}
+
+describe("GET /api/workspaces/[name]/sessions/[sessionId]/provider-calls", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("SESSION_API_URL", "https://session-api:8080");
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("proxies provider-calls request to backend", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ providerCalls: [{ id: "pc1", model: "gpt-4" }] }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.providerCalls).toHaveLength(1);
+
+    const fetchUrl = mockFetch.mock.calls[1][0] as string;
+    expect(fetchUrl).toContain("/api/v1/sessions/sess-123/provider-calls");
+  });
+
+  it("returns 404 when session belongs to a different namespace (IDOR prevention)", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace("namespace-a") as Awaited<ReturnType<typeof getWorkspace>>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "namespace-b" } }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Session not found");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 when SESSION_API_URL is not set", async () => {
+    vi.stubEnv("SESSION_API_URL", "");
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 403 when user lacks workspace access", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: false, role: null, permissions: noPermissions });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/route.ts
@@ -2,15 +2,17 @@
  * Session provider calls proxy route.
  *
  * GET /api/workspaces/{name}/sessions/{sessionId}/provider-calls
- *   → SESSION_API_URL/api/v1/sessions/{sessionId}/provider-calls
+ *   -> SESSION_API_URL/api/v1/sessions/{sessionId}/provider-calls
+ *
+ * Verifies the session belongs to the workspace's namespace before
+ * returning data (prevents cross-workspace IDOR).
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { verifySessionNamespace } from "../../session-namespace-guard";
 import type { WorkspaceAccess } from "@/types/workspace";
 import type { User } from "@/lib/auth/types";
-
-const SESSION_API_URL = process.env.SESSION_API_URL;
 
 type Params = { name: string; sessionId: string };
 
@@ -22,17 +24,12 @@ export const GET = withWorkspaceAccess<Params>(
     _access: WorkspaceAccess,
     _user: User
   ): Promise<NextResponse> => {
-    const { sessionId } = await context.params;
+    const { name, sessionId } = await context.params;
 
-    if (!SESSION_API_URL) {
-      return NextResponse.json(
-        { error: "Session API not configured", providerCalls: [] },
-        { status: 503 }
-      );
-    }
+    const guard = await verifySessionNamespace(name, sessionId);
+    if (!guard.ok) return guard.response;
 
-    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
-    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/provider-calls`;
+    const targetUrl = `${guard.baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/provider-calls`;
 
     try {
       const response = await fetch(targetUrl, {

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/route.test.ts
@@ -13,6 +13,10 @@ vi.mock("@/lib/auth/workspace-authz", () => ({
   checkWorkspaceAccess: vi.fn(),
 }));
 
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
 const mockUser = {
   id: "testuser-id",
   provider: "oauth" as const,
@@ -36,6 +40,13 @@ function createMockContext() {
   return { params: Promise.resolve({ name: "test-ws", sessionId: "sess-123" }) };
 }
 
+function mockWorkspace(namespace = "test-ns") {
+  return {
+    metadata: { name: "test-ws" },
+    spec: { namespace: { name: namespace } },
+  };
+}
+
 describe("GET /api/workspaces/[name]/sessions/[sessionId]", () => {
   beforeEach(() => {
     vi.resetModules();
@@ -50,10 +61,19 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]", () => {
   it("proxies session detail to backend", async () => {
     const { getUser } = await import("@/lib/auth");
     const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
 
+    // First fetch: namespace guard fetches session metadata
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
+    // Second fetch: actual session detail request
     mockFetch.mockResolvedValueOnce({
       ok: true,
       status: 200,
@@ -67,7 +87,7 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]", () => {
     const body = await response.json();
     expect(body.session.id).toBe("sess-123");
 
-    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    const fetchUrl = mockFetch.mock.calls[1][0] as string;
     expect(fetchUrl).toContain("/api/v1/sessions/sess-123");
   });
 
@@ -88,10 +108,19 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]", () => {
   it("returns 502 on fetch error", async () => {
     const { getUser } = await import("@/lib/auth");
     const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
 
+    // Namespace guard succeeds
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
+    // Actual request fails
     mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
 
     const { GET } = await import("./route");
@@ -116,10 +145,13 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]", () => {
   it("forwards backend error status", async () => {
     const { getUser } = await import("@/lib/auth");
     const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
 
+    // Namespace guard: session not found at backend level
     mockFetch.mockResolvedValueOnce({
       ok: false,
       status: 404,
@@ -130,5 +162,33 @@ describe("GET /api/workspaces/[name]/sessions/[sessionId]", () => {
     const response = await GET(createMockRequest(), createMockContext());
 
     expect(response.status).toBe(404);
+  });
+
+  it("returns 404 when session belongs to a different namespace (IDOR prevention)", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    // Workspace resolves to namespace-a
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace("namespace-a") as Awaited<ReturnType<typeof getWorkspace>>);
+
+    // Session belongs to namespace-b
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "namespace-b" } }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Session not found");
+
+    // Should NOT make a second fetch for the actual data
+    expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/route.ts
@@ -2,15 +2,17 @@
  * Session detail proxy route.
  *
  * GET /api/workspaces/{name}/sessions/{sessionId}
- *   → SESSION_API_URL/api/v1/sessions/{sessionId}
+ *   -> SESSION_API_URL/api/v1/sessions/{sessionId}
+ *
+ * Verifies the session belongs to the workspace's namespace before
+ * returning data (prevents cross-workspace IDOR).
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { verifySessionNamespace } from "../session-namespace-guard";
 import type { WorkspaceAccess } from "@/types/workspace";
 import type { User } from "@/lib/auth/types";
-
-const SESSION_API_URL = process.env.SESSION_API_URL;
 
 type Params = { name: string; sessionId: string };
 
@@ -22,17 +24,12 @@ export const GET = withWorkspaceAccess<Params>(
     _access: WorkspaceAccess,
     _user: User
   ): Promise<NextResponse> => {
-    const { sessionId } = await context.params;
+    const { name, sessionId } = await context.params;
 
-    if (!SESSION_API_URL) {
-      return NextResponse.json(
-        { error: "Session API not configured" },
-        { status: 503 }
-      );
-    }
+    const guard = await verifySessionNamespace(name, sessionId);
+    if (!guard.ok) return guard.response;
 
-    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
-    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}`;
+    const targetUrl = `${guard.baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}`;
 
     try {
       const response = await fetch(targetUrl, {

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/route.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Tests for session tool-calls proxy route.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/workspace-authz", () => ({
+  checkWorkspaceAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+const mockUser = {
+  id: "testuser-id",
+  provider: "oauth" as const,
+  username: "testuser",
+  email: "test@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+const noPermissions = { read: false, write: false, delete: false, manageMembers: false };
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function createMockRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost:3000/api/workspaces/test-ws/sessions/sess-123/tool-calls",
+    { method: "GET" }
+  );
+}
+
+function createMockContext() {
+  return { params: Promise.resolve({ name: "test-ws", sessionId: "sess-123" }) };
+}
+
+function mockWorkspace(namespace = "test-ns") {
+  return {
+    metadata: { name: "test-ws" },
+    spec: { namespace: { name: namespace } },
+  };
+}
+
+describe("GET /api/workspaces/[name]/sessions/[sessionId]/tool-calls", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("SESSION_API_URL", "https://session-api:8080");
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("proxies tool-calls request to backend", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace() as Awaited<ReturnType<typeof getWorkspace>>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "test-ns" } }),
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ toolCalls: [{ id: "tc1", name: "read_file" }] }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.toolCalls).toHaveLength(1);
+
+    const fetchUrl = mockFetch.mock.calls[1][0] as string;
+    expect(fetchUrl).toContain("/api/v1/sessions/sess-123/tool-calls");
+  });
+
+  it("returns 404 when session belongs to a different namespace (IDOR prevention)", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace("namespace-a") as Awaited<ReturnType<typeof getWorkspace>>);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-123", namespace: "namespace-b" } }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(404);
+    const body = await response.json();
+    expect(body.error).toBe("Session not found");
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 when SESSION_API_URL is not set", async () => {
+    vi.stubEnv("SESSION_API_URL", "");
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPermissions });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 403 when user lacks workspace access", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: false, role: null, permissions: noPermissions });
+
+    const { GET } = await import("./route");
+    const response = await GET(createMockRequest(), createMockContext());
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/route.ts
@@ -2,15 +2,17 @@
  * Session tool calls proxy route.
  *
  * GET /api/workspaces/{name}/sessions/{sessionId}/tool-calls
- *   → SESSION_API_URL/api/v1/sessions/{sessionId}/tool-calls
+ *   -> SESSION_API_URL/api/v1/sessions/{sessionId}/tool-calls
+ *
+ * Verifies the session belongs to the workspace's namespace before
+ * returning data (prevents cross-workspace IDOR).
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { verifySessionNamespace } from "../../session-namespace-guard";
 import type { WorkspaceAccess } from "@/types/workspace";
 import type { User } from "@/lib/auth/types";
-
-const SESSION_API_URL = process.env.SESSION_API_URL;
 
 type Params = { name: string; sessionId: string };
 
@@ -22,17 +24,12 @@ export const GET = withWorkspaceAccess<Params>(
     _access: WorkspaceAccess,
     _user: User
   ): Promise<NextResponse> => {
-    const { sessionId } = await context.params;
+    const { name, sessionId } = await context.params;
 
-    if (!SESSION_API_URL) {
-      return NextResponse.json(
-        { error: "Session API not configured", toolCalls: [] },
-        { status: 503 }
-      );
-    }
+    const guard = await verifySessionNamespace(name, sessionId);
+    if (!guard.ok) return guard.response;
 
-    const baseUrl = SESSION_API_URL.endsWith("/") ? SESSION_API_URL.slice(0, -1) : SESSION_API_URL;
-    const targetUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/tool-calls`;
+    const targetUrl = `${guard.baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}/tool-calls`;
 
     try {
       const response = await fetch(targetUrl, {

--- a/dashboard/src/app/api/workspaces/[name]/sessions/session-namespace-guard.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/session-namespace-guard.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for session namespace guard.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("verifySessionNamespace", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.stubEnv("SESSION_API_URL", "https://session-api:8080");
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  it("returns ok when session namespace matches workspace namespace", async () => {
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    vi.mocked(getWorkspace).mockResolvedValue({
+      metadata: { name: "test-ws" },
+      spec: { namespace: { name: "team-a-ns" } },
+    } as ReturnType<typeof getWorkspace> extends Promise<infer T> ? NonNullable<T> : never);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-1", namespace: "team-a-ns" } }),
+    });
+
+    const { verifySessionNamespace } = await import("./session-namespace-guard");
+    const result = await verifySessionNamespace("test-ws", "sess-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.namespace).toBe("team-a-ns");
+      expect(result.baseUrl).toBe("https://session-api:8080");
+    }
+  });
+
+  it("returns 404 when session namespace does not match workspace (IDOR)", async () => {
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    vi.mocked(getWorkspace).mockResolvedValue({
+      metadata: { name: "workspace-a" },
+      spec: { namespace: { name: "namespace-a" } },
+    } as ReturnType<typeof getWorkspace> extends Promise<infer T> ? NonNullable<T> : never);
+
+    // Session belongs to namespace-b, not namespace-a
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-from-b", namespace: "namespace-b" } }),
+    });
+
+    const { verifySessionNamespace } = await import("./session-namespace-guard");
+    const result = await verifySessionNamespace("workspace-a", "sess-from-b");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+      const body = await result.response.json();
+      expect(body.error).toBe("Session not found");
+    }
+  });
+
+  it("returns 503 when SESSION_API_URL is not set", async () => {
+    vi.stubEnv("SESSION_API_URL", "");
+
+    const { verifySessionNamespace } = await import("./session-namespace-guard");
+    const result = await verifySessionNamespace("test-ws", "sess-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(503);
+    }
+  });
+
+  it("returns 404 when workspace does not exist", async () => {
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    vi.mocked(getWorkspace).mockResolvedValue(null);
+
+    const { verifySessionNamespace } = await import("./session-namespace-guard");
+    const result = await verifySessionNamespace("no-such-ws", "sess-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+      const body = await result.response.json();
+      expect(body.error).toBe("Workspace not found");
+    }
+  });
+
+  it("forwards backend 404 when session does not exist", async () => {
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    vi.mocked(getWorkspace).mockResolvedValue({
+      metadata: { name: "test-ws" },
+      spec: { namespace: { name: "test-ns" } },
+    } as ReturnType<typeof getWorkspace> extends Promise<infer T> ? NonNullable<T> : never);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: "session not found" }),
+    });
+
+    const { verifySessionNamespace } = await import("./session-namespace-guard");
+    const result = await verifySessionNamespace("test-ws", "no-such-session");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(404);
+    }
+  });
+
+  it("returns 502 when session-api fetch fails", async () => {
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    vi.mocked(getWorkspace).mockResolvedValue({
+      metadata: { name: "test-ws" },
+      spec: { namespace: { name: "test-ns" } },
+    } as ReturnType<typeof getWorkspace> extends Promise<infer T> ? NonNullable<T> : never);
+
+    mockFetch.mockRejectedValueOnce(new Error("Connection refused"));
+
+    const { verifySessionNamespace } = await import("./session-namespace-guard");
+    const result = await verifySessionNamespace("test-ws", "sess-1");
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.response.status).toBe(502);
+    }
+  });
+
+  it("strips trailing slash from SESSION_API_URL", async () => {
+    vi.stubEnv("SESSION_API_URL", "https://session-api:8080/");
+
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    vi.mocked(getWorkspace).mockResolvedValue({
+      metadata: { name: "test-ws" },
+      spec: { namespace: { name: "test-ns" } },
+    } as ReturnType<typeof getWorkspace> extends Promise<infer T> ? NonNullable<T> : never);
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ session: { id: "sess-1", namespace: "test-ns" } }),
+    });
+
+    const { verifySessionNamespace } = await import("./session-namespace-guard");
+    const result = await verifySessionNamespace("test-ws", "sess-1");
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.baseUrl).toBe("https://session-api:8080");
+    }
+
+    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    expect(fetchUrl).not.toContain("//api");
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/sessions/session-namespace-guard.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/session-namespace-guard.ts
@@ -1,0 +1,99 @@
+/**
+ * Session namespace guard.
+ *
+ * Verifies that a session belongs to the workspace's namespace before
+ * returning data. Prevents IDOR attacks where a user with access to
+ * workspace A could read sessions from workspace B by guessing session IDs.
+ */
+
+import { NextResponse } from "next/server";
+import { getWorkspace } from "@/lib/k8s/workspace-route-helpers";
+
+const SESSION_API_URL = process.env.SESSION_API_URL;
+
+/**
+ * Resolve the workspace namespace and verify the session belongs to it.
+ *
+ * Fetches the session metadata from session-api, then compares its namespace
+ * against the workspace's namespace. Returns an error response if:
+ *  - SESSION_API_URL is not configured (503)
+ *  - The workspace does not exist (404)
+ *  - The session does not exist (404 forwarded from backend)
+ *  - The session's namespace does not match the workspace's namespace (404)
+ *
+ * @returns `{ ok: true, namespace, baseUrl }` on success, or
+ *          `{ ok: false, response }` with an appropriate HTTP error.
+ */
+export async function verifySessionNamespace(
+  workspaceName: string,
+  sessionId: string
+): Promise<
+  | { ok: true; namespace: string; baseUrl: string }
+  | { ok: false; response: NextResponse }
+> {
+  if (!SESSION_API_URL) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Session API not configured" },
+        { status: 503 }
+      ),
+    };
+  }
+
+  const workspace = await getWorkspace(workspaceName);
+  if (!workspace) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Workspace not found" },
+        { status: 404 }
+      ),
+    };
+  }
+
+  const namespace = workspace.spec.namespace.name;
+  const baseUrl = SESSION_API_URL.endsWith("/")
+    ? SESSION_API_URL.slice(0, -1)
+    : SESSION_API_URL;
+
+  // Fetch session metadata to verify namespace ownership.
+  const sessionUrl = `${baseUrl}/api/v1/sessions/${encodeURIComponent(sessionId)}`;
+  let sessionResponse: Response;
+  try {
+    sessionResponse = await fetch(sessionUrl, {
+      headers: { Accept: "application/json" },
+    });
+  } catch {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Failed to connect to Session API" },
+        { status: 502 }
+      ),
+    };
+  }
+
+  if (!sessionResponse.ok) {
+    const data = await sessionResponse.json();
+    return {
+      ok: false,
+      response: NextResponse.json(data, { status: sessionResponse.status }),
+    };
+  }
+
+  const sessionData = await sessionResponse.json();
+  const sessionNamespace: string | undefined = sessionData?.session?.namespace;
+
+  if (sessionNamespace !== namespace) {
+    return {
+      ok: false,
+      response: NextResponse.json(
+        { error: "Session not found" },
+        { status: 404 }
+      ),
+    };
+  }
+
+  return { ok: true, namespace, baseUrl };
+}

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -88,11 +88,6 @@ export default defineConfig({
         "src/app/api/workspaces/[name]/arena/projects/**",
         "src/app/api/workspaces/[name]/arena/sources/[sourceName]/file/**",
 
-        // Session sub-route proxies — simple pass-through to session-api
-        "src/app/api/workspaces/[name]/sessions/[sessionId]/tool-calls/**",
-        "src/app/api/workspaces/[name]/sessions/[sessionId]/provider-calls/**",
-        "src/app/api/workspaces/[name]/sessions/[sessionId]/events/**",
-
         // Other API routes that require K8s infrastructure
         "src/app/api/workspaces/[name]/agents/**",
         "src/app/api/workspaces/[name]/costs/**",

--- a/ee/pkg/privacy/deletion.go
+++ b/ee/pkg/privacy/deletion.go
@@ -27,6 +27,7 @@ var (
 	ErrInvalidScope      = errors.New("scope must be one of: all, workspace, date_range")
 	ErrRequestNotFound   = errors.New("deletion request not found")
 	ErrAlreadyProcessing = errors.New("deletion request is already being processed")
+	ErrMissingDateRange  = errors.New("at least one of dateFrom or dateTo is required for date_range scope")
 )
 
 // Status constants for deletion requests.
@@ -88,7 +89,10 @@ type DeletionStore interface {
 
 // SessionDeleter abstracts session lookup and deletion across storage tiers.
 type SessionDeleter interface {
-	ListSessionsByUser(ctx context.Context, userID string, workspace string) ([]string, error)
+	ListSessionsByUser(
+		ctx context.Context, userID, workspace string,
+		dateFrom, dateTo *time.Time,
+	) ([]string, error)
 	DeleteSession(ctx context.Context, sessionID string) error
 }
 
@@ -192,8 +196,8 @@ func (s *DeletionService) ProcessRequest(ctx context.Context, id string) error {
 		return fmt.Errorf("updating request status: %w", err)
 	}
 
-	// Find sessions for the user.
-	sessionIDs, err := s.deleter.ListSessionsByUser(ctx, req.UserID, req.Workspace)
+	// Find sessions for the user, applying date range when scope requires it.
+	sessionIDs, err := s.deleter.ListSessionsByUser(ctx, req.UserID, req.Workspace, req.DateFrom, req.DateTo)
 	if err != nil {
 		return s.failRequest(ctx, req, fmt.Sprintf("listing sessions: %v", err))
 	}
@@ -290,6 +294,9 @@ func validateInput(input *CreateDeletionRequest) error {
 	}
 	if !validScopes[input.Scope] {
 		return ErrInvalidScope
+	}
+	if input.Scope == "date_range" && input.DateFrom == nil && input.DateTo == nil {
+		return ErrMissingDateRange
 	}
 	return nil
 }

--- a/ee/pkg/privacy/deletion_test.go
+++ b/ee/pkg/privacy/deletion_test.go
@@ -65,7 +65,8 @@ func (m *MockDeletionStore) GetRequest(_ context.Context, id string) (*DeletionR
 func (m *MockDeletionStore) UpdateRequest(_ context.Context, req *DeletionRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.requests[req.ID] = req
+	cp := *req
+	m.requests[req.ID] = &cp
 	return nil
 }
 

--- a/ee/pkg/privacy/deletion_test.go
+++ b/ee/pkg/privacy/deletion_test.go
@@ -83,9 +83,18 @@ func (m *MockDeletionStore) ListRequestsByUser(_ context.Context, userID string)
 
 // MockSessionDeleter is a mock for SessionDeleter.
 type MockSessionDeleter struct {
-	Sessions    map[string][]string // userID+workspace -> sessionIDs
-	DeleteError error               // error to return on delete
-	FailIDs     map[string]bool     // session IDs that should fail on delete
+	Sessions     map[string][]string // userID+workspace -> sessionIDs
+	DeleteError  error               // error to return on delete
+	FailIDs      map[string]bool     // session IDs that should fail on delete
+	LastDateFrom *time.Time          // captures the dateFrom arg from the last call
+	LastDateTo   *time.Time          // captures the dateTo arg from the last call
+	AllSessions  []*sessionWithDates // all sessions with dates for date-range filtering
+}
+
+// sessionWithDates is a test helper that pairs a session ID with a creation time.
+type sessionWithDates struct {
+	ID        string
+	CreatedAt time.Time
 }
 
 func NewMockSessionDeleter() *MockSessionDeleter {
@@ -95,7 +104,28 @@ func NewMockSessionDeleter() *MockSessionDeleter {
 	}
 }
 
-func (m *MockSessionDeleter) ListSessionsByUser(_ context.Context, userID string, workspace string) ([]string, error) {
+func (m *MockSessionDeleter) ListSessionsByUser(
+	_ context.Context, userID, workspace string,
+	dateFrom, dateTo *time.Time,
+) ([]string, error) {
+	m.LastDateFrom = dateFrom
+	m.LastDateTo = dateTo
+
+	// If AllSessions is set, filter by date range (for date_range scope tests).
+	if len(m.AllSessions) > 0 {
+		var result []string
+		for _, s := range m.AllSessions {
+			if dateFrom != nil && s.CreatedAt.Before(*dateFrom) {
+				continue
+			}
+			if dateTo != nil && s.CreatedAt.After(*dateTo) {
+				continue
+			}
+			result = append(result, s.ID)
+		}
+		return result, nil
+	}
+
 	key := userID + "|" + workspace
 	return m.Sessions[key], nil
 }
@@ -226,18 +256,27 @@ func TestCreateRequest_AllReasons(t *testing.T) {
 }
 
 func TestCreateRequest_AllScopes(t *testing.T) {
-	scopes := []string{"all", "workspace", "date_range"}
-	for _, scope := range scopes {
-		t.Run(scope, func(t *testing.T) {
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	scopes := []struct {
+		scope    string
+		dateFrom *time.Time
+	}{
+		{"all", nil},
+		{"workspace", nil},
+		{"date_range", &from},
+	}
+	for _, sc := range scopes {
+		t.Run(sc.scope, func(t *testing.T) {
 			store := NewMockDeletionStore()
 			svc := newTestService(store, NewMockSessionDeleter(), nil)
 			req, err := svc.CreateRequest(context.Background(), &CreateDeletionRequest{
-				UserID: "user-1",
-				Reason: "gdpr_erasure",
-				Scope:  scope,
+				UserID:   "user-1",
+				Reason:   "gdpr_erasure",
+				Scope:    sc.scope,
+				DateFrom: sc.dateFrom,
 			})
 			require.NoError(t, err)
-			assert.Equal(t, scope, req.Scope)
+			assert.Equal(t, sc.scope, req.Scope)
 		})
 	}
 }
@@ -668,6 +707,7 @@ func TestMapErrorToStatus(t *testing.T) {
 		{"required field", ErrMissingUserID, http.StatusBadRequest},
 		{"invalid reason", ErrInvalidReason, http.StatusBadRequest},
 		{"already processing", ErrAlreadyProcessing, http.StatusConflict},
+		{"missing date range", ErrMissingDateRange, http.StatusBadRequest},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -867,7 +907,7 @@ func TestWarmStoreSessionDeleter_ListSessionsByUser(t *testing.T) {
 	}
 	deleter := NewWarmStoreSessionDeleter(mock)
 
-	ids, err := deleter.ListSessionsByUser(context.Background(), "user-1", "ws")
+	ids, err := deleter.ListSessionsByUser(context.Background(), "user-1", "ws", nil, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"s1", "s2"}, ids)
 }
@@ -876,7 +916,7 @@ func TestWarmStoreSessionDeleter_ListSessionsByUser_Error(t *testing.T) {
 	mock := &MockWarmStoreProvider{listErr: errors.New("list failed")}
 	deleter := NewWarmStoreSessionDeleter(mock)
 
-	_, err := deleter.ListSessionsByUser(context.Background(), "user-1", "")
+	_, err := deleter.ListSessionsByUser(context.Background(), "user-1", "", nil, nil)
 	assert.Error(t, err)
 }
 
@@ -884,7 +924,7 @@ func TestWarmStoreSessionDeleter_ListSessionsByUser_Empty(t *testing.T) {
 	mock := &MockWarmStoreProvider{sessions: []*session.Session{}}
 	deleter := NewWarmStoreSessionDeleter(mock)
 
-	ids, err := deleter.ListSessionsByUser(context.Background(), "user-1", "")
+	ids, err := deleter.ListSessionsByUser(context.Background(), "user-1", "", nil, nil)
 	require.NoError(t, err)
 	assert.Empty(t, ids)
 }
@@ -909,6 +949,98 @@ func TestWarmStoreSessionDeleter_DeleteSession_Error(t *testing.T) {
 func TestNewWarmStoreSessionDeleter(t *testing.T) {
 	deleter := NewWarmStoreSessionDeleter(&MockWarmStoreProvider{})
 	assert.NotNil(t, deleter)
+}
+
+// --- date_range scope tests -------------------------------------------------
+
+func TestCreateRequest_DateRangeScopeMissingDates(t *testing.T) {
+	store := NewMockDeletionStore()
+	svc := newTestService(store, NewMockSessionDeleter(), nil)
+
+	_, err := svc.CreateRequest(context.Background(), &CreateDeletionRequest{
+		UserID: "user-1",
+		Reason: "gdpr_erasure",
+		Scope:  "date_range",
+		// No DateFrom or DateTo provided
+	})
+
+	assert.ErrorIs(t, err, ErrMissingDateRange)
+}
+
+func TestCreateRequest_DateRangeScopeWithDateFrom(t *testing.T) {
+	store := NewMockDeletionStore()
+	svc := newTestService(store, NewMockSessionDeleter(), nil)
+
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	req, err := svc.CreateRequest(context.Background(), &CreateDeletionRequest{
+		UserID:   "user-1",
+		Reason:   "gdpr_erasure",
+		Scope:    "date_range",
+		DateFrom: &from,
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "date_range", req.Scope)
+	assert.Equal(t, &from, req.DateFrom)
+}
+
+func TestProcessRequest_DateRangeOnlyDeletesMatchingSessions(t *testing.T) {
+	store := NewMockDeletionStore()
+	deleter := NewMockSessionDeleter()
+	svc := newTestService(store, deleter, nil)
+
+	// Set up sessions with different dates.
+	deleter.AllSessions = []*sessionWithDates{
+		{ID: "sess-old", CreatedAt: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)},
+		{ID: "sess-in-range", CreatedAt: time.Date(2026, 2, 15, 0, 0, 0, 0, time.UTC)},
+		{ID: "sess-recent", CreatedAt: time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC)},
+	}
+
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	req, err := svc.CreateRequest(context.Background(), &CreateDeletionRequest{
+		UserID:   "user-1",
+		Reason:   "gdpr_erasure",
+		Scope:    "date_range",
+		DateFrom: &from,
+		DateTo:   &to,
+	})
+	require.NoError(t, err)
+
+	err = svc.ProcessRequest(context.Background(), req.ID)
+	require.NoError(t, err)
+
+	updated, err := store.GetRequest(context.Background(), req.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "completed", updated.Status)
+	// Only sess-in-range should be deleted (sess-old is before range, sess-recent is after).
+	assert.Equal(t, 1, updated.SessionsDeleted)
+
+	// Verify the date filters were passed through.
+	assert.Equal(t, &from, deleter.LastDateFrom)
+	assert.Equal(t, &to, deleter.LastDateTo)
+}
+
+func TestProcessRequest_AllScopePassesNilDates(t *testing.T) {
+	store := NewMockDeletionStore()
+	deleter := NewMockSessionDeleter()
+	svc := newTestService(store, deleter, nil)
+
+	deleter.Sessions["user-1|"] = []string{"sess-1"}
+
+	req, err := svc.CreateRequest(context.Background(), &CreateDeletionRequest{
+		UserID: "user-1",
+		Reason: "gdpr_erasure",
+		Scope:  "all",
+	})
+	require.NoError(t, err)
+
+	err = svc.ProcessRequest(context.Background(), req.ID)
+	require.NoError(t, err)
+
+	// All scope should not pass date filters.
+	assert.Nil(t, deleter.LastDateFrom)
+	assert.Nil(t, deleter.LastDateTo)
 }
 
 // --- failRequest tests ------------------------------------------------------
@@ -945,7 +1077,9 @@ type failingListDeleter struct {
 	listErr error
 }
 
-func (f *failingListDeleter) ListSessionsByUser(_ context.Context, _ string, _ string) ([]string, error) {
+func (f *failingListDeleter) ListSessionsByUser(
+	_ context.Context, _, _ string, _, _ *time.Time,
+) ([]string, error) {
 	return nil, f.listErr
 }
 

--- a/ee/pkg/privacy/middleware.go
+++ b/ee/pkg/privacy/middleware.go
@@ -86,7 +86,9 @@ func (m *PrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 			return // 204 already sent
 		}
 
-		m.applyRedaction(r, policy, sessionID)
+		if !m.applyRedaction(w, r, policy, sessionID) {
+			return // 500 already sent
+		}
 
 		next.ServeHTTP(w, r)
 	})
@@ -98,18 +100,23 @@ func isWriteMethod(method string) bool {
 }
 
 // applyRedaction redacts PII from the request body if the policy requires it.
-func (m *PrivacyMiddleware) applyRedaction(r *http.Request, policy *EffectivePolicy, sessionID string) {
+// Returns true if the request should continue, false if it was blocked.
+func (m *PrivacyMiddleware) applyRedaction(
+	w http.ResponseWriter, r *http.Request, policy *EffectivePolicy, sessionID string,
+) bool {
 	if policy.Recording.PII == nil || !policy.Recording.PII.Redact {
-		return
+		return true
 	}
 	redactedBody, err := redactRequestBody(
 		r.Body, r.URL.Path, m.redactor, policy.Recording.PII,
 	)
 	if err != nil {
-		m.log.Error(err, "body redaction failed", "sessionID", sessionID)
-		return
+		m.log.Error(err, "body redaction failed, blocking request", "sessionID", sessionID)
+		http.Error(w, "redaction failed", http.StatusInternalServerError)
+		return false
 	}
 	r.Body = redactedBody
+	return true
 }
 
 // checkOptOut checks whether the user has opted out. Returns a non-nil error

--- a/ee/pkg/privacy/middleware_test.go
+++ b/ee/pkg/privacy/middleware_test.go
@@ -256,6 +256,43 @@ func TestPrivacyMiddleware_OptOutNoUserID(t *testing.T) {
 	assert.True(t, called, "should pass through when no user ID header")
 }
 
+func TestPrivacyMiddleware_RedactionFailureReturns500(t *testing.T) {
+	called := false
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	})
+
+	lookup := &mockSessionLookup{ns: "default", agent: "test-agent"}
+	cache := NewSessionMetadataCache(lookup, 100)
+
+	watcher := &PolicyWatcher{}
+	watcher.policies.Store("test", &omniav1alpha1.SessionPrivacyPolicy{
+		Spec: omniav1alpha1.SessionPrivacyPolicySpec{
+			Level: omniav1alpha1.PolicyLevelGlobal,
+			Recording: omniav1alpha1.RecordingConfig{
+				Enabled: true,
+				PII: &omniav1alpha1.PIIConfig{
+					Redact:   true,
+					Patterns: []string{"ssn"},
+					Strategy: omniav1alpha1.RedactionStrategyReplace,
+				},
+			},
+		},
+	})
+
+	r := redaction.NewRedactor()
+	mw := NewPrivacyMiddleware(watcher, cache, r, nil, logr.Discard())
+
+	// Send invalid JSON to a /messages endpoint — redaction will fail on unmarshal.
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/abc-123/messages",
+		strings.NewReader(`not valid json`))
+	rr := httptest.NewRecorder()
+	mw.Wrap(handler).ServeHTTP(rr, req)
+
+	assert.False(t, called, "handler should not be called when redaction fails")
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
 func TestSessionMetadataCache_Eviction(t *testing.T) {
 	lookup := &mockSessionLookup{ns: "ns1", agent: "agent1"}
 	cache := NewSessionMetadataCache(lookup, 2)

--- a/ee/pkg/privacy/redact_body.go
+++ b/ee/pkg/privacy/redact_body.go
@@ -44,8 +44,7 @@ func redactRequestBody(
 
 	redacted, err := redactByEndpoint(data, path, redactor, pii)
 	if err != nil {
-		// On redaction error, return original body to avoid data loss.
-		return io.NopCloser(bytes.NewReader(data)), nil
+		return nil, fmt.Errorf("redacting request body: %w", err)
 	}
 
 	return io.NopCloser(bytes.NewReader(redacted)), nil

--- a/ee/pkg/privacy/session_deleter.go
+++ b/ee/pkg/privacy/session_deleter.go
@@ -10,6 +10,7 @@ package privacy
 
 import (
 	"context"
+	"time"
 
 	"github.com/altairalabs/omnia/internal/session/providers"
 )
@@ -24,12 +25,18 @@ func NewWarmStoreSessionDeleter(warm providers.WarmStoreProvider) *WarmStoreSess
 	return &WarmStoreSessionDeleter{warm: warm}
 }
 
-// ListSessionsByUser lists session IDs for a user, optionally filtered by workspace.
+// ListSessionsByUser lists session IDs for a user, optionally filtered by workspace and date range.
 func (d *WarmStoreSessionDeleter) ListSessionsByUser(
-	ctx context.Context, userID string, workspace string,
+	ctx context.Context, userID string, workspace string, dateFrom *time.Time, dateTo *time.Time,
 ) ([]string, error) {
 	opts := providers.SessionListOpts{
 		WorkspaceName: workspace,
+	}
+	if dateFrom != nil {
+		opts.CreatedAfter = *dateFrom
+	}
+	if dateTo != nil {
+		opts.CreatedBefore = *dateTo
 	}
 	// Use a large limit to get all sessions. In production, this should
 	// be paginated, but for deletion workflows we need all IDs.

--- a/internal/runtime/media.go
+++ b/internal/runtime/media.go
@@ -59,11 +59,17 @@ func (r *MediaResolver) ResolveURL(url string) (base64Data, mimeType string, isP
 	switch {
 	case strings.HasPrefix(url, schemeFile):
 		path := strings.TrimPrefix(url, schemeFile)
+		if err := r.validatePathContainment(path); err != nil {
+			return "", "", false, err
+		}
 		return r.resolveLocalFile(path)
 
 	case strings.HasPrefix(url, schemeMock):
 		filename := strings.TrimPrefix(url, schemeMock)
 		path := filepath.Join(r.mediaBasePath, filename)
+		if err := r.validatePathContainment(path); err != nil {
+			return "", "", false, err
+		}
 		return r.resolveLocalFile(path)
 
 	case strings.HasPrefix(url, schemeHTTP), strings.HasPrefix(url, schemeHTTPS):
@@ -74,6 +80,18 @@ func (r *MediaResolver) ResolveURL(url string) (base64Data, mimeType string, isP
 	default:
 		return "", "", false, fmt.Errorf("unsupported URL scheme: %s", url)
 	}
+}
+
+// validatePathContainment checks that the resolved path is within the media base directory,
+// preventing directory traversal attacks.
+func (r *MediaResolver) validatePathContainment(path string) error {
+	cleanBase := filepath.Clean(r.mediaBasePath)
+	cleanPath := filepath.Clean(path)
+	// The resolved path must be within the base directory (or be the base directory itself).
+	if !strings.HasPrefix(cleanPath, cleanBase+string(filepath.Separator)) && cleanPath != cleanBase {
+		return fmt.Errorf("path traversal attempt blocked: resolved path %s is outside base %s", cleanPath, cleanBase)
+	}
+	return nil
 }
 
 // resolveLocalFile reads a local file and returns its base64-encoded contents.

--- a/internal/runtime/media_test.go
+++ b/internal/runtime/media_test.go
@@ -101,9 +101,10 @@ func TestMediaResolver_ResolveURL_HTTPPassthrough(t *testing.T) {
 }
 
 func TestMediaResolver_ResolveURL_MissingFile(t *testing.T) {
-	resolver := NewMediaResolver("/test/media")
+	tmpDir := t.TempDir()
+	resolver := NewMediaResolver(tmpDir)
 
-	_, _, _, err := resolver.ResolveURL("file:///nonexistent/file.png")
+	_, _, _, err := resolver.ResolveURL("file://" + filepath.Join(tmpDir, "nonexistent.png"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "not found")
 }
@@ -210,6 +211,53 @@ func TestIsResolvableURL(t *testing.T) {
 			assert.Equal(t, tc.expected, result)
 		})
 	}
+}
+
+func TestMediaResolver_ResolveURL_PathTraversal(t *testing.T) {
+	tmpDir := t.TempDir()
+	resolver := NewMediaResolver(tmpDir)
+
+	testCases := []struct {
+		name string
+		url  string
+	}{
+		{"mock traversal with dot-dot", "mock://../../etc/passwd"},
+		{"mock traversal with nested dot-dot", "mock://subdir/../../../etc/passwd"},
+		{"file traversal with dot-dot", "file://" + filepath.Join(tmpDir, "../../etc/passwd")},
+		{"file traversal absolute outside base", "file:///etc/passwd"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, err := resolver.ResolveURL(tc.url)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "path traversal attempt blocked")
+		})
+	}
+}
+
+func TestMediaResolver_ResolveURL_PathTraversal_ValidPaths(t *testing.T) {
+	// Ensure legitimate subdirectory paths still work
+	tmpDir := t.TempDir()
+	subDir := filepath.Join(tmpDir, "subdir")
+	err := os.MkdirAll(subDir, 0755)
+	require.NoError(t, err)
+
+	testFile := filepath.Join(subDir, "image.png")
+	err = os.WriteFile(testFile, []byte("fake png"), 0644)
+	require.NoError(t, err)
+
+	resolver := NewMediaResolver(tmpDir)
+
+	// Subdirectory path should work
+	_, mimeType, _, err := resolver.ResolveURL("mock://subdir/image.png")
+	require.NoError(t, err)
+	assert.Equal(t, "image/png", mimeType)
+
+	// file:// within base should work
+	_, mimeType, _, err = resolver.ResolveURL("file://" + testFile)
+	require.NoError(t, err)
+	assert.Equal(t, "image/png", mimeType)
 }
 
 func TestMediaResolver_ResolveURL_AudioFiles(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses the highest-priority security vulnerabilities identified during the code review cycle.

### Runtime: Path traversal in MediaResolver
- `mock://` and `file://` URL handlers now validate resolved paths stay within the media base directory
- Uses `filepath.Clean` prefix checking to prevent `../../etc/passwd` escapes
- Added tests for traversal attempts and valid subdirectory paths

### Privacy: Fail-closed redaction
- **Breaking behavior change**: When PII redaction fails, the middleware now returns HTTP 500 instead of passing unredacted content to storage
- Fixed `redactRequestBody` to propagate errors instead of silently returning the original body
- Added test verifying 500 on redaction failure

### Privacy: date_range deletion scope fix
- `ListSessionsByUser` now accepts and applies `DateFrom`/`DateTo` parameters
- Requests with `scope=date_range` must include at least one date bound (returns error otherwise)
- Previously, date_range scope silently deleted ALL sessions regardless of dates
- Added tests for date validation and filtered deletion

### Dashboard: IDOR in session proxy routes
- Session detail proxy routes now verify the session belongs to the workspace's namespace
- Prevents cross-namespace session data access via direct session ID

## Test plan
- [x] Runtime media tests pass (traversal blocked, valid paths work)
- [x] Privacy tests pass (fail-closed, date range filtering)
- [x] Dashboard tests pass (ESLint, TypeScript, Vitest)
- [x] Pre-commit checks pass (lint, vet, coverage ≥80%)
- [ ] CI green