### PR TITLE
fix: register metav1 in privacy PolicyWatcher scheme

### DIFF
--- a/ee/pkg/privacy/watcher.go
+++ b/ee/pkg/privacy/watcher.go
@@ -46,6 +46,7 @@ type PolicyWatcher struct {
 // It uses the provided REST config to communicate with the K8s API server.
 func NewPolicyWatcher(config *rest.Config, log logr.Logger) (*PolicyWatcher, error) {
 	scheme := runtime.NewScheme()
+	metav1.AddToGroupVersion(scheme, omniav1alpha1.GroupVersion)
 	if err := omniav1alpha1.AddToScheme(scheme); err != nil {
 		return nil, fmt.Errorf("adding EE scheme: %w", err)
 	}


### PR DESCRIPTION
The PolicyWatcher's scheme only had the EE CRD types registered but not `metav1`, which is needed to decode the `WatchEvent` envelope on the K8s watch stream.

This caused the runtime error:
```
unable to decode an event from the watch stream: unable to decode to metav1.WatchEvent
```

One-line fix: `metav1.AddToGroupVersion(scheme, omniav1alpha1.GroupVersion)`