### PR TITLE
fix: add ee/api to session-api Tiltfile build context

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -214,6 +214,7 @@ docker_build(
     only=[
         './cmd/session-api',
         './internal',
+        './ee/api',
         './ee/pkg',
         './ee/internal',
         './pkg',


### PR DESCRIPTION
The privacy package (wired in PR #635) imports `ee/api/v1alpha1` for SessionPrivacyPolicy types, but the Tiltfile `docker_build` `only` list did not include `./ee/api`. This caused the Tilt dev build to fail with:

```
ee/pkg/privacy/merge.go:12:2: no required module provides package github.com/altairalabs/omnia/ee/api/v1alpha1
```

One-line fix: add `'./ee/api'` to the `only` list.