### PR TITLE
fix: register metav1 WatchEvent under v1 group (not CRD group)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,9 @@
 # Re-include SQL migration files for go:embed (session-api)
 !internal/session/postgres/migrations/*.sql
 
+# Re-include OpenAPI spec for go:embed (session-api docs)
+!internal/session/api/openapi.yaml
+
 # Re-include embedded license public key for go:embed
 !pkg/
 !pkg/license/

--- a/Tiltfile
+++ b/Tiltfile
@@ -704,6 +704,7 @@ k8s_resource(
 k8s_resource(
     'omnia-session-api',
     labels=['session-api'],
+    port_forwards=['8082:8080'],  # Session API (REST + /docs)
     resource_deps=['omnia-postgres'],
 )
 

--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -40,8 +40,12 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	goredis "github.com/redis/go-redis/v9"
 	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
 	"github.com/altairalabs/omnia/ee/pkg/audit"
 	"github.com/altairalabs/omnia/ee/pkg/metrics"
 	"github.com/altairalabs/omnia/ee/pkg/privacy"
@@ -709,11 +713,15 @@ func wrapPrivacyMiddleware(
 		return next
 	}
 
-	watcher, err := privacy.NewPolicyWatcher(kubeConfig, log)
+	scheme := runtime.NewScheme()
+	utilruntime.Must(omniav1alpha1.AddToScheme(scheme))
+	k8sClient, err := client.New(kubeConfig, client.Options{Scheme: scheme})
 	if err != nil {
-		log.Error(err, "privacy middleware skipped", "reason", "policy watcher creation failed")
+		log.Error(err, "privacy middleware skipped", "reason", "k8s client creation failed")
 		return next
 	}
+
+	watcher := privacy.NewPolicyWatcher(k8sClient, log)
 
 	// Start the watcher asynchronously; it syncs the cache in the background.
 	go func() {

--- a/ee/internal/controller/policywatcher_envtest_test.go
+++ b/ee/internal/controller/policywatcher_envtest_test.go
@@ -16,6 +16,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
@@ -29,21 +31,29 @@ var _ = Describe("PolicyWatcher envtest integration", func() {
 	)
 
 	Context("When watching SessionPrivacyPolicy CRDs via a real API server", func() {
-		It("should create a PolicyWatcher with the envtest config", func() {
-			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+		It("should create a PolicyWatcher with a controller-runtime client", func() {
+			k8s, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 			Expect(err).NotTo(HaveOccurred())
+
+			pw := privacy.NewPolicyWatcher(k8s, logr.Discard())
+			pw.SetPollInterval(500 * time.Millisecond)
 			Expect(pw).NotTo(BeNil())
 		})
 
 		It("should sync cache and detect created policies", func() {
-			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+			k8s, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 			Expect(err).NotTo(HaveOccurred())
+
+			pw := privacy.NewPolicyWatcher(k8s, logr.Discard())
+			pw.SetPollInterval(500 * time.Millisecond)
 
 			watchCtx, watchCancel := context.WithCancel(ctx)
 			defer watchCancel()
 
-			err = pw.Start(watchCtx)
-			Expect(err).NotTo(HaveOccurred())
+			go func() {
+				defer GinkgoRecover()
+				_ = pw.Start(watchCtx)
+			}()
 
 			// Initially no policies — GetEffectivePolicy should return nil
 			Expect(pw.GetEffectivePolicy("default", "my-agent")).To(BeNil())
@@ -70,7 +80,7 @@ var _ = Describe("PolicyWatcher envtest integration", func() {
 				_ = k8sClient.Delete(ctx, policy)
 			})
 
-			// The informer should pick up the policy within a few seconds
+			// The poll loop should pick up the policy within a few seconds
 			Eventually(func(g Gomega) {
 				ep := pw.GetEffectivePolicy("default", "my-agent")
 				g.Expect(ep).NotTo(BeNil())
@@ -83,11 +93,11 @@ var _ = Describe("PolicyWatcher envtest integration", func() {
 		})
 
 		It("should detect policy deletion", func() {
-			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+			k8s, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 			Expect(err).NotTo(HaveOccurred())
 
-			watchCtx, watchCancel := context.WithCancel(ctx)
-			defer watchCancel()
+			pw := privacy.NewPolicyWatcher(k8s, logr.Discard())
+			pw.SetPollInterval(500 * time.Millisecond)
 
 			// Create the policy before starting the watcher
 			policy := &omniav1alpha1.SessionPrivacyPolicy{
@@ -103,8 +113,13 @@ var _ = Describe("PolicyWatcher envtest integration", func() {
 			}
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
 
-			err = pw.Start(watchCtx)
-			Expect(err).NotTo(HaveOccurred())
+			watchCtx, watchCancel := context.WithCancel(ctx)
+			defer watchCancel()
+
+			go func() {
+				defer GinkgoRecover()
+				_ = pw.Start(watchCtx)
+			}()
 
 			// Wait until the policy appears in cache
 			Eventually(func() *privacy.EffectivePolicy {
@@ -121,14 +136,19 @@ var _ = Describe("PolicyWatcher envtest integration", func() {
 		})
 
 		It("should observe workspace-scoped policies", func() {
-			pw, err := privacy.NewPolicyWatcher(cfg, logr.Discard())
+			k8s, err := client.New(cfg, client.Options{Scheme: scheme.Scheme})
 			Expect(err).NotTo(HaveOccurred())
+
+			pw := privacy.NewPolicyWatcher(k8s, logr.Discard())
+			pw.SetPollInterval(500 * time.Millisecond)
 
 			watchCtx, watchCancel := context.WithCancel(ctx)
 			defer watchCancel()
 
-			err = pw.Start(watchCtx)
-			Expect(err).NotTo(HaveOccurred())
+			go func() {
+				defer GinkgoRecover()
+				_ = pw.Start(watchCtx)
+			}()
 
 			// Create a global policy as the parent
 			globalPolicy := &omniav1alpha1.SessionPrivacyPolicy{

--- a/ee/pkg/privacy/watcher.go
+++ b/ee/pkg/privacy/watcher.go
@@ -15,12 +15,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
 )
@@ -34,83 +29,80 @@ type EffectivePolicy struct {
 	UserOptOut *omniav1alpha1.UserOptOutConfig
 }
 
-// PolicyWatcher uses a shared informer to watch SessionPrivacyPolicy CRDs
-// and maintains an in-memory cache of effective policies keyed by scope.
+// PolicyWatcher polls SessionPrivacyPolicy CRDs and maintains an in-memory
+// cache of policies for fast lookup by the privacy middleware.
 type PolicyWatcher struct {
-	informer cache.SharedIndexInformer
-	policies sync.Map // key: string (namespace/name) -> *omniav1alpha1.SessionPrivacyPolicy
-	log      logr.Logger
+	client       client.Client
+	policies     sync.Map // key: string (namespace/name) -> *omniav1alpha1.SessionPrivacyPolicy
+	pollInterval time.Duration
+	log          logr.Logger
 }
 
-// NewPolicyWatcher creates a watcher that observes SessionPrivacyPolicy CRDs.
-// It uses the provided REST config to communicate with the K8s API server.
-func NewPolicyWatcher(config *rest.Config, log logr.Logger) (*PolicyWatcher, error) {
-	scheme := runtime.NewScheme()
-	metav1.AddToGroupVersion(scheme, omniav1alpha1.GroupVersion)
-	if err := omniav1alpha1.AddToScheme(scheme); err != nil {
-		return nil, fmt.Errorf("adding EE scheme: %w", err)
+// NewPolicyWatcher creates a watcher that observes SessionPrivacyPolicy CRDs
+// using a controller-runtime client.
+func NewPolicyWatcher(k8sClient client.Client, log logr.Logger) *PolicyWatcher {
+	return &PolicyWatcher{
+		client:       k8sClient,
+		pollInterval: 30 * time.Second,
+		log:          log.WithName("policy-watcher"),
 	}
-
-	codecs := serializer.NewCodecFactory(scheme)
-	cfg := *config
-	cfg.APIPath = "/apis"
-	cfg.GroupVersion = &omniav1alpha1.GroupVersion
-	cfg.NegotiatedSerializer = codecs.WithoutConversion()
-
-	client, err := rest.RESTClientFor(&cfg)
-	if err != nil {
-		return nil, fmt.Errorf("creating REST client: %w", err)
-	}
-
-	listWatcher := &cache.ListWatch{
-		ListFunc: func(opts metav1.ListOptions) (runtime.Object, error) {
-			result := &omniav1alpha1.SessionPrivacyPolicyList{}
-			err := client.Get().
-				Resource("sessionprivacypolicies").
-				VersionedParams(&opts, runtime.NewParameterCodec(scheme)).
-				Do(context.Background()).
-				Into(result)
-			return result, err
-		},
-		WatchFunc: func(opts metav1.ListOptions) (watch.Interface, error) {
-			return client.Get().
-				Resource("sessionprivacypolicies").
-				VersionedParams(&opts, runtime.NewParameterCodec(scheme)).
-				Watch(context.Background())
-		},
-	}
-
-	informer := cache.NewSharedIndexInformer(
-		listWatcher,
-		&omniav1alpha1.SessionPrivacyPolicy{},
-		10*time.Minute, // resync period
-		cache.Indexers{},
-	)
-
-	w := &PolicyWatcher{
-		informer: informer,
-		log:      log.WithName("policy-watcher"),
-	}
-
-	// Register event handlers to maintain the in-memory cache.
-	_, _ = informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc:    func(obj any) { w.onAdd(obj) },
-		UpdateFunc: func(_, newObj any) { w.onAdd(newObj) },
-		DeleteFunc: func(obj any) { w.onDelete(obj) },
-	})
-
-	return w, nil
 }
 
-// Start begins watching for SessionPrivacyPolicy changes. Blocks until ctx is
-// cancelled or the informer fails to sync.
+// SetPollInterval overrides the default poll interval (for testing).
+func (w *PolicyWatcher) SetPollInterval(d time.Duration) {
+	w.pollInterval = d
+}
+
+// Start begins watching for SessionPrivacyPolicy changes. It performs an
+// initial list, then polls periodically. Blocks until ctx is cancelled.
 func (w *PolicyWatcher) Start(ctx context.Context) error {
-	go w.informer.Run(ctx.Done())
-
-	if !cache.WaitForCacheSync(ctx.Done(), w.informer.HasSynced) {
-		return fmt.Errorf("policy watcher cache sync failed")
+	if err := w.loadPolicies(ctx); err != nil {
+		return fmt.Errorf("initial policy load failed: %w", err)
 	}
 	w.log.Info("policy watcher synced")
+
+	ticker := time.NewTicker(w.pollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			if err := w.loadPolicies(ctx); err != nil {
+				w.log.Error(err, "policy reload failed")
+			}
+		}
+	}
+}
+
+// loadPolicies lists all SessionPrivacyPolicy resources and updates the cache.
+func (w *PolicyWatcher) loadPolicies(ctx context.Context) error {
+	var list omniav1alpha1.SessionPrivacyPolicyList
+	if err := w.client.List(ctx, &list); err != nil {
+		return fmt.Errorf("listing policies: %w", err)
+	}
+
+	// Track which keys are still present.
+	seen := make(map[string]bool, len(list.Items))
+
+	for i := range list.Items {
+		p := &list.Items[i]
+		key := policyKey(p)
+		seen[key] = true
+		w.policies.Store(key, p.DeepCopy())
+		w.log.V(1).Info("policy cached", "name", p.Name, "level", p.Spec.Level)
+	}
+
+	// Remove policies no longer present.
+	w.policies.Range(func(k, _ any) bool {
+		if !seen[k.(string)] {
+			w.policies.Delete(k)
+			w.log.V(1).Info("policy removed", "key", k)
+		}
+		return true
+	})
+
 	return nil
 }
 
@@ -192,34 +184,6 @@ func findByLevel(
 		}
 	}
 	return nil
-}
-
-func (w *PolicyWatcher) onAdd(obj any) {
-	p, ok := obj.(*omniav1alpha1.SessionPrivacyPolicy)
-	if !ok {
-		return
-	}
-	key := policyKey(p)
-	w.policies.Store(key, p.DeepCopy())
-	w.log.V(1).Info("policy cached", "name", p.Name, "level", p.Spec.Level)
-}
-
-func (w *PolicyWatcher) onDelete(obj any) {
-	p, ok := obj.(*omniav1alpha1.SessionPrivacyPolicy)
-	if !ok {
-		// Handle DeletedFinalStateUnknown
-		tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-		if !ok {
-			return
-		}
-		p, ok = tombstone.Obj.(*omniav1alpha1.SessionPrivacyPolicy)
-		if !ok {
-			return
-		}
-	}
-	key := policyKey(p)
-	w.policies.Delete(key)
-	w.log.V(1).Info("policy removed", "name", p.Name)
 }
 
 func policyKey(p *omniav1alpha1.SessionPrivacyPolicy) string {

--- a/ee/pkg/privacy/watcher_test.go
+++ b/ee/pkg/privacy/watcher_test.go
@@ -11,6 +11,7 @@ package privacy
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -313,4 +314,71 @@ func TestNewPolicyWatcher(t *testing.T) {
 	w := NewPolicyWatcher(fakeClient, logr.Discard())
 	require.NotNil(t, w)
 	assert.NotNil(t, w.client)
+}
+
+func TestStart_CancellationStopsPolling(t *testing.T) {
+	scheme := testScheme()
+	p := newTestPolicy("start-test", omniav1alpha1.PolicyLevelGlobal)
+	p.Namespace = testNamespace
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(p).Build()
+
+	w := NewPolicyWatcher(fakeClient, logr.Discard())
+	w.SetPollInterval(50 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- w.Start(ctx) }()
+
+	// Wait for initial load
+	require.Eventually(t, func() bool {
+		return w.GetEffectivePolicy("", "") != nil
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+
+	err := <-errCh
+	assert.NoError(t, err)
+}
+
+func TestStart_InitialLoadError(t *testing.T) {
+	// A client with no scheme can't list SessionPrivacyPolicy — triggers error.
+	badClient := fake.NewClientBuilder().Build()
+
+	w := NewPolicyWatcher(badClient, logr.Discard())
+	err := w.Start(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "initial policy load failed")
+}
+
+func TestStart_ReloadErrorLogged(t *testing.T) {
+	scheme := testScheme()
+	p := newTestPolicy("reload-test", omniav1alpha1.PolicyLevelGlobal)
+	p.Namespace = testNamespace
+
+	// Start with a working client.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(p).Build()
+
+	w := NewPolicyWatcher(fakeClient, logr.Discard())
+	w.SetPollInterval(50 * time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() { _ = w.Start(ctx) }()
+
+	// Wait for initial load to succeed.
+	require.Eventually(t, func() bool {
+		return w.GetEffectivePolicy("", "") != nil
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Swap the client to one that will fail on List — simulates a reload error.
+	w.client = fake.NewClientBuilder().Build()
+
+	// Let a poll cycle run — the error is logged, not returned.
+	time.Sleep(100 * time.Millisecond)
+
+	// Watcher should still be running (not crashed).
+	// The old cached policy should still be present.
+	assert.NotNil(t, w.GetEffectivePolicy("", ""))
 }

--- a/ee/pkg/privacy/watcher_test.go
+++ b/ee/pkg/privacy/watcher_test.go
@@ -10,20 +10,26 @@ package privacy
 
 import (
 	"context"
-	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/cache"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	corev1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
 )
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = omniav1alpha1.AddToScheme(s)
+	return s
+}
+
+const testNamespace = "default"
 
 func newTestPolicy(name string, level omniav1alpha1.PolicyLevel) *omniav1alpha1.SessionPrivacyPolicy {
 	p := &omniav1alpha1.SessionPrivacyPolicy{
@@ -120,34 +126,6 @@ func TestPolicyWatcher_GetEffectivePolicy_WorkspaceMismatch(t *testing.T) {
 	// Only global should match — workspace doesn't match namespace
 }
 
-func TestPolicyWatcher_OnAddAndDelete(t *testing.T) {
-	w := &PolicyWatcher{log: logr.Discard()}
-
-	p := newTestPolicy("test-policy", omniav1alpha1.PolicyLevelGlobal)
-	w.onAdd(p)
-
-	// Should be in cache
-	result := w.GetEffectivePolicy("ns", "agent")
-	require.NotNil(t, result)
-
-	// Delete it
-	w.onDelete(p)
-	result = w.GetEffectivePolicy("ns", "agent")
-	assert.Nil(t, result)
-}
-
-func TestPolicyWatcher_OnDelete_WrongType(t *testing.T) {
-	w := &PolicyWatcher{log: logr.Discard()}
-	// Should not panic
-	w.onDelete("not-a-policy")
-}
-
-func TestPolicyWatcher_OnAdd_WrongType(t *testing.T) {
-	w := &PolicyWatcher{log: logr.Discard()}
-	// Should not panic
-	w.onAdd("not-a-policy")
-}
-
 func TestPolicyKey(t *testing.T) {
 	p := &omniav1alpha1.SessionPrivacyPolicy{
 		ObjectMeta: metav1.ObjectMeta{Name: "test", Namespace: "ns"},
@@ -164,10 +142,30 @@ func TestCollectPolicies(t *testing.T) {
 	assert.Len(t, result, 2)
 }
 
+func TestCollectPolicies_SkipsNonPolicyValues(t *testing.T) {
+	w := &PolicyWatcher{log: logr.Discard()}
+	w.policies.Store("valid", newTestPolicy("valid", omniav1alpha1.PolicyLevelGlobal))
+	w.policies.Store("invalid", "not-a-policy")
+
+	result := w.collectPolicies()
+	assert.Len(t, result, 1)
+	assert.Equal(t, "valid", result[0].Name)
+}
+
 func TestBuildPolicyChain_EmptyNamespace(t *testing.T) {
 	global := newTestPolicy("global", omniav1alpha1.PolicyLevelGlobal)
 	chain := buildPolicyChain([]*omniav1alpha1.SessionPrivacyPolicy{global}, "", "")
 	assert.Len(t, chain, 1)
+}
+
+func TestBuildPolicyChain_AgentWithoutNamespace(t *testing.T) {
+	agent := newTestPolicy("agent", omniav1alpha1.PolicyLevelAgent)
+	agent.Spec.AgentRef = &corev1alpha1.NamespacedObjectReference{
+		Name: "my-agent", Namespace: "ns",
+	}
+	// agentName set but namespace empty — agent policy should not be included
+	chain := buildPolicyChain([]*omniav1alpha1.SessionPrivacyPolicy{agent}, "", "my-agent")
+	assert.Len(t, chain, 0)
 }
 
 func TestFindByLevel_GlobalDefault(t *testing.T) {
@@ -181,97 +179,6 @@ func TestFindByLevel_NoMatch(t *testing.T) {
 	global := newTestPolicy("global", omniav1alpha1.PolicyLevelGlobal)
 	result := findByLevel([]*omniav1alpha1.SessionPrivacyPolicy{global}, omniav1alpha1.PolicyLevelWorkspace, "ns", "")
 	assert.Nil(t, result)
-}
-
-func TestPolicyWatcher_OnDelete_Tombstone(t *testing.T) {
-	w := &PolicyWatcher{log: logr.Discard()}
-
-	p := newTestPolicy("tomb-policy", omniav1alpha1.PolicyLevelGlobal)
-	w.onAdd(p)
-
-	// Verify policy is cached
-	result := w.GetEffectivePolicy("ns", "agent")
-	require.NotNil(t, result)
-
-	// Delete via tombstone (DeletedFinalStateUnknown wraps the real object)
-	tombstone := cache.DeletedFinalStateUnknown{
-		Key: "/tomb-policy",
-		Obj: p,
-	}
-	w.onDelete(tombstone)
-
-	result = w.GetEffectivePolicy("ns", "agent")
-	assert.Nil(t, result)
-}
-
-func TestPolicyWatcher_OnDelete_TombstoneWrongInnerType(t *testing.T) {
-	w := &PolicyWatcher{log: logr.Discard()}
-
-	// Tombstone wrapping a non-policy object — should not panic
-	tombstone := cache.DeletedFinalStateUnknown{
-		Key: "bad-key",
-		Obj: "not-a-policy",
-	}
-	w.onDelete(tombstone)
-}
-
-func TestNewPolicyWatcher(t *testing.T) {
-	// Start a test HTTP server that responds to API discovery.
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-		resp := `{"kind":"SessionPrivacyPolicyList",` +
-			`"apiVersion":"omnia.altairalabs.com/v1alpha1",` +
-			`"metadata":{},"items":[]}`
-		_, _ = w.Write([]byte(resp))
-	}))
-	defer srv.Close()
-
-	cfg := &rest.Config{Host: srv.URL}
-	pw, err := NewPolicyWatcher(cfg, logr.Discard())
-	require.NoError(t, err)
-	require.NotNil(t, pw)
-	assert.NotNil(t, pw.informer)
-}
-
-func TestPolicyWatcher_Start_SyncFailure(t *testing.T) {
-	// Cancel the context immediately so cache sync fails.
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	// Use a test server that will never respond (context already cancelled).
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
-
-	cfg := &rest.Config{Host: srv.URL}
-	pw, err := NewPolicyWatcher(cfg, logr.Discard())
-	require.NoError(t, err)
-
-	err = pw.Start(ctx)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "cache sync failed")
-}
-
-func TestCollectPolicies_SkipsNonPolicyValues(t *testing.T) {
-	w := &PolicyWatcher{log: logr.Discard()}
-	w.policies.Store("valid", newTestPolicy("valid", omniav1alpha1.PolicyLevelGlobal))
-	w.policies.Store("invalid", "not-a-policy")
-
-	result := w.collectPolicies()
-	assert.Len(t, result, 1)
-	assert.Equal(t, "valid", result[0].Name)
-}
-
-func TestBuildPolicyChain_AgentWithoutNamespace(t *testing.T) {
-	agent := newTestPolicy("agent", omniav1alpha1.PolicyLevelAgent)
-	agent.Spec.AgentRef = &corev1alpha1.NamespacedObjectReference{
-		Name: "my-agent", Namespace: "ns",
-	}
-	// agentName set but namespace empty — agent policy should not be included
-	chain := buildPolicyChain([]*omniav1alpha1.SessionPrivacyPolicy{agent}, "", "my-agent")
-	assert.Len(t, chain, 0)
 }
 
 func TestFindByLevel_WorkspaceNilRef(t *testing.T) {
@@ -310,4 +217,100 @@ func TestFindByLevel_AgentNamespaceMismatch(t *testing.T) {
 
 	result := findByLevel([]*omniav1alpha1.SessionPrivacyPolicy{agent}, omniav1alpha1.PolicyLevelAgent, "ns", "my-agent")
 	assert.Nil(t, result)
+}
+
+// --- loadPolicies tests using fake client ---
+
+func TestLoadPolicies_PopulatesCache(t *testing.T) {
+	scheme := testScheme()
+	p1 := newTestPolicy("policy-1", omniav1alpha1.PolicyLevelGlobal)
+	p1.Namespace = testNamespace
+	p2 := newTestPolicy("policy-2", omniav1alpha1.PolicyLevelWorkspace)
+	p2.Namespace = testNamespace
+	p2.Spec.WorkspaceRef = &corev1alpha1.LocalObjectReference{Name: "my-ns"}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(p1, p2).
+		Build()
+
+	w := NewPolicyWatcher(fakeClient, logr.Discard())
+	err := w.loadPolicies(context.Background())
+	require.NoError(t, err)
+
+	policies := w.collectPolicies()
+	assert.Len(t, policies, 2)
+}
+
+func TestLoadPolicies_RemovesDeletedPolicies(t *testing.T) {
+	scheme := testScheme()
+	p1 := newTestPolicy("policy-1", omniav1alpha1.PolicyLevelGlobal)
+	p1.Namespace = testNamespace
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(p1).
+		Build()
+
+	w := NewPolicyWatcher(fakeClient, logr.Discard())
+
+	// First load — policy-1 should be cached
+	err := w.loadPolicies(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, w.collectPolicies(), 1)
+
+	// Delete the policy from the fake client
+	require.NoError(t, fakeClient.Delete(context.Background(), p1))
+
+	// Second load — cache should be empty
+	err = w.loadPolicies(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, w.collectPolicies(), 0)
+}
+
+func TestLoadPolicies_GetEffectivePolicy_AfterLoad(t *testing.T) {
+	scheme := testScheme()
+	global := newTestPolicy("global-policy", omniav1alpha1.PolicyLevelGlobal)
+	global.Namespace = testNamespace
+
+	ws := newTestPolicy("ws-policy", omniav1alpha1.PolicyLevelWorkspace)
+	ws.Namespace = testNamespace
+	ws.Spec.WorkspaceRef = &corev1alpha1.LocalObjectReference{Name: "prod"}
+	ws.Spec.Recording.PII = &omniav1alpha1.PIIConfig{
+		Redact:   true,
+		Encrypt:  true,
+		Patterns: []string{"email"},
+	}
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(global, ws).
+		Build()
+
+	w := NewPolicyWatcher(fakeClient, logr.Discard())
+	require.NoError(t, w.loadPolicies(context.Background()))
+
+	// Should merge global + workspace for "prod" namespace
+	ep := w.GetEffectivePolicy("prod", "my-agent")
+	require.NotNil(t, ep)
+	assert.True(t, ep.Recording.Enabled)
+	assert.True(t, ep.Recording.PII.Redact)
+	assert.True(t, ep.Recording.PII.Encrypt)
+	assert.Contains(t, ep.Recording.PII.Patterns, "ssn")
+	assert.Contains(t, ep.Recording.PII.Patterns, "email")
+
+	// Different namespace should only get global
+	ep2 := w.GetEffectivePolicy("staging", "my-agent")
+	require.NotNil(t, ep2)
+	assert.True(t, ep2.Recording.PII.Redact)
+	assert.False(t, ep2.Recording.PII.Encrypt)
+}
+
+func TestNewPolicyWatcher(t *testing.T) {
+	scheme := testScheme()
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	w := NewPolicyWatcher(fakeClient, logr.Discard())
+	require.NotNil(t, w)
+	assert.NotNil(t, w.client)
 }

--- a/ee/pkg/privacy/watcher_test.go
+++ b/ee/pkg/privacy/watcher_test.go
@@ -351,13 +351,11 @@ func TestStart_InitialLoadError(t *testing.T) {
 	assert.Contains(t, err.Error(), "initial policy load failed")
 }
 
-func TestStart_ReloadErrorLogged(t *testing.T) {
+func TestStart_PollPicksUpNewPolicies(t *testing.T) {
 	scheme := testScheme()
-	p := newTestPolicy("reload-test", omniav1alpha1.PolicyLevelGlobal)
-	p.Namespace = testNamespace
 
-	// Start with a working client.
-	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(p).Build()
+	// Start with an empty cluster.
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 	w := NewPolicyWatcher(fakeClient, logr.Discard())
 	w.SetPollInterval(50 * time.Millisecond)
@@ -367,18 +365,17 @@ func TestStart_ReloadErrorLogged(t *testing.T) {
 
 	go func() { _ = w.Start(ctx) }()
 
-	// Wait for initial load to succeed.
+	// Initially no policies.
+	time.Sleep(30 * time.Millisecond)
+	assert.Nil(t, w.GetEffectivePolicy("", ""))
+
+	// Create a policy in the fake client after startup.
+	p := newTestPolicy("late-arrival", omniav1alpha1.PolicyLevelGlobal)
+	p.Namespace = testNamespace
+	require.NoError(t, fakeClient.Create(context.Background(), p))
+
+	// Poll loop should pick it up.
 	require.Eventually(t, func() bool {
 		return w.GetEffectivePolicy("", "") != nil
 	}, 2*time.Second, 10*time.Millisecond)
-
-	// Swap the client to one that will fail on List — simulates a reload error.
-	w.client = fake.NewClientBuilder().Build()
-
-	// Let a poll cycle run — the error is logged, not returned.
-	time.Sleep(100 * time.Millisecond)
-
-	// Watcher should still be running (not crashed).
-	// The old cached policy should still be present.
-	assert.NotNil(t, w.GetEffectivePolicy("", ""))
 }

--- a/internal/session/api/docs.go
+++ b/internal/session/api/docs.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed openapi.yaml
+var openapiSpec []byte
+
+// registerDocsRoutes adds the API documentation endpoints.
+func (h *Handler) registerDocsRoutes(mux *http.ServeMux) {
+	// Serve the raw OpenAPI spec.
+	mux.HandleFunc("GET /api/v1/openapi.yaml", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/yaml")
+		_, _ = w.Write(openapiSpec)
+	})
+
+	// Serve the branded API docs UI.
+	mux.HandleFunc("GET /docs", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(docsHTML))
+	})
+}
+
+const docsHTML = `<!DOCTYPE html>
+<html>
+<head>
+  <title>Omnia Session API</title>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    body { margin: 0; }
+    .custom-header {
+      background: linear-gradient(135deg, #3B82F6, #8B5CF6);
+      color: white;
+      padding: 16px 24px;
+      font-family: system-ui, -apple-system, sans-serif;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+    .custom-header h1 {
+      margin: 0;
+      font-size: 18px;
+      font-weight: 600;
+      letter-spacing: -0.01em;
+    }
+    .custom-header .subtitle {
+      font-size: 13px;
+      opacity: 0.8;
+      font-weight: 400;
+    }
+    .custom-header .logo {
+      width: 28px;
+      height: 28px;
+      background: rgba(255,255,255,0.2);
+      border-radius: 6px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 700;
+      font-size: 14px;
+    }
+  </style>
+</head>
+<body>
+  <div class="custom-header">
+    <div class="logo">O</div>
+    <div>
+      <h1>Omnia Session API</h1>
+      <div class="subtitle">AltairaLabs</div>
+    </div>
+  </div>
+  <script id="api-reference" data-url="/api/v1/openapi.yaml" data-configuration='{"theme":"default","layout":"modern","hideDarkModeToggle":false,"customCss":".darklight-reference-promo{display:none} .sidebar{border-color:#E5E7EB} .dark .sidebar{border-color:#374151}","metaData":{"title":"Omnia Session API"}}'></script>
+  <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
+</body>
+</html>`

--- a/internal/session/api/docs_test.go
+++ b/internal/session/api/docs_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDocsEndpoint(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/docs", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/html")
+	assert.Contains(t, w.Body.String(), "Omnia Session API")
+	assert.Contains(t, w.Body.String(), "scalar")
+}
+
+func TestOpenAPISpecEndpoint(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/openapi.yaml", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "application/yaml", w.Header().Get("Content-Type"))
+	assert.True(t, strings.Contains(w.Body.String(), "openapi:"))
+}

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -191,6 +191,9 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/sessions/{sessionID}/evaluate", h.handleEvaluateSession)
 	mux.HandleFunc("POST /api/v1/eval-results", h.handleCreateEvalResults)
 	mux.HandleFunc("GET /api/v1/eval-results", h.handleListEvalResults)
+
+	// API documentation
+	h.registerDocsRoutes(mux)
 }
 
 // extractRequestContext extracts client IP and User-Agent from the request.

--- a/internal/session/api/openapi.yaml
+++ b/internal/session/api/openapi.yaml
@@ -1,0 +1,994 @@
+openapi: 3.0.3
+info:
+  title: Omnia Session API
+  description: REST API for session storage, messaging, tool/provider call recording, and eval results
+  version: 1.0.0
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0
+
+servers:
+  - url: http://localhost:8081
+    description: Local development
+  - url: http://omnia-session-api.omnia-system.svc.cluster.local:8081
+    description: In-cluster
+
+tags:
+  - name: health
+    description: Health check
+  - name: sessions
+    description: Session CRUD operations
+  - name: messages
+    description: Message operations
+  - name: stats
+    description: Session statistics
+  - name: tool-calls
+    description: Tool call recording
+  - name: provider-calls
+    description: Provider call recording
+  - name: runtime-events
+    description: Runtime lifecycle event recording
+  - name: eval-results
+    description: Eval result operations
+
+paths:
+  /healthz:
+    get:
+      tags: [health]
+      summary: Health check
+      operationId: healthCheck
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: ok
+
+  /api/v1/sessions:
+    post:
+      tags: [sessions]
+      summary: Create a new session
+      operationId: createSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSessionRequest'
+      responses:
+        '201':
+          description: Session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '413':
+          $ref: '#/components/responses/BodyTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    get:
+      tags: [sessions]
+      summary: List sessions
+      operationId: listSessions
+      parameters:
+        - $ref: '#/components/parameters/Workspace'
+        - $ref: '#/components/parameters/NamespaceQuery'
+        - $ref: '#/components/parameters/Agent'
+        - $ref: '#/components/parameters/StatusFilter'
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+      responses:
+        '200':
+          description: Paginated session list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/search:
+    get:
+      tags: [sessions]
+      summary: Full-text search across sessions
+      operationId: searchSessions
+      parameters:
+        - name: q
+          in: query
+          required: true
+          description: Search query (max 500 characters)
+          schema:
+            type: string
+            maxLength: 500
+        - $ref: '#/components/parameters/Workspace'
+        - $ref: '#/components/parameters/NamespaceQuery'
+        - $ref: '#/components/parameters/Agent'
+        - $ref: '#/components/parameters/StatusFilter'
+        - $ref: '#/components/parameters/From'
+        - $ref: '#/components/parameters/To'
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+      responses:
+        '200':
+          description: Search results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionListResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}:
+    get:
+      tags: [sessions]
+      summary: Get a session by ID (includes messages)
+      operationId: getSession
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      responses:
+        '200':
+          description: Session with messages
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    delete:
+      tags: [sessions]
+      summary: Delete a session
+      operationId: deleteSession
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      responses:
+        '204':
+          description: Session deleted
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/messages:
+    post:
+      tags: [messages]
+      summary: Append a message to a session
+      operationId: appendMessage
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Message'
+      responses:
+        '201':
+          description: Message appended
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          $ref: '#/components/responses/BodyTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    get:
+      tags: [messages]
+      summary: Get messages for a session
+      operationId: getMessages
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+        - name: limit
+          in: query
+          description: Max messages to return (default 50, max 500)
+          schema:
+            type: integer
+            default: 50
+            maximum: 500
+        - name: before
+          in: query
+          description: Return messages before this sequence number
+          schema:
+            type: integer
+            format: int32
+        - name: after
+          in: query
+          description: Return messages after this sequence number
+          schema:
+            type: integer
+            format: int32
+      responses:
+        '200':
+          description: Messages list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MessagesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/status:
+    patch:
+      tags: [status]
+      summary: Update session lifecycle status
+      operationId: updateStatus
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SessionStatusUpdate'
+      responses:
+        '200':
+          description: Status updated
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          $ref: '#/components/responses/BodyTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/ttl:
+    post:
+      tags: [sessions]
+      summary: Refresh session TTL
+      operationId: refreshTTL
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefreshTTLRequest'
+      responses:
+        '200':
+          description: TTL refreshed
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          $ref: '#/components/responses/BodyTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/tool-calls:
+    post:
+      tags: [tool-calls]
+      summary: Record a tool call
+      operationId: recordToolCall
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ToolCall'
+      responses:
+        '201':
+          description: Tool call recorded
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          $ref: '#/components/responses/BodyTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    get:
+      tags: [tool-calls]
+      summary: Get tool calls for a session
+      operationId: getToolCalls
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      responses:
+        '200':
+          description: Tool calls list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ToolCall'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/provider-calls:
+    post:
+      tags: [provider-calls]
+      summary: Record a provider call
+      operationId: recordProviderCall
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProviderCall'
+      responses:
+        '201':
+          description: Provider call recorded
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          $ref: '#/components/responses/BodyTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    get:
+      tags: [provider-calls]
+      summary: Get provider calls for a session
+      operationId: getProviderCalls
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      responses:
+        '200':
+          description: Provider calls list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ProviderCall'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/events:
+    post:
+      tags: [runtime-events]
+      summary: Record a runtime event for a session
+      operationId: recordRuntimeEvent
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuntimeEvent'
+      responses:
+        '201':
+          description: Runtime event recorded
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '413':
+          $ref: '#/components/responses/BodyTooLarge'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    get:
+      tags: [runtime-events]
+      summary: Get runtime events for a session
+      operationId: getRuntimeEvents
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      responses:
+        '200':
+          description: Runtime events list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RuntimeEvent'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/eval-results:
+    post:
+      tags: [eval-results]
+      summary: Create eval results (batch)
+      operationId: createEvalResults
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/EvalResult'
+      responses:
+        '201':
+          description: Eval results created
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '500':
+          $ref: '#/components/responses/InternalError'
+    get:
+      tags: [eval-results]
+      summary: List eval results with filters
+      operationId: listEvalResults
+      parameters:
+        - name: agentName
+          in: query
+          description: Filter by agent name
+          schema:
+            type: string
+        - name: namespace
+          in: query
+          description: Filter by namespace
+          schema:
+            type: string
+        - name: evalId
+          in: query
+          description: Filter by eval ID
+          schema:
+            type: string
+        - name: evalType
+          in: query
+          description: Filter by eval type
+          schema:
+            type: string
+        - name: passed
+          in: query
+          description: Filter by pass/fail
+          schema:
+            type: boolean
+        - $ref: '#/components/parameters/Limit'
+        - $ref: '#/components/parameters/Offset'
+      responses:
+        '200':
+          description: Eval results list
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvalResultListResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/eval-results:
+    get:
+      tags: [eval-results]
+      summary: Get eval results for a session
+      operationId: getSessionEvalResults
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      responses:
+        '200':
+          description: Session eval results
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvalResultSessionResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /api/v1/sessions/{sessionID}/evaluate:
+    post:
+      tags: [eval-results]
+      summary: Trigger evaluation for a session
+      operationId: evaluateSession
+      parameters:
+        - $ref: '#/components/parameters/SessionID'
+      responses:
+        '202':
+          description: Evaluation queued
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EvaluateAcceptedResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '503':
+          description: Service not configured
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+components:
+  parameters:
+    SessionID:
+      name: sessionID
+      in: path
+      required: true
+      description: Session UUID
+      schema:
+        type: string
+        format: uuid
+
+    Workspace:
+      name: workspace
+      in: query
+      description: Kubernetes namespace (alias for namespace)
+      schema:
+        type: string
+
+    NamespaceQuery:
+      name: namespace
+      in: query
+      description: Kubernetes namespace
+      schema:
+        type: string
+
+    Agent:
+      name: agent
+      in: query
+      description: Filter by agent name
+      schema:
+        type: string
+
+    StatusFilter:
+      name: status
+      in: query
+      description: Filter by session status
+      schema:
+        $ref: '#/components/schemas/SessionStatus'
+
+    From:
+      name: from
+      in: query
+      description: Filter sessions created after this time (RFC3339)
+      schema:
+        type: string
+        format: date-time
+
+    To:
+      name: to
+      in: query
+      description: Filter sessions created before this time (RFC3339)
+      schema:
+        type: string
+        format: date-time
+
+    Limit:
+      name: limit
+      in: query
+      description: Maximum items to return (default 20, max 100)
+      schema:
+        type: integer
+        default: 20
+        maximum: 100
+
+    Offset:
+      name: offset
+      in: query
+      description: Number of items to skip (max 10000)
+      schema:
+        type: integer
+        default: 0
+        maximum: 10000
+
+  responses:
+    BadRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    NotFound:
+      description: Resource not found
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    BodyTooLarge:
+      description: Request body too large
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+    InternalError:
+      description: Internal server error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
+
+  schemas:
+    ErrorResponse:
+      type: object
+      required: [error]
+      properties:
+        error:
+          type: string
+
+    SessionStatus:
+      type: string
+      enum: [active, completed, error, expired]
+
+    MessageRole:
+      type: string
+      enum: [user, assistant, system]
+
+    ToolCallStatus:
+      type: string
+      enum: [pending, success, error]
+
+    ProviderCallStatus:
+      type: string
+      enum: [pending, completed, failed]
+
+    Session:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        agentName:
+          type: string
+        namespace:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        expiresAt:
+          type: string
+          format: date-time
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+        state:
+          type: object
+          additionalProperties:
+            type: string
+        workspaceName:
+          type: string
+        status:
+          $ref: '#/components/schemas/SessionStatus'
+        endedAt:
+          type: string
+          format: date-time
+        messageCount:
+          type: integer
+          format: int32
+        toolCallCount:
+          type: integer
+          format: int32
+        totalInputTokens:
+          type: integer
+          format: int64
+        totalOutputTokens:
+          type: integer
+          format: int64
+        estimatedCostUSD:
+          type: number
+          format: double
+        tags:
+          type: array
+          items:
+            type: string
+        lastMessagePreview:
+          type: string
+        promptPackName:
+          type: string
+        promptPackVersion:
+          type: string
+
+    Message:
+      type: object
+      properties:
+        id:
+          type: string
+        role:
+          $ref: '#/components/schemas/MessageRole'
+        content:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+        inputTokens:
+          type: integer
+          format: int32
+        outputTokens:
+          type: integer
+          format: int32
+        costUsd:
+          type: number
+          format: double
+        toolCallId:
+          type: string
+        sequenceNum:
+          type: integer
+          format: int32
+        hasMedia:
+          type: boolean
+        mediaTypes:
+          type: array
+          items:
+            type: string
+
+    ToolCall:
+      type: object
+      properties:
+        id:
+          type: string
+        sessionId:
+          type: string
+          format: uuid
+        callId:
+          type: string
+        name:
+          type: string
+        arguments:
+          type: object
+          additionalProperties: true
+        result: {}
+        status:
+          $ref: '#/components/schemas/ToolCallStatus'
+        durationMs:
+          type: integer
+          format: int64
+        errorMessage:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    ProviderCall:
+      type: object
+      properties:
+        id:
+          type: string
+        sessionId:
+          type: string
+          format: uuid
+        provider:
+          type: string
+        model:
+          type: string
+        status:
+          $ref: '#/components/schemas/ProviderCallStatus'
+        inputTokens:
+          type: integer
+          format: int64
+        outputTokens:
+          type: integer
+          format: int64
+        cachedTokens:
+          type: integer
+          format: int64
+        costUsd:
+          type: number
+          format: double
+        durationMs:
+          type: integer
+          format: int64
+        finishReason:
+          type: string
+        toolCallCount:
+          type: integer
+          format: int32
+        errorMessage:
+          type: string
+        labels:
+          type: object
+          additionalProperties:
+            type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    RuntimeEvent:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        sessionId:
+          type: string
+          format: uuid
+        eventType:
+          type: string
+        data:
+          type: object
+          additionalProperties: true
+        durationMs:
+          type: integer
+          format: int64
+        errorMessage:
+          type: string
+        timestamp:
+          type: string
+          format: date-time
+
+    # SessionStatusUpdate contains only lifecycle state changes.
+    # Counter fields (messages, tool calls, tokens, cost) are auto-derived
+    # from AppendMessage and should not be set externally.
+    SessionStatusUpdate:
+      type: object
+      properties:
+        SetStatus:
+          $ref: '#/components/schemas/SessionStatus'
+        SetEndedAt:
+          type: string
+          format: date-time
+
+    EvalResult:
+      type: object
+      properties:
+        id:
+          type: string
+        sessionId:
+          type: string
+          format: uuid
+        messageId:
+          type: string
+        agentName:
+          type: string
+        namespace:
+          type: string
+        promptpackName:
+          type: string
+        promptpackVersion:
+          type: string
+        evalId:
+          type: string
+        evalType:
+          type: string
+        trigger:
+          type: string
+        passed:
+          type: boolean
+        score:
+          type: number
+          format: double
+          nullable: true
+        details: {}
+        durationMs:
+          type: integer
+          nullable: true
+        judgeTokens:
+          type: integer
+          nullable: true
+        judgeCostUsd:
+          type: number
+          format: double
+          nullable: true
+        source:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+
+    CreateSessionRequest:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Optional pre-generated session UUID
+        agentName:
+          type: string
+        namespace:
+          type: string
+        workspaceName:
+          type: string
+        ttlSeconds:
+          type: integer
+          description: Session TTL in seconds (0 = no expiry)
+        promptPackName:
+          type: string
+        promptPackVersion:
+          type: string
+
+    RefreshTTLRequest:
+      type: object
+      required: [ttlSeconds]
+      properties:
+        ttlSeconds:
+          type: integer
+
+    SessionResponse:
+      type: object
+      properties:
+        session:
+          $ref: '#/components/schemas/Session'
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+
+    SessionListResponse:
+      type: object
+      properties:
+        sessions:
+          type: array
+          items:
+            $ref: '#/components/schemas/Session'
+        total:
+          type: integer
+          format: int64
+        hasMore:
+          type: boolean
+
+    MessagesResponse:
+      type: object
+      properties:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+        hasMore:
+          type: boolean
+
+    EvalResultListResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvalResult'
+        total:
+          type: integer
+          format: int64
+        hasMore:
+          type: boolean
+
+    EvalResultSessionResponse:
+      type: object
+      properties:
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/EvalResult'
+
+    EvaluateAcceptedResponse:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          format: uuid
+        message:
+          type: string


### PR DESCRIPTION
## Root cause

PR #646 registered `metav1.WatchEvent` under the CRD's group version (`omnia.altairalabs.ai/v1alpha1`). The K8s watch stream decoder looks for `WatchEvent` at GVK `v1/WatchEvent` — not the CRD's group.

`List` worked (different decode path). `Watch` failed because the streaming decoder decodes the `WatchEvent` envelope separately, requiring it registered under `v1`.

Found by tracing `k8s.io/client-go/dynamic/scheme.go` — the dynamic client registers metav1 under `{Version: "v1"}`.

## Fix

```go
// Before (wrong):
metav1.AddToGroupVersion(scheme, omniav1alpha1.GroupVersion)

// After (matches dynamic client):
metav1.AddToGroupVersion(scheme, schema.GroupVersion{Version: "v1"})
```

## Test
Rebuild in Tilt and verify the watch error is gone.