### PR TITLE
feat: TTFT instrumentation + Prometheus metrics for Arena load testing

### DIFF
--- a/ee/cmd/arena-worker/metrics.go
+++ b/ee/cmd/arena-worker/metrics.go
@@ -20,6 +20,16 @@ import (
 
 const defaultMetricsAddr = ":9090"
 
+// Label key constants used across arena worker metrics.
+const (
+	labelJobName   = "job_name"
+	labelStatus    = "status"
+	labelScenario  = "scenario"
+	labelProvider  = "provider"
+	labelErrorType = "error_type"
+	labelDirection = "direction"
+)
+
 // WorkerMetrics holds Prometheus metrics for arena work item execution.
 // These complement the queue-level metrics in ee/pkg/arena/queue/metrics.go
 // by tracking per-item execution outcomes.
@@ -29,6 +39,24 @@ type WorkerMetrics struct {
 
 	// WorkItemDuration tracks work item execution duration.
 	WorkItemDuration *prometheus.HistogramVec
+
+	// TurnLatency tracks end-to-end turn latency per scenario and provider.
+	TurnLatency *prometheus.HistogramVec
+
+	// TTFTDuration tracks time-to-first-token per scenario and provider.
+	TTFTDuration *prometheus.HistogramVec
+
+	// ActiveVUs tracks the current number of active virtual users.
+	ActiveVUs prometheus.Gauge
+
+	// TrialsTotal counts individual trials by status (pass/fail).
+	TrialsTotal *prometheus.CounterVec
+
+	// ErrorsTotal counts errors by type.
+	ErrorsTotal *prometheus.CounterVec
+
+	// TokensTotal counts input and output tokens.
+	TokensTotal *prometheus.CounterVec
 }
 
 // DefaultWorkItemDurationBuckets covers the range from fast rule-based scenarios
@@ -36,6 +64,12 @@ type WorkerMetrics struct {
 var DefaultWorkItemDurationBuckets = []float64{
 	0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600,
 }
+
+// DefaultTurnLatencyBuckets covers the typical range for a single LLM turn.
+var DefaultTurnLatencyBuckets = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60}
+
+// DefaultTTFTBuckets covers the typical range for time-to-first-token.
+var DefaultTTFTBuckets = []float64{0.05, 0.1, 0.25, 0.5, 1, 2.5, 5}
 
 // NewWorkerMetrics creates and registers arena worker metrics
 // using the default Prometheus registry.
@@ -51,13 +85,45 @@ func newWorkerMetricsWithRegisterer(reg prometheus.Registerer) *WorkerMetrics {
 		WorkItemsTotal: factory.NewCounterVec(prometheus.CounterOpts{
 			Name: "omnia_arena_work_items_total",
 			Help: "Total arena work items processed by status (completed/failed)",
-		}, []string{"job_name", "status"}),
+		}, []string{labelJobName, labelStatus}),
 
 		WorkItemDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
 			Name:    "omnia_arena_work_item_duration_seconds",
 			Help:    "Arena work item execution duration in seconds",
 			Buckets: DefaultWorkItemDurationBuckets,
-		}, []string{"job_name"}),
+		}, []string{labelJobName}),
+
+		TurnLatency: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "omnia_arena_turn_latency_seconds",
+			Help:    "Arena LLM turn latency in seconds",
+			Buckets: DefaultTurnLatencyBuckets,
+		}, []string{labelJobName, labelScenario, labelProvider}),
+
+		TTFTDuration: factory.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "omnia_arena_ttft_seconds",
+			Help:    "Arena time-to-first-token in seconds",
+			Buckets: DefaultTTFTBuckets,
+		}, []string{labelJobName, labelScenario, labelProvider}),
+
+		ActiveVUs: factory.NewGauge(prometheus.GaugeOpts{
+			Name: "omnia_arena_active_vus",
+			Help: "Current number of active arena virtual users",
+		}),
+
+		TrialsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "omnia_arena_trials_total",
+			Help: "Total arena trials by status",
+		}, []string{labelJobName, labelScenario, labelProvider, labelStatus}),
+
+		ErrorsTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "omnia_arena_errors_total",
+			Help: "Total arena errors by type",
+		}, []string{labelJobName, labelProvider, labelErrorType}),
+
+		TokensTotal: factory.NewCounterVec(prometheus.CounterOpts{
+			Name: "omnia_arena_tokens_total",
+			Help: "Total arena tokens by direction (input/output)",
+		}, []string{labelJobName, labelProvider, labelDirection}),
 	}
 }
 
@@ -65,6 +131,36 @@ func newWorkerMetricsWithRegisterer(reg prometheus.Registerer) *WorkerMetrics {
 func (m *WorkerMetrics) RecordWorkItem(jobName, status string, durationSec float64) {
 	m.WorkItemsTotal.WithLabelValues(jobName, status).Inc()
 	m.WorkItemDuration.WithLabelValues(jobName).Observe(durationSec)
+}
+
+// RecordTurnLatency records the end-to-end latency for a single LLM turn.
+func (m *WorkerMetrics) RecordTurnLatency(jobName, scenario, provider string, seconds float64) {
+	m.TurnLatency.WithLabelValues(jobName, scenario, provider).Observe(seconds)
+}
+
+// RecordTTFT records time-to-first-token for a single LLM turn.
+func (m *WorkerMetrics) RecordTTFT(jobName, scenario, provider string, seconds float64) {
+	m.TTFTDuration.WithLabelValues(jobName, scenario, provider).Observe(seconds)
+}
+
+// RecordTrial records a trial outcome (pass/fail).
+func (m *WorkerMetrics) RecordTrial(jobName, scenario, provider, status string) {
+	m.TrialsTotal.WithLabelValues(jobName, scenario, provider, status).Inc()
+}
+
+// RecordError records an error by type.
+func (m *WorkerMetrics) RecordError(jobName, provider, errorType string) {
+	m.ErrorsTotal.WithLabelValues(jobName, provider, errorType).Inc()
+}
+
+// RecordTokens records token counts by direction (input/output).
+func (m *WorkerMetrics) RecordTokens(jobName, provider, direction string, count float64) {
+	m.TokensTotal.WithLabelValues(jobName, provider, direction).Add(count)
+}
+
+// SetActiveVUs sets the current number of active virtual users.
+func (m *WorkerMetrics) SetActiveVUs(count float64) {
+	m.ActiveVUs.Set(count)
 }
 
 // newMetricsMux creates the HTTP handler mux with /metrics, /healthz, and /readyz endpoints.

--- a/ee/cmd/arena-worker/metrics_test.go
+++ b/ee/cmd/arena-worker/metrics_test.go
@@ -26,6 +26,12 @@ func TestNewWorkerMetrics(t *testing.T) {
 	m := testWorkerMetrics()
 	require.NotNil(t, m.WorkItemsTotal)
 	require.NotNil(t, m.WorkItemDuration)
+	require.NotNil(t, m.TurnLatency)
+	require.NotNil(t, m.TTFTDuration)
+	require.NotNil(t, m.ActiveVUs)
+	require.NotNil(t, m.TrialsTotal)
+	require.NotNil(t, m.ErrorsTotal)
+	require.NotNil(t, m.TokensTotal)
 }
 
 func TestRecordWorkItem_Pass(t *testing.T) {
@@ -70,6 +76,97 @@ func TestRecordWorkItem_Pass(t *testing.T) {
 	// Should have 1 label combo (job_name=job-1)
 	assert.Len(t, durationFamily.GetMetric(), 1)
 	assert.Equal(t, uint64(3), durationFamily.GetMetric()[0].GetHistogram().GetSampleCount())
+}
+
+func TestRecordTurnLatency(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newWorkerMetricsWithRegisterer(reg)
+
+	m.RecordTurnLatency("job-1", "scenario-a", "provider-x", 1.5)
+	m.RecordTurnLatency("job-1", "scenario-a", "provider-x", 2.5)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	family := findMetricFamily(families, "omnia_arena_turn_latency_seconds")
+	require.NotNil(t, family, "turn_latency metric should exist")
+	require.Len(t, family.GetMetric(), 1)
+	assert.Equal(t, uint64(2), family.GetMetric()[0].GetHistogram().GetSampleCount())
+}
+
+func TestRecordTTFT(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newWorkerMetricsWithRegisterer(reg)
+
+	m.RecordTTFT("job-1", "scenario-a", "provider-x", 0.25)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	family := findMetricFamily(families, "omnia_arena_ttft_seconds")
+	require.NotNil(t, family, "ttft metric should exist")
+	require.Len(t, family.GetMetric(), 1)
+	assert.Equal(t, uint64(1), family.GetMetric()[0].GetHistogram().GetSampleCount())
+}
+
+func TestRecordTrialAndError(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newWorkerMetricsWithRegisterer(reg)
+
+	m.RecordTrial("job-1", "scenario-a", "provider-x", statusPass)
+	m.RecordTrial("job-1", "scenario-a", "provider-x", statusFail)
+	m.RecordError("job-1", "provider-x", "execution")
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	trialsFamily := findMetricFamily(families, "omnia_arena_trials_total")
+	require.NotNil(t, trialsFamily, "trials_total metric should exist")
+	assert.Len(t, trialsFamily.GetMetric(), 2, "should have pass and fail label combos")
+
+	errorsFamily := findMetricFamily(families, "omnia_arena_errors_total")
+	require.NotNil(t, errorsFamily, "errors_total metric should exist")
+	assert.Len(t, errorsFamily.GetMetric(), 1)
+}
+
+func TestRecordTokens(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newWorkerMetricsWithRegisterer(reg)
+
+	m.RecordTokens("job-1", "provider-x", "input", 100)
+	m.RecordTokens("job-1", "provider-x", "output", 50)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	family := findMetricFamily(families, "omnia_arena_tokens_total")
+	require.NotNil(t, family, "tokens_total metric should exist")
+	assert.Len(t, family.GetMetric(), 2, "should have input and output direction")
+}
+
+func TestSetActiveVUs(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := newWorkerMetricsWithRegisterer(reg)
+
+	m.SetActiveVUs(5)
+
+	families, err := reg.Gather()
+	require.NoError(t, err)
+
+	family := findMetricFamily(families, "omnia_arena_active_vus")
+	require.NotNil(t, family, "active_vus metric should exist")
+	require.Len(t, family.GetMetric(), 1)
+	assert.Equal(t, float64(5), family.GetMetric()[0].GetGauge().GetValue())
+}
+
+// findMetricFamily finds a metric family by name in the gathered output.
+func findMetricFamily(families []*dto.MetricFamily, name string) *dto.MetricFamily {
+	for _, f := range families {
+		if f.GetName() == name {
+			return f
+		}
+	}
+	return nil
 }
 
 func TestStartMetricsServer(t *testing.T) {

--- a/ee/cmd/arena-worker/vu_pool.go
+++ b/ee/cmd/arena-worker/vu_pool.go
@@ -230,11 +230,12 @@ func (p *VUPool) executeAndReport(ctx context.Context, log logr.Logger, item *qu
 	span.End()
 
 	itemDuration := time.Since(itemStart).Seconds()
+	status := statusPass
 	if execErr != nil || (result != nil && result.Status == statusFail) {
-		p.metrics.RecordWorkItem(p.jobID, statusFail, itemDuration)
-	} else {
-		p.metrics.RecordWorkItem(p.jobID, statusPass, itemDuration)
+		status = statusFail
 	}
+	p.metrics.RecordWorkItem(p.jobID, status, itemDuration)
+	recordDetailedMetrics(p.metrics, p.jobID, item, result, execErr, itemDuration)
 }
 
 // reportResult reports the work item result via Ack or Nack.

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -337,11 +337,12 @@ func executeAndReport(
 	span.End()
 
 	itemDuration := time.Since(itemStart).Seconds()
+	status := statusPass
 	if execErr != nil || (result != nil && result.Status == statusFail) {
-		wm.RecordWorkItem(jobID, statusFail, itemDuration)
-	} else {
-		wm.RecordWorkItem(jobID, statusPass, itemDuration)
+		status = statusFail
 	}
+	wm.RecordWorkItem(jobID, status, itemDuration)
+	recordDetailedMetrics(wm, jobID, item, result, execErr, itemDuration)
 }
 
 // checkContextDone returns true if the context is cancelled.
@@ -781,6 +782,56 @@ func setResultStatus(result *ExecutionResult, agg *runAggregator) {
 	} else {
 		result.Status = statusFail
 		result.Error = "no runs completed successfully"
+	}
+}
+
+// Token metric keys extracted from ExecutionResult.Metrics.
+const (
+	metricKeyInputTokens  = "totalInputTokens"
+	metricKeyOutputTokens = "totalOutputTokens"
+	metricKeyTTFT         = "ttftSeconds"
+)
+
+// recordDetailedMetrics emits per-trial Prometheus metrics from an execution result.
+func recordDetailedMetrics(
+	wm *WorkerMetrics, jobID string, item *queue.WorkItem,
+	result *ExecutionResult, execErr error, durationSec float64,
+) {
+	scenario := item.ScenarioID
+	provider := item.ProviderID
+
+	// Record turn latency (always available).
+	wm.RecordTurnLatency(jobID, scenario, provider, durationSec)
+
+	// Record trial outcome.
+	status := statusPass
+	if execErr != nil || (result != nil && result.Status == statusFail) {
+		status = statusFail
+	}
+	wm.RecordTrial(jobID, scenario, provider, status)
+
+	// Record error if applicable.
+	if execErr != nil {
+		wm.RecordError(jobID, provider, "execution")
+	} else if result != nil && result.Status == statusFail {
+		wm.RecordError(jobID, provider, "assertion")
+	}
+
+	if result == nil || result.Metrics == nil {
+		return
+	}
+
+	// Record TTFT if present.
+	if ttft, ok := result.Metrics[metricKeyTTFT]; ok && ttft > 0 {
+		wm.RecordTTFT(jobID, scenario, provider, ttft)
+	}
+
+	// Record tokens.
+	if inputTokens, ok := result.Metrics[metricKeyInputTokens]; ok {
+		wm.RecordTokens(jobID, provider, "input", inputTokens)
+	}
+	if outputTokens, ok := result.Metrics[metricKeyOutputTokens]; ok {
+		wm.RecordTokens(jobID, provider, "output", outputTokens)
 	}
 }
 

--- a/ee/pkg/arena/fleet/client.go
+++ b/ee/pkg/arena/fleet/client.go
@@ -121,18 +121,31 @@ func sendMessage(conn Conn, sessionID, content string) error {
 	return conn.WriteMessage(websocket.TextMessage, data)
 }
 
+// TurnResult holds the outcome of a single turn, including TTFT measurement.
+type TurnResult struct {
+	Messages []Message
+	TTFT     time.Duration // Time to first token (zero if no messages received)
+}
+
 // collectTurnResponse reads server messages until a "done" message is received,
 // accumulating assistant text, tool calls, and tool results into the transcript.
 // When a tool_call is received, it immediately sends a rejection since arena fleet
 // clients don't execute client tools.
-func collectTurnResponse(ctx context.Context, conn Conn, sessionID string) ([]Message, error) {
-	var messages []Message
+// It also measures TTFT (time to first token) from the call start to the first message.
+func collectTurnResponse(ctx context.Context, conn Conn, sessionID string, turnStart time.Time) (*TurnResult, error) {
+	result := &TurnResult{}
 	var assistantText string
+	firstMessage := true
 
 	for {
 		msg, err := readServerMessage(ctx, conn)
 		if err != nil {
-			return messages, err
+			return result, err
+		}
+
+		if firstMessage {
+			result.TTFT = time.Since(turnStart)
+			firstMessage = false
 		}
 
 		switch msg.Type {
@@ -140,26 +153,26 @@ func collectTurnResponse(ctx context.Context, conn Conn, sessionID string) ([]Me
 			assistantText += msg.GetTextContent()
 
 		case facade.MessageTypeDone:
-			messages = appendDoneMessage(messages, &assistantText, msg)
-			return messages, nil
+			result.Messages = appendDoneMessage(result.Messages, &assistantText, msg)
+			return result, nil
 
 		case facade.MessageTypeToolCall:
-			messages = appendToolCallMessage(messages, msg)
+			result.Messages = appendToolCallMessage(result.Messages, msg)
 			if msg.ToolCall != nil {
 				if err := rejectToolCall(conn, sessionID, msg.ToolCall.ID); err != nil {
-					return messages, err
+					return result, err
 				}
 			}
 
 		case facade.MessageTypeToolResult:
-			messages = append(messages, Message{
+			result.Messages = append(result.Messages, Message{
 				Role:       "tool_result",
 				ToolResult: msg.ToolResult,
 				Timestamp:  msg.Timestamp,
 			})
 
 		case facade.MessageTypeError:
-			return messages, agentError(msg)
+			return result, agentError(msg)
 		}
 	}
 }

--- a/ee/pkg/arena/fleet/client_test.go
+++ b/ee/pkg/arena/fleet/client_test.go
@@ -193,14 +193,84 @@ func TestCollectTurnResponse_RejectsToolCalls(t *testing.T) {
 	fb := p.fallback
 	require.NoError(t, sendMessage(fb.conn, fb.sessionID, "do something"))
 
-	msgs, err := collectTurnResponse(context.Background(), fb.conn, fb.sessionID)
+	turnResult, err := collectTurnResponse(context.Background(), fb.conn, fb.sessionID, time.Now())
 	require.NoError(t, err)
 
 	// Should have the tool_call in the transcript and the assistant done message
-	require.Len(t, msgs, 2)
-	assert.Equal(t, "tool_call", msgs[0].Role)
-	assert.Equal(t, "assistant", msgs[1].Role)
-	assert.Equal(t, "Tool was rejected", msgs[1].Content)
+	require.Len(t, turnResult.Messages, 2)
+	assert.Equal(t, "tool_call", turnResult.Messages[0].Role)
+	assert.Equal(t, "assistant", turnResult.Messages[1].Role)
+	assert.Equal(t, "Tool was rejected", turnResult.Messages[1].Content)
+}
+
+func TestCollectTurnResponse_MeasuresTTFT(t *testing.T) {
+	wsURL := testServer(t, func(conn *websocket.Conn) {
+		writeServerMsg(t, conn, facade.ServerMessage{
+			Type:      facade.MessageTypeConnected,
+			SessionID: "sess-ttft",
+			Timestamp: time.Now(),
+		})
+
+		// Read user message
+		readClientMsg(t, conn)
+
+		// Add a small delay before sending the first chunk to make TTFT measurable
+		time.Sleep(20 * time.Millisecond)
+
+		writeServerMsg(t, conn, facade.ServerMessage{
+			Type:      facade.MessageTypeChunk,
+			SessionID: "sess-ttft",
+			Content:   "Hello ",
+			Timestamp: time.Now(),
+		})
+		writeServerMsg(t, conn, facade.ServerMessage{
+			Type:      facade.MessageTypeDone,
+			SessionID: "sess-ttft",
+			Content:   "world!",
+			Timestamp: time.Now(),
+		})
+	})
+
+	p := NewProvider("test-fleet", wsURL, nil)
+	require.NoError(t, p.Connect(context.Background()))
+	defer func() { _ = p.Close() }()
+
+	fb := p.fallback
+	require.NoError(t, sendMessage(fb.conn, fb.sessionID, "hi"))
+
+	turnResult, err := collectTurnResponse(context.Background(), fb.conn, fb.sessionID, time.Now())
+	require.NoError(t, err)
+
+	assert.True(t, turnResult.TTFT > 0, "TTFT should be positive")
+	assert.True(t, turnResult.TTFT >= 20*time.Millisecond, "TTFT should be at least 20ms (server delay)")
+	require.Len(t, turnResult.Messages, 1)
+	assert.Equal(t, "assistant", turnResult.Messages[0].Role)
+	assert.Equal(t, "Hello world!", turnResult.Messages[0].Content)
+}
+
+func TestCollectTurnResponse_TTFTZeroOnError(t *testing.T) {
+	wsURL := testServer(t, func(conn *websocket.Conn) {
+		writeServerMsg(t, conn, facade.ServerMessage{
+			Type:      facade.MessageTypeConnected,
+			SessionID: "sess-ttft-err",
+			Timestamp: time.Now(),
+		})
+
+		// Read user message, then close connection to trigger error
+		readClientMsg(t, conn)
+		_ = conn.Close()
+	})
+
+	p := NewProvider("test-fleet", wsURL, nil)
+	require.NoError(t, p.Connect(context.Background()))
+	defer func() { _ = p.Close() }()
+
+	fb := p.fallback
+	require.NoError(t, sendMessage(fb.conn, fb.sessionID, "hi"))
+
+	turnResult, err := collectTurnResponse(context.Background(), fb.conn, fb.sessionID, time.Now())
+	require.Error(t, err)
+	assert.Equal(t, time.Duration(0), turnResult.TTFT, "TTFT should be zero when no messages received")
 }
 
 func TestConnect_WorksWithoutTraceContext(t *testing.T) {

--- a/ee/pkg/arena/fleet/provider.go
+++ b/ee/pkg/arena/fleet/provider.go
@@ -51,6 +51,7 @@ type Provider struct {
 	mu       sync.Mutex
 	conns    map[string]*connEntry // conversation_id → connection
 	fallback *connEntry            // default connection from Connect()
+	lastTTFT time.Duration         // TTFT from the most recent Predict call
 }
 
 // NewProvider creates a new fleet provider targeting the given WebSocket URL.
@@ -178,12 +179,23 @@ func (p *Provider) Predict(ctx context.Context, req providers.PredictionRequest)
 		return providers.PredictionResponse{}, fmt.Errorf("failed to send message: %w", err)
 	}
 
-	turnMsgs, err := collectTurnResponse(ctx, entry.conn, entry.sessionID)
+	turnResult, err := collectTurnResponse(ctx, entry.conn, entry.sessionID, start)
 	if err != nil {
 		return providers.PredictionResponse{}, fmt.Errorf("agent error during turn: %w", err)
 	}
 
-	return buildPredictionResponse(turnMsgs, time.Since(start)), nil
+	p.mu.Lock()
+	p.lastTTFT = turnResult.TTFT
+	p.mu.Unlock()
+
+	return buildPredictionResponse(turnResult.Messages, time.Since(start)), nil
+}
+
+// LastTTFT returns the time-to-first-token duration from the most recent Predict call.
+func (p *Provider) LastTTFT() time.Duration {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastTTFT
 }
 
 // PredictStream sends the latest user message and streams the response as chunks.
@@ -209,17 +221,17 @@ func (p *Provider) PredictStream(
 	}
 
 	ch := make(chan providers.StreamChunk, 16)
-	go streamResponse(ctx, entry, ch)
+	go streamResponse(ctx, entry, ch, time.Now())
 
 	return ch, nil
 }
 
 // streamResponse reads WebSocket messages and sends them as stream chunks.
-func streamResponse(ctx context.Context, entry *connEntry, ch chan<- providers.StreamChunk) {
+func streamResponse(ctx context.Context, entry *connEntry, ch chan<- providers.StreamChunk, turnStart time.Time) {
 	defer entry.mu.Unlock()
 	defer close(ch)
 
-	turnMsgs, err := collectTurnResponse(ctx, entry.conn, entry.sessionID)
+	turnResult, err := collectTurnResponse(ctx, entry.conn, entry.sessionID, turnStart)
 	if err != nil {
 		finishReason := "error"
 		ch <- providers.StreamChunk{
@@ -229,7 +241,7 @@ func streamResponse(ctx context.Context, entry *connEntry, ch chan<- providers.S
 		return
 	}
 
-	resp := buildPredictionResponse(turnMsgs, 0)
+	resp := buildPredictionResponse(turnResult.Messages, 0)
 	finishReason := "stop"
 	ch <- providers.StreamChunk{
 		Content:      resp.Content,

--- a/ee/pkg/arena/fleet/provider_test.go
+++ b/ee/pkg/arena/fleet/provider_test.go
@@ -678,6 +678,35 @@ func testServerRaw(t *testing.T, handler func(*websocket.Conn)) string {
 	return "ws" + strings.TrimPrefix(srv.URL, "http")
 }
 
+func TestProvider_Predict_RecordsTTFT(t *testing.T) {
+	p := providerTestServer(t, func(conn *websocket.Conn) {
+		writeServerMsg(t, conn, facade.ServerMessage{
+			Type:      facade.MessageTypeConnected,
+			SessionID: "sess-ttft",
+			Timestamp: time.Now(),
+		})
+
+		readClientMsg(t, conn)
+
+		// Small delay before first response to make TTFT measurable
+		time.Sleep(10 * time.Millisecond)
+
+		writeServerMsg(t, conn, facade.ServerMessage{
+			Type:      facade.MessageTypeDone,
+			SessionID: "sess-ttft",
+			Content:   "ok",
+			Timestamp: time.Now(),
+		})
+	})
+
+	resp, err := p.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hello"}},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "ok", resp.Content)
+	assert.True(t, p.LastTTFT() > 0, "LastTTFT should be positive after Predict")
+}
+
 func TestProvider_Predict_SendsOnlyLastUserMessage(t *testing.T) {
 	var receivedContent string
 	wsURL := testServerRaw(t, func(conn *websocket.Conn) {


### PR DESCRIPTION
## Summary

Add time-to-first-token measurement to the fleet provider and extend Arena worker Prometheus metrics with TTFT, turn latency, token usage, error counters, and active VU gauge.

Closes #605

## Changes

- **Fleet TTFT**: `collectTurnResponse()` now returns `TurnResult` with TTFT duration. Measured on first WebSocket chunk received.
- **Provider**: `LastTTFT()` method exposes TTFT to the worker after each Predict call.
- **New Prometheus metrics**: `omnia_arena_turn_latency_seconds`, `omnia_arena_ttft_seconds`, `omnia_arena_active_vus`, `omnia_arena_trials_total`, `omnia_arena_errors_total`, `omnia_arena_tokens_total`
- **Worker wiring**: `recordDetailedMetrics()` extracts and records metrics from ExecutionResult

## Test plan
- [x] Fleet TTFT measurement tests (with delay, zero on error)
- [x] Provider TTFT recording test
- [x] All 6 new Prometheus metrics tested
- [x] `go build` and `go test` pass