### PR TITLE
feat: load profile executor for Arena ramp-up/down

### DIFF
--- a/ee/cmd/arena-worker/load_profile.go
+++ b/ee/cmd/arena-worker/load_profile.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package main
+
+import (
+	"math"
+	"time"
+)
+
+// LoadProfile controls how allowed concurrency changes over time.
+// During ramp-up, concurrency linearly increases from 0 to targetConcurrency.
+// During steady state, it returns targetConcurrency.
+// During ramp-down (triggered by low pending count), it linearly decreases.
+type LoadProfile struct {
+	targetConcurrency int
+	rampUpDuration    time.Duration
+	rampDownDuration  time.Duration
+	startTime         time.Time
+}
+
+// NewLoadProfile creates a load profile from config.
+func NewLoadProfile(concurrency int, rampUp, rampDown time.Duration) *LoadProfile {
+	return &LoadProfile{
+		targetConcurrency: concurrency,
+		rampUpDuration:    rampUp,
+		rampDownDuration:  rampDown,
+	}
+}
+
+// Start records the start time.
+func (lp *LoadProfile) Start() {
+	lp.startTime = time.Now()
+}
+
+// AllowedConcurrency returns the current allowed concurrency based on elapsed
+// time and remaining work items.
+//
+// Ramp-up: linearly increases from 0 to targetConcurrency over rampUpDuration.
+// Steady state: returns targetConcurrency.
+// Ramp-down: triggered when pending < targetConcurrency * 2, linearly decreases.
+//
+// If no ramp durations are configured, always returns targetConcurrency.
+func (lp *LoadProfile) AllowedConcurrency(elapsed time.Duration, pending int) int {
+	if lp.targetConcurrency <= 0 {
+		return 0
+	}
+
+	// No ramp configured — return static target.
+	if lp.rampUpDuration <= 0 && lp.rampDownDuration <= 0 {
+		return lp.targetConcurrency
+	}
+
+	allowed := lp.targetConcurrency
+
+	// Check ramp-up phase.
+	if lp.rampUpDuration > 0 && elapsed < lp.rampUpDuration {
+		allowed = rampUpAllowed(elapsed, lp.rampUpDuration, lp.targetConcurrency)
+	}
+
+	// Check ramp-down phase (triggered by remaining item count).
+	if lp.rampDownDuration > 0 {
+		rampDownAllowed := rampDownByPending(pending, lp.targetConcurrency)
+		if rampDownAllowed < allowed {
+			allowed = rampDownAllowed
+		}
+	}
+
+	return allowed
+}
+
+// rampUpAllowed calculates allowed concurrency during the ramp-up phase.
+func rampUpAllowed(elapsed, rampUpDuration time.Duration, target int) int {
+	ratio := float64(elapsed) / float64(rampUpDuration)
+	if ratio > 1 {
+		ratio = 1
+	}
+	return int(math.Ceil(ratio * float64(target)))
+}
+
+// rampDownByPending calculates allowed concurrency based on remaining pending items.
+// Ramp-down is triggered when pending < targetConcurrency * 2.
+func rampDownByPending(pending, target int) int {
+	threshold := target * 2
+	if pending >= threshold {
+		return target
+	}
+	ratio := float64(pending) / float64(threshold)
+	allowed := int(math.Ceil(ratio * float64(target)))
+	if allowed < 1 {
+		allowed = 1
+	}
+	return allowed
+}

--- a/ee/cmd/arena-worker/load_profile_test.go
+++ b/ee/cmd/arena-worker/load_profile_test.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadProfile_NoRamp(t *testing.T) {
+	lp := NewLoadProfile(10, 0, 0)
+	lp.Start()
+
+	// Should always return target concurrency regardless of elapsed or pending.
+	assert.Equal(t, 10, lp.AllowedConcurrency(0, 100))
+	assert.Equal(t, 10, lp.AllowedConcurrency(5*time.Minute, 100))
+	assert.Equal(t, 10, lp.AllowedConcurrency(5*time.Minute, 1))
+}
+
+func TestLoadProfile_RampUp(t *testing.T) {
+	lp := NewLoadProfile(10, 2*time.Minute, 0)
+	lp.Start()
+
+	// Large pending so ramp-down doesn't trigger.
+	largePending := 1000
+
+	// At 0% elapsed: ceil(0 * 10) = 0, but rampUpAllowed uses ceil
+	// Actually at 0 elapsed, ratio=0, ceil(0)=0 — but the function should return
+	// at least ceil(0)=0. For 0 elapsed exactly, we get 0.
+	// Let's test a tiny elapsed.
+	assert.Equal(t, 0, lp.AllowedConcurrency(0, largePending))
+
+	// At 25%: 30s of 2m = 0.25 * 10 = 2.5 -> ceil = 3
+	assert.Equal(t, 3, lp.AllowedConcurrency(30*time.Second, largePending))
+
+	// At 50%: 60s of 2m = 0.5 * 10 = 5 -> ceil = 5
+	assert.Equal(t, 5, lp.AllowedConcurrency(60*time.Second, largePending))
+
+	// At 100%: 120s of 2m = 1.0 * 10 = 10 -> ceil = 10
+	// But elapsed >= rampUpDuration, so we skip ramp-up and return target.
+	assert.Equal(t, 10, lp.AllowedConcurrency(2*time.Minute, largePending))
+
+	// At 75%: 90s of 2m = 0.75 * 10 = 7.5 -> ceil = 8
+	assert.Equal(t, 8, lp.AllowedConcurrency(90*time.Second, largePending))
+
+	// Past ramp-up: should return target.
+	assert.Equal(t, 10, lp.AllowedConcurrency(5*time.Minute, largePending))
+}
+
+func TestLoadProfile_RampDown(t *testing.T) {
+	lp := NewLoadProfile(10, 0, 30*time.Second)
+	lp.Start()
+
+	// threshold = 10 * 2 = 20
+	// Above threshold: return target.
+	assert.Equal(t, 10, lp.AllowedConcurrency(5*time.Minute, 20))
+	assert.Equal(t, 10, lp.AllowedConcurrency(5*time.Minute, 100))
+
+	// At pending = 15: ratio = 15/20 = 0.75, ceil(0.75 * 10) = ceil(7.5) = 8
+	assert.Equal(t, 8, lp.AllowedConcurrency(5*time.Minute, 15))
+
+	// At pending = 10: ratio = 10/20 = 0.5, ceil(0.5 * 10) = ceil(5) = 5
+	assert.Equal(t, 5, lp.AllowedConcurrency(5*time.Minute, 10))
+
+	// At pending = 5: ratio = 5/20 = 0.25, ceil(0.25 * 10) = ceil(2.5) = 3
+	assert.Equal(t, 3, lp.AllowedConcurrency(5*time.Minute, 5))
+
+	// At pending = 1: ratio = 1/20 = 0.05, ceil(0.05 * 10) = ceil(0.5) = 1
+	assert.Equal(t, 1, lp.AllowedConcurrency(5*time.Minute, 1))
+
+	// At pending = 0: ratio = 0, ceil(0) = 0 -> max(1, 0) = 1
+	assert.Equal(t, 1, lp.AllowedConcurrency(5*time.Minute, 0))
+}
+
+func TestLoadProfile_RampUpAndDown(t *testing.T) {
+	lp := NewLoadProfile(10, 2*time.Minute, 30*time.Second)
+	lp.Start()
+
+	// During ramp-up with plenty of pending items.
+	assert.Equal(t, 3, lp.AllowedConcurrency(30*time.Second, 100))
+
+	// Steady state: past ramp-up, plenty of pending items.
+	assert.Equal(t, 10, lp.AllowedConcurrency(5*time.Minute, 100))
+
+	// During ramp-up AND low pending: should take the minimum.
+	// Ramp-up at 30s: ceil(0.25 * 10) = 3
+	// Ramp-down at pending=5: ceil(0.25 * 10) = 3
+	assert.Equal(t, 3, lp.AllowedConcurrency(30*time.Second, 5))
+
+	// During ramp-up at 90s: ceil(0.75 * 10) = 8
+	// Ramp-down at pending=10: ceil(0.5 * 10) = 5
+	// min(8, 5) = 5
+	assert.Equal(t, 5, lp.AllowedConcurrency(90*time.Second, 10))
+}
+
+func TestLoadProfile_SteadyState(t *testing.T) {
+	lp := NewLoadProfile(10, 1*time.Minute, 30*time.Second)
+	lp.Start()
+
+	// Between ramp-up end and ramp-down trigger: target concurrency.
+	// elapsed > rampUpDuration, pending >= threshold (20)
+	assert.Equal(t, 10, lp.AllowedConcurrency(2*time.Minute, 50))
+	assert.Equal(t, 10, lp.AllowedConcurrency(10*time.Minute, 20))
+}
+
+func TestLoadProfile_ZeroConcurrency(t *testing.T) {
+	lp := NewLoadProfile(0, 1*time.Minute, 30*time.Second)
+	lp.Start()
+
+	assert.Equal(t, 0, lp.AllowedConcurrency(30*time.Second, 100))
+	assert.Equal(t, 0, lp.AllowedConcurrency(5*time.Minute, 0))
+}
+
+func TestLoadProfile_ZeroRampDurations(t *testing.T) {
+	// Zero ramp durations should behave like no ramp.
+	lp := NewLoadProfile(5, 0, 0)
+	lp.Start()
+
+	assert.Equal(t, 5, lp.AllowedConcurrency(0, 0))
+	assert.Equal(t, 5, lp.AllowedConcurrency(time.Hour, 1000))
+}
+
+func TestLoadProfile_LargeValues(t *testing.T) {
+	lp := NewLoadProfile(1000, 10*time.Minute, 1*time.Minute)
+	lp.Start()
+
+	// 50% ramp-up: ceil(0.5 * 1000) = 500
+	assert.Equal(t, 500, lp.AllowedConcurrency(5*time.Minute, 10000))
+
+	// Steady state.
+	assert.Equal(t, 1000, lp.AllowedConcurrency(15*time.Minute, 10000))
+
+	// Ramp-down at pending = 1000: threshold = 2000, ratio = 0.5, ceil(500) = 500
+	assert.Equal(t, 500, lp.AllowedConcurrency(15*time.Minute, 1000))
+}
+
+func TestLoadProfile_ConcurrencyOfOne(t *testing.T) {
+	lp := NewLoadProfile(1, 1*time.Minute, 30*time.Second)
+	lp.Start()
+
+	// Ramp-up at 50%: ceil(0.5 * 1) = ceil(0.5) = 1
+	assert.Equal(t, 1, lp.AllowedConcurrency(30*time.Second, 100))
+
+	// Ramp-down at pending 1: threshold=2, ratio=0.5, ceil(0.5*1)=1
+	assert.Equal(t, 1, lp.AllowedConcurrency(5*time.Minute, 1))
+
+	// Ramp-down at pending 0: max(1, 0) = 1
+	assert.Equal(t, 1, lp.AllowedConcurrency(5*time.Minute, 0))
+}
+
+func TestLoadProfile_Start(t *testing.T) {
+	lp := NewLoadProfile(10, 1*time.Minute, 0)
+	assert.True(t, lp.startTime.IsZero())
+	lp.Start()
+	assert.False(t, lp.startTime.IsZero())
+}
+
+func TestRampUpAllowed(t *testing.T) {
+	tests := []struct {
+		name     string
+		elapsed  time.Duration
+		rampUp   time.Duration
+		target   int
+		expected int
+	}{
+		{"zero elapsed", 0, 2 * time.Minute, 10, 0},
+		{"quarter", 30 * time.Second, 2 * time.Minute, 10, 3},
+		{"half", 1 * time.Minute, 2 * time.Minute, 10, 5},
+		{"full", 2 * time.Minute, 2 * time.Minute, 10, 10},
+		{"over 100 percent", 5 * time.Minute, 2 * time.Minute, 10, 10},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, rampUpAllowed(tc.elapsed, tc.rampUp, tc.target))
+		})
+	}
+}
+
+func TestRampDownByPending(t *testing.T) {
+	tests := []struct {
+		name     string
+		pending  int
+		target   int
+		expected int
+	}{
+		{"above threshold", 30, 10, 10},
+		{"at threshold", 20, 10, 10},
+		{"three quarters", 15, 10, 8},
+		{"half", 10, 10, 5},
+		{"quarter", 5, 10, 3},
+		{"one item", 1, 10, 1},
+		{"zero pending", 0, 10, 1},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, rampDownByPending(tc.pending, tc.target))
+		})
+	}
+}

--- a/ee/cmd/arena-worker/vu_pool.go
+++ b/ee/cmd/arena-worker/vu_pool.go
@@ -35,6 +35,7 @@ type VUPoolConfig struct {
 	Log          logr.Logger
 	Metrics      *WorkerMetrics
 	PollInterval time.Duration
+	Profile      *LoadProfile // Optional load profile for ramp-up/down
 	Execute      func(ctx context.Context, item *queue.WorkItem) (*ExecutionResult, error)
 }
 
@@ -47,6 +48,7 @@ type VUPool struct {
 	log          logr.Logger
 	metrics      *WorkerMetrics
 	pollInterval time.Duration
+	profile      *LoadProfile
 	execute      func(ctx context.Context, item *queue.WorkItem) (*ExecutionResult, error)
 }
 
@@ -68,6 +70,7 @@ func NewVUPool(cfg VUPoolConfig) *VUPool {
 		log:          cfg.Log,
 		metrics:      cfg.Metrics,
 		pollInterval: pollInterval,
+		profile:      cfg.Profile,
 		execute:      cfg.Execute,
 	}
 }
@@ -76,9 +79,14 @@ func NewVUPool(cfg VUPoolConfig) *VUPool {
 // Each VU independently pops, executes, and reports work items.
 // Returns the first fatal error encountered, or nil on clean shutdown.
 func (p *VUPool) Run(ctx context.Context) error {
+	if p.profile != nil {
+		p.profile.Start()
+	}
+
 	p.log.Info("VU pool starting",
 		"vus", p.size,
 		"concurrency", p.concurrency,
+		"hasProfile", p.profile != nil,
 		"jobID", p.jobID,
 	)
 
@@ -178,7 +186,14 @@ func (p *VUPool) atConcurrencyLimit(ctx context.Context) (bool, error) {
 		}
 		return false, fmt.Errorf("failed to check concurrency: %w", err)
 	}
-	return progress.Processing >= p.concurrency, nil
+
+	limit := p.concurrency
+	if p.profile != nil {
+		elapsed := time.Since(p.profile.startTime)
+		limit = p.profile.AllowedConcurrency(elapsed, progress.Pending)
+	}
+
+	return progress.Processing >= limit, nil
 }
 
 // handleVUPopError handles errors from queue.Pop within a VU loop.

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -112,8 +112,10 @@ type Config struct {
 	Verbose       bool // Enable verbose/debug output from promptarena
 
 	// VU pool configuration
-	VUsPerWorker int // Number of virtual users (goroutines) per worker, default 1
-	Concurrency  int // Global concurrency limit (0 = unlimited)
+	VUsPerWorker int           // Number of virtual users (goroutines) per worker, default 1
+	Concurrency  int           // Global concurrency limit (0 = unlimited)
+	RampUp       time.Duration // Ramp-up duration (0 = no ramp-up)
+	RampDown     time.Duration // Ramp-down duration (0 = no ramp-down)
 
 	// Override configurations (resolved from CRDs)
 	ToolOverrides map[string]ToolOverrideConfig // Tool name -> override config
@@ -171,6 +173,8 @@ func loadConfig() (*Config, error) {
 
 	cfg.VUsPerWorker = getIntEnvOrDefault("ARENA_VUS_PER_WORKER", 1)
 	cfg.Concurrency = getIntEnvOrDefault("ARENA_CONCURRENCY", 0)
+	cfg.RampUp = getDurationEnv("ARENA_RAMP_UP", 0)
+	cfg.RampDown = getDurationEnv("ARENA_RAMP_DOWN", 0)
 
 	if cfg.JobName == "" {
 		return nil, errors.New("ARENA_JOB_NAME is required")
@@ -251,6 +255,10 @@ func processWorkItems(
 
 	// Use VU pool for concurrent processing when configured.
 	if cfg.VUsPerWorker > 1 || cfg.Concurrency > 1 {
+		var profile *LoadProfile
+		if cfg.RampUp > 0 || cfg.RampDown > 0 {
+			profile = NewLoadProfile(cfg.Concurrency, cfg.RampUp, cfg.RampDown)
+		}
 		pool := NewVUPool(VUPoolConfig{
 			Size:         cfg.VUsPerWorker,
 			Concurrency:  cfg.Concurrency,
@@ -259,6 +267,7 @@ func processWorkItems(
 			Log:          log,
 			Metrics:      wm,
 			PollInterval: cfg.PollInterval,
+			Profile:      profile,
 			Execute: func(ctx context.Context, item *queue.WorkItem) (*ExecutionResult, error) {
 				return executeWorkItem(ctx, log, cfg, item, bundlePath)
 			},

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -694,6 +694,20 @@ func (r *ArenaJobReconciler) createWorkerJob(ctx context.Context, arenaJob *omni
 			Name:  "ARENA_CONCURRENCY",
 			Value: fmt.Sprintf("%d", arenaJob.Spec.LoadTest.Concurrency),
 		})
+		if arenaJob.Spec.LoadTest.Ramp != nil {
+			if arenaJob.Spec.LoadTest.Ramp.Up != "" {
+				env = append(env, corev1.EnvVar{
+					Name:  "ARENA_RAMP_UP",
+					Value: arenaJob.Spec.LoadTest.Ramp.Up,
+				})
+			}
+			if arenaJob.Spec.LoadTest.Ramp.Down != "" {
+				env = append(env, corev1.EnvVar{
+					Name:  "ARENA_RAMP_DOWN",
+					Value: arenaJob.Spec.LoadTest.Ramp.Down,
+				})
+			}
+		}
 	}
 
 	// Inject SESSION_API_URL for session recording if configured


### PR DESCRIPTION
## Summary

Implement a load profile executor that controls how concurrency changes over time during Arena load tests. Linear ramp-up from 0 to target, count-based ramp-down when items are draining.

Closes #604

## Changes

- **`LoadProfile`**: New module with `AllowedConcurrency(elapsed, pending)` — linear ramp-up, count-based ramp-down
- **VU pool integration**: `atConcurrencyLimit` uses load profile when present, falls back to static check
- **Config**: `ARENA_RAMP_UP`/`ARENA_RAMP_DOWN` env vars parsed as durations
- **Controller**: Sets ramp env vars from `spec.loadTest.ramp.up`/`down`

## Test plan
- [x] 12 test functions covering ramp-up, ramp-down, steady state, edge cases
- [x] 100% coverage on load_profile.go
- [x] `go build` and `go test` pass