### PR TITLE
feat: pass SESSION_API_URL to arena worker pods

### DIFF
--- a/ee/cmd/omnia-arena-controller/main.go
+++ b/ee/cmd/omnia-arena-controller/main.go
@@ -285,6 +285,7 @@ func main() {
 		StorageManager:        storageManager,
 		TracingEnabled:        tracingEnabled,
 		TracingEndpoint:       tracingEndpoint,
+		SessionAPIURL:         sessionAPIURL,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, errUnableToCreateController, logKeyController, "ArenaJob")
 		os.Exit(1)

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -123,6 +123,9 @@ type ArenaJobReconciler struct {
 	TracingEnabled bool
 	// TracingEndpoint is the OTLP gRPC endpoint for arena worker tracing.
 	TracingEndpoint string
+	// SessionAPIURL is the session-api URL for recording arena sessions.
+	// When set, worker pods receive SESSION_API_URL and record provider calls to PostgreSQL.
+	SessionAPIURL string
 }
 
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=arenajobs,verbs=get;list;watch;create;update;patch;delete
@@ -669,6 +672,14 @@ func (r *ArenaJobReconciler) createWorkerJob(ctx context.Context, arenaJob *omni
 		}, corev1.EnvVar{
 			Name:  "LOG_LEVEL",
 			Value: "debug",
+		})
+	}
+
+	// Inject SESSION_API_URL for session recording if configured
+	if r.SessionAPIURL != "" {
+		env = append(env, corev1.EnvVar{
+			Name:  "SESSION_API_URL",
+			Value: r.SessionAPIURL,
 		})
 	}
 


### PR DESCRIPTION
## Summary

Part of #634 — completes the wiring from PR #650 by injecting `SESSION_API_URL` into arena worker pod specs via the ArenaJob controller.

Without this, worker pods have no `SESSION_API_URL` env var and the session recording added in #650 is silently disabled.

- Adds `SessionAPIURL` field to `ArenaJobReconciler`
- Injects it as env var in worker pod specs (same pattern as `ArenaDevSessionReconciler`)
- The `--session-api-url` flag already exists in the arena controller main.go and is already passed by both the Helm chart and Tiltfile

## Test plan

- [x] `go build ./ee/cmd/omnia-arena-controller/... ./ee/internal/controller/...`
- [x] Pre-commit hooks pass
- [ ] Deploy and run arena job — verify worker pod has `SESSION_API_URL` env var