### PR TITLE
fix: facade session lifecycle bugs and runtime error leakage

### DIFF
--- a/internal/facade/connection.go
+++ b/internal/facade/connection.go
@@ -101,9 +101,25 @@ func (s *Server) cleanupConnection(c *Connection, log logr.Logger) {
 	s.metrics.ConnectionClosed()
 
 	if c.sessionID != "" && c.sessionPersisted {
+		s.metrics.SessionClosed()
 		s.submitCompletion(func() {
 			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 			defer cancel()
+
+			// Read the session to check its current status. If the session
+			// already has a terminal status (e.g. "error"), do not overwrite
+			// it with "completed".
+			sess, err := s.sessionStore.GetSession(ctx, c.sessionID)
+			if err != nil {
+				log.Error(err, "session lookup for completion failed", "sessionID", c.sessionID)
+				return
+			}
+			if session.IsTerminalStatus(sess.Status) {
+				log.V(1).Info("session already terminal, skipping completion",
+					"sessionID", c.sessionID, "status", sess.Status)
+				return
+			}
+
 			if err := s.sessionStore.UpdateSessionStats(ctx, c.sessionID, session.SessionStatsUpdate{
 				SetStatus:  session.SessionStatusCompleted,
 				SetEndedAt: time.Now(),

--- a/internal/facade/session.go
+++ b/internal/facade/session.go
@@ -231,6 +231,8 @@ func (s *Server) ensureSession(ctx context.Context, c *Connection, sessionID str
 		return "", err
 	}
 
+	s.metrics.SessionCreated()
+
 	return sess.ID, nil
 }
 

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -375,12 +375,14 @@ func (s *Server) Converse(stream runtimev1.RuntimeService_ConverseServer) error 
 			s.log.Error(err, "failed to process message",
 				"sessionID", msg.GetSessionId())
 
-			// Send error to client
+			// Send a generic error to the client. The detailed error is
+			// logged above but must not be forwarded because it may contain
+			// sensitive information such as provider API keys.
 			_ = stream.Send(&runtimev1.ServerMessage{
 				Message: &runtimev1.ServerMessage_Error{
 					Error: &runtimev1.Error{
 						Code:    "INTERNAL_ERROR",
-						Message: err.Error(),
+						Message: "an internal error occurred while processing the message",
 					},
 				},
 			})

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -62,10 +62,15 @@ const (
 	SessionStatusExpired SessionStatus = "expired"
 )
 
-// isTerminalStatus returns true if the status is a terminal state
+// IsTerminalStatus returns true if the status is a terminal state
 // that should not be overwritten by subsequent transitions.
-func isTerminalStatus(s SessionStatus) bool {
+func IsTerminalStatus(s SessionStatus) bool {
 	return s == SessionStatusCompleted || s == SessionStatusError || s == SessionStatusExpired
+}
+
+// isTerminalStatus is an unexported alias kept for internal callers.
+func isTerminalStatus(s SessionStatus) bool {
+	return IsTerminalStatus(s)
 }
 
 // Message represents a single message in a conversation.


### PR DESCRIPTION
## Summary

Fixes three bugs identified in the facade and runtime code reviews.

- **Session status overwrite**: `cleanupConnection` now checks for terminal status before overwriting with "completed", preventing error sessions from being masked as successful on disconnect
- **Session metrics**: `SessionCreated()`/`SessionClosed()` now called in `ensureSession` and `cleanupConnection`, fixing the always-zero `omnia_agent_sessions_active` Prometheus gauge
- **Runtime error leakage**: gRPC server no longer sends raw internal errors (which could include provider API keys) to clients; returns generic message instead, keeps details in server logs

## Test plan
- [x] Facade tests pass
- [x] Runtime tests pass
- [x] Pre-commit checks pass (lint, vet, coverage ≥80%)
- [ ] CI green