### PR TITLE
fix: session-api wave 3 — rename UpdateSessionStats, LIMIT+1 pagination, single-query status updates

### DIFF
--- a/api/session-api/openapi.yaml
+++ b/api/session-api/openapi.yaml
@@ -227,11 +227,11 @@ paths:
         '500':
           $ref: '#/components/responses/InternalError'
 
-  /api/v1/sessions/{sessionID}/stats:
+  /api/v1/sessions/{sessionID}/status:
     patch:
-      tags: [stats]
-      summary: Incrementally update session statistics
-      operationId: updateStats
+      tags: [status]
+      summary: Update session lifecycle status
+      operationId: updateStatus
       parameters:
         - $ref: '#/components/parameters/SessionID'
       requestBody:
@@ -239,10 +239,10 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/SessionStatsUpdate'
+              $ref: '#/components/schemas/SessionStatusUpdate'
       responses:
         '200':
-          description: Stats updated
+          description: Status updated
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -843,10 +843,10 @@ components:
           type: string
           format: date-time
 
-    # SessionStatsUpdate contains only lifecycle state changes.
+    # SessionStatusUpdate contains only lifecycle state changes.
     # Counter fields (messages, tool calls, tokens, cost) are auto-derived
     # from AppendMessage and should not be set externally.
-    SessionStatsUpdate:
+    SessionStatusUpdate:
       type: object
       properties:
         SetStatus:

--- a/dashboard/src/app/api/workspaces/[name]/sessions/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/sessions/route.ts
@@ -47,7 +47,7 @@ export const GET = withWorkspaceAccess(
     const params = new URLSearchParams();
     params.set("namespace", namespace);
 
-    const forwardParams = ["agent", "status", "from", "to", "limit", "offset", "q"];
+    const forwardParams = ["agent", "status", "from", "to", "limit", "offset", "q", "count"];
     for (const key of forwardParams) {
       const value = request.nextUrl.searchParams.get(key);
       if (value) params.set(key, value);

--- a/dashboard/src/app/sessions/page.tsx
+++ b/dashboard/src/app/sessions/page.tsx
@@ -119,6 +119,7 @@ export default function SessionsPage() {
     const opts: SessionListOptions = {
       limit: PAGE_SIZE,
       offset: page * PAGE_SIZE,
+      count: true,
     };
     if (statusFilter !== "all") opts.status = statusFilter as Session["status"];
     if (agentFilter !== "all") opts.agent = agentFilter;

--- a/dashboard/src/lib/api/session-api-schema.d.ts
+++ b/dashboard/src/lib/api/session-api-schema.d.ts
@@ -93,7 +93,7 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/api/v1/sessions/{sessionID}/stats": {
+    "/api/v1/sessions/{sessionID}/status": {
         parameters: {
             query?: never;
             header?: never;
@@ -331,7 +331,7 @@ export interface components {
             /** Format: date-time */
             createdAt?: string;
         };
-        SessionStatsUpdate: {
+        SessionStatusUpdate: {
             /** Format: int32 */
             AddInputTokens?: number;
             /** Format: int32 */
@@ -731,7 +731,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["SessionStatsUpdate"];
+                "application/json": components["schemas"]["SessionStatusUpdate"];
             };
         };
         responses: {

--- a/dashboard/src/lib/data/session-api-service.ts
+++ b/dashboard/src/lib/data/session-api-service.ts
@@ -158,6 +158,7 @@ export class SessionApiService {
     if (options?.to) params.set("to", options.to);
     if (options?.limit) params.set("limit", String(options.limit));
     if (options?.offset) params.set("offset", String(options.offset));
+    if (options?.count) params.set("count", "true");
 
     const queryString = params.toString();
     const suffix = queryString ? `?${queryString}` : "";
@@ -175,7 +176,7 @@ export class SessionApiService {
     const data = await response.json();
     return {
       sessions: (data.sessions || []).map(transformApiSessionSummary),
-      total: data.total || 0,
+      total: data.total ?? -1,
       hasMore: data.hasMore || false,
     };
   }
@@ -215,6 +216,7 @@ export class SessionApiService {
     if (options.to) params.set("to", options.to);
     if (options.limit) params.set("limit", String(options.limit));
     if (options.offset) params.set("offset", String(options.offset));
+    if (options.count) params.set("count", "true");
 
     const response = await fetch(
       `${SESSION_API_BASE}/${encodeURIComponent(workspace)}/sessions?${params.toString()}`
@@ -229,7 +231,7 @@ export class SessionApiService {
     const data = await response.json();
     return {
       sessions: (data.sessions || []).map(transformApiSessionSummary),
-      total: data.total || 0,
+      total: data.total ?? -1,
       hasMore: data.hasMore || false,
     };
   }

--- a/dashboard/src/types/session.ts
+++ b/dashboard/src/types/session.ts
@@ -115,6 +115,8 @@ export interface SessionListOptions {
   to?: string; // ISO date string
   limit?: number;
   offset?: number;
+  /** Request a total count from the server (triggers a separate COUNT query). */
+  count?: boolean;
 }
 
 // Options for searching sessions (extends list options with query)

--- a/ee/pkg/privacy/deletion_test.go
+++ b/ee/pkg/privacy/deletion_test.go
@@ -758,8 +758,8 @@ func (m *MockWarmStoreProvider) UpdateSession(
 	return nil
 }
 
-func (m *MockWarmStoreProvider) UpdateSessionStats(
-	_ context.Context, _ string, _ session.SessionStatsUpdate,
+func (m *MockWarmStoreProvider) UpdateSessionStatus(
+	_ context.Context, _ string, _ session.SessionStatusUpdate,
 ) error {
 	return nil
 }

--- a/ee/pkg/privacy/session_lookup_adapter_test.go
+++ b/ee/pkg/privacy/session_lookup_adapter_test.go
@@ -32,7 +32,7 @@ func (m *lookupMockWarm) GetSession(_ context.Context, _ string) (*session.Sessi
 	return m.sess, m.getErr
 }
 func (m *lookupMockWarm) UpdateSession(context.Context, *session.Session) error { return nil }
-func (m *lookupMockWarm) UpdateSessionStats(context.Context, string, session.SessionStatsUpdate) error {
+func (m *lookupMockWarm) UpdateSessionStatus(context.Context, string, session.SessionStatusUpdate) error {
 	return nil
 }
 func (m *lookupMockWarm) RefreshTTL(context.Context, string, time.Time) error           { return nil }

--- a/internal/compaction/engine_test.go
+++ b/internal/compaction/engine_test.go
@@ -84,7 +84,7 @@ func (m *mockWarmStore) GetSession(context.Context, string) (*session.Session, e
 
 func (m *mockWarmStore) UpdateSession(context.Context, *session.Session) error { return nil }
 
-func (m *mockWarmStore) UpdateSessionStats(context.Context, string, session.SessionStatsUpdate) error {
+func (m *mockWarmStore) UpdateSessionStatus(context.Context, string, session.SessionStatusUpdate) error {
 	return nil
 }
 

--- a/internal/facade/connection.go
+++ b/internal/facade/connection.go
@@ -120,7 +120,7 @@ func (s *Server) cleanupConnection(c *Connection, log logr.Logger) {
 				return
 			}
 
-			if err := s.sessionStore.UpdateSessionStats(ctx, c.sessionID, session.SessionStatsUpdate{
+			if err := s.sessionStore.UpdateSessionStatus(ctx, c.sessionID, session.SessionStatusUpdate{
 				SetStatus:  session.SessionStatusCompleted,
 				SetEndedAt: time.Now(),
 			}); err != nil {

--- a/internal/facade/recording_writer.go
+++ b/internal/facade/recording_writer.go
@@ -229,11 +229,11 @@ func (w *recordingResponseWriter) WriteError(code, message string) error {
 			w.log.Error(storeErr, "failed to record error message")
 		}
 
-		if storeErr := w.store.UpdateSessionStats(ctx, w.sessionID, session.SessionStatsUpdate{
+		if storeErr := w.store.UpdateSessionStatus(ctx, w.sessionID, session.SessionStatusUpdate{
 			SetStatus:  session.SessionStatusError,
 			SetEndedAt: time.Now(),
 		}); storeErr != nil {
-			w.log.Error(storeErr, "failed to update session stats for error")
+			w.log.Error(storeErr, "failed to update session status for error")
 		}
 	})
 

--- a/internal/runtime/event_store.go
+++ b/internal/runtime/event_store.go
@@ -44,7 +44,7 @@ type eventAction struct {
 	providerCall *session.ProviderCall
 	evalResult   *session.EvalResult
 	event        *session.RuntimeEvent
-	stats        session.SessionStatsUpdate
+	stats        session.SessionStatusUpdate
 }
 
 // Metadata key constants to avoid string duplication (SonarCloud go:S1192).
@@ -806,8 +806,8 @@ func (s *OmniaEventStore) writeMessageAndStats(ctx context.Context, sessionID st
 	}
 
 	if action.stats.SetStatus != "" || !action.stats.SetEndedAt.IsZero() {
-		if err := s.sessionStore.UpdateSessionStats(ctx, sessionID, action.stats); err != nil {
-			log.Error(err, "failed to update session stats",
+		if err := s.sessionStore.UpdateSessionStatus(ctx, sessionID, action.stats); err != nil {
+			log.Error(err, "failed to update session status",
 				"sessionID", sessionID, "eventType", eventType)
 		}
 	}

--- a/internal/runtime/event_store_test.go
+++ b/internal/runtime/event_store_test.go
@@ -37,7 +37,7 @@ import (
 type mockSessionStore struct {
 	mu            sync.Mutex
 	messages      []session.Message
-	stats         []session.SessionStatsUpdate
+	stats         []session.SessionStatusUpdate
 	toolCalls     []session.ToolCall
 	providerCalls []session.ProviderCall
 	runtimeEvents []session.RuntimeEvent
@@ -83,7 +83,7 @@ func (m *mockSessionStore) RefreshTTL(_ context.Context, _ string, _ time.Durati
 	return nil
 }
 
-func (m *mockSessionStore) UpdateSessionStats(_ context.Context, _ string, update session.SessionStatsUpdate) error {
+func (m *mockSessionStore) UpdateSessionStatus(_ context.Context, _ string, update session.SessionStatusUpdate) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.stats = append(m.stats, update)
@@ -246,10 +246,10 @@ func (m *mockSessionStore) getMessages() []session.Message {
 	return result
 }
 
-func (m *mockSessionStore) getStats() []session.SessionStatsUpdate {
+func (m *mockSessionStore) getStats() []session.SessionStatusUpdate {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	result := make([]session.SessionStatsUpdate, len(m.stats))
+	result := make([]session.SessionStatusUpdate, len(m.stats))
 	copy(result, m.stats)
 	return result
 }
@@ -274,7 +274,7 @@ func (m *mockSessionStore) waitForMessages(t *testing.T, count int) {
 }
 
 // waitForStats waits until the expected number of stats updates is recorded.
-// UpdateSessionStats is called after AppendMessage in the same goroutine,
+// UpdateSessionStatus is called after AppendMessage in the same goroutine,
 // so waitForMessages alone is not sufficient to guarantee stats are available.
 func (m *mockSessionStore) waitForStats(t *testing.T, count int) {
 	t.Helper()

--- a/internal/session/api/event_publisher_test.go
+++ b/internal/session/api/event_publisher_test.go
@@ -184,9 +184,9 @@ func TestAppendMessage_PublishErrorDoesNotFailRequest(t *testing.T) {
 	require.NoError(t, err) // Must succeed even though publish fails.
 }
 
-// --- UpdateSessionStats event tests -----------------------------------------
+// --- UpdateSessionStatus event tests -----------------------------------------
 
-func TestUpdateSessionStats_CompletedPublishesEvent(t *testing.T) {
+func TestUpdateSessionStatus_CompletedPublishesEvent(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:        "s1",
@@ -200,7 +200,7 @@ func TestUpdateSessionStats_CompletedPublishesEvent(t *testing.T) {
 	pub := &mockEventPublisher{}
 	svc := newServiceWithPublisher(registry, pub)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	require.NoError(t, err)
@@ -213,7 +213,7 @@ func TestUpdateSessionStats_CompletedPublishesEvent(t *testing.T) {
 	assert.NotEmpty(t, events[0].Timestamp)
 }
 
-func TestUpdateSessionStats_NoEventOnNonCompletedStatus(t *testing.T) {
+func TestUpdateSessionStatus_NoEventOnNonCompletedStatus(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:     "s1",
@@ -225,14 +225,14 @@ func TestUpdateSessionStats_NoEventOnNonCompletedStatus(t *testing.T) {
 	pub := &mockEventPublisher{}
 	svc := newServiceWithPublisher(registry, pub)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{})
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{})
 	require.NoError(t, err)
 
 	time.Sleep(50 * time.Millisecond)
 	assert.Empty(t, pub.getEvents())
 }
 
-func TestUpdateSessionStats_NoEventWhenAlreadyCompleted(t *testing.T) {
+func TestUpdateSessionStatus_NoEventWhenAlreadyCompleted(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:     "s1",
@@ -245,7 +245,7 @@ func TestUpdateSessionStats_NoEventWhenAlreadyCompleted(t *testing.T) {
 	svc := newServiceWithPublisher(registry, pub)
 
 	// Re-setting to completed when already completed should not publish.
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	require.NoError(t, err)
@@ -254,7 +254,7 @@ func TestUpdateSessionStats_NoEventWhenAlreadyCompleted(t *testing.T) {
 	assert.Empty(t, pub.getEvents())
 }
 
-func TestUpdateSessionStats_NilPublisherDoesNotPanic(t *testing.T) {
+func TestUpdateSessionStatus_NilPublisherDoesNotPanic(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:     "s1",
@@ -265,7 +265,7 @@ func TestUpdateSessionStats_NilPublisherDoesNotPanic(t *testing.T) {
 	registry.SetWarmStore(warm)
 	svc := newServiceWithPublisher(registry, nil)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestAppendMessage_AssistantPublishesEventWithPromptPack(t *testing.T) {
 	assert.Equal(t, "v3", events[0].PromptPackVersion)
 }
 
-func TestUpdateSessionStats_CompletedPublishesEventWithPromptPack(t *testing.T) {
+func TestUpdateSessionStatus_CompletedPublishesEventWithPromptPack(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:                "s1",
@@ -435,7 +435,7 @@ func TestUpdateSessionStats_CompletedPublishesEventWithPromptPack(t *testing.T) 
 	pub := &mockEventPublisher{}
 	svc := newServiceWithPublisher(registry, pub)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	require.NoError(t, err)

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -143,7 +143,7 @@ type AppendMessageRequest struct {
 
 // UpdateStatsRequest is the JSON body for PATCH /api/v1/sessions/{sessionID}/stats.
 type UpdateStatsRequest struct {
-	session.SessionStatsUpdate
+	session.SessionStatusUpdate
 }
 
 // RefreshTTLRequest is the JSON body for POST /api/v1/sessions/{sessionID}/ttl.
@@ -168,7 +168,8 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	// Write endpoints
 	mux.HandleFunc("POST /api/v1/sessions", h.handleCreateSession)
 	mux.HandleFunc("POST /api/v1/sessions/{sessionID}/messages", h.handleAppendMessage)
-	mux.HandleFunc("PATCH /api/v1/sessions/{sessionID}/stats", h.handleUpdateStats)
+	mux.HandleFunc("PATCH /api/v1/sessions/{sessionID}/status", h.handleUpdateStats)
+	mux.HandleFunc("PATCH /api/v1/sessions/{sessionID}/stats", h.handleUpdateStats) // backward-compat alias
 	mux.HandleFunc("POST /api/v1/sessions/{sessionID}/ttl", h.handleRefreshTTL)
 	mux.HandleFunc("DELETE /api/v1/sessions/{sessionID}", h.handleDeleteSession)
 
@@ -490,7 +491,7 @@ func (h *Handler) handleUpdateStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	h.limitBody(w, r)
-	var update session.SessionStatsUpdate
+	var update session.SessionStatusUpdate
 	if err := json.NewDecoder(r.Body).Decode(&update); err != nil {
 		if isMaxBytesError(err) {
 			writeError(w, ErrBodyTooLarge)
@@ -501,15 +502,15 @@ func (h *Handler) handleUpdateStats(w http.ResponseWriter, r *http.Request) {
 	}
 
 	log := h.requestLog(r.Context())
-	if err := h.service.UpdateSessionStats(r.Context(), sessionID, update); err != nil {
+	if err := h.service.UpdateSessionStatus(r.Context(), sessionID, update); err != nil {
 		if !errors.Is(err, session.ErrSessionNotFound) {
-			log.Error(err, "UpdateSessionStats failed", "sessionID", sessionID)
+			log.Error(err, "UpdateSessionStatus failed", "sessionID", sessionID)
 		}
 		writeError(w, err)
 		return
 	}
 
-	log.V(2).Info("session stats updated", "sessionID", sessionID)
+	log.V(2).Info("session status updated", "sessionID", sessionID)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/internal/session/api/handler_test.go
+++ b/internal/session/api/handler_test.go
@@ -143,7 +143,7 @@ func (m *mockWarmStore) UpdateSession(_ context.Context, s *session.Session) err
 	return nil
 }
 
-func (m *mockWarmStore) UpdateSessionStats(_ context.Context, sessionID string, update session.SessionStatsUpdate) error {
+func (m *mockWarmStore) UpdateSessionStatus(_ context.Context, sessionID string, update session.SessionStatusUpdate) error {
 	s, ok := m.sessions[sessionID]
 	if !ok {
 		return session.ErrSessionNotFound
@@ -1647,7 +1647,7 @@ func TestHandleUpdateStats_OK(t *testing.T) {
 	h.RegisterRoutes(mux)
 
 	body := `{"setStatus":"completed","setEndedAt":"2026-01-01T00:00:00Z"}`
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+testSessionID+"/stats", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+testSessionID+"/status", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -1670,7 +1670,7 @@ func TestHandleUpdateStats_NotFound(t *testing.T) {
 	h.RegisterRoutes(mux)
 
 	body := `{"setStatus":"completed"}`
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/00000000-0000-0000-0000-000000000099/stats", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/00000000-0000-0000-0000-000000000099/status", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -1863,7 +1863,7 @@ func TestHandleRegisterRoutes_WriteEndpoints(t *testing.T) {
 	}{
 		{http.MethodPost, "/api/v1/sessions", `{"id":"` + testSessionIDOther + `","agentName":"a","namespace":"ns"}`, http.StatusCreated},
 		{http.MethodPost, "/api/v1/sessions/" + testSessionID + "/messages", `{"id":"m","role":"user","content":"hi"}`, http.StatusCreated},
-		{http.MethodPatch, "/api/v1/sessions/" + testSessionID + "/stats", `{"addMessages":1}`, http.StatusOK},
+		{http.MethodPatch, "/api/v1/sessions/" + testSessionID + "/status", `{"addMessages":1}`, http.StatusOK},
 		{http.MethodPost, "/api/v1/sessions/" + testSessionID + "/ttl", `{"ttlSeconds":60}`, http.StatusOK},
 	}
 
@@ -1962,7 +1962,7 @@ func TestHandleUpdateStats_BodyTooLarge(t *testing.T) {
 	h.RegisterRoutes(mux)
 
 	body := `{"addInputTokens":100,"addOutputTokens":50,"addMessages":1}`
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+testSessionID+"/stats", bytes.NewBufferString(body))
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+testSessionID+"/status", bytes.NewBufferString(body))
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -1977,7 +1977,7 @@ func TestHandleUpdateStats_NoBody(t *testing.T) {
 	mux := http.NewServeMux()
 	h.RegisterRoutes(mux)
 
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+testSessionID+"/stats", nil)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/"+testSessionID+"/status", nil)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -2164,9 +2164,9 @@ func TestHandleGetSession_GetMessagesError(t *testing.T) {
 }
 
 func TestHandleUpdateStats_InternalError(t *testing.T) {
-	// Test the path where UpdateSessionStats returns a non-NotFound error.
+	// Test the path where UpdateSessionStatus returns a non-NotFound error.
 	warm := newMockWarmStore()
-	// Don't add session - UpdateSessionStats will return ErrSessionNotFound.
+	// Don't add session - UpdateSessionStatus will return ErrSessionNotFound.
 	// We need to test the "!errors.Is(err, session.ErrSessionNotFound)" branch too.
 	// That branch logs and returns 500. For now, test the 404 path which
 	// covers the error return without logging.
@@ -2180,7 +2180,7 @@ func TestHandleUpdateStats_InternalError(t *testing.T) {
 	h.RegisterRoutes(mux)
 
 	body := strings.NewReader(`{"addInputTokens": 10}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/00000000-0000-0000-0000-000000000099/stats", body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions/00000000-0000-0000-0000-000000000099/status", body)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, req)
 
@@ -2196,7 +2196,7 @@ func TestHandleUpdateStats_MissingSessionID(t *testing.T) {
 	h := NewHandler(svc, logr.Discard())
 
 	body := strings.NewReader(`{"addInputTokens": 10}`)
-	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions//stats", body)
+	req := httptest.NewRequest(http.MethodPatch, "/api/v1/sessions//status", body)
 	rec := httptest.NewRecorder()
 
 	// Call directly to test empty sessionID path.

--- a/internal/session/api/openapi_test.go
+++ b/internal/session/api/openapi_test.go
@@ -116,7 +116,7 @@ func TestOpenAPISchemaMatchesGoTypes(t *testing.T) {
 		// Request/response types (internal/session/api/)
 		"CreateSessionRequest":      reflect.TypeOf(CreateSessionRequest{}),
 		"RefreshTTLRequest":         reflect.TypeOf(RefreshTTLRequest{}),
-		"SessionStatsUpdate":        reflect.TypeOf(session.SessionStatsUpdate{}),
+		"SessionStatusUpdate":       reflect.TypeOf(session.SessionStatusUpdate{}),
 		"SessionResponse":           reflect.TypeOf(SessionResponse{}),
 		"SessionListResponse":       reflect.TypeOf(SessionListResponse{}),
 		"MessagesResponse":          reflect.TypeOf(MessagesResponse{}),
@@ -225,7 +225,7 @@ func TestOpenAPIRoutesMatchHandler(t *testing.T) {
 		"GET /api/v1/sessions/{sessionID}/messages",
 		"POST /api/v1/sessions",
 		"POST /api/v1/sessions/{sessionID}/messages",
-		"PATCH /api/v1/sessions/{sessionID}/stats",
+		"PATCH /api/v1/sessions/{sessionID}/status",
 		"POST /api/v1/sessions/{sessionID}/ttl",
 		"DELETE /api/v1/sessions/{sessionID}",
 		"POST /api/v1/sessions/{sessionID}/tool-calls",

--- a/internal/session/api/service.go
+++ b/internal/session/api/service.go
@@ -297,10 +297,11 @@ func (s *SessionService) AppendMessage(ctx context.Context, sessionID string, ms
 	return nil
 }
 
-// UpdateSessionStats applies incremental counter updates to a session atomically.
-// The warm store performs the update in a single SQL statement to prevent
-// concurrent updates from overwriting each other.
-func (s *SessionService) UpdateSessionStats(ctx context.Context, sessionID string, update session.SessionStatsUpdate) error {
+// UpdateSessionStatus applies session lifecycle status updates atomically.
+// When the warm store supports StatusUpdaterWithResult (e.g. Postgres), the
+// update, previous-status check, and metadata lookup are done in a single
+// query. Otherwise, it falls back to separate queries.
+func (s *SessionService) UpdateSessionStatus(ctx context.Context, sessionID string, update session.SessionStatusUpdate) error {
 	if sessionID == "" {
 		return ErrMissingSessionID
 	}
@@ -309,7 +310,40 @@ func (s *SessionService) UpdateSessionStats(ctx context.Context, sessionID strin
 		return ErrWarmStoreRequired
 	}
 
-	// Check previous status before update so we only publish on actual transitions.
+	// Fast path: single query returning previous status + metadata.
+	if updater, ok := warm.(providers.StatusUpdaterWithResult); ok {
+		return s.updateStatusOptimized(ctx, sessionID, update, updater)
+	}
+
+	// Slow path: separate queries for stores without RETURNING support.
+	return s.updateStatusFallback(ctx, sessionID, update, warm)
+}
+
+// updateStatusOptimized performs the status update, transition check,
+// and metadata lookup in a single DB query via StatusUpdaterWithResult.
+func (s *SessionService) updateStatusOptimized(ctx context.Context, sessionID string, update session.SessionStatusUpdate, updater providers.StatusUpdaterWithResult) error {
+	result, err := updater.UpdateSessionStatusReturning(ctx, sessionID, update)
+	if err != nil {
+		return err
+	}
+
+	s.refreshHotCacheTTL(sessionID)
+
+	if result.Applied && update.SetStatus == session.SessionStatusCompleted &&
+		result.PreviousStatus != session.SessionStatusCompleted {
+		s.publishSessionCompleted(ctx, &session.Session{
+			ID:                sessionID,
+			AgentName:         result.AgentName,
+			Namespace:         result.Namespace,
+			PromptPackName:    result.PromptPackName,
+			PromptPackVersion: result.PromptPackVersion,
+		})
+	}
+	return nil
+}
+
+// updateStatusFallback uses separate queries for pre-check and post-read.
+func (s *SessionService) updateStatusFallback(ctx context.Context, sessionID string, update session.SessionStatusUpdate, warm providers.WarmStoreProvider) error {
 	var previousStatus session.SessionStatus
 	if update.SetStatus == session.SessionStatusCompleted {
 		if prev, getErr := warm.GetSession(ctx, sessionID); getErr == nil {
@@ -317,20 +351,12 @@ func (s *SessionService) UpdateSessionStats(ctx context.Context, sessionID strin
 		}
 	}
 
-	// Use atomic update to avoid read-modify-write race conditions.
-	if err := warm.UpdateSessionStats(ctx, sessionID, update); err != nil {
+	if err := warm.UpdateSessionStatus(ctx, sessionID, update); err != nil {
 		return err
 	}
 
-	// Refresh hot cache TTL on stats updates to keep active sessions cached.
-	s.pushToHotCache(func(ctx context.Context, hot providers.HotCacheProvider) {
-		if err := hot.RefreshTTL(ctx, sessionID, s.cacheTTL); err != nil {
-			// Session may not be in cache yet — that's fine.
-			s.log.V(2).Info("hot cache TTL refresh skipped", "sessionID", sessionID, "reason", err.Error())
-		}
-	})
+	s.refreshHotCacheTTL(sessionID)
 
-	// Only publish completion event when the status actually transitions to completed.
 	if update.SetStatus == session.SessionStatusCompleted && previousStatus != session.SessionStatusCompleted {
 		sess, getErr := warm.GetSession(ctx, sessionID)
 		if getErr == nil {
@@ -338,6 +364,15 @@ func (s *SessionService) UpdateSessionStats(ctx context.Context, sessionID strin
 		}
 	}
 	return nil
+}
+
+// refreshHotCacheTTL extends the hot cache TTL for an active session.
+func (s *SessionService) refreshHotCacheTTL(sessionID string) {
+	s.pushToHotCache(func(ctx context.Context, hot providers.HotCacheProvider) {
+		if err := hot.RefreshTTL(ctx, sessionID, s.cacheTTL); err != nil {
+			s.log.V(2).Info("hot cache TTL refresh skipped", "sessionID", sessionID, "reason", err.Error())
+		}
+	})
 }
 
 // RefreshTTL extends the expiry of a session.

--- a/internal/session/api/service_test.go
+++ b/internal/session/api/service_test.go
@@ -139,24 +139,24 @@ func TestAppendMessage_Success(t *testing.T) {
 	assert.Len(t, warm.appendedMsgs["s1"], 1)
 }
 
-// --- UpdateSessionStats ---
+// --- UpdateSessionStatus ---
 
-func TestUpdateSessionStats_EmptySessionID(t *testing.T) {
+func TestUpdateSessionStatus_EmptySessionID(t *testing.T) {
 	registry := providers.NewRegistry()
 	registry.SetWarmStore(newMockWarmStore())
 	svc := newServiceWithRegistry(registry, nil)
 
-	err := svc.UpdateSessionStats(context.Background(), "", session.SessionStatsUpdate{})
+	err := svc.UpdateSessionStatus(context.Background(), "", session.SessionStatusUpdate{})
 	assert.ErrorIs(t, err, ErrMissingSessionID)
 }
 
-func TestUpdateSessionStats_NoWarmStore(t *testing.T) {
+func TestUpdateSessionStatus_NoWarmStore(t *testing.T) {
 	svc := newServiceWithRegistry(providers.NewRegistry(), nil)
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{})
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{})
 	assert.ErrorIs(t, err, ErrWarmStoreRequired)
 }
 
-func TestUpdateSessionStats_AppliesIncrements(t *testing.T) {
+func TestUpdateSessionStatus_AppliesIncrements(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:                "s1",
@@ -170,7 +170,7 @@ func TestUpdateSessionStats_AppliesIncrements(t *testing.T) {
 	registry.SetWarmStore(warm)
 	svc := newServiceWithRegistry(registry, nil)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	require.NoError(t, err)
@@ -179,17 +179,17 @@ func TestUpdateSessionStats_AppliesIncrements(t *testing.T) {
 	assert.Equal(t, session.SessionStatusCompleted, updated.Status)
 }
 
-func TestUpdateSessionStats_SessionNotFound(t *testing.T) {
+func TestUpdateSessionStatus_SessionNotFound(t *testing.T) {
 	warm := newMockWarmStore()
 	registry := providers.NewRegistry()
 	registry.SetWarmStore(warm)
 	svc := newServiceWithRegistry(registry, nil)
 
-	err := svc.UpdateSessionStats(context.Background(), "nonexistent", session.SessionStatsUpdate{})
+	err := svc.UpdateSessionStatus(context.Background(), "nonexistent", session.SessionStatusUpdate{})
 	assert.ErrorIs(t, err, session.ErrSessionNotFound)
 }
 
-func TestUpdateSessionStats_NoStatusChange(t *testing.T) {
+func TestUpdateSessionStatus_NoStatusChange(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:     "s1",
@@ -200,13 +200,13 @@ func TestUpdateSessionStats_NoStatusChange(t *testing.T) {
 	registry.SetWarmStore(warm)
 	svc := newServiceWithRegistry(registry, nil)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{})
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{})
 	require.NoError(t, err)
 	require.Len(t, warm.updatedSessions, 1)
 	assert.Equal(t, session.SessionStatusActive, warm.updatedSessions[0].Status)
 }
 
-func TestUpdateSessionStats_CompletionTransitionPublishes(t *testing.T) {
+func TestUpdateSessionStatus_CompletionTransitionPublishes(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:     "s1",
@@ -217,7 +217,7 @@ func TestUpdateSessionStats_CompletionTransitionPublishes(t *testing.T) {
 	registry.SetWarmStore(warm)
 	svc := newServiceWithRegistry(registry, nil)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestUpdateSessionStats_CompletionTransitionPublishes(t *testing.T) {
 	assert.Equal(t, session.SessionStatusCompleted, warm.updatedSessions[0].Status)
 }
 
-func TestUpdateSessionStats_AlreadyCompletedNoRepublish(t *testing.T) {
+func TestUpdateSessionStatus_AlreadyCompletedNoRepublish(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:     "s1",
@@ -237,14 +237,14 @@ func TestUpdateSessionStats_AlreadyCompletedNoRepublish(t *testing.T) {
 	svc := newServiceWithRegistry(registry, nil)
 
 	// Updating a session that's already completed should still work
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	require.NoError(t, err)
 	require.Len(t, warm.updatedSessions, 1)
 }
 
-func TestUpdateSessionStats_NonCompletedStatusSkipsLookup(t *testing.T) {
+func TestUpdateSessionStatus_NonCompletedStatusSkipsLookup(t *testing.T) {
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{
 		ID:     "s1",
@@ -256,7 +256,7 @@ func TestUpdateSessionStats_NonCompletedStatusSkipsLookup(t *testing.T) {
 	svc := newServiceWithRegistry(registry, nil)
 
 	// Non-completed status should not trigger the completion lookup/publish path
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{})
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{})
 	require.NoError(t, err)
 	require.Len(t, warm.updatedSessions, 1)
 	assert.Equal(t, session.SessionStatusActive, warm.updatedSessions[0].Status)
@@ -750,7 +750,7 @@ func TestAppendMessage_WriteThroughToHotCache(t *testing.T) {
 	assert.Equal(t, "m1", hot.appendCalls[0].msg.ID)
 }
 
-func TestUpdateSessionStats_RefreshesTTLInHotCache(t *testing.T) {
+func TestUpdateSessionStatus_RefreshesTTLInHotCache(t *testing.T) {
 	hot := newTrackingHotCache()
 	warm := newMockWarmStore()
 	warm.sessions["s1"] = &session.Session{ID: "s1", Status: session.SessionStatusActive}
@@ -759,7 +759,7 @@ func TestUpdateSessionStats_RefreshesTTLInHotCache(t *testing.T) {
 	registry.SetWarmStore(warm)
 	svc := newServiceWithRegistry(registry, nil)
 
-	err := svc.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusActive,
 	})
 	require.NoError(t, err)

--- a/internal/session/api/service_test.go
+++ b/internal/session/api/service_test.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -769,4 +770,230 @@ func TestUpdateSessionStatus_RefreshesTTLInHotCache(t *testing.T) {
 	defer hot.mu.Unlock()
 	require.Len(t, hot.refreshCalls, 1)
 	assert.Equal(t, "s1", hot.refreshCalls[0])
+}
+
+// --- mockWarmStoreWithUpdater implements StatusUpdaterWithResult ---
+
+// mockWarmStoreWithUpdater wraps mockWarmStore and implements StatusUpdaterWithResult
+// so the optimized path in UpdateSessionStatus is exercised.
+type mockWarmStoreWithUpdater struct {
+	mockWarmStore
+	result *providers.StatusUpdateResult
+	err    error
+	called bool
+}
+
+func newMockWarmStoreWithUpdater() *mockWarmStoreWithUpdater {
+	return &mockWarmStoreWithUpdater{
+		mockWarmStore: mockWarmStore{
+			sessions:     make(map[string]*session.Session),
+			messages:     make(map[string][]*session.Message),
+			appendedMsgs: make(map[string][]*session.Message),
+		},
+	}
+}
+
+func (m *mockWarmStoreWithUpdater) UpdateSessionStatusReturning(_ context.Context, _ string, _ session.SessionStatusUpdate) (*providers.StatusUpdateResult, error) {
+	m.called = true
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.result, nil
+}
+
+// --- updateStatusOptimized tests (via StatusUpdaterWithResult) ---
+
+func TestUpdateSessionStatus_Optimized_Applied(t *testing.T) {
+	warm := newMockWarmStoreWithUpdater()
+	warm.result = &providers.StatusUpdateResult{
+		Applied:           true,
+		PreviousStatus:    session.SessionStatusActive,
+		AgentName:         "test-agent",
+		Namespace:         "test-ns",
+		PromptPackName:    "pp1",
+		PromptPackVersion: "v1",
+	}
+
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(warm)
+	svc := newServiceWithRegistry(registry, nil)
+
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
+		SetStatus: session.SessionStatusCompleted,
+	})
+	require.NoError(t, err)
+	assert.True(t, warm.called)
+	// Verify fallback path was NOT used (no updatedSessions entries).
+	assert.Empty(t, warm.updatedSessions)
+}
+
+func TestUpdateSessionStatus_Optimized_Skipped(t *testing.T) {
+	warm := newMockWarmStoreWithUpdater()
+	warm.result = &providers.StatusUpdateResult{
+		Applied:        false,
+		PreviousStatus: session.SessionStatusCompleted,
+	}
+
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(warm)
+	svc := newServiceWithRegistry(registry, nil)
+
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
+		SetStatus: session.SessionStatusCompleted,
+	})
+	require.NoError(t, err)
+	assert.True(t, warm.called)
+}
+
+func TestUpdateSessionStatus_Optimized_Error(t *testing.T) {
+	warm := newMockWarmStoreWithUpdater()
+	warm.err = errors.New("db connection lost")
+
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(warm)
+	svc := newServiceWithRegistry(registry, nil)
+
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
+		SetStatus: session.SessionStatusCompleted,
+	})
+	assert.EqualError(t, err, "db connection lost")
+	assert.True(t, warm.called)
+}
+
+func TestUpdateSessionStatus_Optimized_CompletionPublishesEvent(t *testing.T) {
+	warm := newMockWarmStoreWithUpdater()
+	warm.result = &providers.StatusUpdateResult{
+		Applied:           true,
+		PreviousStatus:    session.SessionStatusActive,
+		AgentName:         "test-agent",
+		Namespace:         "test-ns",
+		PromptPackName:    "pp1",
+		PromptPackVersion: "v1",
+	}
+
+	pub := &mockEventPublisher{}
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(warm)
+	cfg := ServiceConfig{EventPublisher: pub}
+	svc := NewSessionService(registry, cfg, logr.Discard())
+
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
+		SetStatus: session.SessionStatusCompleted,
+	})
+	require.NoError(t, err)
+
+	// publishSessionCompleted fires async — wait for the event.
+	events := pub.waitForEvents(t, 1, 2*time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, "session.completed", events[0].EventType)
+	assert.Equal(t, "s1", events[0].SessionID)
+	assert.Equal(t, "test-agent", events[0].AgentName)
+	assert.Equal(t, "test-ns", events[0].Namespace)
+	assert.Equal(t, "pp1", events[0].PromptPackName)
+	assert.Equal(t, "v1", events[0].PromptPackVersion)
+}
+
+func TestUpdateSessionStatus_Optimized_AlreadyCompletedNoPublish(t *testing.T) {
+	warm := newMockWarmStoreWithUpdater()
+	warm.result = &providers.StatusUpdateResult{
+		Applied:        true,
+		PreviousStatus: session.SessionStatusCompleted,
+	}
+
+	pub := &mockEventPublisher{}
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(warm)
+	cfg := ServiceConfig{EventPublisher: pub}
+	svc := NewSessionService(registry, cfg, logr.Discard())
+
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
+		SetStatus: session.SessionStatusCompleted,
+	})
+	require.NoError(t, err)
+
+	// No event should be published — already completed.
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, pub.getEvents())
+}
+
+func TestUpdateSessionStatus_Optimized_NonCompletedStatusNoPublish(t *testing.T) {
+	warm := newMockWarmStoreWithUpdater()
+	warm.result = &providers.StatusUpdateResult{
+		Applied:        true,
+		PreviousStatus: session.SessionStatusActive,
+	}
+
+	pub := &mockEventPublisher{}
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(warm)
+	cfg := ServiceConfig{EventPublisher: pub}
+	svc := NewSessionService(registry, cfg, logr.Discard())
+
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
+		SetStatus: session.SessionStatusActive,
+	})
+	require.NoError(t, err)
+
+	// Non-completed status should not publish.
+	time.Sleep(50 * time.Millisecond)
+	assert.Empty(t, pub.getEvents())
+}
+
+func TestUpdateSessionStatus_Optimized_RefreshesTTLInHotCache(t *testing.T) {
+	hot := newTrackingHotCache()
+	warm := newMockWarmStoreWithUpdater()
+	warm.result = &providers.StatusUpdateResult{
+		Applied:        true,
+		PreviousStatus: session.SessionStatusActive,
+	}
+
+	registry := providers.NewRegistry()
+	registry.SetHotCache(hot)
+	registry.SetWarmStore(warm)
+	svc := newServiceWithRegistry(registry, nil)
+
+	err := svc.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
+		SetStatus: session.SessionStatusActive,
+	})
+	require.NoError(t, err)
+
+	hot.waitOne()
+	hot.mu.Lock()
+	defer hot.mu.Unlock()
+	require.Len(t, hot.refreshCalls, 1)
+	assert.Equal(t, "s1", hot.refreshCalls[0])
+}
+
+// --- RecordRuntimeEvent service tests ---
+
+func TestRecordRuntimeEvent_EmptySessionID(t *testing.T) {
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(newMockWarmStore())
+	svc := newServiceWithRegistry(registry, nil)
+
+	err := svc.RecordRuntimeEvent(context.Background(), "", &session.RuntimeEvent{})
+	assert.ErrorIs(t, err, ErrMissingSessionID)
+}
+
+func TestRecordRuntimeEvent_NoWarmStore(t *testing.T) {
+	svc := newServiceWithRegistry(providers.NewRegistry(), nil)
+	err := svc.RecordRuntimeEvent(context.Background(), "s1", &session.RuntimeEvent{})
+	assert.ErrorIs(t, err, ErrWarmStoreRequired)
+}
+
+func TestRecordRuntimeEvent_Success(t *testing.T) {
+	warm := newMockWarmStore()
+	warm.sessions["s1"] = &session.Session{ID: "s1"}
+
+	registry := providers.NewRegistry()
+	registry.SetWarmStore(warm)
+	svc := newServiceWithRegistry(registry, nil)
+
+	evt := &session.RuntimeEvent{
+		ID:        "evt1",
+		SessionID: "s1",
+		EventType: "pipeline.started",
+	}
+	err := svc.RecordRuntimeEvent(context.Background(), "s1", evt)
+	require.NoError(t, err)
 }

--- a/internal/session/httpclient/buffer_test.go
+++ b/internal/session/httpclient/buffer_test.go
@@ -246,12 +246,12 @@ func TestBufferedWrite_StatsAndTTL(t *testing.T) {
 		_, _ = store.GetSession(context.Background(), "x")
 	}
 
-	// UpdateSessionStats should buffer.
-	err := store.UpdateSessionStats(context.Background(), "s1", session.SessionStatsUpdate{
+	// UpdateSessionStatus should buffer.
+	err := store.UpdateSessionStatus(context.Background(), "s1", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusActive,
 	})
 	if err != nil {
-		t.Fatalf("UpdateSessionStats: expected nil (buffered), got: %v", err)
+		t.Fatalf("UpdateSessionStatus: expected nil (buffered), got: %v", err)
 	}
 
 	// RefreshTTL should buffer.

--- a/internal/session/httpclient/integration_test.go
+++ b/internal/session/httpclient/integration_test.go
@@ -89,7 +89,7 @@ func (w *integrationWarmStore) AppendMessage(_ context.Context, sessionID string
 	return nil
 }
 
-func (w *integrationWarmStore) UpdateSessionStats(_ context.Context, sessionID string, update session.SessionStatsUpdate) error {
+func (w *integrationWarmStore) UpdateSessionStatus(_ context.Context, sessionID string, update session.SessionStatusUpdate) error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	s, ok := w.sessions[sessionID]
@@ -276,10 +276,10 @@ func TestIntegration_FullRecordingChain(t *testing.T) {
 	require.NoError(t, err, "AppendMessage (assistant) should succeed")
 
 	// 4. Update session status (counters are now auto-derived by AppendMessage)
-	err = store.UpdateSessionStats(ctx, sess.ID, session.SessionStatsUpdate{
+	err = store.UpdateSessionStatus(ctx, sess.ID, session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusActive,
 	})
-	require.NoError(t, err, "UpdateSessionStats should succeed")
+	require.NoError(t, err, "UpdateSessionStatus should succeed")
 
 	// 5. Verify messages landed in warm store
 	msgs := warmStore.getMessages(sess.ID)

--- a/internal/session/httpclient/store.go
+++ b/internal/session/httpclient/store.go
@@ -113,7 +113,7 @@ func WithBufferMaxAge(d time.Duration) StoreOption {
 // Store implements session.Store by calling the session-api over HTTP.
 // It is used by the facade's recordingResponseWriter for session persistence.
 //
-// Write operations (AppendMessage, UpdateSessionStats, RefreshTTL) are buffered
+// Write operations (AppendMessage, UpdateSessionStatus, RefreshTTL) are buffered
 // on transient failure and retried automatically when session-api recovers.
 type Store struct {
 	baseURL      string
@@ -277,13 +277,13 @@ func (s *Store) AppendMessage(ctx context.Context, sessionID string, msg session
 	return nil
 }
 
-// UpdateSessionStats sends incremental updates via PATCH /api/v1/sessions/{sessionID}/stats.
+// UpdateSessionStatus sends lifecycle status updates via PATCH /api/v1/sessions/{sessionID}/status.
 // On transient failure, the write is buffered and retried automatically.
-func (s *Store) UpdateSessionStats(ctx context.Context, sessionID string, update session.SessionStatsUpdate) error {
-	path := fmt.Sprintf("/api/v1/sessions/%s/stats", sessionID)
+func (s *Store) UpdateSessionStatus(ctx context.Context, sessionID string, update session.SessionStatusUpdate) error {
+	path := fmt.Sprintf("/api/v1/sessions/%s/status", sessionID)
 	body, err := json.Marshal(&update)
 	if err != nil {
-		return fmt.Errorf("update session stats: encode: %w", err)
+		return fmt.Errorf("update session status: encode: %w", err)
 	}
 
 	resp, err := s.doWithRetry(ctx, http.MethodPatch, path, body)

--- a/internal/session/httpclient/store_test.go
+++ b/internal/session/httpclient/store_test.go
@@ -133,8 +133,8 @@ func mockSessionAPI(t *testing.T) *httptest.Server {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	// PATCH /api/v1/sessions/{sessionID}/stats
-	mux.HandleFunc("PATCH /api/v1/sessions/{sessionID}/stats", func(w http.ResponseWriter, r *http.Request) {
+	// PATCH /api/v1/sessions/{sessionID}/status
+	mux.HandleFunc("PATCH /api/v1/sessions/{sessionID}/status", func(w http.ResponseWriter, r *http.Request) {
 		id := r.PathValue("sessionID")
 		if _, ok := sessions[id]; !ok {
 			w.Header().Set("Content-Type", "application/json")
@@ -401,7 +401,7 @@ func TestAppendMessage_ServerError(t *testing.T) {
 	}
 }
 
-func TestUpdateSessionStats_OK(t *testing.T) {
+func TestUpdateSessionStatus_OK(t *testing.T) {
 	srv := mockSessionAPI(t)
 	defer srv.Close()
 
@@ -416,7 +416,7 @@ func TestUpdateSessionStats_OK(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 
-	err = store.UpdateSessionStats(context.Background(), created.ID, session.SessionStatsUpdate{
+	err = store.UpdateSessionStatus(context.Background(), created.ID, session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusActive,
 	})
 	if err != nil {
@@ -424,14 +424,14 @@ func TestUpdateSessionStats_OK(t *testing.T) {
 	}
 }
 
-func TestUpdateSessionStats_NotFound(t *testing.T) {
+func TestUpdateSessionStatus_NotFound(t *testing.T) {
 	srv := mockSessionAPI(t)
 	defer srv.Close()
 
 	store := NewStore(srv.URL, logr.Discard())
 	t.Cleanup(func() { _ = store.Close() })
 
-	err := store.UpdateSessionStats(context.Background(), "nonexistent", session.SessionStatsUpdate{
+	err := store.UpdateSessionStatus(context.Background(), "nonexistent", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusActive,
 	})
 	if err != session.ErrSessionNotFound {
@@ -439,7 +439,7 @@ func TestUpdateSessionStats_NotFound(t *testing.T) {
 	}
 }
 
-func TestUpdateSessionStats_ServerError(t *testing.T) {
+func TestUpdateSessionStatus_ServerError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
@@ -449,7 +449,7 @@ func TestUpdateSessionStats_ServerError(t *testing.T) {
 
 	store := NewStore(srv.URL, logr.Discard())
 	t.Cleanup(func() { _ = store.Close() })
-	err := store.UpdateSessionStats(context.Background(), "x", session.SessionStatsUpdate{
+	err := store.UpdateSessionStatus(context.Background(), "x", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusActive,
 	})
 	if err == nil {
@@ -585,8 +585,8 @@ func TestServerErrorResponses(t *testing.T) {
 		t.Fatal("AppendMessage: expected error")
 	}
 
-	if err := store.UpdateSessionStats(ctx, "x", session.SessionStatsUpdate{SetStatus: session.SessionStatusActive}); err == nil {
-		t.Fatal("UpdateSessionStats: expected error")
+	if err := store.UpdateSessionStatus(ctx, "x", session.SessionStatusUpdate{SetStatus: session.SessionStatusActive}); err == nil {
+		t.Fatal("UpdateSessionStatus: expected error")
 	}
 
 	if err := store.RefreshTTL(ctx, "x", time.Hour); err == nil {

--- a/internal/session/memory.go
+++ b/internal/session/memory.go
@@ -314,8 +314,8 @@ func (m *MemoryStore) Close() error {
 	return nil
 }
 
-// UpdateSessionStats atomically increments session-level counters.
-func (m *MemoryStore) UpdateSessionStats(ctx context.Context, sessionID string, update SessionStatsUpdate) error {
+// UpdateSessionStatus atomically increments session-level counters.
+func (m *MemoryStore) UpdateSessionStatus(ctx context.Context, sessionID string, update SessionStatusUpdate) error {
 	if err := ctx.Err(); err != nil {
 		return err
 	}

--- a/internal/session/otlp/transformer.go
+++ b/internal/session/otlp/transformer.go
@@ -39,7 +39,7 @@ type SessionWriter interface {
 	GetSession(ctx context.Context, sessionID string) (*session.Session, error)
 	CreateSession(ctx context.Context, sess *session.Session) error
 	AppendMessage(ctx context.Context, sessionID string, msg *session.Message) error
-	UpdateSessionStats(ctx context.Context, sessionID string, update session.SessionStatsUpdate) error
+	UpdateSessionStatus(ctx context.Context, sessionID string, update session.SessionStatusUpdate) error
 }
 
 // Transformer converts OTLP GenAI spans into session data.

--- a/internal/session/otlp/transformer_test.go
+++ b/internal/session/otlp/transformer_test.go
@@ -37,7 +37,7 @@ import (
 type MockSessionWriter struct {
 	sessions map[string]*session.Session
 	messages map[string][]*session.Message
-	stats    map[string]session.SessionStatsUpdate
+	stats    map[string]session.SessionStatusUpdate
 
 	getSessionErr   error
 	createErr       error
@@ -50,7 +50,7 @@ func newMockWriter() *MockSessionWriter {
 	return &MockSessionWriter{
 		sessions: make(map[string]*session.Session),
 		messages: make(map[string][]*session.Message),
-		stats:    make(map[string]session.SessionStatsUpdate),
+		stats:    make(map[string]session.SessionStatusUpdate),
 	}
 }
 
@@ -81,7 +81,7 @@ func (m *MockSessionWriter) AppendMessage(_ context.Context, sessionID string, m
 	return nil
 }
 
-func (m *MockSessionWriter) UpdateSessionStats(_ context.Context, sessionID string, update session.SessionStatsUpdate) error {
+func (m *MockSessionWriter) UpdateSessionStatus(_ context.Context, sessionID string, update session.SessionStatusUpdate) error {
 	if m.updateStatsErr != nil {
 		return m.updateStatsErr
 	}
@@ -609,7 +609,7 @@ func TestProcessExport_ToolSpan_NoTokenUpdate(t *testing.T) {
 
 	_, err := transformer.ProcessExport(context.Background(), []*tracepb.ResourceSpans{rs})
 	require.NoError(t, err)
-	assert.Empty(t, writer.stats, "tool spans should not trigger UpdateSessionStats")
+	assert.Empty(t, writer.stats, "tool spans should not trigger UpdateSessionStatus")
 
 	msgs := writer.messages["conv-tool-no-tokens"]
 	require.Len(t, msgs, 1)

--- a/internal/session/providers/postgres/provider.go
+++ b/internal/session/providers/postgres/provider.go
@@ -468,10 +468,15 @@ func (p *Provider) ListSessions(ctx context.Context, opts providers.SessionListO
 		sort = "ASC"
 	}
 
-	// Data query — no window function, uses index-backed LIMIT/OFFSET.
+	// Fetch limit+1 rows to determine HasMore without a separate COUNT(*).
+	fetchLimit := opts.Limit
+	if fetchLimit > 0 {
+		fetchLimit++
+	}
+
 	dataQuery := `SELECT ` + sessionColumns + ` FROM sessions WHERE 1=1` + qb.Where() +
 		` ORDER BY created_at ` + sort
-	dataQuery = qb.AppendPagination(dataQuery, opts.Limit, opts.Offset)
+	dataQuery = qb.AppendPagination(dataQuery, fetchLimit, opts.Offset)
 
 	rows, err := p.pool.Query(ctx, dataQuery, qb.Args()...)
 	if err != nil {
@@ -482,19 +487,23 @@ func (p *Provider) ListSessions(ctx context.Context, opts providers.SessionListO
 		return nil, err
 	}
 
-	// Separate count query — simple aggregate that can use index-only scans.
-	countQB := &pgutil.QueryBuilder{}
-	p.applySessionFilters(countQB, opts)
-	countQuery := `SELECT count(*) FROM sessions WHERE 1=1` + countQB.Where()
-	var totalCount int64
-	if err := p.pool.QueryRow(ctx, countQuery, countQB.Args()...).Scan(&totalCount); err != nil {
-		return nil, fmt.Errorf("postgres: count sessions: %w", err)
+	hasMore := opts.Limit > 0 && len(sessions) > opts.Limit
+	if hasMore {
+		sessions = sessions[:opts.Limit]
+	}
+
+	totalCount := int64(-1)
+	if opts.IncludeCount {
+		totalCount, err = p.countSessions(ctx, opts)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &providers.SessionPage{
 		Sessions:   sessions,
 		TotalCount: totalCount,
-		HasMore:    int64(opts.Offset)+int64(len(sessions)) < totalCount,
+		HasMore:    hasMore,
 	}, nil
 }
 
@@ -510,10 +519,15 @@ func (p *Provider) SearchSessions(ctx context.Context, query string, opts provid
 		sort = "ASC"
 	}
 
-	// Data query.
+	// Fetch limit+1 rows to determine HasMore without a separate COUNT(*).
+	fetchLimit := opts.Limit
+	if fetchLimit > 0 {
+		fetchLimit++
+	}
+
 	dataSQL := `SELECT ` + sessionColumns + ` FROM sessions s WHERE 1=1` + qb.Where() +
 		` ORDER BY s.created_at ` + sort
-	dataSQL = qb.AppendPagination(dataSQL, opts.Limit, opts.Offset)
+	dataSQL = qb.AppendPagination(dataSQL, fetchLimit, opts.Offset)
 
 	rows, err := p.pool.Query(ctx, dataSQL, qb.Args()...)
 	if err != nil {
@@ -524,23 +538,49 @@ func (p *Provider) SearchSessions(ctx context.Context, query string, opts provid
 		return nil, err
 	}
 
-	// Separate count query.
-	countQB := &pgutil.QueryBuilder{}
-	countQB.Add("EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.id AND m.search_vector @@ plainto_tsquery('english', $?))", query)
-	p.applySessionFilters(countQB, opts)
+	hasMore := opts.Limit > 0 && len(sessions) > opts.Limit
+	if hasMore {
+		sessions = sessions[:opts.Limit]
+	}
 
-	countSQL := `SELECT count(*) FROM sessions s WHERE 1=1` + countQB.Where()
-
-	var totalCount int64
-	if err := p.pool.QueryRow(ctx, countSQL, countQB.Args()...).Scan(&totalCount); err != nil {
-		return nil, fmt.Errorf("postgres: count search sessions: %w", err)
+	totalCount := int64(-1)
+	if opts.IncludeCount {
+		totalCount, err = p.countSearchSessions(ctx, query, opts)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &providers.SessionPage{
 		Sessions:   sessions,
 		TotalCount: totalCount,
-		HasMore:    int64(opts.Offset)+int64(len(sessions)) < totalCount,
+		HasMore:    hasMore,
 	}, nil
+}
+
+// countSessions runs a separate COUNT(*) query for ListSessions.
+func (p *Provider) countSessions(ctx context.Context, opts providers.SessionListOpts) (int64, error) {
+	countQB := &pgutil.QueryBuilder{}
+	p.applySessionFilters(countQB, opts)
+	countQuery := `SELECT count(*) FROM sessions WHERE 1=1` + countQB.Where()
+	var total int64
+	if err := p.pool.QueryRow(ctx, countQuery, countQB.Args()...).Scan(&total); err != nil {
+		return 0, fmt.Errorf("postgres: count sessions: %w", err)
+	}
+	return total, nil
+}
+
+// countSearchSessions runs a separate COUNT(*) query for SearchSessions.
+func (p *Provider) countSearchSessions(ctx context.Context, query string, opts providers.SessionListOpts) (int64, error) {
+	countQB := &pgutil.QueryBuilder{}
+	countQB.Add("EXISTS (SELECT 1 FROM messages m WHERE m.session_id = s.id AND m.search_vector @@ plainto_tsquery('english', $?))", query)
+	p.applySessionFilters(countQB, opts)
+	countSQL := `SELECT count(*) FROM sessions s WHERE 1=1` + countQB.Where()
+	var total int64
+	if err := p.pool.QueryRow(ctx, countSQL, countQB.Args()...).Scan(&total); err != nil {
+		return 0, fmt.Errorf("postgres: count search sessions: %w", err)
+	}
+	return total, nil
 }
 
 func (p *Provider) applySessionFilters(qb *pgutil.QueryBuilder, opts providers.SessionListOpts) {
@@ -567,32 +607,63 @@ func (p *Provider) applySessionFilters(qb *pgutil.QueryBuilder, opts providers.S
 	}
 }
 
-// UpdateSessionStats atomically updates session status and ended_at.
-// Counter increments (messages, tool calls, tokens, cost) are auto-derived
-// from AppendMessage and should not be set via this method.
-func (p *Provider) UpdateSessionStats(ctx context.Context, sessionID string, update session.SessionStatsUpdate) error {
-	query := `UPDATE sessions SET
+// UpdateSessionStatus atomically updates session status and ended_at.
+// Delegates to UpdateSessionStatusReturning and discards the result metadata.
+func (p *Provider) UpdateSessionStatus(ctx context.Context, sessionID string, update session.SessionStatusUpdate) error {
+	_, err := p.UpdateSessionStatusReturning(ctx, sessionID, update)
+	return err
+}
+
+// Compile-time interface check for the optional StatusUpdaterWithResult.
+var _ providers.StatusUpdaterWithResult = (*Provider)(nil)
+
+// UpdateSessionStatusReturning atomically updates session status and ended_at,
+// returning the previous status and session metadata in the same query via a
+// CTE + RETURNING clause. This eliminates the need for separate pre-check and
+// post-read GetSession queries when detecting status transitions.
+func (p *Provider) UpdateSessionStatusReturning(ctx context.Context, sessionID string, update session.SessionStatusUpdate) (*providers.StatusUpdateResult, error) {
+	query := `WITH prev AS (
+		SELECT id, status, agent_name, namespace, prompt_pack_name, prompt_pack_version
+		FROM sessions WHERE id = $1 FOR UPDATE
+	)
+	UPDATE sessions SET
 		status = CASE
-			WHEN status IN ('completed','error','expired') THEN status
+			WHEN (SELECT status FROM prev) IN ('completed','error','expired') THEN status
 			WHEN $2::text = '' THEN status
 			ELSE $2::text END,
 		updated_at = $3,
 		ended_at = CASE WHEN $4::timestamptz IS NULL THEN ended_at ELSE $4::timestamptz END
-	WHERE id = $1`
+	WHERE id = $1
+	RETURNING
+		(SELECT status FROM prev) AS previous_status,
+		agent_name, namespace, prompt_pack_name, prompt_pack_version`
 
-	res, err := p.pool.Exec(ctx, query,
+	var prevStatus string
+	var agentName, namespace string
+	var promptPackName, promptPackVersion *string
+
+	err := p.pool.QueryRow(ctx, query,
 		sessionID,
 		string(update.SetStatus),
 		time.Now(),
 		pgutil.NullTime(update.SetEndedAt),
-	)
+	).Scan(&prevStatus, &agentName, &namespace, &promptPackName, &promptPackVersion)
 	if err != nil {
-		return fmt.Errorf("postgres: update session stats: %w", err)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, session.ErrSessionNotFound
+		}
+		return nil, fmt.Errorf("postgres: update session status: %w", err)
 	}
-	if res.RowsAffected() == 0 {
-		return session.ErrSessionNotFound
-	}
-	return nil
+
+	applied := !session.IsTerminalStatus(session.SessionStatus(prevStatus)) && update.SetStatus != ""
+	return &providers.StatusUpdateResult{
+		Applied:           applied,
+		PreviousStatus:    session.SessionStatus(prevStatus),
+		AgentName:         agentName,
+		Namespace:         namespace,
+		PromptPackName:    pgutil.DerefString(promptPackName),
+		PromptPackVersion: pgutil.DerefString(promptPackVersion),
+	}, nil
 }
 
 // --- Tool call and provider call management ---------------------------------

--- a/internal/session/providers/postgres/provider_test.go
+++ b/internal/session/providers/postgres/provider_test.go
@@ -572,7 +572,7 @@ func TestListSessions_All(t *testing.T) {
 		require.NoError(t, p.CreateSession(ctx, s))
 	}
 
-	page, err := p.ListSessions(ctx, providers.SessionListOpts{})
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(3), page.TotalCount)
 	assert.Len(t, page.Sessions, 3)
@@ -595,7 +595,7 @@ func TestListSessions_FilterAgent(t *testing.T) {
 	require.NoError(t, p.CreateSession(ctx, s1))
 	require.NoError(t, p.CreateSession(ctx, s2))
 
-	page, err := p.ListSessions(ctx, providers.SessionListOpts{AgentName: "agent-a"})
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{AgentName: "agent-a", IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
 	assert.Equal(t, "agent-a", page.Sessions[0].AgentName)
@@ -617,7 +617,7 @@ func TestListSessions_FilterNamespace(t *testing.T) {
 	require.NoError(t, p.CreateSession(ctx, s1))
 	require.NoError(t, p.CreateSession(ctx, s2))
 
-	page, err := p.ListSessions(ctx, providers.SessionListOpts{Namespace: "ns-a"})
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Namespace: "ns-a", IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
 	assert.Equal(t, "ns-a", page.Sessions[0].Namespace)
@@ -639,7 +639,7 @@ func TestListSessions_FilterStatus(t *testing.T) {
 	require.NoError(t, p.CreateSession(ctx, s1))
 	require.NoError(t, p.CreateSession(ctx, s2))
 
-	page, err := p.ListSessions(ctx, providers.SessionListOpts{Status: session.SessionStatusActive})
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Status: session.SessionStatusActive, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
 	assert.Equal(t, session.SessionStatusActive, page.Sessions[0].Status)
@@ -662,17 +662,17 @@ func TestListSessions_FilterTags(t *testing.T) {
 	require.NoError(t, p.CreateSession(ctx, s2))
 
 	// Filter for "alpha" — only s1
-	page, err := p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"alpha"}})
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"alpha"}, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
 
 	// Filter for "beta" — both
-	page, err = p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"beta"}})
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"beta"}, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), page.TotalCount)
 
 	// Filter for "alpha" AND "beta" — only s1
-	page, err = p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"alpha", "beta"}})
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Tags: []string{"alpha", "beta"}, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
 }
@@ -696,6 +696,7 @@ func TestListSessions_FilterDateRange(t *testing.T) {
 	page, err := p.ListSessions(ctx, providers.SessionListOpts{
 		CreatedAfter:  now.Add(-90 * time.Minute),
 		CreatedBefore: now.Add(-30 * time.Minute),
+		IncludeCount:  true,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
@@ -716,12 +717,12 @@ func TestListSessions_SortOrder(t *testing.T) {
 	require.NoError(t, p.CreateSession(ctx, s2))
 
 	// Default (DESC)
-	page, err := p.ListSessions(ctx, providers.SessionListOpts{})
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, s2.ID, page.Sessions[0].ID)
 
 	// ASC
-	page, err = p.ListSessions(ctx, providers.SessionListOpts{SortOrder: providers.SortAsc})
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{SortOrder: providers.SortAsc, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, s1.ID, page.Sessions[0].ID)
 }
@@ -741,20 +742,20 @@ func TestListSessions_Pagination(t *testing.T) {
 	}
 
 	// Page 1
-	page, err := p.ListSessions(ctx, providers.SessionListOpts{Limit: 2})
+	page, err := p.ListSessions(ctx, providers.SessionListOpts{Limit: 2, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Len(t, page.Sessions, 2)
 	assert.Equal(t, int64(5), page.TotalCount)
 	assert.True(t, page.HasMore)
 
 	// Page 2
-	page, err = p.ListSessions(ctx, providers.SessionListOpts{Limit: 2, Offset: 2})
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Limit: 2, Offset: 2, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Len(t, page.Sessions, 2)
 	assert.True(t, page.HasMore)
 
 	// Last page
-	page, err = p.ListSessions(ctx, providers.SessionListOpts{Limit: 2, Offset: 4})
+	page, err = p.ListSessions(ctx, providers.SessionListOpts{Limit: 2, Offset: 4, IncludeCount: true})
 	require.NoError(t, err)
 	assert.Len(t, page.Sessions, 1)
 	assert.False(t, page.HasMore)
@@ -783,7 +784,7 @@ func TestSearchSessions_Basic(t *testing.T) {
 	require.NoError(t, p.AppendMessage(ctx, s2.ID, msg2))
 
 	// Search for "kubernetes"
-	page, err := p.SearchSessions(ctx, "kubernetes", providers.SessionListOpts{})
+	page, err := p.SearchSessions(ctx, "kubernetes", providers.SessionListOpts{IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
 	assert.Equal(t, s1.ID, page.Sessions[0].ID)
@@ -804,7 +805,7 @@ func TestSearchSessions_NoResults(t *testing.T) {
 	msg := &session.Message{ID: "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380a01", Role: session.RoleUser, Content: "Hello world", Timestamp: now, SequenceNum: 1}
 	require.NoError(t, p.AppendMessage(ctx, s.ID, msg))
 
-	page, err := p.SearchSessions(ctx, "nonexistentterm", providers.SessionListOpts{})
+	page, err := p.SearchSessions(ctx, "nonexistentterm", providers.SessionListOpts{IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), page.TotalCount)
 	assert.Empty(t, page.Sessions)
@@ -833,7 +834,7 @@ func TestSearchSessions_WithFilters(t *testing.T) {
 	require.NoError(t, p.AppendMessage(ctx, s2.ID, msg2))
 
 	// Search with agent filter.
-	page, err := p.SearchSessions(ctx, "kubernetes", providers.SessionListOpts{AgentName: "agent-a"})
+	page, err := p.SearchSessions(ctx, "kubernetes", providers.SessionListOpts{AgentName: "agent-a", IncludeCount: true})
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), page.TotalCount)
 	assert.Equal(t, "agent-a", page.Sessions[0].AgentName)
@@ -1054,7 +1055,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Nil(t, cfg.TLS)
 }
 
-func TestUpdateSessionStats_Atomic(t *testing.T) {
+func TestUpdateSessionStatus_Atomic(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -1078,10 +1079,10 @@ func TestUpdateSessionStats_Atomic(t *testing.T) {
 	require.NoError(t, p.CreateSession(ctx, s))
 
 	// Apply status update (counters are now auto-derived by AppendMessage).
-	update := session.SessionStatsUpdate{
+	update := session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	}
-	require.NoError(t, p.UpdateSessionStats(ctx, s.ID, update))
+	require.NoError(t, p.UpdateSessionStatus(ctx, s.ID, update))
 
 	// Verify the status was applied.
 	got, err := p.GetSession(ctx, s.ID)
@@ -1089,20 +1090,20 @@ func TestUpdateSessionStats_Atomic(t *testing.T) {
 	assert.Equal(t, session.SessionStatusCompleted, got.Status)
 }
 
-func TestUpdateSessionStats_NotFound(t *testing.T) {
+func TestUpdateSessionStatus_NotFound(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
 	ctx := context.Background()
 	p := newProvider(t)
 
-	err := p.UpdateSessionStats(ctx, "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b99", session.SessionStatsUpdate{
+	err := p.UpdateSessionStatus(ctx, "b0eebc99-9c0b-4ef8-bb6d-6bb9bd380b99", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusCompleted,
 	})
 	assert.ErrorIs(t, err, session.ErrSessionNotFound)
 }
 
-func TestUpdateSessionStats_EmptyStatus(t *testing.T) {
+func TestUpdateSessionStatus_EmptyStatus(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -1121,8 +1122,8 @@ func TestUpdateSessionStats_EmptyStatus(t *testing.T) {
 	require.NoError(t, p.CreateSession(ctx, s))
 
 	// Update without setting status should preserve existing status.
-	update := session.SessionStatsUpdate{}
-	require.NoError(t, p.UpdateSessionStats(ctx, s.ID, update))
+	update := session.SessionStatusUpdate{}
+	require.NoError(t, p.UpdateSessionStatus(ctx, s.ID, update))
 
 	got, err := p.GetSession(ctx, s.ID)
 	require.NoError(t, err)

--- a/internal/session/providers/providers.go
+++ b/internal/session/providers/providers.go
@@ -92,6 +92,9 @@ type SessionListOpts struct {
 	CreatedBefore time.Time
 	// Tags filters sessions that have all of the specified tags.
 	Tags []string
+	// IncludeCount, when true, runs a separate COUNT(*) query to populate
+	// SessionPage.TotalCount. When false, TotalCount is set to -1.
+	IncludeCount bool
 }
 
 // SessionPage is a paginated result of sessions.

--- a/internal/session/providers/providers_test.go
+++ b/internal/session/providers/providers_test.go
@@ -173,7 +173,7 @@ func (m *mockWarmStore) UpdateSession(_ context.Context, s *session.Session) err
 	return nil
 }
 
-func (m *mockWarmStore) UpdateSessionStats(_ context.Context, sessionID string, update session.SessionStatsUpdate) error {
+func (m *mockWarmStore) UpdateSessionStatus(_ context.Context, sessionID string, update session.SessionStatusUpdate) error {
 	s, ok := m.sessions[sessionID]
 	if !ok {
 		return session.ErrSessionNotFound
@@ -333,9 +333,14 @@ func (m *mockWarmStore) ListSessions(_ context.Context, opts SessionListOpts) (*
 		results = results[:opts.Limit]
 	}
 
+	totalCount := int64(-1)
+	if opts.IncludeCount {
+		totalCount = total
+	}
+
 	return &SessionPage{
 		Sessions:   results,
-		TotalCount: total,
+		TotalCount: totalCount,
 		HasMore:    hasMore,
 	}, nil
 }
@@ -362,9 +367,14 @@ func (m *mockWarmStore) SearchSessions(_ context.Context, query string, opts Ses
 		results = results[:opts.Limit]
 	}
 
+	totalCount := int64(-1)
+	if opts.IncludeCount {
+		totalCount = total
+	}
+
 	return &SessionPage{
 		Sessions:   results,
-		TotalCount: total,
+		TotalCount: totalCount,
 		HasMore:    hasMore,
 	}, nil
 }
@@ -943,7 +953,7 @@ func TestWarmStore_ListSessions(t *testing.T) {
 	}
 
 	t.Run("filter by namespace", func(t *testing.T) {
-		page, err := store.ListSessions(ctx, SessionListOpts{Namespace: "ns-1"})
+		page, err := store.ListSessions(ctx, SessionListOpts{Namespace: "ns-1", IncludeCount: true})
 		if err != nil {
 			t.Fatalf("ListSessions failed: %v", err)
 		}
@@ -953,7 +963,7 @@ func TestWarmStore_ListSessions(t *testing.T) {
 	})
 
 	t.Run("filter by agent", func(t *testing.T) {
-		page, err := store.ListSessions(ctx, SessionListOpts{AgentName: "agent-a"})
+		page, err := store.ListSessions(ctx, SessionListOpts{AgentName: "agent-a", IncludeCount: true})
 		if err != nil {
 			t.Fatalf("ListSessions failed: %v", err)
 		}
@@ -963,7 +973,7 @@ func TestWarmStore_ListSessions(t *testing.T) {
 	})
 
 	t.Run("filter by status", func(t *testing.T) {
-		page, err := store.ListSessions(ctx, SessionListOpts{Status: session.SessionStatusCompleted})
+		page, err := store.ListSessions(ctx, SessionListOpts{Status: session.SessionStatusCompleted, IncludeCount: true})
 		if err != nil {
 			t.Fatalf("ListSessions failed: %v", err)
 		}
@@ -973,7 +983,7 @@ func TestWarmStore_ListSessions(t *testing.T) {
 	})
 
 	t.Run("filter by tags", func(t *testing.T) {
-		page, err := store.ListSessions(ctx, SessionListOpts{Tags: []string{"prod"}})
+		page, err := store.ListSessions(ctx, SessionListOpts{Tags: []string{"prod"}, IncludeCount: true})
 		if err != nil {
 			t.Fatalf("ListSessions failed: %v", err)
 		}
@@ -983,7 +993,7 @@ func TestWarmStore_ListSessions(t *testing.T) {
 	})
 
 	t.Run("pagination", func(t *testing.T) {
-		page, err := store.ListSessions(ctx, SessionListOpts{Limit: 2})
+		page, err := store.ListSessions(ctx, SessionListOpts{Limit: 2, IncludeCount: true})
 		if err != nil {
 			t.Fatalf("ListSessions failed: %v", err)
 		}
@@ -1024,7 +1034,7 @@ func TestWarmStore_SearchSessions(t *testing.T) {
 		LastMessagePreview: "Build failed",
 	})
 
-	page, err := store.SearchSessions(ctx, "chatbot", SessionListOpts{})
+	page, err := store.SearchSessions(ctx, "chatbot", SessionListOpts{IncludeCount: true})
 	if err != nil {
 		t.Fatalf("SearchSessions failed: %v", err)
 	}
@@ -1032,7 +1042,7 @@ func TestWarmStore_SearchSessions(t *testing.T) {
 		t.Errorf("TotalCount = %d, want 1", page.TotalCount)
 	}
 
-	page, err = store.SearchSessions(ctx, "hello", SessionListOpts{})
+	page, err = store.SearchSessions(ctx, "hello", SessionListOpts{IncludeCount: true})
 	if err != nil {
 		t.Fatalf("SearchSessions failed: %v", err)
 	}

--- a/internal/session/providers/warm_store.go
+++ b/internal/session/providers/warm_store.go
@@ -39,11 +39,11 @@ type WarmStoreProvider interface {
 	// Returns session.ErrSessionNotFound if the session does not exist.
 	UpdateSession(ctx context.Context, s *session.Session) error
 
-	// UpdateSessionStats atomically increments session-level counters.
+	// UpdateSessionStatus atomically updates session lifecycle state.
 	// Implementations should use a single atomic SQL statement to avoid
 	// read-modify-write race conditions. Returns session.ErrSessionNotFound
 	// if the session does not exist.
-	UpdateSessionStats(ctx context.Context, sessionID string, update session.SessionStatsUpdate) error
+	UpdateSessionStatus(ctx context.Context, sessionID string, update session.SessionStatusUpdate) error
 
 	// DeleteSession removes a session and all its associated data.
 	// Returns session.ErrSessionNotFound if the session does not exist.
@@ -132,4 +132,29 @@ type WarmStoreProvider interface {
 
 	// Close releases resources held by the provider.
 	Close() error
+}
+
+// StatusUpdateResult contains metadata returned by an optimized status update
+// so the caller can detect transitions and build events without extra queries.
+type StatusUpdateResult struct {
+	// Applied is true when the update modified the row (session existed and
+	// was not already in a terminal status).
+	Applied bool
+	// PreviousStatus is the session status before the update was applied.
+	PreviousStatus session.SessionStatus
+	// AgentName of the updated session.
+	AgentName string
+	// Namespace of the updated session.
+	Namespace string
+	// PromptPackName of the updated session.
+	PromptPackName string
+	// PromptPackVersion of the updated session.
+	PromptPackVersion string
+}
+
+// StatusUpdaterWithResult is an optional interface that WarmStoreProvider
+// implementations can satisfy to return metadata from status updates in a
+// single query, avoiding extra GetSession round-trips.
+type StatusUpdaterWithResult interface {
+	UpdateSessionStatusReturning(ctx context.Context, sessionID string, update session.SessionStatusUpdate) (*StatusUpdateResult, error)
 }

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -221,10 +221,6 @@ type SessionStatusUpdate struct {
 	SetEndedAt time.Time     // zero means no change
 }
 
-// SessionStatsUpdate is an alias for backward compatibility during migration.
-// Deprecated: Use SessionStatusUpdate instead.
-type SessionStatsUpdate = SessionStatusUpdate
-
 // ToolCallStatus represents the lifecycle state of a tool call.
 type ToolCallStatus string
 
@@ -388,10 +384,10 @@ type Store interface {
 	// Returns ErrSessionNotFound if the session does not exist.
 	RefreshTTL(ctx context.Context, sessionID string, ttl time.Duration) error
 
-	// UpdateSessionStats atomically increments session-level counters.
+	// UpdateSessionStatus atomically updates session lifecycle state.
 	// Returns ErrSessionNotFound if the session does not exist.
 	// Returns ErrSessionExpired if the session has expired.
-	UpdateSessionStats(ctx context.Context, sessionID string, update SessionStatsUpdate) error
+	UpdateSessionStatus(ctx context.Context, sessionID string, update SessionStatusUpdate) error
 
 	// RecordToolCall appends a tool call lifecycle event (started, completed, failed).
 	// Each event is a separate row; rows sharing the same CallID represent one logical call.

--- a/pkg/sessionapi/client.gen.go
+++ b/pkg/sessionapi/client.gen.go
@@ -199,8 +199,8 @@ type SessionResponse struct {
 	Session  *Session   `json:"session,omitempty"`
 }
 
-// SessionStatsUpdate defines model for SessionStatsUpdate.
-type SessionStatsUpdate struct {
+// SessionStatusUpdate defines model for SessionStatusUpdate.
+type SessionStatusUpdate struct {
 	AddCostUSD      *float64       `json:"AddCostUSD,omitempty"`
 	AddInputTokens  *int32         `json:"AddInputTokens,omitempty"`
 	AddMessages     *int32         `json:"AddMessages,omitempty"`
@@ -382,8 +382,8 @@ type AppendMessageJSONRequestBody = Message
 // RecordProviderCallJSONRequestBody defines body for RecordProviderCall for application/json ContentType.
 type RecordProviderCallJSONRequestBody = ProviderCall
 
-// UpdateStatsJSONRequestBody defines body for UpdateStats for application/json ContentType.
-type UpdateStatsJSONRequestBody = SessionStatsUpdate
+// UpdateStatusJSONRequestBody defines body for UpdateStatus for application/json ContentType.
+type UpdateStatusJSONRequestBody = SessionStatusUpdate
 
 // RecordToolCallJSONRequestBody defines body for RecordToolCall for application/json ContentType.
 type RecordToolCallJSONRequestBody = ToolCall
@@ -511,10 +511,10 @@ type ClientInterface interface {
 
 	RecordProviderCall(ctx context.Context, sessionID SessionID, body RecordProviderCallJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	// UpdateStatsWithBody request with any body
-	UpdateStatsWithBody(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	// UpdateStatusWithBody request with any body
+	UpdateStatusWithBody(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 
-	UpdateStats(ctx context.Context, sessionID SessionID, body UpdateStatsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
+	UpdateStatus(ctx context.Context, sessionID SessionID, body UpdateStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// GetToolCalls request
 	GetToolCalls(ctx context.Context, sessionID SessionID, reqEditors ...RequestEditorFn) (*http.Response, error)
@@ -737,8 +737,8 @@ func (c *Client) RecordProviderCall(ctx context.Context, sessionID SessionID, bo
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateStatsWithBody(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateStatsRequestWithBody(c.Server, sessionID, contentType, body)
+func (c *Client) UpdateStatusWithBody(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateStatusRequestWithBody(c.Server, sessionID, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -749,8 +749,8 @@ func (c *Client) UpdateStatsWithBody(ctx context.Context, sessionID SessionID, c
 	return c.Client.Do(req)
 }
 
-func (c *Client) UpdateStats(ctx context.Context, sessionID SessionID, body UpdateStatsJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewUpdateStatsRequest(c.Server, sessionID, body)
+func (c *Client) UpdateStatus(ctx context.Context, sessionID SessionID, body UpdateStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewUpdateStatusRequest(c.Server, sessionID, body)
 	if err != nil {
 		return nil, err
 	}
@@ -1744,19 +1744,19 @@ func NewRecordProviderCallRequestWithBody(server string, sessionID SessionID, co
 	return req, nil
 }
 
-// NewUpdateStatsRequest calls the generic UpdateStats builder with application/json body
-func NewUpdateStatsRequest(server string, sessionID SessionID, body UpdateStatsJSONRequestBody) (*http.Request, error) {
+// NewUpdateStatusRequest calls the generic UpdateStatus builder with application/json body
+func NewUpdateStatusRequest(server string, sessionID SessionID, body UpdateStatusJSONRequestBody) (*http.Request, error) {
 	var bodyReader io.Reader
 	buf, err := json.Marshal(body)
 	if err != nil {
 		return nil, err
 	}
 	bodyReader = bytes.NewReader(buf)
-	return NewUpdateStatsRequestWithBody(server, sessionID, "application/json", bodyReader)
+	return NewUpdateStatusRequestWithBody(server, sessionID, "application/json", bodyReader)
 }
 
-// NewUpdateStatsRequestWithBody generates requests for UpdateStats with any type of body
-func NewUpdateStatsRequestWithBody(server string, sessionID SessionID, contentType string, body io.Reader) (*http.Request, error) {
+// NewUpdateStatusRequestWithBody generates requests for UpdateStatus with any type of body
+func NewUpdateStatusRequestWithBody(server string, sessionID SessionID, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
@@ -1771,7 +1771,7 @@ func NewUpdateStatsRequestWithBody(server string, sessionID SessionID, contentTy
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/sessions/%s/stats", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/sessions/%s/status", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -2036,10 +2036,10 @@ type ClientWithResponsesInterface interface {
 
 	RecordProviderCallWithResponse(ctx context.Context, sessionID SessionID, body RecordProviderCallJSONRequestBody, reqEditors ...RequestEditorFn) (*RecordProviderCallResponse, error)
 
-	// UpdateStatsWithBodyWithResponse request with any body
-	UpdateStatsWithBodyWithResponse(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateStatsResponse, error)
+	// UpdateStatusWithBodyWithResponse request with any body
+	UpdateStatusWithBodyWithResponse(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateStatusResponse, error)
 
-	UpdateStatsWithResponse(ctx context.Context, sessionID SessionID, body UpdateStatsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateStatsResponse, error)
+	UpdateStatusWithResponse(ctx context.Context, sessionID SessionID, body UpdateStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateStatusResponse, error)
 
 	// GetToolCallsWithResponse request
 	GetToolCallsWithResponse(ctx context.Context, sessionID SessionID, reqEditors ...RequestEditorFn) (*GetToolCallsResponse, error)
@@ -2377,7 +2377,7 @@ func (r RecordProviderCallResponse) StatusCode() int {
 	return 0
 }
 
-type UpdateStatsResponse struct {
+type UpdateStatusResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
 	JSON400      *BadRequest
@@ -2387,7 +2387,7 @@ type UpdateStatsResponse struct {
 }
 
 // Status returns HTTPResponse.Status
-func (r UpdateStatsResponse) Status() string {
+func (r UpdateStatusResponse) Status() string {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.Status
 	}
@@ -2395,7 +2395,7 @@ func (r UpdateStatsResponse) Status() string {
 }
 
 // StatusCode returns HTTPResponse.StatusCode
-func (r UpdateStatsResponse) StatusCode() int {
+func (r UpdateStatusResponse) StatusCode() int {
 	if r.HTTPResponse != nil {
 		return r.HTTPResponse.StatusCode
 	}
@@ -2647,21 +2647,21 @@ func (c *ClientWithResponses) RecordProviderCallWithResponse(ctx context.Context
 	return ParseRecordProviderCallResponse(rsp)
 }
 
-// UpdateStatsWithBodyWithResponse request with arbitrary body returning *UpdateStatsResponse
-func (c *ClientWithResponses) UpdateStatsWithBodyWithResponse(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateStatsResponse, error) {
-	rsp, err := c.UpdateStatsWithBody(ctx, sessionID, contentType, body, reqEditors...)
+// UpdateStatusWithBodyWithResponse request with arbitrary body returning *UpdateStatusResponse
+func (c *ClientWithResponses) UpdateStatusWithBodyWithResponse(ctx context.Context, sessionID SessionID, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*UpdateStatusResponse, error) {
+	rsp, err := c.UpdateStatusWithBody(ctx, sessionID, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseUpdateStatsResponse(rsp)
+	return ParseUpdateStatusResponse(rsp)
 }
 
-func (c *ClientWithResponses) UpdateStatsWithResponse(ctx context.Context, sessionID SessionID, body UpdateStatsJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateStatsResponse, error) {
-	rsp, err := c.UpdateStats(ctx, sessionID, body, reqEditors...)
+func (c *ClientWithResponses) UpdateStatusWithResponse(ctx context.Context, sessionID SessionID, body UpdateStatusJSONRequestBody, reqEditors ...RequestEditorFn) (*UpdateStatusResponse, error) {
+	rsp, err := c.UpdateStatus(ctx, sessionID, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
-	return ParseUpdateStatsResponse(rsp)
+	return ParseUpdateStatusResponse(rsp)
 }
 
 // GetToolCallsWithResponse request returning *GetToolCallsResponse
@@ -3285,15 +3285,15 @@ func ParseRecordProviderCallResponse(rsp *http.Response) (*RecordProviderCallRes
 	return response, nil
 }
 
-// ParseUpdateStatsResponse parses an HTTP response from a UpdateStatsWithResponse call
-func ParseUpdateStatsResponse(rsp *http.Response) (*UpdateStatsResponse, error) {
+// ParseUpdateStatusResponse parses an HTTP response from a UpdateStatusWithResponse call
+func ParseUpdateStatusResponse(rsp *http.Response) (*UpdateStatusResponse, error) {
 	bodyBytes, err := io.ReadAll(rsp.Body)
 	defer func() { _ = rsp.Body.Close() }()
 	if err != nil {
 		return nil, err
 	}
 
-	response := &UpdateStatsResponse{
+	response := &UpdateStatusResponse{
 		Body:         bodyBytes,
 		HTTPResponse: rsp,
 	}

--- a/pkg/sessionapi/convert.go
+++ b/pkg/sessionapi/convert.go
@@ -153,11 +153,11 @@ func ProviderCallToAPI(pc session.ProviderCall) ProviderCall {
 	return out
 }
 
-// StatsUpdateToAPI converts an internal SessionStatsUpdate to a generated SessionStatsUpdate.
+// StatusUpdateToAPI converts an internal SessionStatusUpdate to a generated SessionStatusUpdate.
 // Only SetStatus and SetEndedAt are populated — counter fields (Add*) are auto-derived
 // from AppendMessage and are no longer set externally.
-func StatsUpdateToAPI(u session.SessionStatsUpdate) SessionStatsUpdate {
-	out := SessionStatsUpdate{}
+func StatusUpdateToAPI(u session.SessionStatusUpdate) SessionStatusUpdate {
+	out := SessionStatusUpdate{}
 	if u.SetStatus != "" {
 		status := SessionStatus(u.SetStatus)
 		out.SetStatus = &status

--- a/pkg/sessionapi/convert_test.go
+++ b/pkg/sessionapi/convert_test.go
@@ -199,21 +199,21 @@ func TestProviderCallToAPI(t *testing.T) {
 	assert.Equal(t, int32(2), deref(result.ToolCallCount))
 }
 
-func TestStatsUpdateToAPI(t *testing.T) {
+func TestStatusUpdateToAPI(t *testing.T) {
 	endedAt := time.Now().Truncate(time.Second)
-	u := session.SessionStatsUpdate{
+	u := session.SessionStatusUpdate{
 		SetStatus:  session.SessionStatusCompleted,
 		SetEndedAt: endedAt,
 	}
 
-	result := StatsUpdateToAPI(u)
+	result := StatusUpdateToAPI(u)
 
 	assert.Equal(t, SessionStatusCompleted, *result.SetStatus)
 	assert.Equal(t, endedAt, *result.SetEndedAt)
 }
 
-func TestStatsUpdateToAPI_NoChange(t *testing.T) {
-	result := StatsUpdateToAPI(session.SessionStatsUpdate{})
+func TestStatusUpdateToAPI_NoChange(t *testing.T) {
+	result := StatusUpdateToAPI(session.SessionStatusUpdate{})
 
 	assert.Nil(t, result.SetStatus)
 	assert.Nil(t, result.SetEndedAt)
@@ -679,10 +679,10 @@ func TestEvalResultDetailsRoundTrip(t *testing.T) {
 	assert.Equal(t, "value", nested["key"])
 }
 
-func TestStatsUpdateRoundTrip_EmptyStatus(t *testing.T) {
-	u := session.SessionStatsUpdate{}
+func TestStatusUpdateRoundTrip_EmptyStatus(t *testing.T) {
+	u := session.SessionStatusUpdate{}
 
-	result := StatsUpdateToAPI(u)
+	result := StatusUpdateToAPI(u)
 
 	assert.Nil(t, result.SetStatus, "empty status should produce nil")
 	assert.Nil(t, result.SetEndedAt, "zero time should produce nil")


### PR DESCRIPTION
## Summary

Completes the session-api work items SA-03, SA-06, and SA-08.

### SA-03: Rename UpdateSessionStats → UpdateSessionStatus (30 files)
- **Breaking API change**: `PATCH /api/v1/sessions/{id}/stats` → `PATCH .../status` (old route kept as backward-compat alias)
- `SessionStatsUpdate` type alias removed — `SessionStatusUpdate` is now the canonical name
- All callers, mocks, tests, OpenAPI spec, and generated client updated
- The method only sets `status` and `ended_at`; counters are auto-derived from CTEs

### SA-06: Replace count(*) with LIMIT+1 in ListSessions/SearchSessions
- Default behavior: no count query, `TotalCount = -1`, `HasMore` determined by fetching `limit+1` rows
- Opt-in: `?count=true` query param triggers the count query for pagination UIs that need total
- Dashboard sessions page passes `count=true`; all other callers skip the extra query
- Eliminates 1 expensive query per list/search call

### SA-08: Reduce status transition from 3 to 1 DB query
- Postgres provider adds `UpdateSessionStatusReturning` using `UPDATE...RETURNING` with CTE
- Captures previous status and session metadata (agent, namespace) in a single round trip
- Service layer uses optional `StatusUpdaterWithResult` interface — fast path for Postgres, fallback for other stores
- Eliminates 2 DB round trips per session completion

## Test plan
- [x] All session tests pass (unit, integration, postgres provider, redis)
- [x] Facade, runtime, compaction, privacy tests pass
- [x] Dashboard tests pass (ESLint, TypeScript, Vitest)
- [x] Pre-commit checks pass (lint, vet, coverage ≥80%)
- [ ] CI green