### PR TITLE
feat: VU pool for concurrent Arena work item processing

### DIFF
--- a/ee/cmd/arena-worker/vu_pool.go
+++ b/ee/cmd/arena-worker/vu_pool.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+)
+
+// VUPoolConfig holds the configuration for creating a VUPool.
+type VUPoolConfig struct {
+	Size         int // Number of VU goroutines
+	Concurrency  int // Global concurrency limit (0 = unlimited)
+	Queue        queue.WorkQueue
+	JobID        string
+	Log          logr.Logger
+	Metrics      *WorkerMetrics
+	PollInterval time.Duration
+	Execute      func(ctx context.Context, item *queue.WorkItem) (*ExecutionResult, error)
+}
+
+// VUPool manages a pool of virtual users that concurrently process work items.
+type VUPool struct {
+	size         int
+	concurrency  int
+	queue        queue.WorkQueue
+	jobID        string
+	log          logr.Logger
+	metrics      *WorkerMetrics
+	pollInterval time.Duration
+	execute      func(ctx context.Context, item *queue.WorkItem) (*ExecutionResult, error)
+}
+
+// NewVUPool creates a new VU pool from the given configuration.
+func NewVUPool(cfg VUPoolConfig) *VUPool {
+	size := cfg.Size
+	if size < 1 {
+		size = 1
+	}
+	pollInterval := cfg.PollInterval
+	if pollInterval == 0 {
+		pollInterval = 100 * time.Millisecond
+	}
+	return &VUPool{
+		size:         size,
+		concurrency:  cfg.Concurrency,
+		queue:        cfg.Queue,
+		jobID:        cfg.JobID,
+		log:          cfg.Log,
+		metrics:      cfg.Metrics,
+		pollInterval: pollInterval,
+		execute:      cfg.Execute,
+	}
+}
+
+// Run starts all VU goroutines and blocks until all have finished.
+// Each VU independently pops, executes, and reports work items.
+// Returns the first fatal error encountered, or nil on clean shutdown.
+func (p *VUPool) Run(ctx context.Context) error {
+	p.log.Info("VU pool starting",
+		"vus", p.size,
+		"concurrency", p.concurrency,
+		"jobID", p.jobID,
+	)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, p.size)
+
+	for i := range p.size {
+		wg.Add(1)
+		go func(vuID int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					p.log.Error(fmt.Errorf("panic: %v", r), "VU panicked", "vu", fmt.Sprintf("vu-%d", vuID))
+				}
+			}()
+			vuLog := p.log.WithValues("vu", fmt.Sprintf("vu-%d", vuID))
+			if err := p.vuLoop(ctx, vuLog); err != nil {
+				errCh <- err
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	// Return the first error, if any.
+	for err := range errCh {
+		if err != nil {
+			return err
+		}
+	}
+
+	p.log.Info("VU pool finished", "jobID", p.jobID)
+	return nil
+}
+
+// vuLoop is the main loop for a single virtual user.
+func (p *VUPool) vuLoop(ctx context.Context, log logr.Logger) error {
+	emptyCount := 0
+	maxEmptyPolls := 10
+
+	log.V(1).Info("VU started")
+
+	for {
+		if ctx.Err() != nil {
+			log.V(1).Info("VU shutting down")
+			return nil
+		}
+
+		// Check concurrency limit before popping.
+		if p.concurrency > 0 {
+			atLimit, checkErr := p.atConcurrencyLimit(ctx)
+			if checkErr != nil {
+				return checkErr
+			}
+			if atLimit {
+				time.Sleep(p.pollInterval)
+				continue
+			}
+		}
+
+		item, err := p.queue.Pop(ctx, p.jobID)
+		if err != nil {
+			done, resetCount, retErr := p.handleVUPopError(ctx, log, err, emptyCount, maxEmptyPolls)
+			if retErr != nil {
+				return retErr
+			}
+			if done {
+				return nil
+			}
+			emptyCount = resetCount
+			continue
+		}
+
+		emptyCount = 0
+		log.Info("work item popped",
+			"itemID", item.ID,
+			"scenarioID", item.ScenarioID,
+			"providerID", item.ProviderID,
+		)
+
+		p.executeAndReport(ctx, log, item)
+	}
+}
+
+// atConcurrencyLimit checks if the global concurrency limit has been reached.
+// This is a best-effort check: between checking Progress and calling Pop,
+// other VUs may also pass this check and pop items. The actual in-flight count
+// may briefly exceed the concurrency limit by up to (VUsPerWorker - 1).
+// For load testing, this is acceptable — the limit controls approximate pressure,
+// not an exact contract.
+func (p *VUPool) atConcurrencyLimit(ctx context.Context) (bool, error) {
+	progress, err := p.queue.Progress(ctx, p.jobID)
+	if err != nil {
+		if errors.Is(err, queue.ErrJobNotFound) {
+			return false, nil
+		}
+		return false, fmt.Errorf("failed to check concurrency: %w", err)
+	}
+	return progress.Processing >= p.concurrency, nil
+}
+
+// handleVUPopError handles errors from queue.Pop within a VU loop.
+func (p *VUPool) handleVUPopError(
+	ctx context.Context, log logr.Logger, err error, emptyCount, maxEmptyPolls int,
+) (bool, int, error) {
+	if !errors.Is(err, queue.ErrQueueEmpty) {
+		return false, emptyCount, fmt.Errorf("failed to pop work item: %w", err)
+	}
+
+	emptyCount++
+	if emptyCount >= maxEmptyPolls {
+		done, checkErr := checkJobCompletion(ctx, log, p.queue, p.jobID, emptyCount)
+		if checkErr != nil {
+			return false, 0, checkErr
+		}
+		if done {
+			return true, 0, nil
+		}
+		emptyCount = 0
+	}
+
+	time.Sleep(p.pollInterval)
+	return false, emptyCount, nil
+}
+
+// executeAndReport runs a single work item and reports the result.
+func (p *VUPool) executeAndReport(ctx context.Context, log logr.Logger, item *queue.WorkItem) {
+	itemCtx, itemCancel := context.WithTimeout(ctx, maxItemTimeout)
+	itemCtx, span := otel.Tracer("omnia-arena-worker").Start(itemCtx, "arena.work-item",
+		trace.WithAttributes(
+			attribute.String("arena.job", p.jobID),
+			attribute.String("arena.scenario", item.ScenarioID),
+			attribute.String("arena.provider", item.ProviderID),
+		),
+	)
+	itemStart := time.Now()
+	result, execErr := p.execute(itemCtx, item)
+	if execErr != nil {
+		span.RecordError(execErr)
+	}
+	itemCancel()
+	if itemCtx.Err() == context.DeadlineExceeded {
+		execErr = fmt.Errorf("work item timed out after %v", maxItemTimeout)
+	}
+
+	ackCtx := trace.ContextWithSpan(ctx, span)
+	p.reportResult(ackCtx, log, item, result, execErr)
+	span.End()
+
+	itemDuration := time.Since(itemStart).Seconds()
+	if execErr != nil || (result != nil && result.Status == statusFail) {
+		p.metrics.RecordWorkItem(p.jobID, statusFail, itemDuration)
+	} else {
+		p.metrics.RecordWorkItem(p.jobID, statusPass, itemDuration)
+	}
+}
+
+// reportResult reports the work item result via Ack or Nack.
+func (p *VUPool) reportResult(
+	ctx context.Context, log logr.Logger, item *queue.WorkItem,
+	result *ExecutionResult, execErr error,
+) {
+	// Use a fresh context for ack/nack if the parent is cancelled,
+	// so in-flight items are properly reported during shutdown.
+	reportCtx := ctx
+	if ctx.Err() != nil {
+		var cancel context.CancelFunc
+		reportCtx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+	}
+
+	if execErr != nil {
+		log.Error(execErr, "work item failed", "itemID", item.ID)
+		if err := p.queue.Nack(reportCtx, p.jobID, item.ID, execErr); err != nil {
+			log.Error(err, "failed to nack item", "itemID", item.ID)
+		}
+		return
+	}
+
+	resultJSON, _ := json.Marshal(result)
+	log.Info("work item completed",
+		"itemID", item.ID,
+		"status", result.Status,
+		"durationMs", result.DurationMs,
+	)
+	if err := p.queue.Ack(reportCtx, p.jobID, item.ID, resultJSON); err != nil {
+		log.Error(err, "failed to ack item", "itemID", item.ID)
+	}
+}

--- a/ee/cmd/arena-worker/vu_pool_test.go
+++ b/ee/cmd/arena-worker/vu_pool_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+)
+
+const testJobID = "test-job"
+
+// pushTestItems is a helper that pushes n work items to the queue.
+func pushTestItems(t *testing.T, q *queue.MemoryQueue, n int) {
+	t.Helper()
+	items := make([]queue.WorkItem, n)
+	for i := range n {
+		items[i] = queue.WorkItem{
+			ID:          fmt.Sprintf("item-%d", i),
+			ScenarioID:  "scenario-1",
+			ProviderID:  "provider-1",
+			MaxAttempts: 1,
+		}
+	}
+	require.NoError(t, q.Push(context.Background(), testJobID, items))
+}
+
+// newTestMetrics creates WorkerMetrics with an isolated registry for tests.
+func newTestMetrics() *WorkerMetrics {
+	return newWorkerMetricsWithRegisterer(prometheus.NewRegistry())
+}
+
+// concurrencyTracker provides a reusable execute function that tracks
+// peak concurrency and total items processed.
+type concurrencyTracker struct {
+	processed         atomic.Int32
+	maxConcurrent     atomic.Int32
+	currentConcurrent atomic.Int32
+	workDuration      time.Duration
+}
+
+func (ct *concurrencyTracker) execute(_ context.Context, _ *queue.WorkItem) (*ExecutionResult, error) {
+	cur := ct.currentConcurrent.Add(1)
+	for {
+		old := ct.maxConcurrent.Load()
+		if cur <= old || ct.maxConcurrent.CompareAndSwap(old, cur) {
+			break
+		}
+	}
+	time.Sleep(ct.workDuration)
+	ct.currentConcurrent.Add(-1)
+	ct.processed.Add(1)
+	return &ExecutionResult{Status: statusPass, DurationMs: float64(ct.workDuration.Milliseconds())}, nil
+}
+
+func TestVUPool_SingleVU(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	defer func() { require.NoError(t, q.Close()) }()
+
+	pushTestItems(t, q, 5)
+
+	var processed atomic.Int32
+	pool := NewVUPool(VUPoolConfig{
+		Size:         1,
+		Concurrency:  0,
+		Queue:        q,
+		JobID:        testJobID,
+		Log:          testr.New(t),
+		Metrics:      newTestMetrics(),
+		PollInterval: 10 * time.Millisecond,
+		Execute: func(_ context.Context, _ *queue.WorkItem) (*ExecutionResult, error) {
+			processed.Add(1)
+			return &ExecutionResult{Status: statusPass, DurationMs: 1}, nil
+		},
+	})
+
+	err := pool.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(5), processed.Load())
+}
+
+func TestVUPool_MultipleVUs(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	defer func() { require.NoError(t, q.Close()) }()
+
+	pushTestItems(t, q, 10)
+
+	ct := &concurrencyTracker{workDuration: 50 * time.Millisecond}
+	pool := NewVUPool(VUPoolConfig{
+		Size:         3,
+		Concurrency:  0,
+		Queue:        q,
+		JobID:        testJobID,
+		Log:          testr.New(t),
+		Metrics:      newTestMetrics(),
+		PollInterval: 10 * time.Millisecond,
+		Execute:      ct.execute,
+	})
+
+	err := pool.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(10), ct.processed.Load())
+	assert.Greater(t, ct.maxConcurrent.Load(), int32(1), "expected concurrent execution with 3 VUs")
+}
+
+func TestVUPool_GracefulShutdown(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	defer func() { require.NoError(t, q.Close()) }()
+
+	pushTestItems(t, q, 20)
+
+	var processed atomic.Int32
+	startedCh := make(chan struct{})
+
+	pool := NewVUPool(VUPoolConfig{
+		Size:         2,
+		Concurrency:  0,
+		Queue:        q,
+		JobID:        testJobID,
+		Log:          testr.New(t),
+		Metrics:      newTestMetrics(),
+		PollInterval: 10 * time.Millisecond,
+		Execute: func(_ context.Context, _ *queue.WorkItem) (*ExecutionResult, error) {
+			select {
+			case startedCh <- struct{}{}:
+			default:
+			}
+			time.Sleep(100 * time.Millisecond)
+			processed.Add(1)
+			return &ExecutionResult{Status: statusPass, DurationMs: 100}, nil
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- pool.Run(ctx)
+	}()
+
+	// Wait for at least one item to start processing, then cancel.
+	<-startedCh
+	cancel()
+
+	err := <-done
+	require.NoError(t, err)
+
+	p := processed.Load()
+	assert.Greater(t, p, int32(0), "expected at least one item processed before shutdown")
+	assert.Less(t, p, int32(20), "expected shutdown to stop before processing all items")
+}
+
+func TestVUPool_ConcurrencyLimit(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	defer func() { require.NoError(t, q.Close()) }()
+
+	pushTestItems(t, q, 6)
+
+	ct := &concurrencyTracker{workDuration: 80 * time.Millisecond}
+	pool := NewVUPool(VUPoolConfig{
+		Size:         4,
+		Concurrency:  2,
+		Queue:        q,
+		JobID:        testJobID,
+		Log:          testr.New(t),
+		Metrics:      newTestMetrics(),
+		PollInterval: 10 * time.Millisecond,
+		Execute:      ct.execute,
+	})
+
+	err := pool.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(6), ct.processed.Load())
+	assert.LessOrEqual(t, ct.maxConcurrent.Load(), int32(2),
+		"concurrency limit should cap simultaneous processing")
+}
+
+func TestVUPool_ExecuteError(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	defer func() { require.NoError(t, q.Close()) }()
+
+	pushTestItems(t, q, 3)
+
+	var processed atomic.Int32
+	pool := NewVUPool(VUPoolConfig{
+		Size:         2,
+		Concurrency:  0,
+		Queue:        q,
+		JobID:        testJobID,
+		Log:          testr.New(t),
+		Metrics:      newTestMetrics(),
+		PollInterval: 10 * time.Millisecond,
+		Execute: func(_ context.Context, item *queue.WorkItem) (*ExecutionResult, error) {
+			processed.Add(1)
+			if item.ID == "item-1" {
+				return nil, fmt.Errorf("simulated failure")
+			}
+			return &ExecutionResult{Status: statusPass, DurationMs: 1}, nil
+		},
+	})
+
+	err := pool.Run(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), processed.Load())
+
+	failed, fErr := q.GetFailedItems(context.Background(), testJobID)
+	require.NoError(t, fErr)
+	assert.Len(t, failed, 1)
+	assert.Equal(t, "item-1", failed[0].ID)
+}
+
+func TestVUPool_SizeDefaultsToOne(t *testing.T) {
+	pool := NewVUPool(VUPoolConfig{
+		Size: 0,
+	})
+	assert.Equal(t, 1, pool.size)
+}
+
+func TestVUPool_EmptyQueue(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	defer func() { require.NoError(t, q.Close()) }()
+
+	require.NoError(t, q.Push(context.Background(), testJobID, []queue.WorkItem{}))
+
+	pool := NewVUPool(VUPoolConfig{
+		Size:         2,
+		Concurrency:  0,
+		Queue:        q,
+		JobID:        testJobID,
+		Log:          testr.New(t),
+		Metrics:      newTestMetrics(),
+		PollInterval: 10 * time.Millisecond,
+		Execute: func(_ context.Context, _ *queue.WorkItem) (*ExecutionResult, error) {
+			t.Fatal("execute should not be called on empty queue")
+			return nil, nil
+		},
+	})
+
+	err := pool.Run(context.Background())
+	require.NoError(t, err)
+}

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -110,6 +111,10 @@ type Config struct {
 	ShutdownDelay time.Duration
 	Verbose       bool // Enable verbose/debug output from promptarena
 
+	// VU pool configuration
+	VUsPerWorker int // Number of virtual users (goroutines) per worker, default 1
+	Concurrency  int // Global concurrency limit (0 = unlimited)
+
 	// Override configurations (resolved from CRDs)
 	ToolOverrides map[string]ToolOverrideConfig // Tool name -> override config
 
@@ -164,6 +169,9 @@ func loadConfig() (*Config, error) {
 		Verbose:        os.Getenv("ARENA_VERBOSE") == "true",
 	}
 
+	cfg.VUsPerWorker = getIntEnvOrDefault("ARENA_VUS_PER_WORKER", 1)
+	cfg.Concurrency = getIntEnvOrDefault("ARENA_CONCURRENCY", 0)
+
 	if cfg.JobName == "" {
 		return nil, errors.New("ARENA_JOB_NAME is required")
 	}
@@ -177,6 +185,15 @@ func loadConfig() (*Config, error) {
 func getEnvOrDefault(key, defaultValue string) string {
 	if v := os.Getenv(key); v != "" {
 		return v
+	}
+	return defaultValue
+}
+
+func getIntEnvOrDefault(key string, defaultValue int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
 	}
 	return defaultValue
 }
@@ -211,8 +228,6 @@ func processWorkItems(
 	q queue.WorkQueue, bundlePath string, wm *WorkerMetrics,
 ) error {
 	jobID := cfg.JobName
-	emptyCount := 0
-	maxEmptyPolls := 10 // Exit after this many consecutive empty polls
 
 	// Derive a deterministic trace ID from the job name so traces are easy
 	// to look up in Tempo without searching by span attribute.
@@ -234,6 +249,35 @@ func processWorkItems(
 	)
 	defer rootSpan.End()
 
+	// Use VU pool for concurrent processing when configured.
+	if cfg.VUsPerWorker > 1 || cfg.Concurrency > 1 {
+		pool := NewVUPool(VUPoolConfig{
+			Size:         cfg.VUsPerWorker,
+			Concurrency:  cfg.Concurrency,
+			Queue:        q,
+			JobID:        jobID,
+			Log:          log,
+			Metrics:      wm,
+			PollInterval: cfg.PollInterval,
+			Execute: func(ctx context.Context, item *queue.WorkItem) (*ExecutionResult, error) {
+				return executeWorkItem(ctx, log, cfg, item, bundlePath)
+			},
+		})
+		return pool.Run(ctx)
+	}
+
+	// Single-VU mode: existing sequential loop (backward compatible).
+	return processSingleVU(ctx, log, cfg, q, jobID, bundlePath, wm)
+}
+
+// processSingleVU is the original single-threaded work item processing loop.
+func processSingleVU(
+	ctx context.Context, log logr.Logger, cfg *Config,
+	q queue.WorkQueue, jobID, bundlePath string, wm *WorkerMetrics,
+) error {
+	emptyCount := 0
+	maxEmptyPolls := 10
+
 	log.Info("processing work items", "jobID", jobID)
 
 	for {
@@ -241,7 +285,6 @@ func processWorkItems(
 			return nil
 		}
 
-		// Pop next work item
 		item, err := q.Pop(ctx, jobID)
 		if err != nil {
 			done, resetCount, retErr := handlePopError(ctx, log, err, emptyCount, maxEmptyPolls, cfg, q, jobID)
@@ -255,47 +298,49 @@ func processWorkItems(
 			continue
 		}
 
-		emptyCount = 0 // Reset on successful pop
-
+		emptyCount = 0
 		log.Info("work item popped",
 			"itemID", item.ID,
 			"scenarioID", item.ScenarioID,
 			"providerID", item.ProviderID,
 		)
 
-		// Execute with per-item timeout, wrapped in a trace span.
-		// The span covers the full lifecycle: execute → ack/nack so that
-		// Redis operations are correlated under the work-item span.
-		itemCtx, itemCancel := context.WithTimeout(ctx, maxItemTimeout)
-		itemCtx, span := otel.Tracer("omnia-arena-worker").Start(itemCtx, "arena.work-item",
-			trace.WithAttributes(
-				attribute.String("arena.job", jobID),
-				attribute.String("arena.scenario", item.ScenarioID),
-				attribute.String("arena.provider", item.ProviderID),
-			),
-		)
-		itemStart := time.Now()
-		result, execErr := executeWorkItem(itemCtx, log, cfg, item, bundlePath)
-		if execErr != nil {
-			span.RecordError(execErr)
-		}
-		itemCancel()
-		if itemCtx.Err() == context.DeadlineExceeded {
-			execErr = fmt.Errorf("work item timed out after %v", maxItemTimeout)
-		}
-		// Ack/Nack uses the root ctx (not the timed-out itemCtx) but carries
-		// the work-item span so Redis operations are children of this item.
-		ackCtx := trace.ContextWithSpan(ctx, span)
-		reportWorkItemResult(ackCtx, log, q, jobID, item, result, execErr)
-		span.End()
+		executeAndReport(ctx, log, cfg, q, jobID, item, bundlePath, wm)
+	}
+}
 
-		// Record work item metrics
-		itemDuration := time.Since(itemStart).Seconds()
-		if execErr != nil || (result != nil && result.Status == statusFail) {
-			wm.RecordWorkItem(jobID, statusFail, itemDuration)
-		} else {
-			wm.RecordWorkItem(jobID, statusPass, itemDuration)
-		}
+// executeAndReport runs a work item and reports the result via Ack/Nack.
+func executeAndReport(
+	ctx context.Context, log logr.Logger, cfg *Config,
+	q queue.WorkQueue, jobID string, item *queue.WorkItem,
+	bundlePath string, wm *WorkerMetrics,
+) {
+	itemCtx, itemCancel := context.WithTimeout(ctx, maxItemTimeout)
+	itemCtx, span := otel.Tracer("omnia-arena-worker").Start(itemCtx, "arena.work-item",
+		trace.WithAttributes(
+			attribute.String("arena.job", jobID),
+			attribute.String("arena.scenario", item.ScenarioID),
+			attribute.String("arena.provider", item.ProviderID),
+		),
+	)
+	itemStart := time.Now()
+	result, execErr := executeWorkItem(itemCtx, log, cfg, item, bundlePath)
+	if execErr != nil {
+		span.RecordError(execErr)
+	}
+	itemCancel()
+	if itemCtx.Err() == context.DeadlineExceeded {
+		execErr = fmt.Errorf("work item timed out after %v", maxItemTimeout)
+	}
+	ackCtx := trace.ContextWithSpan(ctx, span)
+	reportWorkItemResult(ackCtx, log, q, jobID, item, result, execErr)
+	span.End()
+
+	itemDuration := time.Since(itemStart).Seconds()
+	if execErr != nil || (result != nil && result.Status == statusFail) {
+		wm.RecordWorkItem(jobID, statusFail, itemDuration)
+	} else {
+		wm.RecordWorkItem(jobID, statusPass, itemDuration)
 	}
 }
 

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -682,6 +682,17 @@ func (r *ArenaJobReconciler) createWorkerJob(ctx context.Context, arenaJob *omni
 		})
 	}
 
+	// Add VU pool configuration from loadTest settings
+	if arenaJob.Spec.LoadTest != nil {
+		env = append(env, corev1.EnvVar{
+			Name:  "ARENA_VUS_PER_WORKER",
+			Value: fmt.Sprintf("%d", arenaJob.Spec.LoadTest.VUsPerWorker),
+		}, corev1.EnvVar{
+			Name:  "ARENA_CONCURRENCY",
+			Value: fmt.Sprintf("%d", arenaJob.Spec.LoadTest.Concurrency),
+		})
+	}
+
 	// Inject SESSION_API_URL for session recording if configured
 	if r.SessionAPIURL != "" {
 		env = append(env, corev1.EnvVar{


### PR DESCRIPTION
## Summary

Add a VU (virtual user) pool to the Arena worker, enabling concurrent work item processing. Each VU independently pops, executes, and reports work items via its own goroutine.

Closes #603

## Changes

- **New `vu_pool.go`**: `VUPool` with configurable size and global concurrency limiting. Each VU runs an independent pop-execute-report loop. Graceful shutdown via context cancellation.
- **Worker refactor**: `processWorkItems()` delegates to VU pool when `VUsPerWorker > 1` or `Concurrency > 0`. Original single-threaded loop preserved for backward compatibility.
- **Config**: New `ARENA_VUS_PER_WORKER` and `ARENA_CONCURRENCY` env vars, read from `loadTest.vusPerWorker` and `loadTest.concurrency` CRD fields.
- **Controller**: Sets env vars on worker pods when `spec.loadTest` is configured.

## Test plan
- [x] Single VU test (backward compatible)
- [x] Multi-VU concurrent processing test
- [x] Graceful shutdown test
- [x] Concurrency limit enforcement test
- [x] Error handling with Nack test
- [x] Empty queue test
- [x] `go build` and `go test` pass