### PR TITLE
feat: add source field to provider calls for judge/selfplay tracking

### DIFF
--- a/api/session-api/openapi.yaml
+++ b/api/session-api/openapi.yaml
@@ -816,6 +816,8 @@ components:
           type: object
           additionalProperties:
             type: string
+        source:
+          type: string
         createdAt:
           type: string
           format: date-time

--- a/dashboard/src/types/session.ts
+++ b/dashboard/src/types/session.ts
@@ -29,6 +29,7 @@ export interface ProviderCall {
   toolCallCount?: number;
   errorMessage?: string;
   labels?: Record<string, string>;
+  source?: string;
   createdAt: string;
 }
 

--- a/internal/runtime/event_store.go
+++ b/internal/runtime/event_store.go
@@ -617,10 +617,12 @@ func (s *OmniaEventStore) convertProviderCallCompleted(event *events.Event) (eve
 		DurationMs:    data.Duration.Milliseconds(),
 		FinishReason:  data.FinishReason,
 		ToolCallCount: int32(data.ToolCallCount),
+		Source:        data.Labels["source"], // TODO: use data.Source when PromptKit publishes the field
 		CreatedAt:     event.Timestamp,
 	}
 
 	// Token/cost counters are atomically updated by RecordProviderCall's CTE.
+	// Only agent calls (source="" or "agent") increment session totals.
 	return eventAction{
 		providerCall: &pc,
 	}, true
@@ -645,6 +647,7 @@ func (s *OmniaEventStore) convertProviderCallFailed(event *events.Event) (eventA
 		Status:       session.ProviderCallStatusFailed,
 		DurationMs:   data.Duration.Milliseconds(),
 		ErrorMessage: errMsg,
+		Source:       data.Labels["source"], // TODO: use data.Source when PromptKit publishes the field
 		CreatedAt:    event.Timestamp,
 	}
 

--- a/internal/runtime/event_store_test.go
+++ b/internal/runtime/event_store_test.go
@@ -608,6 +608,65 @@ func TestOmniaEventStore_AppendProviderCallFailed(t *testing.T) {
 	}
 }
 
+func TestOmniaEventStore_AppendProviderCallCompleted_Source(t *testing.T) {
+	store := &mockSessionStore{}
+	es := NewOmniaEventStore(store, logr.Discard())
+
+	event := &events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "test-session",
+		Timestamp: time.Now(),
+		Data: &events.ProviderCallCompletedData{
+			Provider:     "openai",
+			Model:        "gpt-4o",
+			InputTokens:  50,
+			OutputTokens: 100,
+			Cost:         0.003,
+			FinishReason: "end_turn",
+			Duration:     1 * time.Second,
+			Labels:       map[string]string{"source": "judge"},
+		},
+	}
+
+	if err := es.Append(context.Background(), event); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	store.waitForProviderCalls(t, 1)
+	pcs := store.getProviderCalls()
+	if pcs[0].Source != "judge" {
+		t.Errorf("expected source=judge, got %q", pcs[0].Source)
+	}
+}
+
+func TestOmniaEventStore_AppendProviderCallFailed_Source(t *testing.T) {
+	store := &mockSessionStore{}
+	es := NewOmniaEventStore(store, logr.Discard())
+
+	event := &events.Event{
+		Type:      events.EventProviderCallFailed,
+		SessionID: "test-session",
+		Timestamp: time.Now(),
+		Data: &events.ProviderCallFailedData{
+			Provider: "openai",
+			Model:    "gpt-4o",
+			Error:    errors.New("timeout"),
+			Duration: 1 * time.Second,
+			Labels:   map[string]string{"source": "selfplay"},
+		},
+	}
+
+	if err := es.Append(context.Background(), event); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	store.waitForProviderCalls(t, 1)
+	pcs := store.getProviderCalls()
+	if pcs[0].Source != "selfplay" {
+		t.Errorf("expected source=selfplay, got %q", pcs[0].Source)
+	}
+}
+
 // --- Message events ---
 
 func TestOmniaEventStore_AppendMessageCreated_User(t *testing.T) {

--- a/internal/runtime/events.go
+++ b/internal/runtime/events.go
@@ -55,6 +55,7 @@ func (s *Server) subscribeToEventBusLogging(sessionID string, conv *sdk.Conversa
 			"cost", data.Cost,
 			"finishReason", data.FinishReason,
 			"durationMs", data.Duration.Milliseconds(),
+			"source", data.Labels["source"], // TODO: use data.Source when PromptKit publishes the field
 		)
 	}))
 

--- a/internal/session/postgres/migrations/000024_provider_call_source.down.sql
+++ b/internal/session/postgres/migrations/000024_provider_call_source.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE provider_calls DROP COLUMN source;

--- a/internal/session/postgres/migrations/000024_provider_call_source.up.sql
+++ b/internal/session/postgres/migrations/000024_provider_call_source.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE provider_calls ADD COLUMN source TEXT NOT NULL DEFAULT '';

--- a/internal/session/providers/postgres/conversation_stats_test.go
+++ b/internal/session/providers/postgres/conversation_stats_test.go
@@ -421,6 +421,96 @@ func TestConversationStats_FailedProviderCallDoesNotAddTokens(t *testing.T) {
 	require.Len(t, calls, 2, "2 rows: 1 completed + 1 failed")
 }
 
+// TestConversationStats_NonAgentSourceDoesNotAddTokens verifies that provider
+// calls with source "judge" or "selfplay" are recorded but do NOT increment
+// the session-level token/cost counters. Only agent calls (source="" or "agent")
+// should inflate session totals.
+func TestConversationStats_NonAgentSourceDoesNotAddTokens(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	p := newProvider(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	sess := makeSession("c0eebc99-9c0b-4ef8-bb6d-6bb9bd380c10", now)
+	require.NoError(t, p.CreateSession(ctx, sess))
+
+	// Agent call (empty source) — adds tokens/cost.
+	require.NoError(t, p.RecordProviderCall(ctx, sess.ID, &session.ProviderCall{
+		ID:           uid(60),
+		Provider:     "anthropic",
+		Model:        "claude-sonnet-4-20250514",
+		Status:       session.ProviderCallStatusCompleted,
+		InputTokens:  200,
+		OutputTokens: 80,
+		CostUSD:      0.004,
+		CreatedAt:    now,
+	}))
+
+	// Judge call — should NOT add tokens/cost.
+	require.NoError(t, p.RecordProviderCall(ctx, sess.ID, &session.ProviderCall{
+		ID:           uid(61),
+		Provider:     "openai",
+		Model:        "gpt-4o",
+		Status:       session.ProviderCallStatusCompleted,
+		InputTokens:  50,
+		OutputTokens: 100,
+		CostUSD:      0.003,
+		Source:       "judge",
+		CreatedAt:    now.Add(time.Second),
+	}))
+
+	// Self-play call — should NOT add tokens/cost.
+	require.NoError(t, p.RecordProviderCall(ctx, sess.ID, &session.ProviderCall{
+		ID:           uid(62),
+		Provider:     "openai",
+		Model:        "gpt-4o",
+		Status:       session.ProviderCallStatusCompleted,
+		InputTokens:  75,
+		OutputTokens: 120,
+		CostUSD:      0.005,
+		Source:       "selfplay",
+		CreatedAt:    now.Add(2 * time.Second),
+	}))
+
+	// Explicit "agent" source — SHOULD add tokens/cost.
+	require.NoError(t, p.RecordProviderCall(ctx, sess.ID, &session.ProviderCall{
+		ID:           uid(63),
+		Provider:     "anthropic",
+		Model:        "claude-sonnet-4-20250514",
+		Status:       session.ProviderCallStatusCompleted,
+		InputTokens:  100,
+		OutputTokens: 40,
+		CostUSD:      0.002,
+		Source:       "agent",
+		CreatedAt:    now.Add(3 * time.Second),
+	}))
+
+	got, err := p.GetSession(ctx, sess.ID)
+	require.NoError(t, err)
+
+	// Only agent calls: 200 + 100 = 300 input, 80 + 40 = 120 output, 0.004 + 0.002 = 0.006 cost
+	assert.Equal(t, int64(300), got.TotalInputTokens,
+		"only agent source calls counted: 200 + 100")
+	assert.Equal(t, int64(120), got.TotalOutputTokens,
+		"only agent source calls counted: 80 + 40")
+	assert.InDelta(t, 0.006, got.EstimatedCostUSD, 1e-9,
+		"only agent source calls counted: 0.004 + 0.002")
+
+	// All 4 rows exist.
+	calls, err := p.GetProviderCalls(ctx, sess.ID, providers.PaginationOpts{})
+	require.NoError(t, err)
+	require.Len(t, calls, 4, "4 rows: 2 agent + 1 judge + 1 selfplay")
+
+	// Verify source field is persisted and readable.
+	assert.Equal(t, "", calls[0].Source, "first call: empty source (agent)")
+	assert.Equal(t, "judge", calls[1].Source, "second call: judge")
+	assert.Equal(t, "selfplay", calls[2].Source, "third call: selfplay")
+	assert.Equal(t, "agent", calls[3].Source, "fourth call: explicit agent")
+}
+
 // TestConversationStats_AppendMessageDoesNotAffectTokenCounters verifies that
 // messages with token/cost data (written by both facade and runtime) do NOT
 // inflate session-level counters. Only RecordProviderCall updates those.

--- a/internal/session/providers/postgres/provider.go
+++ b/internal/session/providers/postgres/provider.go
@@ -215,7 +215,7 @@ func scanProviderCall(row pgx.Row) (*session.ProviderCall, error) {
 		&pc.ID, &pc.SessionID, &pc.Provider, &pc.Model,
 		&pc.Status, &pc.InputTokens, &pc.OutputTokens, &pc.CachedTokens,
 		&pc.CostUSD, &durationMs, &finishReason, &pc.ToolCallCount,
-		&errorMessage, &labelsJSON, &pc.CreatedAt,
+		&errorMessage, &labelsJSON, &pc.Source, &pc.CreatedAt,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("postgres: scan provider call: %w", err)
@@ -717,11 +717,13 @@ func (p *Provider) RecordToolCall(ctx context.Context, sessionID string, tc *ses
 
 func (p *Provider) RecordProviderCall(ctx context.Context, sessionID string, pc *session.ProviderCall) error {
 	// Each provider call lifecycle event (completed, failed) is its own row.
-	// Only completed calls add tokens/cost to session counters.
+	// Only completed agent calls add tokens/cost to session counters.
+	// Judge and self-play calls are tracked separately.
+	isAgent := pc.Source == "" || pc.Source == "agent"
 	isCompleted := pc.Status == session.ProviderCallStatusCompleted
 	var inputIncr, outputIncr int64
 	var costIncr float64
-	if isCompleted {
+	if isCompleted && isAgent {
 		inputIncr = pc.InputTokens
 		outputIncr = pc.OutputTokens
 		costIncr = pc.CostUSD
@@ -730,16 +732,16 @@ func (p *Provider) RecordProviderCall(ctx context.Context, sessionID string, pc 
 	query := `WITH sess AS (
 		SELECT id FROM sessions WHERE id = $2
 	), ins AS (
-		INSERT INTO provider_calls (id, session_id, provider, model, status, input_tokens, output_tokens, cached_tokens, cost_usd, duration_ms, finish_reason, tool_call_count, error_message, labels, created_at)
-		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15
+		INSERT INTO provider_calls (id, session_id, provider, model, status, input_tokens, output_tokens, cached_tokens, cost_usd, duration_ms, finish_reason, tool_call_count, error_message, labels, source, created_at)
+		SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16
 		WHERE EXISTS (SELECT 1 FROM sess)
 		RETURNING session_id
 	)
 	UPDATE sessions SET
-		total_input_tokens = total_input_tokens + $16,
-		total_output_tokens = total_output_tokens + $17,
-		estimated_cost_usd = estimated_cost_usd + $18,
-		updated_at = $19
+		total_input_tokens = total_input_tokens + $17,
+		total_output_tokens = total_output_tokens + $18,
+		estimated_cost_usd = estimated_cost_usd + $19,
+		updated_at = $20
 	WHERE id = (SELECT session_id FROM ins)`
 
 	res, err := p.pool.Exec(ctx, query,
@@ -748,7 +750,7 @@ func (p *Provider) RecordProviderCall(ctx context.Context, sessionID string, pc 
 		pc.CostUSD, pgutil.NullInt64(pc.DurationMs),
 		pgutil.NullString(pc.FinishReason), pc.ToolCallCount,
 		pgutil.NullString(pc.ErrorMessage), pgutil.MarshalJSONB(pc.Labels),
-		pc.CreatedAt,
+		pc.Source, pc.CreatedAt,
 		inputIncr, outputIncr, costIncr, time.Now(),
 	)
 	if err != nil {
@@ -803,7 +805,7 @@ func (p *Provider) GetProviderCalls(ctx context.Context, sessionID string, opts 
 	qb := &pgutil.QueryBuilder{}
 	qb.Add(qbSessionID, sessionID)
 
-	query := `SELECT id, session_id, provider, model, status, input_tokens, output_tokens, cached_tokens, cost_usd, duration_ms, finish_reason, tool_call_count, error_message, labels, created_at
+	query := `SELECT id, session_id, provider, model, status, input_tokens, output_tokens, cached_tokens, cost_usd, duration_ms, finish_reason, tool_call_count, error_message, labels, source, created_at
 		FROM provider_calls WHERE 1=1` + qb.Where() + ` ORDER BY created_at ASC`
 	query = qb.AppendPagination(query, opts.Limit, opts.Offset)
 

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -301,6 +301,9 @@ type ProviderCall struct {
 	ErrorMessage string `json:"errorMessage,omitempty"`
 	// Labels contains arbitrary key-value pairs for categorization.
 	Labels map[string]string `json:"labels,omitempty"`
+	// Source identifies what initiated this provider call (e.g., "agent", "judge", "selfplay").
+	// Empty string is treated as "agent" for backward compatibility.
+	Source string `json:"source,omitempty"`
 	// CreatedAt is when the provider call was initiated.
 	CreatedAt time.Time `json:"createdAt"`
 }


### PR DESCRIPTION
## Summary

Closes #634 (partial — persistence path only, event emission comes next in PromptKit).

- Adds a `source` field to `ProviderCall` (Go struct, PostgreSQL, OpenAPI spec, TypeScript type)
- Only agent calls (source `""` or `"agent"`) increment session-level token/cost counters; `judge` and `selfplay` calls are recorded but excluded from session totals
- Bridges to PromptKit via `Labels["source"]` until the SDK publishes a first-class `Source` field on `ProviderCallCompletedData`

## What's left for #634

1. **PromptKit**: emit `ProviderCallCompleted` events with source label for judge and self-play provider calls
2. **Arena worker**: wire up event bus subscriber to forward provider calls to session-api

## Test plan

- [x] `TestOmniaEventStore_AppendProviderCallCompleted_Source` — source propagates from Labels
- [x] `TestOmniaEventStore_AppendProviderCallFailed_Source` — same for failed calls
- [x] `TestConversationStats_NonAgentSourceDoesNotAddTokens` — judge/selfplay excluded from session counters, agent calls included
- [x] `TestOpenAPISchemaMatchesGoTypes/ProviderCall` — OpenAPI spec matches Go struct
- [x] Dashboard typecheck passes