### PR TITLE
feat: typed CompleteItem + Redis accumulators for incremental aggregation

### DIFF
--- a/ee/pkg/arena/queue/complete_item_test.go
+++ b/ee/pkg/arena/queue/complete_item_test.go
@@ -1,0 +1,488 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package queue
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"testing"
+)
+
+const (
+	completeTestJobID = "complete-job-1"
+)
+
+func TestCompleteItemUpdatesAccumulators(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"},
+	}
+	mustPush(t, q, ctx, items)
+	mustPop(t, q, ctx)
+
+	result := &ItemResult{
+		Status:     "pass",
+		DurationMs: 150.5,
+		Metrics:    map[string]float64{"tokens": 100, "cost": 0.05},
+	}
+
+	if err := q.CompleteItem(ctx, completeTestJobID, "item-1", result); err != nil {
+		t.Fatalf("CompleteItem() error = %v", err)
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	assertInt64(t, "Total", stats.Total, 1)
+	assertInt64(t, "Passed", stats.Passed, 1)
+	assertInt64(t, "Failed", stats.Failed, 0)
+	assertFloat64(t, "TotalDurationMs", stats.TotalDurationMs, 150.5)
+	assertInt64(t, "TotalTokens", stats.TotalTokens, 100)
+	assertFloat64(t, "TotalCost", stats.TotalCost, 0.05)
+}
+
+func TestCompleteItemDoesAckBookkeeping(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"},
+	}
+	mustPush(t, q, ctx, items)
+	mustPop(t, q, ctx)
+
+	result := &ItemResult{Status: "pass", DurationMs: 100}
+	if err := q.CompleteItem(ctx, completeTestJobID, "item-1", result); err != nil {
+		t.Fatalf("CompleteItem() error = %v", err)
+	}
+
+	// Verify item moved to completed set
+	completed, err := q.GetCompletedItems(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetCompletedItems() error = %v", err)
+	}
+	if len(completed) != 1 {
+		t.Fatalf("Expected 1 completed item, got %d", len(completed))
+	}
+	if completed[0].ID != "item-1" {
+		t.Errorf("Completed item ID = %s, want item-1", completed[0].ID)
+	}
+
+	// Verify progress reflects completion
+	progress, err := q.Progress(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("Progress() error = %v", err)
+	}
+	if progress.Completed != 1 {
+		t.Errorf("Progress.Completed = %d, want 1", progress.Completed)
+	}
+	if progress.Processing != 0 {
+		t.Errorf("Progress.Processing = %d, want 0", progress.Processing)
+	}
+}
+
+func TestFailItemUpdatesCounters(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"},
+	}
+	mustPush(t, q, ctx, items)
+	mustPop(t, q, ctx)
+
+	testErr := errors.New("execution timeout")
+	if err := q.FailItem(ctx, completeTestJobID, "item-1", testErr); err != nil {
+		t.Fatalf("FailItem() error = %v", err)
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	assertInt64(t, "Total", stats.Total, 1)
+	assertInt64(t, "Passed", stats.Passed, 0)
+	assertInt64(t, "Failed", stats.Failed, 1)
+	assertFloat64(t, "TotalDurationMs", stats.TotalDurationMs, 0)
+
+	// Verify item is in failed set
+	failed, err := q.GetFailedItems(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetFailedItems() error = %v", err)
+	}
+	if len(failed) != 1 {
+		t.Fatalf("Expected 1 failed item, got %d", len(failed))
+	}
+	if failed[0].Error != "execution timeout" {
+		t.Errorf("Failed item error = %s, want 'execution timeout'", failed[0].Error)
+	}
+}
+
+func TestAccumulatorsPerScenarioAndProvider(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"},
+		{ID: "item-2", ScenarioID: "scen-a", ProviderID: "prov-y"},
+		{ID: "item-3", ScenarioID: "scen-b", ProviderID: "prov-x"},
+	}
+	mustPush(t, q, ctx, items)
+
+	// Pop and complete all items
+	for i := 0; i < 3; i++ {
+		mustPop(t, q, ctx)
+	}
+
+	results := []*ItemResult{
+		{Status: "pass", DurationMs: 100, Metrics: map[string]float64{"tokens": 50, "cost": 0.01}},
+		{Status: "fail", DurationMs: 200, Metrics: map[string]float64{"tokens": 80, "cost": 0.02}},
+		{Status: "pass", DurationMs: 150, Metrics: map[string]float64{"tokens": 60, "cost": 0.015}},
+	}
+
+	for i, itemID := range []string{"item-1", "item-2", "item-3"} {
+		if err := q.CompleteItem(ctx, completeTestJobID, itemID, results[i]); err != nil {
+			t.Fatalf("CompleteItem(%s) error = %v", itemID, err)
+		}
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	// Check global stats
+	assertInt64(t, "Total", stats.Total, 3)
+	assertInt64(t, "Passed", stats.Passed, 2)
+	assertInt64(t, "Failed", stats.Failed, 1)
+
+	// Check scenario breakdown
+	scenA := stats.ByScenario["scen-a"]
+	if scenA == nil {
+		t.Fatal("Missing ByScenario[scen-a]")
+	}
+	assertInt64(t, "scen-a.Total", scenA.Total, 2)
+	assertInt64(t, "scen-a.Passed", scenA.Passed, 1)
+	assertInt64(t, "scen-a.Failed", scenA.Failed, 1)
+	assertInt64(t, "scen-a.TotalTokens", scenA.TotalTokens, 130)
+
+	scenB := stats.ByScenario["scen-b"]
+	if scenB == nil {
+		t.Fatal("Missing ByScenario[scen-b]")
+	}
+	assertInt64(t, "scen-b.Total", scenB.Total, 1)
+	assertInt64(t, "scen-b.Passed", scenB.Passed, 1)
+
+	// Check provider breakdown
+	provX := stats.ByProvider["prov-x"]
+	if provX == nil {
+		t.Fatal("Missing ByProvider[prov-x]")
+	}
+	assertInt64(t, "prov-x.Total", provX.Total, 2)
+	assertInt64(t, "prov-x.Passed", provX.Passed, 2)
+	assertFloat64(t, "prov-x.TotalDurationMs", provX.TotalDurationMs, 250)
+
+	provY := stats.ByProvider["prov-y"]
+	if provY == nil {
+		t.Fatal("Missing ByProvider[prov-y]")
+	}
+	assertInt64(t, "prov-y.Total", provY.Total, 1)
+	assertInt64(t, "prov-y.Failed", provY.Failed, 1)
+}
+
+func TestGetStatsReturnsZeroForNewJob(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	stats, err := q.GetStats(ctx, "nonexistent-job")
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	assertInt64(t, "Total", stats.Total, 0)
+	assertInt64(t, "Passed", stats.Passed, 0)
+	assertInt64(t, "Failed", stats.Failed, 0)
+	assertFloat64(t, "TotalDurationMs", stats.TotalDurationMs, 0)
+
+	if stats.ByScenario == nil {
+		t.Error("ByScenario should be non-nil empty map")
+	}
+	if stats.ByProvider == nil {
+		t.Error("ByProvider should be non-nil empty map")
+	}
+}
+
+func TestConcurrentCompleteItem(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	const numItems = 50
+	items := make([]WorkItem, numItems)
+	for i := 0; i < numItems; i++ {
+		items[i] = WorkItem{
+			ID:         fmt.Sprintf("item-%d", i),
+			ScenarioID: "scen-a",
+			ProviderID: "prov-x",
+		}
+	}
+
+	mustPush(t, q, ctx, items)
+
+	// Pop all items first
+	for i := 0; i < numItems; i++ {
+		mustPop(t, q, ctx)
+	}
+
+	// Complete all items concurrently
+	var wg sync.WaitGroup
+	errs := make(chan error, numItems)
+
+	for i := 0; i < numItems; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			result := &ItemResult{
+				Status:     "pass",
+				DurationMs: 100,
+				Metrics:    map[string]float64{"tokens": 10, "cost": 0.001},
+			}
+			if err := q.CompleteItem(ctx, completeTestJobID, fmt.Sprintf("item-%d", idx), result); err != nil {
+				errs <- err
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("Concurrent CompleteItem() error = %v", err)
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	assertInt64(t, "Total", stats.Total, numItems)
+	assertInt64(t, "Passed", stats.Passed, numItems)
+	assertFloat64(t, "TotalDurationMs", stats.TotalDurationMs, float64(numItems)*100)
+	assertInt64(t, "TotalTokens", stats.TotalTokens, int64(numItems)*10)
+}
+
+func TestExtractTokensAndCost(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a"},
+		{ID: "item-2", ScenarioID: "scen-b"},
+	}
+	mustPush(t, q, ctx, items)
+	mustPop(t, q, ctx)
+	mustPop(t, q, ctx)
+
+	// First item uses "totalTokens" and "totalCost" keys
+	result1 := &ItemResult{
+		Status:     "pass",
+		DurationMs: 100,
+		Metrics:    map[string]float64{"totalTokens": 200, "totalCost": 0.10},
+	}
+	if err := q.CompleteItem(ctx, completeTestJobID, "item-1", result1); err != nil {
+		t.Fatalf("CompleteItem() error = %v", err)
+	}
+
+	// Second item uses "tokens" and "cost" keys
+	result2 := &ItemResult{
+		Status:     "pass",
+		DurationMs: 100,
+		Metrics:    map[string]float64{"tokens": 100, "cost": 0.05},
+	}
+	if err := q.CompleteItem(ctx, completeTestJobID, "item-2", result2); err != nil {
+		t.Fatalf("CompleteItem() error = %v", err)
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	// Both token formats should be accumulated
+	assertInt64(t, "TotalTokens", stats.TotalTokens, 300)
+	assertFloat64(t, "TotalCost", stats.TotalCost, 0.15)
+}
+
+func TestFailItemScenarioAndProviderStats(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"},
+	}
+	mustPush(t, q, ctx, items)
+	mustPop(t, q, ctx)
+
+	if err := q.FailItem(ctx, completeTestJobID, "item-1", errors.New("crash")); err != nil {
+		t.Fatalf("FailItem() error = %v", err)
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	scenA := stats.ByScenario["scen-a"]
+	if scenA == nil {
+		t.Fatal("Missing ByScenario[scen-a]")
+	}
+	assertInt64(t, "scen-a.Total", scenA.Total, 1)
+	assertInt64(t, "scen-a.Failed", scenA.Failed, 1)
+
+	provX := stats.ByProvider["prov-x"]
+	if provX == nil {
+		t.Fatal("Missing ByProvider[prov-x]")
+	}
+	assertInt64(t, "prov-x.Total", provX.Total, 1)
+	assertInt64(t, "prov-x.Failed", provX.Failed, 1)
+}
+
+func TestCompleteItemNotFound(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{{ID: "item-1"}}
+	mustPush(t, q, ctx, items)
+
+	// Try to complete without popping first
+	result := &ItemResult{Status: "pass", DurationMs: 100}
+	err := q.CompleteItem(ctx, completeTestJobID, "item-1", result)
+	if err != ErrItemNotFound {
+		t.Fatalf("CompleteItem() error = %v, want ErrItemNotFound", err)
+	}
+}
+
+func TestFailItemNotFound(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{{ID: "item-1"}}
+	mustPush(t, q, ctx, items)
+
+	err := q.FailItem(ctx, completeTestJobID, "item-1", errors.New("crash"))
+	if err != ErrItemNotFound {
+		t.Fatalf("FailItem() error = %v, want ErrItemNotFound", err)
+	}
+}
+
+func TestFailItemJobNotFound(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	err := q.FailItem(ctx, "nonexistent", "item-1", errors.New("crash"))
+	if err != ErrJobNotFound {
+		t.Fatalf("FailItem() error = %v, want ErrJobNotFound", err)
+	}
+}
+
+func TestGetStatsOnClosedQueue(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	_ = q.Close()
+
+	_, err := q.GetStats(context.Background(), completeTestJobID)
+	if err != ErrQueueClosed {
+		t.Fatalf("GetStats() error = %v, want ErrQueueClosed", err)
+	}
+}
+
+func TestCompleteItemMixedPassFail(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a"},
+		{ID: "item-2", ScenarioID: "scen-a"},
+		{ID: "item-3", ScenarioID: "scen-a"},
+	}
+	mustPush(t, q, ctx, items)
+
+	for i := 0; i < 3; i++ {
+		mustPop(t, q, ctx)
+	}
+
+	// Complete item-1 as pass
+	if err := q.CompleteItem(ctx, completeTestJobID, "item-1", &ItemResult{
+		Status: "pass", DurationMs: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fail item-2 via FailItem
+	if err := q.FailItem(ctx, completeTestJobID, "item-2", errors.New("timeout")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Complete item-3 as fail via CompleteItem (worker detected failure)
+	if err := q.CompleteItem(ctx, completeTestJobID, "item-3", &ItemResult{
+		Status: "fail", DurationMs: 300, Error: "assertion failed",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	assertInt64(t, "Total", stats.Total, 3)
+	assertInt64(t, "Passed", stats.Passed, 1)
+	assertInt64(t, "Failed", stats.Failed, 2)
+	assertFloat64(t, "TotalDurationMs", stats.TotalDurationMs, 400) // 100 + 0 + 300
+}
+
+// Test helpers
+
+func mustPush(t *testing.T, q *MemoryQueue, ctx context.Context, items []WorkItem) {
+	t.Helper()
+	if err := q.Push(ctx, completeTestJobID, items); err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+}
+
+func mustPop(t *testing.T, q *MemoryQueue, ctx context.Context) *WorkItem {
+	t.Helper()
+	item, err := q.Pop(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("Pop() error = %v", err)
+	}
+	return item
+}
+
+func assertInt64(t *testing.T, name string, got, want int64) {
+	t.Helper()
+	if got != want {
+		t.Errorf("%s = %d, want %d", name, got, want)
+	}
+}
+
+func assertFloat64(t *testing.T, name string, got, want float64) {
+	t.Helper()
+	if math.Abs(got-want) > 1e-9 {
+		t.Errorf("%s = %f, want %f", name, got, want)
+	}
+}

--- a/ee/pkg/arena/queue/instrumented.go
+++ b/ee/pkg/arena/queue/instrumented.go
@@ -133,5 +133,45 @@ func (q *InstrumentedQueue) GetFailedItems(ctx context.Context, jobID string) ([
 	return q.queue.GetFailedItems(ctx, jobID)
 }
 
+// CompleteItem acknowledges a work item and updates accumulators atomically.
+// Records operation metrics and item completion.
+func (q *InstrumentedQueue) CompleteItem(ctx context.Context, jobID string, itemID string, result *ItemResult) error {
+	start := time.Now()
+
+	err := q.queue.CompleteItem(ctx, jobID, itemID, result)
+
+	duration := time.Since(start).Seconds()
+	q.metrics.RecordOperation(OpCompleteItem, duration, err == nil)
+
+	if err == nil {
+		q.metrics.RecordItemStatusChange(jobID, ItemStatusProcessing, ItemStatusCompleted)
+	}
+
+	return err
+}
+
+// FailItem marks an item as terminally failed and updates failure accumulators.
+// Records operation metrics and item failure.
+func (q *InstrumentedQueue) FailItem(ctx context.Context, jobID string, itemID string, err error) error {
+	start := time.Now()
+
+	failErr := q.queue.FailItem(ctx, jobID, itemID, err)
+
+	duration := time.Since(start).Seconds()
+	q.metrics.RecordOperation(OpFailItem, duration, failErr == nil)
+
+	if failErr == nil {
+		q.metrics.RecordItemStatusChange(jobID, ItemStatusProcessing, ItemStatusFailed)
+	}
+
+	return failErr
+}
+
+// GetStats returns the current accumulator statistics for a job.
+// This is a read-only operation and does not record operation metrics.
+func (q *InstrumentedQueue) GetStats(ctx context.Context, jobID string) (*JobStats, error) {
+	return q.queue.GetStats(ctx, jobID)
+}
+
 // Ensure InstrumentedQueue implements WorkQueue interface.
 var _ WorkQueue = (*InstrumentedQueue)(nil)

--- a/ee/pkg/arena/queue/instrumented_test.go
+++ b/ee/pkg/arena/queue/instrumented_test.go
@@ -590,3 +590,164 @@ func TestInstrumentedQueueGetFailedItems(t *testing.T) {
 		t.Errorf("Expected 0 operations, got %d", len(metrics.operations))
 	}
 }
+
+func TestInstrumentedQueueCompleteItem(t *testing.T) {
+	innerQueue := NewMemoryQueueWithDefaults()
+	metrics := newMockMetrics()
+	q := NewInstrumentedQueue(innerQueue, metrics)
+
+	ctx := context.Background()
+	items := []WorkItem{{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"}}
+	_ = innerQueue.Push(ctx, testJobID, items)
+	_, _ = innerQueue.Pop(ctx, testJobID)
+
+	// Clear metrics from push/pop
+	metrics.operations = nil
+	metrics.statusChanges = nil
+
+	result := &ItemResult{
+		Status:     "pass",
+		DurationMs: 150,
+		Metrics:    map[string]float64{"tokens": 100},
+	}
+	err := q.CompleteItem(ctx, testJobID, "item-1", result)
+	if err != nil {
+		t.Fatalf("CompleteItem() error = %v", err)
+	}
+
+	// Verify operation was recorded
+	if len(metrics.operations) != 1 {
+		t.Fatalf("Expected 1 operation, got %d", len(metrics.operations))
+	}
+	op := metrics.operations[0]
+	if op.operation != OpCompleteItem {
+		t.Errorf("Operation = %s, want %s", op.operation, OpCompleteItem)
+	}
+	if !op.success {
+		t.Error("Success = false, want true")
+	}
+
+	// Verify status change
+	if len(metrics.statusChanges) != 1 {
+		t.Fatalf("Expected 1 status change, got %d", len(metrics.statusChanges))
+	}
+	sc := metrics.statusChanges[0]
+	if sc.oldStatus != ItemStatusProcessing {
+		t.Errorf("OldStatus = %s, want %s", sc.oldStatus, ItemStatusProcessing)
+	}
+	if sc.newStatus != ItemStatusCompleted {
+		t.Errorf("NewStatus = %s, want %s", sc.newStatus, ItemStatusCompleted)
+	}
+}
+
+func TestInstrumentedQueueCompleteItemError(t *testing.T) {
+	innerQueue := NewMemoryQueueWithDefaults()
+	metrics := newMockMetrics()
+	q := NewInstrumentedQueue(innerQueue, metrics)
+
+	ctx := context.Background()
+
+	// CompleteItem on nonexistent item
+	result := &ItemResult{Status: "pass", DurationMs: 100}
+	err := q.CompleteItem(ctx, testJobID, "nonexistent", result)
+	if err != ErrJobNotFound {
+		t.Fatalf("CompleteItem() error = %v, want ErrJobNotFound", err)
+	}
+
+	if len(metrics.operations) != 1 {
+		t.Fatalf("Expected 1 operation, got %d", len(metrics.operations))
+	}
+	if metrics.operations[0].success {
+		t.Error("Success = true, want false")
+	}
+	if len(metrics.statusChanges) != 0 {
+		t.Errorf("Expected 0 status changes, got %d", len(metrics.statusChanges))
+	}
+}
+
+func TestInstrumentedQueueFailItem(t *testing.T) {
+	innerQueue := NewMemoryQueueWithDefaults()
+	metrics := newMockMetrics()
+	q := NewInstrumentedQueue(innerQueue, metrics)
+
+	ctx := context.Background()
+	items := []WorkItem{{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"}}
+	_ = innerQueue.Push(ctx, testJobID, items)
+	_, _ = innerQueue.Pop(ctx, testJobID)
+
+	// Clear metrics
+	metrics.operations = nil
+	metrics.statusChanges = nil
+
+	err := q.FailItem(ctx, testJobID, "item-1", errors.New("crash"))
+	if err != nil {
+		t.Fatalf("FailItem() error = %v", err)
+	}
+
+	if len(metrics.operations) != 1 {
+		t.Fatalf("Expected 1 operation, got %d", len(metrics.operations))
+	}
+	op := metrics.operations[0]
+	if op.operation != OpFailItem {
+		t.Errorf("Operation = %s, want %s", op.operation, OpFailItem)
+	}
+	if !op.success {
+		t.Error("Success = false, want true")
+	}
+
+	// Verify status change
+	if len(metrics.statusChanges) != 1 {
+		t.Fatalf("Expected 1 status change, got %d", len(metrics.statusChanges))
+	}
+	sc := metrics.statusChanges[0]
+	if sc.oldStatus != ItemStatusProcessing {
+		t.Errorf("OldStatus = %s, want %s", sc.oldStatus, ItemStatusProcessing)
+	}
+	if sc.newStatus != ItemStatusFailed {
+		t.Errorf("NewStatus = %s, want %s", sc.newStatus, ItemStatusFailed)
+	}
+}
+
+func TestInstrumentedQueueFailItemError(t *testing.T) {
+	innerQueue := NewMemoryQueueWithDefaults()
+	metrics := newMockMetrics()
+	q := NewInstrumentedQueue(innerQueue, metrics)
+
+	ctx := context.Background()
+
+	err := q.FailItem(ctx, testJobID, "nonexistent", errors.New("crash"))
+	if err != ErrJobNotFound {
+		t.Fatalf("FailItem() error = %v, want ErrJobNotFound", err)
+	}
+
+	if len(metrics.operations) != 1 {
+		t.Fatalf("Expected 1 operation, got %d", len(metrics.operations))
+	}
+	if metrics.operations[0].success {
+		t.Error("Success = true, want false")
+	}
+	if len(metrics.statusChanges) != 0 {
+		t.Errorf("Expected 0 status changes, got %d", len(metrics.statusChanges))
+	}
+}
+
+func TestInstrumentedQueueGetStats(t *testing.T) {
+	innerQueue := NewMemoryQueueWithDefaults()
+	metrics := newMockMetrics()
+	q := NewInstrumentedQueue(innerQueue, metrics)
+
+	ctx := context.Background()
+
+	stats, err := q.GetStats(ctx, "nonexistent-job")
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+	if stats.Total != 0 {
+		t.Errorf("Total = %d, want 0", stats.Total)
+	}
+
+	// Read-only operations should not record metrics
+	if len(metrics.operations) != 0 {
+		t.Errorf("Expected 0 operations, got %d", len(metrics.operations))
+	}
+}

--- a/ee/pkg/arena/queue/memory.go
+++ b/ee/pkg/arena/queue/memory.go
@@ -12,6 +12,7 @@ package queue
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"time"
 )
@@ -36,6 +37,7 @@ type jobState struct {
 	completed  map[string]*WorkItem // Successfully completed items
 	failed     map[string]*WorkItem // Failed items
 	startedAt  *time.Time
+	stats      *JobStats // Accumulated statistics
 }
 
 // NewMemoryQueue creates a new in-memory work queue with the given options.
@@ -287,6 +289,10 @@ func (q *MemoryQueue) getOrCreateJobState(jobID string) *jobState {
 			processing: make(map[string]*WorkItem),
 			completed:  make(map[string]*WorkItem),
 			failed:     make(map[string]*WorkItem),
+			stats: &JobStats{
+				ByScenario: make(map[string]*GroupStats),
+				ByProvider: make(map[string]*GroupStats),
+			},
 		}
 		q.jobs[jobID] = state
 	}
@@ -347,6 +353,194 @@ func (q *MemoryQueue) GetFailedItems(ctx context.Context, jobID string) ([]*Work
 	}
 
 	return items, nil
+}
+
+// CompleteItem acknowledges a work item and updates accumulators atomically.
+func (q *MemoryQueue) CompleteItem(ctx context.Context, jobID string, itemID string, result *ItemResult) error {
+	// Marshal result to JSON for the Ack path
+	resultJSON, err := json.Marshal(result)
+	if err != nil {
+		return err
+	}
+
+	// Do normal Ack bookkeeping
+	if err := q.Ack(ctx, jobID, itemID, resultJSON); err != nil {
+		return err
+	}
+
+	// Update accumulators
+	q.mu.RLock()
+	state := q.jobs[jobID]
+	q.mu.RUnlock()
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	// Get item to extract scenarioID/providerID
+	item := state.completed[itemID]
+	q.updateMemoryStats(state.stats, item, result)
+
+	return nil
+}
+
+// FailItem marks an item as terminally failed and updates failure accumulators.
+func (q *MemoryQueue) FailItem(ctx context.Context, jobID string, itemID string, failErr error) error {
+	q.mu.RLock()
+	if q.closed {
+		q.mu.RUnlock()
+		return ErrQueueClosed
+	}
+
+	state, exists := q.jobs[jobID]
+	q.mu.RUnlock()
+
+	if !exists {
+		return ErrJobNotFound
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	item, exists := state.processing[itemID]
+	if !exists {
+		return ErrItemNotFound
+	}
+
+	// Mark as terminally failed (no retry)
+	now := time.Now()
+	item.Status = ItemStatusFailed
+	item.CompletedAt = &now
+	if failErr != nil {
+		item.Error = failErr.Error()
+	}
+
+	delete(state.processing, itemID)
+	state.failed[itemID] = item
+
+	// Update failure accumulators
+	q.incrementFailureStats(state.stats, item)
+
+	return nil
+}
+
+// GetStats returns the current accumulator statistics for a job.
+func (q *MemoryQueue) GetStats(_ context.Context, jobID string) (*JobStats, error) {
+	q.mu.RLock()
+	if q.closed {
+		q.mu.RUnlock()
+		return nil, ErrQueueClosed
+	}
+
+	state, exists := q.jobs[jobID]
+	q.mu.RUnlock()
+
+	if !exists {
+		// Return zero stats for unknown jobs
+		return &JobStats{
+			ByScenario: make(map[string]*GroupStats),
+			ByProvider: make(map[string]*GroupStats),
+		}, nil
+	}
+
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	// Return a deep copy
+	return q.copyJobStats(state.stats), nil
+}
+
+// updateMemoryStats updates accumulated stats for a completed item.
+func (q *MemoryQueue) updateMemoryStats(stats *JobStats, item *WorkItem, result *ItemResult) {
+	stats.Total++
+	stats.TotalDurationMs += result.DurationMs
+
+	if result.Status == "pass" {
+		stats.Passed++
+	} else {
+		stats.Failed++
+	}
+
+	tokens := extractTokens(result.Metrics)
+	cost := extractCost(result.Metrics)
+	stats.TotalTokens += tokens
+	stats.TotalCost += cost
+
+	// Update scenario stats
+	if item.ScenarioID != "" {
+		gs := q.getOrCreateGroupStats(stats.ByScenario, item.ScenarioID)
+		q.updateGroupStats(gs, result, tokens, cost)
+	}
+
+	// Update provider stats
+	if item.ProviderID != "" {
+		gs := q.getOrCreateGroupStats(stats.ByProvider, item.ProviderID)
+		q.updateGroupStats(gs, result, tokens, cost)
+	}
+}
+
+// incrementFailureStats updates accumulated stats for a failed item.
+func (q *MemoryQueue) incrementFailureStats(stats *JobStats, item *WorkItem) {
+	stats.Total++
+	stats.Failed++
+
+	if item.ScenarioID != "" {
+		gs := q.getOrCreateGroupStats(stats.ByScenario, item.ScenarioID)
+		gs.Total++
+		gs.Failed++
+	}
+
+	if item.ProviderID != "" {
+		gs := q.getOrCreateGroupStats(stats.ByProvider, item.ProviderID)
+		gs.Total++
+		gs.Failed++
+	}
+}
+
+// getOrCreateGroupStats returns or creates a GroupStats entry in the given map.
+func (q *MemoryQueue) getOrCreateGroupStats(m map[string]*GroupStats, key string) *GroupStats {
+	gs, ok := m[key]
+	if !ok {
+		gs = &GroupStats{}
+		m[key] = gs
+	}
+	return gs
+}
+
+// updateGroupStats updates a GroupStats from an ItemResult.
+func (q *MemoryQueue) updateGroupStats(gs *GroupStats, result *ItemResult, tokens int64, cost float64) {
+	gs.Total++
+	gs.TotalDurationMs += result.DurationMs
+	gs.TotalTokens += tokens
+	gs.TotalCost += cost
+
+	if result.Status == "pass" {
+		gs.Passed++
+	} else {
+		gs.Failed++
+	}
+}
+
+// copyJobStats returns a deep copy of JobStats.
+func (q *MemoryQueue) copyJobStats(src *JobStats) *JobStats {
+	dst := &JobStats{
+		Total:           src.Total,
+		Passed:          src.Passed,
+		Failed:          src.Failed,
+		TotalDurationMs: src.TotalDurationMs,
+		TotalTokens:     src.TotalTokens,
+		TotalCost:       src.TotalCost,
+		ByScenario:      make(map[string]*GroupStats, len(src.ByScenario)),
+		ByProvider:      make(map[string]*GroupStats, len(src.ByProvider)),
+	}
+	for k, v := range src.ByScenario {
+		cp := *v
+		dst.ByScenario[k] = &cp
+	}
+	for k, v := range src.ByProvider {
+		cp := *v
+		dst.ByProvider[k] = &cp
+	}
+	return dst
 }
 
 // Ensure MemoryQueue implements WorkQueue interface.

--- a/ee/pkg/arena/queue/metrics.go
+++ b/ee/pkg/arena/queue/metrics.go
@@ -23,10 +23,12 @@ const (
 
 // Operation name constants.
 const (
-	OpPush = "push"
-	OpPop  = "pop"
-	OpAck  = "ack"
-	OpNack = "nack"
+	OpPush         = "push"
+	OpPop          = "pop"
+	OpAck          = "ack"
+	OpNack         = "nack"
+	OpCompleteItem = "complete_item"
+	OpFailItem     = "fail_item"
 )
 
 // QueueMetrics holds Prometheus metrics for arena queue operations.
@@ -117,7 +119,7 @@ func (m *QueueMetrics) Initialize() {
 	m.JobsActive.Set(0)
 
 	// Initialize operation counters for known operations
-	for _, op := range []string{OpPush, OpPop, OpAck, OpNack} {
+	for _, op := range []string{OpPush, OpPop, OpAck, OpNack, OpCompleteItem, OpFailItem} {
 		m.OperationsTotal.WithLabelValues(op, StatusSuccess).Add(0)
 		m.OperationsTotal.WithLabelValues(op, StatusError).Add(0)
 		m.OperationDuration.WithLabelValues(op)

--- a/ee/pkg/arena/queue/queue.go
+++ b/ee/pkg/arena/queue/queue.go
@@ -169,9 +169,102 @@ type WorkQueue interface {
 	// Returns ErrJobNotFound if the job doesn't exist.
 	GetFailedItems(ctx context.Context, jobID string) ([]*WorkItem, error)
 
+	// CompleteItem acknowledges a work item and updates accumulators atomically.
+	// This is the preferred path over Ack for typed result handling.
+	CompleteItem(ctx context.Context, jobID string, itemID string, result *ItemResult) error
+
+	// FailItem marks an item as terminally failed and updates failure accumulators.
+	// Unlike Nack, this does not retry — the item is marked as permanently failed.
+	FailItem(ctx context.Context, jobID string, itemID string, err error) error
+
+	// GetStats returns the current accumulator statistics for a job.
+	// Returns zero-value stats for a new or unknown job.
+	GetStats(ctx context.Context, jobID string) (*JobStats, error)
+
 	// Close releases any resources held by the queue.
 	// After Close is called, all other methods will return ErrQueueClosed.
 	Close() error
+}
+
+// ItemResult is the typed execution result shared between worker and aggregator.
+type ItemResult struct {
+	// Status indicates the execution outcome: "pass" or "fail".
+	Status string `json:"status"`
+
+	// DurationMs is the execution time in milliseconds.
+	DurationMs float64 `json:"durationMs"`
+
+	// Error contains the error message if execution failed.
+	Error string `json:"error,omitempty"`
+
+	// Metrics contains additional numeric metrics like tokens, cost.
+	Metrics map[string]float64 `json:"metrics,omitempty"`
+
+	// Assertions contains individual assertion outcomes.
+	Assertions []AssertionResult `json:"assertions,omitempty"`
+
+	// SessionID is the optional session identifier for this execution.
+	SessionID string `json:"sessionId,omitempty"`
+}
+
+// AssertionResult represents a single assertion outcome.
+type AssertionResult struct {
+	// Name is the assertion identifier or description.
+	Name string `json:"name"`
+
+	// Passed indicates whether the assertion passed.
+	Passed bool `json:"passed"`
+
+	// Message contains additional details about the assertion result.
+	Message string `json:"message,omitempty"`
+}
+
+// JobStats contains accumulated statistics readable at any time during or after execution.
+type JobStats struct {
+	// Total is the total number of completed or failed items.
+	Total int64 `json:"total"`
+
+	// Passed is the number of items that passed.
+	Passed int64 `json:"passed"`
+
+	// Failed is the number of items that failed.
+	Failed int64 `json:"failed"`
+
+	// TotalDurationMs is the sum of all execution durations in milliseconds.
+	TotalDurationMs float64 `json:"totalDurationMs"`
+
+	// TotalTokens is the total token count across all executions.
+	TotalTokens int64 `json:"totalTokens"`
+
+	// TotalCost is the total cost across all executions.
+	TotalCost float64 `json:"totalCost"`
+
+	// ByScenario contains per-scenario statistics.
+	ByScenario map[string]*GroupStats `json:"byScenario,omitempty"`
+
+	// ByProvider contains per-provider statistics.
+	ByProvider map[string]*GroupStats `json:"byProvider,omitempty"`
+}
+
+// GroupStats contains accumulated statistics for a scenario or provider group.
+type GroupStats struct {
+	// Total is the total number of completed or failed items in this group.
+	Total int64 `json:"total"`
+
+	// Passed is the number of items that passed.
+	Passed int64 `json:"passed"`
+
+	// Failed is the number of items that failed.
+	Failed int64 `json:"failed"`
+
+	// TotalDurationMs is the sum of all execution durations in milliseconds.
+	TotalDurationMs float64 `json:"totalDurationMs"`
+
+	// TotalTokens is the total token count.
+	TotalTokens int64 `json:"totalTokens"`
+
+	// TotalCost is the total cost.
+	TotalCost float64 `json:"totalCost"`
 }
 
 // Options contains configuration options for WorkQueue implementations.
@@ -184,6 +277,30 @@ type Options struct {
 	// MaxRetries is the maximum number of times an item can be retried.
 	// Default: 3.
 	MaxRetries int
+}
+
+// extractTokens returns the token count from a metrics map,
+// checking both "totalTokens" and "tokens" keys.
+func extractTokens(metrics map[string]float64) int64 {
+	if v, ok := metrics["totalTokens"]; ok {
+		return int64(v)
+	}
+	if v, ok := metrics["tokens"]; ok {
+		return int64(v)
+	}
+	return 0
+}
+
+// extractCost returns the cost from a metrics map,
+// checking both "totalCost" and "cost" keys.
+func extractCost(metrics map[string]float64) float64 {
+	if v, ok := metrics["totalCost"]; ok {
+		return v
+	}
+	if v, ok := metrics["cost"]; ok {
+		return v
+	}
+	return 0
 }
 
 // DefaultOptions returns the default queue options.

--- a/ee/pkg/arena/queue/queue_test.go
+++ b/ee/pkg/arena/queue/queue_test.go
@@ -260,6 +260,30 @@ func (m *mockQueue) GetFailedItems(_ context.Context, _ string) ([]*WorkItem, er
 	return nil, ErrJobNotFound
 }
 
+func (m *mockQueue) CompleteItem(_ context.Context, _, _ string, _ *ItemResult) error {
+	if m.closed {
+		return ErrQueueClosed
+	}
+	return nil
+}
+
+func (m *mockQueue) FailItem(_ context.Context, _, _ string, _ error) error {
+	if m.closed {
+		return ErrQueueClosed
+	}
+	return nil
+}
+
+func (m *mockQueue) GetStats(_ context.Context, _ string) (*JobStats, error) {
+	if m.closed {
+		return nil, ErrQueueClosed
+	}
+	return &JobStats{
+		ByScenario: make(map[string]*GroupStats),
+		ByProvider: make(map[string]*GroupStats),
+	}, nil
+}
+
 // Compile-time check that mockQueue implements WorkQueue.
 var _ WorkQueue = (*mockQueue)(nil)
 

--- a/ee/pkg/arena/queue/redis.go
+++ b/ee/pkg/arena/queue/redis.go
@@ -721,5 +721,306 @@ func (q *RedisQueue) batchGetItems(ctx context.Context, ids []string) []*WorkIte
 	return allItems
 }
 
+// Redis key constants for accumulator stats.
+const (
+	statsKeySuffix          = ":stats"
+	statsScenarioKeyInfix   = ":stats:scenario:"
+	statsProviderKeyInfix   = ":stats:provider:"
+	statsFieldTotal         = "total"
+	statsFieldPassed        = "passed"
+	statsFieldFailed        = "failed"
+	statsFieldTotalDuration = "totalDurationMs"
+	statsFieldTotalTokens   = "totalTokens"
+	statsFieldTotalCost     = "totalCost"
+)
+
+func (q *RedisQueue) statsKey(jobID string) string {
+	return jobKeyPrefix + jobID + statsKeySuffix
+}
+
+func (q *RedisQueue) statsScenarioKey(jobID, scenarioID string) string {
+	return jobKeyPrefix + jobID + statsScenarioKeyInfix + scenarioID
+}
+
+func (q *RedisQueue) statsProviderKey(jobID, providerID string) string {
+	return jobKeyPrefix + jobID + statsProviderKeyInfix + providerID
+}
+
+// CompleteItem acknowledges a work item and updates accumulators atomically.
+func (q *RedisQueue) CompleteItem(ctx context.Context, jobID string, itemID string, result *ItemResult) error {
+	q.mu.RLock()
+	if q.closed {
+		q.mu.RUnlock()
+		return ErrQueueClosed
+	}
+	q.mu.RUnlock()
+
+	// Remove from processing zset
+	removed, err := q.client.ZRem(ctx, q.processingZSetKey(jobID), itemID).Result()
+	if err != nil {
+		return fmt.Errorf("failed to remove from processing: %w", err)
+	}
+	if removed == 0 {
+		return ErrItemNotFound
+	}
+
+	// Remove from processing list
+	q.client.LRem(ctx, q.processingKey(jobID), 1, itemID)
+
+	// Get the item for scenarioID/providerID
+	item, err := q.getItem(ctx, itemID)
+	if err != nil {
+		return fmt.Errorf("failed to get item: %w", err)
+	}
+
+	// Marshal result JSON and update item
+	resultJSON, marshalErr := json.Marshal(result)
+	if marshalErr != nil {
+		return fmt.Errorf("failed to marshal result: %w", marshalErr)
+	}
+
+	now := time.Now()
+	item.Status = ItemStatusCompleted
+	item.CompletedAt = &now
+	item.Result = resultJSON
+
+	// Build and execute the accumulator pipeline
+	pipe := q.client.Pipeline()
+	q.saveItemPipe(ctx, pipe, item)
+	q.addToCompletedSetPipe(ctx, pipe, jobID, itemID)
+	q.incrementStatsPipe(ctx, pipe, jobID, item, result)
+	_, err = pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to execute complete pipeline: %w", err)
+	}
+
+	return nil
+}
+
+// FailItem marks an item as terminally failed and updates failure accumulators.
+func (q *RedisQueue) FailItem(ctx context.Context, jobID string, itemID string, failErr error) error {
+	q.mu.RLock()
+	if q.closed {
+		q.mu.RUnlock()
+		return ErrQueueClosed
+	}
+	q.mu.RUnlock()
+
+	// Remove from processing zset
+	removed, err := q.client.ZRem(ctx, q.processingZSetKey(jobID), itemID).Result()
+	if err != nil {
+		return fmt.Errorf("failed to remove from processing: %w", err)
+	}
+	if removed == 0 {
+		return ErrItemNotFound
+	}
+
+	// Remove from processing list
+	q.client.LRem(ctx, q.processingKey(jobID), 1, itemID)
+
+	// Get the item for scenarioID/providerID
+	item, err := q.getItem(ctx, itemID)
+	if err != nil {
+		return fmt.Errorf("failed to get item: %w", err)
+	}
+
+	now := time.Now()
+	item.Status = ItemStatusFailed
+	item.CompletedAt = &now
+	if failErr != nil {
+		item.Error = failErr.Error()
+	}
+
+	// Build and execute the failure pipeline
+	pipe := q.client.Pipeline()
+	q.saveItemPipe(ctx, pipe, item)
+	q.addToFailedSetPipe(ctx, pipe, jobID, itemID)
+	q.incrementFailureStatsPipe(ctx, pipe, jobID, item)
+	_, err = pipe.Exec(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to execute fail pipeline: %w", err)
+	}
+
+	return nil
+}
+
+// GetStats returns the current accumulator statistics for a job.
+func (q *RedisQueue) GetStats(ctx context.Context, jobID string) (*JobStats, error) {
+	q.mu.RLock()
+	if q.closed {
+		q.mu.RUnlock()
+		return nil, ErrQueueClosed
+	}
+	q.mu.RUnlock()
+
+	stats := &JobStats{
+		ByScenario: make(map[string]*GroupStats),
+		ByProvider: make(map[string]*GroupStats),
+	}
+
+	// Read main stats hash
+	mainStats, err := q.client.HGetAll(ctx, q.statsKey(jobID)).Result()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stats: %w", err)
+	}
+
+	parseStatsHash(mainStats, stats)
+
+	// Scan for scenario sub-keys
+	q.scanGroupStats(ctx, jobID, statsScenarioKeyInfix, stats.ByScenario)
+
+	// Scan for provider sub-keys
+	q.scanGroupStats(ctx, jobID, statsProviderKeyInfix, stats.ByProvider)
+
+	return stats, nil
+}
+
+// scanGroupStats scans for group stat keys matching the pattern and populates the map.
+func (q *RedisQueue) scanGroupStats(
+	ctx context.Context, jobID string, infix string, target map[string]*GroupStats,
+) {
+	pattern := jobKeyPrefix + jobID + infix + "*"
+	prefixLen := len(jobKeyPrefix + jobID + infix)
+	var cursor uint64
+	for {
+		keys, nextCursor, err := q.client.Scan(ctx, cursor, pattern, sscanCount).Result()
+		if err != nil {
+			return
+		}
+		for _, key := range keys {
+			groupID := key[prefixLen:]
+			data, hErr := q.client.HGetAll(ctx, key).Result()
+			if hErr != nil {
+				continue
+			}
+			gs := &GroupStats{}
+			parseGroupStatsHash(data, gs)
+			target[groupID] = gs
+		}
+		cursor = nextCursor
+		if cursor == 0 {
+			return
+		}
+	}
+}
+
+// incrementStatsPipe adds accumulator increment commands to a pipeline for a completed item.
+func (q *RedisQueue) incrementStatsPipe(
+	ctx context.Context, pipe redis.Pipeliner, jobID string, item *WorkItem, result *ItemResult,
+) {
+	mainKey := q.statsKey(jobID)
+	tokens := extractTokens(result.Metrics)
+	cost := extractCost(result.Metrics)
+
+	q.incrStatsFields(ctx, pipe, mainKey, result.Status, result.DurationMs, tokens, cost)
+
+	if item.ScenarioID != "" {
+		scenKey := q.statsScenarioKey(jobID, item.ScenarioID)
+		q.incrStatsFields(ctx, pipe, scenKey, result.Status, result.DurationMs, tokens, cost)
+	}
+
+	if item.ProviderID != "" {
+		provKey := q.statsProviderKey(jobID, item.ProviderID)
+		q.incrStatsFields(ctx, pipe, provKey, result.Status, result.DurationMs, tokens, cost)
+	}
+}
+
+// incrStatsFields adds HINCRBY/HINCRBYFLOAT commands for a stats hash.
+func (q *RedisQueue) incrStatsFields(
+	ctx context.Context, pipe redis.Pipeliner, key, status string,
+	durationMs float64, tokens int64, cost float64,
+) {
+	pipe.HIncrBy(ctx, key, statsFieldTotal, 1)
+	if status == "pass" {
+		pipe.HIncrBy(ctx, key, statsFieldPassed, 1)
+	} else {
+		pipe.HIncrBy(ctx, key, statsFieldFailed, 1)
+	}
+	pipe.HIncrByFloat(ctx, key, statsFieldTotalDuration, durationMs)
+	pipe.HIncrBy(ctx, key, statsFieldTotalTokens, tokens)
+	pipe.HIncrByFloat(ctx, key, statsFieldTotalCost, cost)
+	pipe.Expire(ctx, key, q.itemTTL)
+}
+
+// incrementFailureStatsPipe adds failure accumulator increment commands to a pipeline.
+func (q *RedisQueue) incrementFailureStatsPipe(
+	ctx context.Context, pipe redis.Pipeliner, jobID string, item *WorkItem,
+) {
+	mainKey := q.statsKey(jobID)
+	q.incrFailureFields(ctx, pipe, mainKey)
+
+	if item.ScenarioID != "" {
+		scenKey := q.statsScenarioKey(jobID, item.ScenarioID)
+		q.incrFailureFields(ctx, pipe, scenKey)
+	}
+
+	if item.ProviderID != "" {
+		provKey := q.statsProviderKey(jobID, item.ProviderID)
+		q.incrFailureFields(ctx, pipe, provKey)
+	}
+}
+
+// incrFailureFields adds HINCRBY commands for failure counters only.
+func (q *RedisQueue) incrFailureFields(
+	ctx context.Context, pipe redis.Pipeliner, key string,
+) {
+	pipe.HIncrBy(ctx, key, statsFieldTotal, 1)
+	pipe.HIncrBy(ctx, key, statsFieldFailed, 1)
+	pipe.Expire(ctx, key, q.itemTTL)
+}
+
+// saveItemPipe adds a SET command to a pipeline for saving a work item.
+func (q *RedisQueue) saveItemPipe(ctx context.Context, pipe redis.Pipeliner, item *WorkItem) {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return
+	}
+	pipe.Set(ctx, q.itemKey(item.ID), data, q.itemTTL)
+}
+
+// addToCompletedSetPipe adds SADD + EXPIRE commands for the completed set.
+func (q *RedisQueue) addToCompletedSetPipe(ctx context.Context, pipe redis.Pipeliner, jobID, itemID string) {
+	completedSetKey := q.completedKey(jobID)
+	pipe.SAdd(ctx, completedSetKey, itemID)
+	pipe.Expire(ctx, completedSetKey, q.itemTTL)
+}
+
+// addToFailedSetPipe adds SADD + EXPIRE commands for the failed set.
+func (q *RedisQueue) addToFailedSetPipe(ctx context.Context, pipe redis.Pipeliner, jobID, itemID string) {
+	failedSetKey := q.failedKey(jobID)
+	pipe.SAdd(ctx, failedSetKey, itemID)
+	pipe.Expire(ctx, failedSetKey, q.itemTTL)
+}
+
+// parseStatsHash parses a Redis hash into a JobStats struct.
+func parseStatsHash(data map[string]string, stats *JobStats) {
+	stats.Total = parseInt64(data[statsFieldTotal])
+	stats.Passed = parseInt64(data[statsFieldPassed])
+	stats.Failed = parseInt64(data[statsFieldFailed])
+	stats.TotalDurationMs = parseFloat64(data[statsFieldTotalDuration])
+	stats.TotalTokens = parseInt64(data[statsFieldTotalTokens])
+	stats.TotalCost = parseFloat64(data[statsFieldTotalCost])
+}
+
+// parseGroupStatsHash parses a Redis hash into a GroupStats struct.
+func parseGroupStatsHash(data map[string]string, gs *GroupStats) {
+	gs.Total = parseInt64(data[statsFieldTotal])
+	gs.Passed = parseInt64(data[statsFieldPassed])
+	gs.Failed = parseInt64(data[statsFieldFailed])
+	gs.TotalDurationMs = parseFloat64(data[statsFieldTotalDuration])
+	gs.TotalTokens = parseInt64(data[statsFieldTotalTokens])
+	gs.TotalCost = parseFloat64(data[statsFieldTotalCost])
+}
+
+func parseInt64(s string) int64 {
+	v, _ := strconv.ParseInt(s, 10, 64)
+	return v
+}
+
+func parseFloat64(s string) float64 {
+	v, _ := strconv.ParseFloat(s, 64)
+	return v
+}
+
 // Ensure RedisQueue implements WorkQueue interface.
 var _ WorkQueue = (*RedisQueue)(nil)


### PR DESCRIPTION
## Summary

Replace raw `Ack([]byte)` with typed `CompleteItem` that atomically updates Redis accumulators on each work item completion. Enables live progress stats and eliminates loading all items at job completion.

Closes #663

## Changes

- **`ItemResult` type**: Shared typed result between worker and aggregator
- **`CompleteItem`/`FailItem`**: New queue methods that update accumulators atomically via Redis pipeline
- **`GetStats`**: Read accumulator state at any time (live progress or final summary)
- **`JobStats`/`GroupStats`**: Accumulated totals with per-scenario and per-provider breakdowns
- Implemented in RedisQueue, MemoryQueue, and InstrumentedQueue
- Existing `Ack`/`Nack` preserved for backward compatibility

## Test plan
- [x] 13 test cases covering accumulators, bookkeeping, concurrent access, edge cases
- [x] 6 InstrumentedQueue tests
- [x] `go build` and `go test` pass