### PR TITLE
feat: wire arena worker session recording via OmniaEventStore

### DIFF
--- a/ee/cmd/arena-worker/SERVICE.md
+++ b/ee/cmd/arena-worker/SERVICE.md
@@ -39,6 +39,7 @@
 | `ARENA_VERBOSE` | no | — | `"true"` for debug logging |
 | `REDIS_ADDR` | no | `redis:6379` | Redis address |
 | `REDIS_PASSWORD` | no | — | Redis password |
+| `SESSION_API_URL` | no | — | Session-api URL for recording arena sessions (opt-in) |
 | `TRACING_ENABLED` | no | — | `"true"` to enable OTel tracing |
 | `TRACING_ENDPOINT` | no | — | OTLP gRPC endpoint |
 
@@ -46,6 +47,7 @@
 - **Redis Streams**: work item status updates (pass/fail, duration, metrics, assertions)
 - **Filesystem**: evaluation output (JUnit XML, JSON reports) written to `/tmp/arena-output`
 - **OTel traces**: spans for work item execution, fleet session links
+- **HTTP** to Session API (optional): session creation, provider call recording, tool call recording via OmniaEventStore
 
 ## Does NOT Own
 - Work item creation or partitioning (Arena Controller's job)

--- a/ee/cmd/arena-worker/session_recording.go
+++ b/ee/cmd/arena-worker/session_recording.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package main
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+
+	"github.com/altairalabs/omnia/internal/runtime"
+	"github.com/altairalabs/omnia/internal/session"
+)
+
+// arenaSessionNamespace is the UUID namespace for deriving deterministic session
+// UUIDs from PromptKit run IDs via UUID5.
+var arenaSessionNamespace = uuid.MustParse("a0e1c2d3-b4f5-6789-abcd-ef0123456789")
+
+// arenaSessionMetadata carries arena context written to session InitialState.
+type arenaSessionMetadata struct {
+	JobName    string
+	Namespace  string
+	Scenario   string
+	ProviderID string
+	JobType    string
+}
+
+// arenaSessionManager lazily creates PostgreSQL sessions for arena engine runs.
+// Each unique event.SessionID (= PromptKit runID) gets its own session and
+// OmniaEventStore instance. Safe for concurrent use by multiple engine runs.
+type arenaSessionManager struct {
+	store    session.Store
+	log      logr.Logger
+	meta     arenaSessionMetadata
+	sessions sync.Map // runSessionID (string) → *managedSession
+}
+
+type managedSession struct {
+	pgSessionID string
+	eventStore  *runtime.OmniaEventStore
+}
+
+func newArenaSessionManager(store session.Store, log logr.Logger, meta arenaSessionMetadata) *arenaSessionManager {
+	return &arenaSessionManager{
+		store: store,
+		log:   log.WithName("arena-session-mgr"),
+		meta:  meta,
+	}
+}
+
+// runIDToUUID derives a deterministic UUID from a PromptKit run ID.
+func runIDToUUID(runID string) string {
+	return uuid.NewSHA1(arenaSessionNamespace, []byte(runID)).String()
+}
+
+// OnEvent is a bus subscriber that lazily creates sessions and delegates to
+// per-session OmniaEventStore instances.
+func (m *arenaSessionManager) OnEvent(event *events.Event) {
+	if event.SessionID == "" {
+		return
+	}
+
+	runSessionID := event.SessionID
+	pgID := runIDToUUID(runSessionID)
+
+	// Fast path: session already exists.
+	if v, ok := m.sessions.Load(runSessionID); ok {
+		ms := v.(*managedSession)
+		event.SessionID = ms.pgSessionID
+		ms.eventStore.OnEvent(event)
+		return
+	}
+
+	// Slow path: create session lazily. LoadOrStore ensures only one goroutine creates it.
+	ms := &managedSession{pgSessionID: pgID}
+	if actual, loaded := m.sessions.LoadOrStore(runSessionID, ms); loaded {
+		// Another goroutine created it first — use theirs.
+		ms = actual.(*managedSession)
+		event.SessionID = ms.pgSessionID
+		ms.eventStore.OnEvent(event)
+		return
+	}
+
+	// We won the race — create the session and event store.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	_, err := m.store.CreateSession(ctx, session.CreateSessionOptions{
+		ID:        pgID,
+		AgentName: m.meta.ProviderID,
+		Namespace: m.meta.Namespace,
+		InitialState: map[string]string{
+			"arena.job":      m.meta.JobName,
+			"arena.scenario": m.meta.Scenario,
+			"arena.provider": m.meta.ProviderID,
+			"arena.type":     m.meta.JobType,
+			"arena.run_id":   runSessionID,
+		},
+	})
+	if err != nil {
+		m.log.Error(err, "failed to create arena session",
+			"runID", runSessionID, "pgSessionID", pgID)
+		m.sessions.Delete(runSessionID)
+		return
+	}
+
+	es := runtime.NewOmniaEventStore(m.store, m.log)
+	es.SetSessionID(pgID)
+	ms.eventStore = es
+
+	m.log.Info("arena session created",
+		"runID", runSessionID, "pgSessionID", pgID)
+
+	event.SessionID = pgID
+	es.OnEvent(event)
+}
+
+// CompleteAll marks all lazily created sessions as completed.
+func (m *arenaSessionManager) CompleteAll(ctx context.Context) {
+	m.sessions.Range(func(key, value any) bool {
+		ms := value.(*managedSession)
+		if ms.eventStore == nil {
+			return true
+		}
+		if err := m.store.UpdateSessionStatus(ctx, ms.pgSessionID, session.SessionStatusUpdate{
+			SetStatus:  session.SessionStatusCompleted,
+			SetEndedAt: time.Now(),
+		}); err != nil {
+			m.log.Error(err, "failed to complete arena session",
+				"runID", key, "pgSessionID", ms.pgSessionID)
+		}
+		return true
+	})
+}

--- a/ee/cmd/arena-worker/session_recording_test.go
+++ b/ee/cmd/arena-worker/session_recording_test.go
@@ -1,0 +1,348 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/session"
+)
+
+// mockSessionStore implements session.Store for testing session creation and status updates.
+type mockSessionStore struct {
+	mu              sync.Mutex
+	createdSessions []session.CreateSessionOptions
+	statusUpdates   map[string]session.SessionStatusUpdate
+	messages        map[string][]session.Message
+	providerCalls   map[string][]session.ProviderCall
+}
+
+func newMockStore() *mockSessionStore {
+	return &mockSessionStore{
+		statusUpdates: make(map[string]session.SessionStatusUpdate),
+		messages:      make(map[string][]session.Message),
+		providerCalls: make(map[string][]session.ProviderCall),
+	}
+}
+
+func (m *mockSessionStore) CreateSession(
+	_ context.Context, opts session.CreateSessionOptions,
+) (*session.Session, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.createdSessions = append(m.createdSessions, opts)
+	return &session.Session{ID: opts.ID, Status: session.SessionStatusActive}, nil
+}
+
+func (m *mockSessionStore) UpdateSessionStatus(_ context.Context, id string, update session.SessionStatusUpdate) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.statusUpdates[id] = update
+	return nil
+}
+
+func (m *mockSessionStore) AppendMessage(_ context.Context, sessionID string, msg session.Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.messages[sessionID] = append(m.messages[sessionID], msg)
+	return nil
+}
+
+func (m *mockSessionStore) RecordProviderCall(_ context.Context, sessionID string, pc session.ProviderCall) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.providerCalls[sessionID] = append(m.providerCalls[sessionID], pc)
+	return nil
+}
+
+func (m *mockSessionStore) RecordToolCall(_ context.Context, _ string, _ session.ToolCall) error {
+	return nil
+}
+func (m *mockSessionStore) GetSession(_ context.Context, _ string) (*session.Session, error) {
+	return nil, session.ErrSessionNotFound
+}
+func (m *mockSessionStore) GetMessages(_ context.Context, _ string) ([]session.Message, error) {
+	return nil, nil
+}
+func (m *mockSessionStore) SetState(_ context.Context, _, _, _ string) error { return nil }
+func (m *mockSessionStore) GetState(_ context.Context, _, _ string) (string, error) {
+	return "", nil
+}
+func (m *mockSessionStore) RefreshTTL(_ context.Context, _ string, _ time.Duration) error {
+	return nil
+}
+func (m *mockSessionStore) DeleteSession(_ context.Context, _ string) error { return nil }
+func (m *mockSessionStore) GetToolCalls(_ context.Context, _ string, _, _ int) ([]session.ToolCall, error) {
+	return nil, nil
+}
+func (m *mockSessionStore) GetProviderCalls(_ context.Context, _ string, _, _ int) ([]session.ProviderCall, error) {
+	return nil, nil
+}
+func (m *mockSessionStore) RecordEvalResult(_ context.Context, _ string, _ session.EvalResult) error {
+	return nil
+}
+func (m *mockSessionStore) RecordRuntimeEvent(_ context.Context, _ string, _ session.RuntimeEvent) error {
+	return nil
+}
+func (m *mockSessionStore) GetRuntimeEvents(_ context.Context, _ string, _, _ int) ([]session.RuntimeEvent, error) {
+	return nil, nil
+}
+func (m *mockSessionStore) Close() error { return nil }
+
+func (m *mockSessionStore) getCreatedSessions() []session.CreateSessionOptions {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]session.CreateSessionOptions{}, m.createdSessions...)
+}
+
+func (m *mockSessionStore) getStatusUpdates() map[string]session.SessionStatusUpdate {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make(map[string]session.SessionStatusUpdate)
+	for k, v := range m.statusUpdates {
+		out[k] = v
+	}
+	return out
+}
+
+// failingSessionStore returns an error on CreateSession.
+type failingSessionStore struct{ mockSessionStore }
+
+func (f *failingSessionStore) CreateSession(
+	_ context.Context, _ session.CreateSessionOptions,
+) (*session.Session, error) {
+	return nil, errors.New("connection refused")
+}
+
+func TestRunIDToUUID(t *testing.T) {
+	// Deterministic: same input → same output
+	id1 := runIDToUUID("2026-03-21T15-04-05Z_openai_us-east_support_a1b2c3d4_0001")
+	id2 := runIDToUUID("2026-03-21T15-04-05Z_openai_us-east_support_a1b2c3d4_0001")
+	assert.Equal(t, id1, id2, "same runID should produce same UUID")
+
+	// Different inputs → different outputs
+	id3 := runIDToUUID("2026-03-21T15-04-05Z_openai_us-east_support_a1b2c3d4_0002")
+	assert.NotEqual(t, id1, id3, "different runIDs should produce different UUIDs")
+
+	// Valid UUID format (36 chars with hyphens)
+	assert.Len(t, id1, 36, "should be valid UUID length")
+}
+
+func TestArenaSessionManager_OnEvent_CreatesSession(t *testing.T) {
+	store := newMockStore()
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+		JobName:    "test-job",
+		Namespace:  "default",
+		Scenario:   "customer-support",
+		ProviderID: "openai-gpt4",
+		JobType:    "arena",
+	})
+
+	event := &events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-001",
+		Timestamp: time.Now(),
+		Data: &events.ProviderCallCompletedData{
+			Provider:     "openai",
+			Model:        "gpt-4o",
+			InputTokens:  100,
+			OutputTokens: 50,
+			Cost:         0.005,
+			Duration:     time.Second,
+		},
+	}
+
+	mgr.OnEvent(event)
+
+	// Wait briefly for async OmniaEventStore write
+	time.Sleep(100 * time.Millisecond)
+
+	sessions := store.getCreatedSessions()
+	require.Len(t, sessions, 1, "should create exactly one session")
+
+	expectedUUID := runIDToUUID("run-001")
+	assert.Equal(t, expectedUUID, sessions[0].ID, "session ID should be UUID5 of runID")
+	assert.Equal(t, "openai-gpt4", sessions[0].AgentName)
+	assert.Equal(t, "default", sessions[0].Namespace)
+	assert.Equal(t, "test-job", sessions[0].InitialState["arena.job"])
+	assert.Equal(t, "customer-support", sessions[0].InitialState["arena.scenario"])
+	assert.Equal(t, "run-001", sessions[0].InitialState["arena.run_id"])
+}
+
+func TestArenaSessionManager_OnEvent_DeduplicatesSessions(t *testing.T) {
+	store := newMockStore()
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+		JobName:    "test-job",
+		Namespace:  "default",
+		ProviderID: "openai",
+	})
+
+	for i := 0; i < 5; i++ {
+		mgr.OnEvent(&events.Event{
+			Type:      events.EventProviderCallCompleted,
+			SessionID: "run-001",
+			Timestamp: time.Now(),
+			Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+		})
+	}
+
+	time.Sleep(100 * time.Millisecond)
+
+	sessions := store.getCreatedSessions()
+	assert.Len(t, sessions, 1, "should create session only once despite 5 events")
+}
+
+func TestArenaSessionManager_OnEvent_MultipleRuns(t *testing.T) {
+	store := newMockStore()
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+		JobName:    "test-job",
+		Namespace:  "default",
+		ProviderID: "openai",
+	})
+
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-001",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+	})
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-002",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "anthropic"},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	sessions := store.getCreatedSessions()
+	assert.Len(t, sessions, 2, "should create one session per unique runID")
+}
+
+func TestArenaSessionManager_OnEvent_SkipsEmptySessionID(t *testing.T) {
+	store := newMockStore()
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{})
+
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{},
+	})
+
+	sessions := store.getCreatedSessions()
+	assert.Empty(t, sessions, "should not create session for empty SessionID")
+}
+
+func TestArenaSessionManager_CompleteAll(t *testing.T) {
+	store := newMockStore()
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+		JobName:    "test-job",
+		Namespace:  "default",
+		ProviderID: "openai",
+	})
+
+	// Create two sessions
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-001",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+	})
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-002",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	mgr.CompleteAll(context.Background())
+
+	updates := store.getStatusUpdates()
+	uuid1 := runIDToUUID("run-001")
+	uuid2 := runIDToUUID("run-002")
+
+	require.Contains(t, updates, uuid1, "should complete run-001 session")
+	require.Contains(t, updates, uuid2, "should complete run-002 session")
+	assert.Equal(t, session.SessionStatusCompleted, updates[uuid1].SetStatus)
+	assert.Equal(t, session.SessionStatusCompleted, updates[uuid2].SetStatus)
+	assert.False(t, updates[uuid1].SetEndedAt.IsZero(), "should set ended_at")
+}
+
+func TestArenaSessionManager_OnEvent_CreateSessionError(t *testing.T) {
+	store := &failingSessionStore{}
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+		JobName:    "test-job",
+		Namespace:  "default",
+		ProviderID: "openai",
+	})
+
+	// Should not panic on CreateSession error
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-fail",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+	})
+
+	// Second event for same runID should retry (entry was deleted on error)
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-fail",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+	})
+
+	// CompleteAll should handle empty sessions gracefully (no sessions created due to errors)
+	mgr.CompleteAll(context.Background())
+
+	// No sessions should have been created since CreateSession always fails
+	assert.Empty(t, store.getCreatedSessions(), "no sessions created when store fails")
+}
+
+func TestArenaSessionManager_CompleteAll_UpdateError(t *testing.T) {
+	store := &mockSessionStore{
+		statusUpdates: make(map[string]session.SessionStatusUpdate),
+		messages:      make(map[string][]session.Message),
+		providerCalls: make(map[string][]session.ProviderCall),
+	}
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+		JobName:    "test-job",
+		Namespace:  "default",
+		ProviderID: "openai",
+	})
+
+	// Create a session
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-err",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify CompleteAll doesn't panic and marks sessions completed
+	mgr.CompleteAll(context.Background())
+
+	updates := store.getStatusUpdates()
+	uuid := runIDToUUID("run-err")
+	assert.Equal(t, session.SessionStatusCompleted, updates[uuid].SetStatus)
+}

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 	arenastatestore "github.com/AltairaLabs/PromptKit/tools/arena/statestore"
@@ -35,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+	"github.com/altairalabs/omnia/internal/session/httpclient"
 	"github.com/altairalabs/omnia/pkg/k8s"
 )
 
@@ -98,6 +100,9 @@ type Config struct {
 	RedisPassword string
 	RedisDB       int
 
+	// Session recording
+	SessionAPIURL string // Optional session-api URL for recording arena sessions
+
 	// Worker configuration
 	WorkDir       string
 	PollInterval  time.Duration
@@ -147,6 +152,7 @@ func loadConfig() (*Config, error) {
 		ContentPath:    os.Getenv("ARENA_CONTENT_PATH"),
 		ContentVersion: os.Getenv("ARENA_CONTENT_VERSION"),
 		ConfigFile:     os.Getenv("ARENA_CONFIG_FILE"), // Config file name in content path
+		SessionAPIURL:  os.Getenv("SESSION_API_URL"),
 		RedisAddr:      getEnvOrDefault("REDIS_ADDR", "redis:6379"),
 		RedisPassword:  os.Getenv("REDIS_PASSWORD"),
 		RedisDB:        0,
@@ -477,6 +483,26 @@ func executeWorkItem(
 			log.Error(closeErr, "failed to close engine")
 		}
 	}()
+
+	// Wire session recording if session-api is configured.
+	// Events from all engine runs are forwarded to session-api via OmniaEventStore.
+	if cfg.SessionAPIURL != "" {
+		sessionMgr := newArenaSessionManager(
+			httpclient.NewStore(cfg.SessionAPIURL, log),
+			log,
+			arenaSessionMetadata{
+				JobName:    cfg.JobName,
+				Namespace:  cfg.JobNamespace,
+				Scenario:   item.ScenarioID,
+				ProviderID: item.ProviderID,
+				JobType:    cfg.JobType,
+			},
+		)
+		bus := events.NewEventBus()
+		bus.SubscribeAll(sessionMgr.OnEvent)
+		eng.SetEventBus(bus)
+		defer sessionMgr.CompleteAll(ctx)
+	}
 
 	// Determine scenario filter
 	scenarioFilter := []string{}


### PR DESCRIPTION
## Summary

Part of #634 — adds optional session recording to the arena worker so provider calls, tool calls, and messages from arena runs are persisted to PostgreSQL via session-api.

- New `ArenaSessionManager` lazily creates sessions per PromptKit runID (UUID5 derived) with arena metadata (job, scenario, provider, type) in `InitialState`
- Subscribes to the engine's `EventBus` and delegates to per-session `OmniaEventStore` instances
- Designed for concurrent runs — each run's events self-route by `SessionID`
- Opt-in via `SESSION_API_URL` env var (no change when unset)

Builds on #649 which added the `source` field to `ProviderCall` — once PromptKit labels judge/selfplay calls, they'll be tagged correctly in the recorded sessions.

## Test plan

- [x] `TestRunIDToUUID` — deterministic UUID5 derivation
- [x] `TestArenaSessionManager_OnEvent_CreatesSession` — lazy session creation with metadata
- [x] `TestArenaSessionManager_OnEvent_DeduplicatesSessions` — only one session per runID
- [x] `TestArenaSessionManager_OnEvent_MultipleRuns` — concurrent run support
- [x] `TestArenaSessionManager_OnEvent_SkipsEmptySessionID` — no session for empty ID
- [x] `TestArenaSessionManager_OnEvent_CreateSessionError` — graceful error handling
- [x] `TestArenaSessionManager_CompleteAll` — marks all sessions completed
- [x] `TestArenaSessionManager_CompleteAll_UpdateError` — completes sessions on update