### PR TITLE
fix: Helm chart — PDB selector, session-api NetworkPolicy, container port

### DIFF
--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -27,6 +27,7 @@ spec:
         {{- end }}
       labels:
         {{- include "omnia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: controller-manager
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/omnia/templates/session-api/deployment.yaml
+++ b/charts/omnia/templates/session-api/deployment.yaml
@@ -90,7 +90,7 @@ spec:
             {{- end }}
           ports:
             - name: api
-              containerPort: 8080
+              containerPort: {{ .Values.sessionApi.service.port }}
               protocol: TCP
             - name: health
               containerPort: 8081

--- a/charts/omnia/templates/session-api/networkpolicy.yaml
+++ b/charts/omnia/templates/session-api/networkpolicy.yaml
@@ -1,0 +1,39 @@
+{{- if and .Values.sessionApi.enabled .Values.sessionApi.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "omnia.sessionApi.fullname" . }}
+  labels:
+    {{- include "omnia.sessionApi.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "omnia.sessionApi.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    # Allow ingress from facade (agent) pods — primary session-api client
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: omnia-agent
+      ports:
+        - port: {{ .Values.sessionApi.service.port }}
+          protocol: TCP
+    # Allow ingress from the operator (proxy routes)
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "omnia.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: {{ .Values.sessionApi.service.port }}
+          protocol: TCP
+    # Allow ingress from the dashboard (proxy routes)
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "omnia.dashboard.selectorLabels" . | nindent 14 }}
+      ports:
+        - port: {{ .Values.sessionApi.service.port }}
+          protocol: TCP
+{{- end }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -731,13 +731,9 @@ sessionApi:
     dev:
       enabled: false
     # -- PgBouncer connection pooling (recommended for production)
-    # Deploy a PgBouncer sidecar or standalone proxy in front of PostgreSQL
-    # to reduce connection overhead and improve scalability. When enabled,
-    # session-api and compaction jobs connect through PgBouncer instead of
-    # directly to PostgreSQL.
-    # NOTE: This section defines configuration values only. The actual PgBouncer
-    # deployment template is not included — use an external PgBouncer operator
-    # or add a sidecar container to your PostgreSQL deployment.
+    # IMPORTANT: These values are NOT consumed by any Helm template. They exist
+    # as a reference for operators deploying an external PgBouncer (e.g., via
+    # PgBouncer operator or a sidecar). No chart-managed PgBouncer is created.
     pgbouncer:
       # -- Enable PgBouncer connection pooling
       enabled: false
@@ -814,6 +810,10 @@ sessionApi:
     targetMemoryUtilizationPercentage: 80
   # -- Additional environment variables for the session-api container
   extraEnv: []
+  # -- NetworkPolicy to restrict ingress to session-api (defense-in-depth)
+  networkPolicy:
+    # -- Enable NetworkPolicy for session-api (requires a CNI that supports NetworkPolicy)
+    enabled: false
 
 # ============================================================================
 # Session Privacy Configuration


### PR DESCRIPTION
## Summary

Fixes Helm chart issues from the review backlog (Wave 5).

### PDB selector mismatch (P0)
- Operator PDB selected on `app.kubernetes.io/component: controller-manager` but the operator deployment never set this label on pods
- PDB was matching zero pods, providing no disruption protection
- Fix: Added the missing label to the operator deployment pod template

### NetworkPolicy for session-api (P1)
- Session-api has no authentication (planned mTLS via Istio)
- Added defense-in-depth NetworkPolicy restricting ingress to:
  - Facade/agent pods (primary client)
  - Operator pods (proxy routes)
  - Dashboard pods (proxy routes)
- Gated behind `sessionApi.networkPolicy.enabled: false` (default off)

### Container port configurable (P1)
- Session-api container port was hardcoded at 8080 while service port was configurable
- Now uses `{{ .Values.sessionApi.service.port }}`

### PgBouncer values clarified (P2)
- Documented that pgbouncer values are reference config for external deployments, not consumed by templates

## Test plan
- [x] `helm template` renders cleanly
- [x] PDB selector matches operator pod labels
- [x] NetworkPolicy renders when enabled
- [x] Container port tracks service port
- [ ] CI green