### PR TITLE
fix: wire up accumulators, TTFT, token metrics, and active VU gauge

### DIFF
--- a/ee/cmd/arena-worker/main_test.go
+++ b/ee/cmd/arena-worker/main_test.go
@@ -25,6 +25,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
+	pkproviders "github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
 	"github.com/prometheus/client_golang/prometheus"
@@ -593,6 +594,142 @@ func TestPopulateMetrics(t *testing.T) {
 		if result.Metrics["runsFailed"] != 2 {
 			t.Errorf("expected runsFailed=2, got %v", result.Metrics["runsFailed"])
 		}
+	})
+}
+
+func TestPopulateMetrics_Tokens(t *testing.T) {
+	t.Run("includes token counts when present", func(t *testing.T) {
+		result := &ExecutionResult{Metrics: make(map[string]float64)}
+		agg := &runAggregator{
+			passCount:    1,
+			inputTokens:  100,
+			outputTokens: 50,
+		}
+
+		populateMetrics(result, agg, 1)
+
+		assert.Equal(t, float64(100), result.Metrics[metricKeyInputTokens])
+		assert.Equal(t, float64(50), result.Metrics[metricKeyOutputTokens])
+	})
+
+	t.Run("omits token counts when zero", func(t *testing.T) {
+		result := &ExecutionResult{Metrics: make(map[string]float64)}
+		agg := &runAggregator{passCount: 1}
+
+		populateMetrics(result, agg, 1)
+
+		_, hasInput := result.Metrics[metricKeyInputTokens]
+		_, hasOutput := result.Metrics[metricKeyOutputTokens]
+		assert.False(t, hasInput, "should not set input tokens when zero")
+		assert.False(t, hasOutput, "should not set output tokens when zero")
+	})
+}
+
+func TestToItemResult(t *testing.T) {
+	t.Run("converts all fields", func(t *testing.T) {
+		exec := &ExecutionResult{
+			Status:     statusPass,
+			DurationMs: 250,
+			Error:      "",
+			Metrics:    map[string]float64{"totalDurationMs": 250},
+			Assertions: []AssertionResult{
+				{Name: "response_valid", Passed: true, Message: "ok"},
+				{Name: "latency_check", Passed: false, Message: "too slow"},
+			},
+		}
+
+		ir := toItemResult(exec)
+
+		assert.Equal(t, statusPass, ir.Status)
+		assert.Equal(t, float64(250), ir.DurationMs)
+		assert.Empty(t, ir.Error)
+		assert.Equal(t, float64(250), ir.Metrics["totalDurationMs"])
+		require.Len(t, ir.Assertions, 2)
+		assert.Equal(t, "response_valid", ir.Assertions[0].Name)
+		assert.True(t, ir.Assertions[0].Passed)
+		assert.Equal(t, "latency_check", ir.Assertions[1].Name)
+		assert.False(t, ir.Assertions[1].Passed)
+	})
+
+	t.Run("handles nil assertions", func(t *testing.T) {
+		exec := &ExecutionResult{
+			Status:     statusFail,
+			DurationMs: 100,
+			Error:      "timeout",
+			Metrics:    map[string]float64{},
+		}
+
+		ir := toItemResult(exec)
+
+		assert.Equal(t, statusFail, ir.Status)
+		assert.Equal(t, "timeout", ir.Error)
+		assert.Empty(t, ir.Assertions)
+	})
+}
+
+func TestReportWorkItemResult_UpdatesAccumulators(t *testing.T) {
+	q := queue.NewMemoryQueueWithDefaults()
+	jobID := "test-accum"
+
+	items := []queue.WorkItem{{ID: "item-1", ScenarioID: "s1", ProviderID: "p1"}}
+	require.NoError(t, q.Push(context.Background(), jobID, items))
+	item, err := q.Pop(context.Background(), jobID)
+	require.NoError(t, err)
+
+	result := &ExecutionResult{
+		Status:     statusPass,
+		DurationMs: 200,
+		Metrics:    map[string]float64{"totalTokens": 500},
+		Assertions: []AssertionResult{{Name: "check", Passed: true}},
+	}
+
+	reportWorkItemResult(context.Background(), testLog(), q, jobID, item, result, nil)
+
+	stats, err := q.GetStats(context.Background(), jobID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Total)
+	assert.Equal(t, int64(1), stats.Passed)
+	assert.Equal(t, float64(200), stats.TotalDurationMs)
+	assert.Equal(t, int64(500), stats.TotalTokens)
+}
+
+func TestExtractFleetTTFT(t *testing.T) {
+	t.Run("no-op when result is nil", func(t *testing.T) {
+		registry := pkproviders.NewRegistry()
+		extractFleetTTFT(registry, nil, nil) // should not panic
+	})
+
+	t.Run("no-op when metrics is nil", func(t *testing.T) {
+		registry := pkproviders.NewRegistry()
+		result := &ExecutionResult{}
+		extractFleetTTFT(registry, nil, result)
+		assert.Nil(t, result.Metrics)
+	})
+
+	t.Run("skips when TTFT already set", func(t *testing.T) {
+		registry := pkproviders.NewRegistry()
+		result := &ExecutionResult{
+			Metrics: map[string]float64{metricKeyTTFT: 1.5},
+		}
+		extractFleetTTFT(registry, []*resolvedFleetProvider{{id: "p1"}}, result)
+		assert.Equal(t, 1.5, result.Metrics[metricKeyTTFT])
+	})
+
+	t.Run("no-op when no fleet providers", func(t *testing.T) {
+		registry := pkproviders.NewRegistry()
+		result := &ExecutionResult{Metrics: make(map[string]float64)}
+		extractFleetTTFT(registry, nil, result)
+		_, hasTTFT := result.Metrics[metricKeyTTFT]
+		assert.False(t, hasTTFT)
+	})
+
+	t.Run("no-op when provider not found in registry", func(t *testing.T) {
+		registry := pkproviders.NewRegistry()
+		result := &ExecutionResult{Metrics: make(map[string]float64)}
+		fps := []*resolvedFleetProvider{{id: "missing"}}
+		extractFleetTTFT(registry, fps, result)
+		_, hasTTFT := result.Metrics[metricKeyTTFT]
+		assert.False(t, hasTTFT)
 	})
 }
 

--- a/ee/cmd/arena-worker/vu_pool.go
+++ b/ee/cmd/arena-worker/vu_pool.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -90,6 +89,10 @@ func (p *VUPool) Run(ctx context.Context) error {
 		"jobID", p.jobID,
 	)
 
+	if p.metrics != nil {
+		p.metrics.SetActiveVUs(float64(p.size))
+	}
+
 	var wg sync.WaitGroup
 	errCh := make(chan error, p.size)
 
@@ -111,6 +114,10 @@ func (p *VUPool) Run(ctx context.Context) error {
 
 	wg.Wait()
 	close(errCh)
+
+	if p.metrics != nil {
+		p.metrics.SetActiveVUs(0)
+	}
 
 	// Return the first error, if any.
 	for err := range errCh {
@@ -253,7 +260,7 @@ func (p *VUPool) executeAndReport(ctx context.Context, log logr.Logger, item *qu
 	recordDetailedMetrics(p.metrics, p.jobID, item, result, execErr, itemDuration)
 }
 
-// reportResult reports the work item result via Ack or Nack.
+// reportResult reports the work item result via CompleteItem or Nack.
 func (p *VUPool) reportResult(
 	ctx context.Context, log logr.Logger, item *queue.WorkItem,
 	result *ExecutionResult, execErr error,
@@ -275,13 +282,12 @@ func (p *VUPool) reportResult(
 		return
 	}
 
-	resultJSON, _ := json.Marshal(result)
 	log.Info("work item completed",
 		"itemID", item.ID,
 		"status", result.Status,
 		"durationMs", result.DurationMs,
 	)
-	if err := p.queue.Ack(reportCtx, p.jobID, item.ID, resultJSON); err != nil {
-		log.Error(err, "failed to ack item", "itemID", item.ID)
+	if err := p.queue.CompleteItem(reportCtx, p.jobID, item.ID, toItemResult(result)); err != nil {
+		log.Error(err, "failed to complete item", "itemID", item.ID)
 	}
 }

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -14,7 +14,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -25,6 +24,7 @@ import (
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	"github.com/AltairaLabs/PromptKit/runtime/events"
+	pkproviders "github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
 	"github.com/AltairaLabs/PromptKit/tools/arena/engine"
 	arenastatestore "github.com/AltairaLabs/PromptKit/tools/arena/statestore"
@@ -36,6 +36,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/altairalabs/omnia/ee/pkg/arena/fleet"
 	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
 	"github.com/altairalabs/omnia/internal/session/httpclient"
 	"github.com/altairalabs/omnia/pkg/k8s"
@@ -433,7 +434,6 @@ func reportWorkItemResult(
 		return
 	}
 
-	resultJSON, _ := json.Marshal(result)
 	log.Info("work item completed",
 		"itemID", item.ID,
 		"status", result.Status,
@@ -445,8 +445,27 @@ func reportWorkItemResult(
 			"error", result.Error,
 		)
 	}
-	if err := q.Ack(ctx, jobID, item.ID, resultJSON); err != nil {
-		log.Error(err, "failed to ack item", "itemID", item.ID)
+	if err := q.CompleteItem(ctx, jobID, item.ID, toItemResult(result)); err != nil {
+		log.Error(err, "failed to complete item", "itemID", item.ID)
+	}
+}
+
+// toItemResult converts an ExecutionResult to a queue.ItemResult for accumulator updates.
+func toItemResult(result *ExecutionResult) *queue.ItemResult {
+	assertions := make([]queue.AssertionResult, len(result.Assertions))
+	for i, a := range result.Assertions {
+		assertions[i] = queue.AssertionResult{
+			Name:    a.Name,
+			Passed:  a.Passed,
+			Message: a.Message,
+		}
+	}
+	return &queue.ItemResult{
+		Status:     result.Status,
+		DurationMs: result.DurationMs,
+		Error:      result.Error,
+		Metrics:    result.Metrics,
+		Assertions: assertions,
 	}
 }
 
@@ -634,7 +653,43 @@ func executeWorkItem(
 
 	// Build result from state store
 	result = buildExecutionResult(log, eng.GetStateStore(), runIDs, start)
+
+	// Extract TTFT from fleet providers — the engine doesn't propagate this,
+	// so we read it directly from the provider after execution completes.
+	extractFleetTTFT(providerRegistry, crdFleetProviders, result)
+
 	return result, nil
+}
+
+// extractFleetTTFT reads LastTTFT from fleet providers and stores the value
+// in result.Metrics so that recordDetailedMetrics can emit the Prometheus histogram.
+func extractFleetTTFT(
+	registry *pkproviders.Registry,
+	fleetProviders []*resolvedFleetProvider,
+	result *ExecutionResult,
+) {
+	if result == nil || result.Metrics == nil {
+		return
+	}
+	// Already set (e.g. by a non-fleet provider that natively reports TTFT).
+	if _, ok := result.Metrics[metricKeyTTFT]; ok {
+		return
+	}
+	for _, fp := range fleetProviders {
+		prov, ok := registry.Get(fp.id)
+		if !ok {
+			continue
+		}
+		fleetProv, ok := prov.(*fleet.Provider)
+		if !ok {
+			continue
+		}
+		ttft := fleetProv.LastTTFT()
+		if ttft > 0 {
+			result.Metrics[metricKeyTTFT] = ttft.Seconds()
+			return // use the first non-zero value
+		}
+	}
 }
 
 // findArenaConfigFile looks for the arena config file in the bundle directory.
@@ -677,6 +732,8 @@ type runAggregator struct {
 	errors        []string
 	totalDuration time.Duration
 	assertions    []AssertionResult
+	inputTokens   int
+	outputTokens  int
 	log           logr.Logger
 }
 
@@ -688,6 +745,14 @@ func (a *runAggregator) processRun(runID string, state *arenastatestore.ArenaCon
 	}
 	meta := state.RunMetadata
 	a.totalDuration += meta.Duration
+
+	// Accumulate token counts from message CostInfo.
+	for _, msg := range state.Messages {
+		if msg.CostInfo != nil {
+			a.inputTokens += msg.CostInfo.InputTokens
+			a.outputTokens += msg.CostInfo.OutputTokens
+		}
+	}
 
 	if meta.Error != "" {
 		a.errors = append(a.errors, fmt.Sprintf("run %s: %s", runID, meta.Error))
@@ -777,6 +842,13 @@ func populateMetrics(result *ExecutionResult, agg *runAggregator, totalRuns int)
 	result.Metrics["runsExecuted"] = float64(totalRuns)
 	result.Metrics["runsPassed"] = float64(agg.passCount)
 	result.Metrics["runsFailed"] = float64(agg.failCount)
+
+	if agg.inputTokens > 0 {
+		result.Metrics[metricKeyInputTokens] = float64(agg.inputTokens)
+	}
+	if agg.outputTokens > 0 {
+		result.Metrics[metricKeyOutputTokens] = float64(agg.outputTokens)
+	}
 }
 
 // setResultStatus determines the overall status based on aggregated counts.

--- a/ee/pkg/arena/fleet/provider.go
+++ b/ee/pkg/arena/fleet/provider.go
@@ -221,13 +221,16 @@ func (p *Provider) PredictStream(
 	}
 
 	ch := make(chan providers.StreamChunk, 16)
-	go streamResponse(ctx, entry, ch, time.Now())
+	go p.streamResponse(ctx, entry, ch, time.Now())
 
 	return ch, nil
 }
 
 // streamResponse reads WebSocket messages and sends them as stream chunks.
-func streamResponse(ctx context.Context, entry *connEntry, ch chan<- providers.StreamChunk, turnStart time.Time) {
+// It is a method on Provider so it can record TTFT like Predict does.
+func (p *Provider) streamResponse(
+	ctx context.Context, entry *connEntry, ch chan<- providers.StreamChunk, turnStart time.Time,
+) {
 	defer entry.mu.Unlock()
 	defer close(ch)
 
@@ -240,6 +243,10 @@ func streamResponse(ctx context.Context, entry *connEntry, ch chan<- providers.S
 		}
 		return
 	}
+
+	p.mu.Lock()
+	p.lastTTFT = turnResult.TTFT
+	p.mu.Unlock()
 
 	resp := buildPredictionResponse(turnResult.Messages, 0)
 	finishReason := "stop"


### PR DESCRIPTION
## Summary

Code review found that several implementations were scaffolded but never hooked up. This PR wires them into the execution pipeline.

## Fixes

1. **Worker uses `CompleteItem` instead of `Ack`** — both single-VU and VU pool paths now call `CompleteItem` on success, which atomically updates Redis accumulators (per-job, per-scenario, per-provider stats). `Nack` retained for failures (handles retry logic).

2. **TTFT extracted from fleet providers** — after `ExecuteRuns()`, the worker reads `LastTTFT()` from fleet providers via the provider registry and stores it in `result.Metrics["ttftSeconds"]`, enabling the `omnia_arena_ttft_seconds` Prometheus histogram.

3. **Token metrics from conversation state** — `buildExecutionResult` now accumulates input/output tokens from `CostInfo` in conversation messages, writing `totalInputTokens`/`totalOutputTokens` to result metrics.

4. **`SetActiveVUs` called from VU pool** — gauge set to pool size on start, zero on shutdown.

5. **`PredictStream` stores TTFT** — `streamResponse` converted from free function to `Provider` method, storing TTFT like `Predict` does.

## Test plan
- [x] `TestReportWorkItemResult_UpdatesAccumulators` — verifies CompleteItem updates JobStats
- [x] `TestExtractFleetTTFT` — verifies nil safety, skip-when-set, not-found paths
- [x] `TestPopulateMetrics_Tokens` — verifies token metric inclusion/omission
- [x] `TestToItemResult` — verifies ExecutionResult→ItemResult conversion
- [x] All existing tests pass