### PR TITLE
fix: add api/ to session-api Tiltfile build context

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -213,6 +213,7 @@ docker_build(
     dockerfile='./Dockerfile.session-api',
     only=[
         './cmd/session-api',
+        './api',
         './internal',
         './ee/api',
         './ee/pkg',


### PR DESCRIPTION
Follow-up to #644. `ee/api/v1alpha1` transitively imports `api/v1alpha1` (core CRD types like `AgentRuntimeSpec`). The previous fix added `./ee/api` but missed `./api`.

Full transitive dependency list verified with `go list -deps ./cmd/session-api/...`.