### PR TITLE
feat: trial-aware partitioning for Arena load testing

### DIFF
--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -519,6 +519,13 @@ func executeWorkItem(
 		defer sessionMgr.CompleteAll(ctx)
 	}
 
+	// Override trials to 1 on all loaded scenarios — the partitioner has already
+	// expanded trial repetitions into separate work items, so PromptKit must not
+	// do its own internal trial expansion.
+	for _, scenario := range arenaCfg.LoadedScenarios {
+		scenario.Trials = 1
+	}
+
 	// Determine scenario filter
 	scenarioFilter := []string{}
 	if item.ScenarioID != "" && item.ScenarioID != defaultScenarioID {

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -45,8 +45,11 @@ import (
 // Workspace label for namespace association
 const labelWorkspace = "omnia.altairalabs.ai/workspace"
 
-// maxWorkItems is the maximum number of scenario x provider work items allowed.
-const maxWorkItems = 10000
+// maxWorkItems limits per job type to prevent runaway matrix expansion.
+const (
+	maxWorkItemsEvaluation = 10000
+	maxWorkItemsLoadTest   = 100000
+)
 
 // ArenaJob condition types
 const (
@@ -1004,9 +1007,14 @@ func (r *ArenaJobReconciler) listScenarios(ctx context.Context, arenaJob *omniav
 	return scenarios, nil
 }
 
-// buildMatrixWorkItems creates scenario × provider work items using the partitioner.
+// buildMatrixWorkItems creates scenario × provider × trial work items using the partitioner.
 // Returns nil if partitioning fails or inputs are empty.
-func (r *ArenaJobReconciler) buildMatrixWorkItems(ctx context.Context, jobName, bundleURL string, scenarios []partitioner.Scenario, providerCRDs []*corev1alpha1.Provider) []queue.WorkItem {
+func (r *ArenaJobReconciler) buildMatrixWorkItems(
+	ctx context.Context, jobName, bundleURL string,
+	scenarios []partitioner.Scenario,
+	providerCRDs []*corev1alpha1.Provider,
+	jobTrials int, jobType omniav1alpha1.ArenaJobType,
+) []queue.WorkItem {
 	log := logf.FromContext(ctx)
 
 	partProviders := make([]partitioner.Provider, len(providerCRDs))
@@ -1024,16 +1032,18 @@ func (r *ArenaJobReconciler) buildMatrixWorkItems(ctx context.Context, jobName, 
 		Scenarios:  scenarios,
 		Providers:  partProviders,
 		MaxRetries: 3,
+		JobTrials:  jobTrials,
 	})
 	if err != nil {
 		log.Error(err, "partitioning failed, falling back to per-provider mode")
 		return nil
 	}
 
-	if result.TotalCombinations > maxWorkItems {
+	limit := maxWorkItemsForJobType(jobType)
+	if result.TotalCombinations > limit {
 		log.Error(nil, "work item matrix exceeds limit, falling back to per-provider mode",
 			"totalCombinations", result.TotalCombinations,
-			"maxWorkItems", maxWorkItems)
+			"maxWorkItems", limit)
 		return nil
 	}
 
@@ -1043,11 +1053,20 @@ func (r *ArenaJobReconciler) buildMatrixWorkItems(ctx context.Context, jobName, 
 		result.Items[i].Attempt = 1
 		result.Items[i].CreatedAt = now
 	}
-	log.Info("created scenario × provider work items",
+	log.Info("created scenario × provider × trial work items",
 		"scenarios", result.ScenarioCount,
 		"providers", result.ProviderCount,
+		"trials", result.TrialCount,
 		"items", result.TotalCombinations)
 	return result.Items
+}
+
+// maxWorkItemsForJobType returns the work item limit for a given job type.
+func maxWorkItemsForJobType(jobType omniav1alpha1.ArenaJobType) int {
+	if jobType == omniav1alpha1.ArenaJobTypeLoadTest {
+		return maxWorkItemsLoadTest
+	}
+	return maxWorkItemsEvaluation
 }
 
 // buildFallbackWorkItems creates per-provider work items (or a single default item).
@@ -1139,11 +1158,20 @@ func (r *ArenaJobReconciler) enqueueWorkItems(
 	matrixProviders := filterArrayModeProviders(providerCRDs, resolvedGroups)
 	log.V(1).Info("building work items", "providerIDs", providerIDs, "matrixProviders", len(matrixProviders))
 
+	// Resolve job-level trials override (nil pointer = 0 = use per-scenario defaults)
+	jobTrials := 0
+	if arenaJob.Spec.Trials != nil {
+		jobTrials = int(*arenaJob.Spec.Trials)
+	}
+
 	var items []queue.WorkItem
 	if len(scenarios) > 0 && len(matrixProviders) > 0 {
-		items = r.buildMatrixWorkItems(ctx, arenaJob.Name, bundleURL, scenarios, matrixProviders)
+		items = r.buildMatrixWorkItems(ctx, arenaJob.Name, bundleURL, scenarios, matrixProviders, jobTrials, arenaJob.Spec.Type)
 	}
 	if len(items) == 0 {
+		if jobTrials > 0 {
+			log.Info("trial configuration ignored in fallback mode", "trials", jobTrials)
+		}
 		items = buildFallbackWorkItems(arenaJob.Name, bundleURL, providerIDs)
 	}
 

--- a/ee/internal/controller/arenajob_controller_test.go
+++ b/ee/internal/controller/arenajob_controller_test.go
@@ -2440,7 +2440,7 @@ spec:
 				}
 			}
 
-			items := reconciler.buildMatrixWorkItems(ctx, "test-job", "bundle-url", scenarios, providerCRDs)
+			items := reconciler.buildMatrixWorkItems(ctx, "test-job", "bundle-url", scenarios, providerCRDs, 0, omniav1alpha1.ArenaJobTypeEvaluation)
 			Expect(items).To(BeNil())
 		})
 
@@ -2460,7 +2460,7 @@ spec:
 				{ObjectMeta: metav1.ObjectMeta{Name: "p2", Namespace: "default"}},
 			}
 
-			items := reconciler.buildMatrixWorkItems(ctx, "test-job", "bundle-url", scenarios, providerCRDs)
+			items := reconciler.buildMatrixWorkItems(ctx, "test-job", "bundle-url", scenarios, providerCRDs, 0, omniav1alpha1.ArenaJobTypeEvaluation)
 			Expect(items).To(HaveLen(4)) // 2 scenarios x 2 providers
 		})
 	})

--- a/ee/pkg/arena/partitioner/partitioner.go
+++ b/ee/pkg/arena/partitioner/partitioner.go
@@ -38,6 +38,10 @@ type Scenario struct {
 
 	// Tags are optional labels for categorization.
 	Tags []string `json:"tags,omitempty"`
+
+	// Trials is the number of times to execute this scenario for statistical evaluation.
+	// When > 1, each scenario × provider combination produces N work items.
+	Trials int `json:"trials,omitempty"`
 }
 
 // Provider represents a provider configuration for work items.
@@ -71,6 +75,11 @@ type PartitionInput struct {
 
 	// Config is optional configuration to include in work items.
 	Config map[string]any
+
+	// JobTrials is a job-level trial count override.
+	// If > 0, overrides per-scenario Trials for all scenarios.
+	// If 0, per-scenario Trials is used (defaulting to 1 if unset).
+	JobTrials int
 }
 
 // PartitionResult contains the result of partitioning.
@@ -78,7 +87,7 @@ type PartitionResult struct {
 	// Items is the list of generated work items.
 	Items []queue.WorkItem
 
-	// TotalCombinations is the total number of scenario × provider combinations.
+	// TotalCombinations is the total number of scenario × provider × trial combinations.
 	TotalCombinations int
 
 	// ScenarioCount is the number of scenarios.
@@ -86,9 +95,12 @@ type PartitionResult struct {
 
 	// ProviderCount is the number of providers.
 	ProviderCount int
+
+	// TrialCount is the total number of trials across all scenarios.
+	TrialCount int
 }
 
-// Partition creates work items for each scenario × provider combination.
+// Partition creates work items for each scenario × provider × trial combination.
 // Each work item represents a single evaluation that can be independently executed.
 func Partition(input PartitionInput) (*PartitionResult, error) {
 	if len(input.Scenarios) == 0 {
@@ -98,37 +110,54 @@ func Partition(input PartitionInput) (*PartitionResult, error) {
 		return nil, fmt.Errorf("no providers provided")
 	}
 
-	totalCombinations := len(input.Scenarios) * len(input.Providers)
-	items := make([]queue.WorkItem, 0, totalCombinations)
+	totalTrials := 0
+	items := make([]queue.WorkItem, 0, len(input.Scenarios)*len(input.Providers)*max(input.JobTrials, 1))
 
-	// Create work item for each scenario × provider combination
 	for _, scenario := range input.Scenarios {
-		for _, provider := range input.Providers {
-			config, err := buildConfig(input.Config, scenario, provider)
-			if err != nil {
-				return nil, fmt.Errorf("failed to build config for %s/%s: %w",
-					scenario.ID, provider.ID, err)
-			}
+		trialCount := resolveTrialCount(input.JobTrials, scenario.Trials)
+		totalTrials += trialCount
 
-			item := queue.WorkItem{
-				ID:          generateItemID(input.JobID, scenario.ID, provider.ID),
-				JobID:       input.JobID,
-				ScenarioID:  scenario.ID,
-				ProviderID:  provider.ID,
-				BundleURL:   input.BundleURL,
-				Config:      config,
-				MaxAttempts: input.MaxRetries,
+		for _, provider := range input.Providers {
+			for trial := 0; trial < trialCount; trial++ {
+				config, err := buildTrialConfig(input.Config, scenario, provider, trial, trialCount)
+				if err != nil {
+					return nil, fmt.Errorf("failed to build config for %s/%s trial %d: %w",
+						scenario.ID, provider.ID, trial, err)
+				}
+
+				item := queue.WorkItem{
+					ID:          generateItemID(input.JobID, scenario.ID, provider.ID),
+					JobID:       input.JobID,
+					ScenarioID:  scenario.ID,
+					ProviderID:  provider.ID,
+					BundleURL:   input.BundleURL,
+					Config:      config,
+					MaxAttempts: input.MaxRetries,
+				}
+				items = append(items, item)
 			}
-			items = append(items, item)
 		}
 	}
 
 	return &PartitionResult{
 		Items:             items,
-		TotalCombinations: totalCombinations,
+		TotalCombinations: len(items),
 		ScenarioCount:     len(input.Scenarios),
 		ProviderCount:     len(input.Providers),
+		TrialCount:        totalTrials,
 	}, nil
+}
+
+// resolveTrialCount returns the effective trial count using the priority:
+// jobTrials (if > 0) > scenarioTrials (if > 0) > 1.
+func resolveTrialCount(jobTrials, scenarioTrials int) int {
+	if jobTrials > 0 {
+		return jobTrials
+	}
+	if scenarioTrials > 0 {
+		return scenarioTrials
+	}
+	return 1
 }
 
 // Filter applies include/exclude patterns to a list of scenarios.
@@ -186,8 +215,11 @@ func generateItemID(_, scenarioID, _ string) string {
 	return fmt.Sprintf("%s-%s", scenarioID[:min(8, len(scenarioID))], uuid.New().String()[:8])
 }
 
-// buildConfig creates the config JSON for a work item.
-func buildConfig(base map[string]any, scenario Scenario, provider Provider) ([]byte, error) {
+// buildTrialConfig creates the config JSON for a work item including trial metadata.
+func buildTrialConfig(
+	base map[string]any, scenario Scenario, provider Provider,
+	trialIndex, totalTrials int,
+) ([]byte, error) {
 	config := make(map[string]any)
 
 	// Copy base config
@@ -211,13 +243,21 @@ func buildConfig(base map[string]any, scenario Scenario, provider Provider) ([]b
 		"namespace": provider.Namespace,
 	}
 
+	// Add trial metadata
+	config["trialIndex"] = trialIndex
+	config["totalTrials"] = totalTrials
+
 	return json.Marshal(config)
 }
 
 // EstimateWorkItems returns the estimated number of work items without creating them.
 // Useful for progress tracking and resource planning.
-func EstimateWorkItems(scenarioCount, providerCount int) int {
-	return scenarioCount * providerCount
+// The trials parameter is the average trial count per scenario (use 1 for backward compatibility).
+func EstimateWorkItems(scenarioCount, providerCount, trials int) int {
+	if trials < 1 {
+		trials = 1
+	}
+	return scenarioCount * providerCount * trials
 }
 
 // Batch splits work items into batches of the specified size.

--- a/ee/pkg/arena/partitioner/partitioner_test.go
+++ b/ee/pkg/arena/partitioner/partitioner_test.go
@@ -115,6 +115,131 @@ func TestPartitionWithConfig(t *testing.T) {
 	if provider["name"] != "provider" {
 		t.Errorf("config[provider][name] = %v, want provider", provider["name"])
 	}
+
+	// Verify trial metadata is present
+	if config["trialIndex"] != float64(0) {
+		t.Errorf("config[trialIndex] = %v, want 0", config["trialIndex"])
+	}
+	if config["totalTrials"] != float64(1) {
+		t.Errorf("config[totalTrials] = %v, want 1", config["totalTrials"])
+	}
+}
+
+func TestPartitionWithTrials(t *testing.T) {
+	input := PartitionInput{
+		JobID:     "job-1",
+		BundleURL: "http://example.com/bundle.tar.gz",
+		Scenarios: []Scenario{
+			{ID: "s1", Name: "S1", Path: "s1.yaml", Trials: 3},
+			{ID: "s2", Name: "S2", Path: "s2.yaml"},
+		},
+		Providers: []Provider{
+			{ID: "p1", Name: "p1", Namespace: "ns"},
+		},
+	}
+
+	result, err := Partition(input)
+	if err != nil {
+		t.Fatalf("Partition() error = %v", err)
+	}
+
+	// s1 has 3 trials, s2 has 0 (defaults to 1) → (3+1) × 1 provider = 4 items
+	if len(result.Items) != 4 {
+		t.Errorf("len(Items) = %d, want 4", len(result.Items))
+	}
+	if result.TotalCombinations != 4 {
+		t.Errorf("TotalCombinations = %d, want 4", result.TotalCombinations)
+	}
+	if result.TrialCount != 4 {
+		t.Errorf("TrialCount = %d, want 4", result.TrialCount)
+	}
+
+	// Verify trial indices in config for s1 (first 3 items)
+	for i := 0; i < 3; i++ {
+		var cfg map[string]any
+		if err := json.Unmarshal(result.Items[i].Config, &cfg); err != nil {
+			t.Fatalf("unmarshal config[%d]: %v", i, err)
+		}
+		if cfg["trialIndex"] != float64(i) {
+			t.Errorf("item[%d] trialIndex = %v, want %d", i, cfg["trialIndex"], i)
+		}
+		if cfg["totalTrials"] != float64(3) {
+			t.Errorf("item[%d] totalTrials = %v, want 3", i, cfg["totalTrials"])
+		}
+	}
+
+	// s2's single trial should have trialIndex=0, totalTrials=1
+	var cfg map[string]any
+	if err := json.Unmarshal(result.Items[3].Config, &cfg); err != nil {
+		t.Fatalf("unmarshal config[3]: %v", err)
+	}
+	if cfg["trialIndex"] != float64(0) {
+		t.Errorf("item[3] trialIndex = %v, want 0", cfg["trialIndex"])
+	}
+	if cfg["totalTrials"] != float64(1) {
+		t.Errorf("item[3] totalTrials = %v, want 1", cfg["totalTrials"])
+	}
+}
+
+func TestPartitionJobTrialsOverride(t *testing.T) {
+	input := PartitionInput{
+		JobID:     "job-1",
+		BundleURL: "http://example.com/bundle.tar.gz",
+		Scenarios: []Scenario{
+			{ID: "s1", Name: "S1", Path: "s1.yaml", Trials: 3},
+			{ID: "s2", Name: "S2", Path: "s2.yaml", Trials: 5},
+		},
+		Providers: []Provider{
+			{ID: "p1", Name: "p1", Namespace: "ns"},
+		},
+		JobTrials: 10,
+	}
+
+	result, err := Partition(input)
+	if err != nil {
+		t.Fatalf("Partition() error = %v", err)
+	}
+
+	// JobTrials=10 overrides per-scenario → 2 scenarios × 1 provider × 10 trials = 20
+	if len(result.Items) != 20 {
+		t.Errorf("len(Items) = %d, want 20", len(result.Items))
+	}
+	if result.TrialCount != 20 {
+		t.Errorf("TrialCount = %d, want 20", result.TrialCount)
+	}
+
+	// All items should have totalTrials=10
+	var cfg map[string]any
+	if err := json.Unmarshal(result.Items[0].Config, &cfg); err != nil {
+		t.Fatalf("unmarshal config: %v", err)
+	}
+	if cfg["totalTrials"] != float64(10) {
+		t.Errorf("totalTrials = %v, want 10", cfg["totalTrials"])
+	}
+}
+
+func TestResolveTrialCount(t *testing.T) {
+	tests := []struct {
+		name           string
+		jobTrials      int
+		scenarioTrials int
+		want           int
+	}{
+		{"job overrides scenario", 5, 3, 5},
+		{"scenario used when no job override", 0, 3, 3},
+		{"defaults to 1 when both zero", 0, 0, 1},
+		{"job overrides even when scenario is zero", 5, 0, 5},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveTrialCount(tt.jobTrials, tt.scenarioTrials)
+			if got != tt.want {
+				t.Errorf("resolveTrialCount(%d, %d) = %d, want %d",
+					tt.jobTrials, tt.scenarioTrials, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestPartitionNoScenarios(t *testing.T) {
@@ -226,20 +351,24 @@ func TestEstimateWorkItems(t *testing.T) {
 	tests := []struct {
 		scenarios int
 		providers int
+		trials    int
 		want      int
 	}{
-		{10, 5, 50},
-		{1, 1, 1},
-		{100, 10, 1000},
-		{0, 5, 0},
-		{5, 0, 0},
+		{10, 5, 1, 50},
+		{1, 1, 1, 1},
+		{100, 10, 1, 1000},
+		{0, 5, 1, 0},
+		{5, 0, 1, 0},
+		{10, 5, 3, 150},
+		{2, 2, 0, 4},  // trials < 1 defaults to 1
+		{2, 2, -1, 4}, // negative trials defaults to 1
 	}
 
 	for _, tt := range tests {
-		got := EstimateWorkItems(tt.scenarios, tt.providers)
+		got := EstimateWorkItems(tt.scenarios, tt.providers, tt.trials)
 		if got != tt.want {
-			t.Errorf("EstimateWorkItems(%d, %d) = %d, want %d",
-				tt.scenarios, tt.providers, got, tt.want)
+			t.Errorf("EstimateWorkItems(%d, %d, %d) = %d, want %d",
+				tt.scenarios, tt.providers, tt.trials, got, tt.want)
 		}
 	}
 }

--- a/ee/pkg/arena/partitioner/scenarios.go
+++ b/ee/pkg/arena/partitioner/scenarios.go
@@ -35,7 +35,8 @@ type scenarioFile struct {
 		Name string `yaml:"name"`
 	} `yaml:"metadata"`
 	Spec struct {
-		ID string `yaml:"id"`
+		ID     string `yaml:"id"`
+		Trials int    `yaml:"trials"`
 	} `yaml:"spec"`
 }
 
@@ -110,9 +111,10 @@ func readScenarioFile(absPath, relativePath string) (*Scenario, error) {
 	}
 
 	return &Scenario{
-		ID:   id,
-		Name: name,
-		Path: relativePath,
+		ID:     id,
+		Name:   name,
+		Path:   relativePath,
+		Trials: sf.Spec.Trials,
 	}, nil
 }
 

--- a/ee/pkg/arena/partitioner/scenarios_test.go
+++ b/ee/pkg/arena/partitioner/scenarios_test.go
@@ -270,6 +270,49 @@ func TestDeriveIDFromFilename(t *testing.T) {
 	}
 }
 
+func TestListScenariosFromConfigReadsTrials(t *testing.T) {
+	dir := t.TempDir()
+
+	writeFile(t, filepath.Join(dir, "load.scenario.yaml"), `
+metadata:
+  name: Load Test
+spec:
+  id: load-test
+  trials: 50
+`)
+
+	writeFile(t, filepath.Join(dir, "simple.scenario.yaml"), `
+metadata:
+  name: Simple Test
+spec:
+  id: simple-test
+`)
+
+	configPath := filepath.Join(dir, "config.arena.yaml")
+	writeFile(t, configPath, `
+spec:
+  scenarios:
+    - file: load.scenario.yaml
+    - file: simple.scenario.yaml
+`)
+
+	scenarios, err := ListScenariosFromConfig(configPath)
+	if err != nil {
+		t.Fatalf("ListScenariosFromConfig() error = %v", err)
+	}
+
+	if len(scenarios) != 2 {
+		t.Fatalf("len(scenarios) = %d, want 2", len(scenarios))
+	}
+
+	if scenarios[0].Trials != 50 {
+		t.Errorf("scenarios[0].Trials = %d, want 50", scenarios[0].Trials)
+	}
+	if scenarios[1].Trials != 0 {
+		t.Errorf("scenarios[1].Trials = %d, want 0 (unset)", scenarios[1].Trials)
+	}
+}
+
 func TestListScenariosFromConfigEmptyFileEntry(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary

Extend the Arena partitioner to create `scenario × provider × trial` work items, and override PromptKit's internal trial expansion in the worker so each work item executes exactly one trial.

Closes #662

## Changes

- **Partitioner**: `Partition()` now creates N work items per scenario×provider, with `trialIndex` and `totalTrials` in each item's config. Trial count resolution: job-level > per-scenario > default 1.
- **Scenario loading**: `ListScenariosFromConfig()` reads `spec.trials` from scenario YAML files.
- **Controller**: Per-job-type `maxWorkItems` limits (10k evaluation, 100k loadtest). Passes `spec.trials` to partitioner.
- **Worker**: Overrides `Trials = 1` on all loaded scenarios before `GenerateRunPlan()` to prevent PromptKit's internal trial expansion.

## Test plan
- [x] Partitioner unit tests for trial expansion, priority resolution, backward compatibility
- [x] Scenario loading test for trials field
- [x] Controller test calls updated for new parameters
- [x] `go build` and `go test` pass