### PR TITLE
test: add envtest integration tests for PolicyWatcher and ToolPolicyWatcher

### DIFF
--- a/ee/internal/controller/policywatcher_envtest_test.go
+++ b/ee/internal/controller/policywatcher_envtest_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	corev1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/privacy"
+)
+
+var _ = Describe("PolicyWatcher envtest integration", func() {
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	Context("When watching SessionPrivacyPolicy CRDs via a real API server", func() {
+		It("should create a PolicyWatcher with the envtest config", func() {
+			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pw).NotTo(BeNil())
+		})
+
+		It("should sync cache and detect created policies", func() {
+			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			watchCtx, watchCancel := context.WithCancel(ctx)
+			defer watchCancel()
+
+			err = pw.Start(watchCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Initially no policies — GetEffectivePolicy should return nil
+			Expect(pw.GetEffectivePolicy("default", "my-agent")).To(BeNil())
+
+			// Create a global SessionPrivacyPolicy via the real K8s API
+			policy := &omniav1alpha1.SessionPrivacyPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "envtest-global-policy",
+				},
+				Spec: omniav1alpha1.SessionPrivacyPolicySpec{
+					Level: omniav1alpha1.PolicyLevelGlobal,
+					Recording: omniav1alpha1.RecordingConfig{
+						Enabled: true,
+						PII: &omniav1alpha1.PIIConfig{
+							Redact:   true,
+							Patterns: []string{"ssn"},
+						},
+					},
+					UserOptOut: &omniav1alpha1.UserOptOutConfig{Enabled: true},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, policy)
+			})
+
+			// The informer should pick up the policy within a few seconds
+			Eventually(func(g Gomega) {
+				ep := pw.GetEffectivePolicy("default", "my-agent")
+				g.Expect(ep).NotTo(BeNil())
+				g.Expect(ep.Recording.Enabled).To(BeTrue())
+				g.Expect(ep.Recording.PII).NotTo(BeNil())
+				g.Expect(ep.Recording.PII.Redact).To(BeTrue())
+				g.Expect(ep.UserOptOut).NotTo(BeNil())
+				g.Expect(ep.UserOptOut.Enabled).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+		})
+
+		It("should detect policy deletion", func() {
+			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			watchCtx, watchCancel := context.WithCancel(ctx)
+			defer watchCancel()
+
+			// Create the policy before starting the watcher
+			policy := &omniav1alpha1.SessionPrivacyPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "envtest-delete-policy",
+				},
+				Spec: omniav1alpha1.SessionPrivacyPolicySpec{
+					Level: omniav1alpha1.PolicyLevelGlobal,
+					Recording: omniav1alpha1.RecordingConfig{
+						Enabled: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+
+			err = pw.Start(watchCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait until the policy appears in cache
+			Eventually(func() *privacy.EffectivePolicy {
+				return pw.GetEffectivePolicy("default", "agent")
+			}, timeout, interval).ShouldNot(BeNil())
+
+			// Delete the policy
+			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
+
+			// Wait until it disappears from cache
+			Eventually(func() *privacy.EffectivePolicy {
+				return pw.GetEffectivePolicy("default", "agent")
+			}, timeout, interval).Should(BeNil())
+		})
+
+		It("should observe workspace-scoped policies", func() {
+			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+
+			watchCtx, watchCancel := context.WithCancel(ctx)
+			defer watchCancel()
+
+			err = pw.Start(watchCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create a global policy as the parent
+			globalPolicy := &omniav1alpha1.SessionPrivacyPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "envtest-ws-global",
+				},
+				Spec: omniav1alpha1.SessionPrivacyPolicySpec{
+					Level: omniav1alpha1.PolicyLevelGlobal,
+					Recording: omniav1alpha1.RecordingConfig{
+						Enabled: true,
+						PII: &omniav1alpha1.PIIConfig{
+							Redact:   true,
+							Patterns: []string{"ssn"},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, globalPolicy)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, globalPolicy)
+			})
+
+			// Create a workspace-scoped policy
+			wsPolicy := &omniav1alpha1.SessionPrivacyPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "envtest-ws-policy",
+				},
+				Spec: omniav1alpha1.SessionPrivacyPolicySpec{
+					Level:        omniav1alpha1.PolicyLevelWorkspace,
+					WorkspaceRef: &corev1alpha1.LocalObjectReference{Name: "test-ns"},
+					Recording: omniav1alpha1.RecordingConfig{
+						Enabled: true,
+						PII: &omniav1alpha1.PIIConfig{
+							Redact:  true,
+							Encrypt: true,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, wsPolicy)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, wsPolicy)
+			})
+
+			// The effective policy for test-ns should merge global + workspace
+			Eventually(func(g Gomega) {
+				ep := pw.GetEffectivePolicy("test-ns", "some-agent")
+				g.Expect(ep).NotTo(BeNil())
+				g.Expect(ep.Recording.PII).NotTo(BeNil())
+				g.Expect(ep.Recording.PII.Redact).To(BeTrue())
+				g.Expect(ep.Recording.PII.Encrypt).To(BeTrue())
+			}, timeout, interval).Should(Succeed())
+
+			// A different namespace should only get the global policy
+			Eventually(func(g Gomega) {
+				ep := pw.GetEffectivePolicy("other-ns", "some-agent")
+				g.Expect(ep).NotTo(BeNil())
+				g.Expect(ep.Recording.PII).NotTo(BeNil())
+				g.Expect(ep.Recording.PII.Redact).To(BeTrue())
+				g.Expect(ep.Recording.PII.Encrypt).To(BeFalse())
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+})

--- a/ee/internal/controller/toolpolicywatcher_envtest_test.go
+++ b/ee/internal/controller/toolpolicywatcher_envtest_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package controller
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/policy"
+)
+
+var _ = Describe("ToolPolicy Watcher envtest integration", func() {
+	const (
+		timeout  = time.Second * 10
+		interval = time.Millisecond * 250
+	)
+
+	discardLogger := func() *slog.Logger {
+		return slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	Context("When using policy.Watcher with a real K8s API server", func() {
+		It("should perform initial load of existing ToolPolicies", func() {
+			eval, err := policy.NewEvaluator()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create a ToolPolicy via the real API
+			tp := &omniav1alpha1.ToolPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "envtest-watcher-load",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.ToolPolicySpec{
+					Selector: omniav1alpha1.ToolPolicySelector{
+						Registry: "test-registry",
+					},
+					Rules: []omniav1alpha1.PolicyRule{
+						{
+							Name: "deny-all",
+							Deny: omniav1alpha1.PolicyRuleDeny{
+								CEL:     "true",
+								Message: "always deny",
+							},
+						},
+					},
+					Mode:      omniav1alpha1.PolicyModeEnforce,
+					OnFailure: omniav1alpha1.OnFailureDeny,
+				},
+			}
+			Expect(k8sClient.Create(ctx, tp)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, tp)
+			})
+
+			// Create watcher using the envtest k8sClient
+			w := policy.NewWatcher(
+				eval,
+				k8sClient,
+				k8sClient.Scheme(),
+				"default",
+				discardLogger(),
+			)
+			Expect(w).NotTo(BeNil())
+
+			// Start in a goroutine (blocks in pollLoop) and cancel after
+			// the evaluator picks up the policy.
+			watchCtx, watchCancel := context.WithCancel(ctx)
+			defer watchCancel()
+
+			go func() {
+				defer GinkgoRecover()
+				_ = w.Start(watchCtx)
+			}()
+
+			// The watcher's initial load should compile the policy
+			Eventually(func() int {
+				return eval.PolicyCount()
+			}, timeout, interval).Should(Equal(1))
+		})
+
+		It("should load multiple policies cluster-wide", func() {
+			eval, err := policy.NewEvaluator()
+			Expect(err).NotTo(HaveOccurred())
+
+			tp1 := &omniav1alpha1.ToolPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "envtest-watcher-multi1",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.ToolPolicySpec{
+					Selector: omniav1alpha1.ToolPolicySelector{
+						Registry: "registry-a",
+					},
+					Rules: []omniav1alpha1.PolicyRule{
+						{
+							Name: "rule-a",
+							Deny: omniav1alpha1.PolicyRuleDeny{
+								CEL:     "true",
+								Message: "deny",
+							},
+						},
+					},
+					Mode:      omniav1alpha1.PolicyModeEnforce,
+					OnFailure: omniav1alpha1.OnFailureDeny,
+				},
+			}
+			Expect(k8sClient.Create(ctx, tp1)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, tp1)
+			})
+
+			tp2 := &omniav1alpha1.ToolPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "envtest-watcher-multi2",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.ToolPolicySpec{
+					Selector: omniav1alpha1.ToolPolicySelector{
+						Registry: "registry-b",
+					},
+					Rules: []omniav1alpha1.PolicyRule{
+						{
+							Name: "rule-b",
+							Deny: omniav1alpha1.PolicyRuleDeny{
+								CEL:     "false",
+								Message: "allow",
+							},
+						},
+					},
+					Mode:      omniav1alpha1.PolicyModeEnforce,
+					OnFailure: omniav1alpha1.OnFailureDeny,
+				},
+			}
+			Expect(k8sClient.Create(ctx, tp2)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, tp2)
+			})
+
+			// Cluster-wide watcher (empty namespace)
+			w := policy.NewWatcher(
+				eval,
+				k8sClient,
+				k8sClient.Scheme(),
+				"", // cluster-wide
+				discardLogger(),
+			)
+
+			watchCtx, watchCancel := context.WithCancel(ctx)
+			defer watchCancel()
+
+			go func() {
+				defer GinkgoRecover()
+				_ = w.Start(watchCtx)
+			}()
+
+			// Both policies should be loaded
+			Eventually(func() int {
+				return eval.PolicyCount()
+			}, timeout, interval).Should(BeNumerically(">=", 2))
+		})
+
+		It("should skip policies with invalid CEL without erroring", func() {
+			eval, err := policy.NewEvaluator()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Create a valid policy
+			validTP := &omniav1alpha1.ToolPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "envtest-watcher-validcel",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.ToolPolicySpec{
+					Selector: omniav1alpha1.ToolPolicySelector{
+						Registry: "valid-registry",
+					},
+					Rules: []omniav1alpha1.PolicyRule{
+						{
+							Name: "valid-rule",
+							Deny: omniav1alpha1.PolicyRuleDeny{
+								CEL:     "true",
+								Message: "deny",
+							},
+						},
+					},
+					Mode:      omniav1alpha1.PolicyModeEnforce,
+					OnFailure: omniav1alpha1.OnFailureDeny,
+				},
+			}
+			Expect(k8sClient.Create(ctx, validTP)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, validTP)
+			})
+
+			// Create a policy with invalid CEL
+			invalidTP := &omniav1alpha1.ToolPolicy{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "envtest-watcher-badcel",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.ToolPolicySpec{
+					Selector: omniav1alpha1.ToolPolicySelector{
+						Registry: "invalid-registry",
+					},
+					Rules: []omniav1alpha1.PolicyRule{
+						{
+							Name: "bad-rule",
+							Deny: omniav1alpha1.PolicyRuleDeny{
+								CEL:     "invalid CEL %%%",
+								Message: "should fail compilation",
+							},
+						},
+					},
+					Mode:      omniav1alpha1.PolicyModeEnforce,
+					OnFailure: omniav1alpha1.OnFailureDeny,
+				},
+			}
+			Expect(k8sClient.Create(ctx, invalidTP)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, invalidTP)
+			})
+
+			w := policy.NewWatcher(
+				eval,
+				k8sClient,
+				k8sClient.Scheme(),
+				"default",
+				discardLogger(),
+			)
+
+			watchCtx, watchCancel := context.WithCancel(ctx)
+			defer watchCancel()
+
+			go func() {
+				defer GinkgoRecover()
+				_ = w.Start(watchCtx)
+			}()
+
+			// Only the valid policy should be compiled; invalid CEL is skipped
+			Eventually(func() int {
+				return eval.PolicyCount()
+			}, timeout, interval).Should(BeNumerically(">=", 1))
+
+			// The invalid policy should not be compiled —
+			// verify via evaluator that only 1 policy is present (not 2)
+			Consistently(func() int {
+				return eval.PolicyCount()
+			}, time.Second, interval).Should(Equal(1))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Adds envtest-based integration tests that exercise K8s informer/watcher components against a real API server, catching integration bugs that mock-only tests miss.

This would have caught the missing `metav1.AddToGroupVersion` bug fixed in PR #646 — the watch stream decode failure only manifests when reading from a real K8s API, not from mock handlers.

### PolicyWatcher (4 specs)
- Watcher creation with real REST config (catches scheme registration bugs)
- Policy appears in cache after CR creation via real API
- Policy removed from cache after CR deletion
- Workspace-scoped policy inheritance and merge end-to-end

### ToolPolicyWatcher (3 specs)
- CEL policy compiled after CR creation
- Cluster-wide policy loading
- Invalid CEL expression gracefully skipped

## Test plan
- [x] All 7 new specs pass locally
- [x] Pre-commit checks pass
- [ ] CI green (envtest runs in Controller Tests job)