### PR TITLE
feat: SLO threshold evaluator for Arena load test pass/fail

### DIFF
--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -38,6 +38,7 @@ import (
 	"github.com/altairalabs/omnia/ee/pkg/arena/partitioner"
 	"github.com/altairalabs/omnia/ee/pkg/arena/providers"
 	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+	"github.com/altairalabs/omnia/ee/pkg/arena/threshold"
 	"github.com/altairalabs/omnia/ee/pkg/license"
 	"github.com/altairalabs/omnia/ee/pkg/workspace"
 )
@@ -1265,6 +1266,11 @@ func (r *ArenaJobReconciler) updateStatusFromJob(ctx context.Context, arenaJob *
 					log.V(1).Info("aggregator not available, skipping result aggregation")
 				}
 
+				// Evaluate SLO thresholds for load tests
+				if r.evaluateLoadTestThresholds(ctx, arenaJob) {
+					hasTestFailures = true
+				}
+
 				// Set phase based on aggregated test results, not just K8s job completion
 				if hasTestFailures {
 					arenaJob.Status.Phase = omniav1alpha1.ArenaJobPhaseFailed
@@ -1329,6 +1335,60 @@ func (r *ArenaJobReconciler) updateStatusFromJob(ctx context.Context, arenaJob *
 		SetCondition(&arenaJob.Status.Conditions, arenaJob.Generation, ArenaJobConditionTypeProgressing, metav1.ConditionTrue,
 			"JobRunning", fmt.Sprintf("Job running: %d/%d completed", job.Status.Succeeded, completions))
 	}
+}
+
+// evaluateLoadTestThresholds checks SLO thresholds for load test jobs.
+// Returns true if any threshold was violated.
+func (r *ArenaJobReconciler) evaluateLoadTestThresholds(
+	ctx context.Context, arenaJob *omniav1alpha1.ArenaJob,
+) bool {
+	log := logf.FromContext(ctx)
+
+	if arenaJob.Spec.LoadTest == nil || len(arenaJob.Spec.LoadTest.Thresholds) == 0 {
+		return false
+	}
+	if r.Queue == nil {
+		log.V(1).Info("queue not available, skipping threshold evaluation")
+		return false
+	}
+
+	stats, err := r.Queue.GetStats(ctx, arenaJob.Name)
+	if err != nil {
+		log.Error(err, "threshold evaluation failed to get stats")
+		return false
+	}
+
+	results, allPassed := threshold.Evaluate(arenaJob.Spec.LoadTest.Thresholds, stats)
+	r.writeThresholdResults(arenaJob, results)
+
+	if !allPassed {
+		log.Info("SLO thresholds violated",
+			"summary", threshold.SummaryLine(results))
+	} else {
+		log.V(1).Info("SLO thresholds passed",
+			"summary", threshold.SummaryLine(results))
+	}
+
+	return !allPassed
+}
+
+// writeThresholdResults adds threshold evaluation results to the job status summary.
+func (r *ArenaJobReconciler) writeThresholdResults(
+	arenaJob *omniav1alpha1.ArenaJob, results []threshold.Result,
+) {
+	if arenaJob.Status.Result == nil {
+		arenaJob.Status.Result = &omniav1alpha1.JobResult{}
+	}
+	if arenaJob.Status.Result.Summary == nil {
+		arenaJob.Status.Result.Summary = make(map[string]string)
+	}
+	summary := arenaJob.Status.Result.Summary
+
+	for _, r := range results {
+		key := "threshold:" + r.Metric
+		summary[key] = r.String()
+	}
+	summary["thresholds_passed"] = threshold.SummaryLine(results)
 }
 
 // handleValidationError handles errors during validation.

--- a/ee/pkg/arena/threshold/evaluator.go
+++ b/ee/pkg/arena/threshold/evaluator.go
@@ -1,0 +1,235 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+// Package threshold evaluates SLO thresholds against accumulated Arena load test statistics.
+package threshold
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"time"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+)
+
+// Result contains the evaluation outcome for a single threshold.
+type Result struct {
+	// Metric is the threshold metric name (e.g., "latency_avg").
+	Metric string
+	// Operator is the comparison operator (e.g., "<").
+	Operator string
+	// Target is the original target value string (e.g., "3s").
+	Target string
+	// Actual is the computed metric value.
+	Actual float64
+	// ActualStr is the human-readable actual value (e.g., "4.2s").
+	ActualStr string
+	// Passed indicates whether the threshold was met.
+	Passed bool
+}
+
+// String returns a human-readable summary like "4.2s < 3s PASS".
+func (r Result) String() string {
+	verdict := "PASS"
+	if !r.Passed {
+		verdict = "FAIL"
+	}
+	return fmt.Sprintf("%s %s %s %s", r.ActualStr, r.Operator, r.Target, verdict)
+}
+
+// Evaluate checks all thresholds against the accumulated job stats.
+// Returns per-threshold results and whether all thresholds passed.
+func Evaluate(thresholds []omniav1alpha1.LoadThreshold, stats *queue.JobStats) ([]Result, bool) {
+	if len(thresholds) == 0 {
+		return nil, true
+	}
+
+	results := make([]Result, 0, len(thresholds))
+	allPassed := true
+
+	for _, t := range thresholds {
+		r := evaluateOne(t, stats)
+		results = append(results, r)
+		if !r.Passed {
+			allPassed = false
+		}
+	}
+
+	return results, allPassed
+}
+
+// evaluateOne evaluates a single threshold against the stats.
+func evaluateOne(t omniav1alpha1.LoadThreshold, stats *queue.JobStats) Result {
+	r := Result{
+		Metric:   string(t.Metric),
+		Operator: string(t.Operator),
+		Target:   t.Value,
+	}
+
+	actual, available := extractMetric(t.Metric, stats)
+	if !available {
+		r.Actual = math.NaN()
+		r.ActualStr = "unavailable"
+		r.Passed = true // don't fail on metrics we can't compute
+		return r
+	}
+
+	r.Actual = actual
+	r.ActualStr = formatMetricValue(t.Metric, actual)
+
+	target, err := parseTargetValue(t.Metric, t.Value)
+	if err != nil {
+		r.ActualStr = "parse error"
+		r.Passed = true // don't fail on unparseable targets
+		return r
+	}
+
+	r.Passed = compare(actual, string(t.Operator), target)
+	return r
+}
+
+// extractMetric returns the metric value from stats and whether it is available.
+func extractMetric(metric omniav1alpha1.LoadThresholdMetric, stats *queue.JobStats) (float64, bool) {
+	switch metric {
+	case omniav1alpha1.LoadThresholdMetricLatencyAvg:
+		return computeAvgLatencySeconds(stats)
+	case omniav1alpha1.LoadThresholdMetricErrorRate:
+		return computeRate(stats.Failed, stats.Total)
+	case omniav1alpha1.LoadThresholdMetricPassRate:
+		return computeRate(stats.Passed, stats.Total)
+	case omniav1alpha1.LoadThresholdMetricTotalCost:
+		return stats.TotalCost, true
+	default:
+		// Percentile and TTFT metrics are not computable from counters alone.
+		return 0, false
+	}
+}
+
+// computeAvgLatencySeconds returns the average latency in seconds.
+func computeAvgLatencySeconds(stats *queue.JobStats) (float64, bool) {
+	if stats.Total == 0 {
+		return 0, false
+	}
+	avgMs := stats.TotalDurationMs / float64(stats.Total)
+	return avgMs / 1000.0, true
+}
+
+// computeRate returns numerator/denominator as a ratio (0..1).
+func computeRate(numerator, denominator int64) (float64, bool) {
+	if denominator == 0 {
+		return 0, false
+	}
+	return float64(numerator) / float64(denominator), true
+}
+
+// parseTargetValue parses the target string into a float64 appropriate for the metric.
+// For latency metrics, duration strings are parsed and converted to seconds.
+// For all other metrics, the string is parsed as a float.
+func parseTargetValue(metric omniav1alpha1.LoadThresholdMetric, value string) (float64, error) {
+	if isLatencyMetric(metric) || isTTFTMetric(metric) {
+		return parseDurationOrFloat(value)
+	}
+	return strconv.ParseFloat(value, 64)
+}
+
+// parseDurationOrFloat tries time.ParseDuration first, then falls back to float parsing.
+// Duration values are returned in seconds.
+func parseDurationOrFloat(value string) (float64, error) {
+	d, err := time.ParseDuration(value)
+	if err == nil {
+		return d.Seconds(), nil
+	}
+	// Fall back to plain float (assumed seconds)
+	return strconv.ParseFloat(value, 64)
+}
+
+// compare applies the operator to actual and target.
+func compare(actual float64, op string, target float64) bool {
+	switch op {
+	case "<":
+		return actual < target
+	case ">":
+		return actual > target
+	case "<=":
+		return actual <= target
+	case ">=":
+		return actual >= target
+	default:
+		return false
+	}
+}
+
+// formatMetricValue returns a human-readable string for the metric value.
+func formatMetricValue(metric omniav1alpha1.LoadThresholdMetric, value float64) string {
+	if isLatencyMetric(metric) || isTTFTMetric(metric) {
+		return formatDuration(value)
+	}
+	if isRateMetric(metric) {
+		return fmt.Sprintf("%.4f", value)
+	}
+	// cost
+	return fmt.Sprintf("%.2f", value)
+}
+
+// formatDuration formats seconds into a human-readable duration string.
+func formatDuration(seconds float64) string {
+	if seconds < 1.0 {
+		return fmt.Sprintf("%.0fms", seconds*1000)
+	}
+	return fmt.Sprintf("%.2fs", seconds)
+}
+
+func isLatencyMetric(m omniav1alpha1.LoadThresholdMetric) bool {
+	switch m {
+	case omniav1alpha1.LoadThresholdMetricLatencyAvg,
+		omniav1alpha1.LoadThresholdMetricLatencyP50,
+		omniav1alpha1.LoadThresholdMetricLatencyP90,
+		omniav1alpha1.LoadThresholdMetricLatencyP95,
+		omniav1alpha1.LoadThresholdMetricLatencyP99:
+		return true
+	}
+	return false
+}
+
+func isTTFTMetric(m omniav1alpha1.LoadThresholdMetric) bool {
+	switch m {
+	case omniav1alpha1.LoadThresholdMetricTTFTAvg,
+		omniav1alpha1.LoadThresholdMetricTTFTP50,
+		omniav1alpha1.LoadThresholdMetricTTFTP90,
+		omniav1alpha1.LoadThresholdMetricTTFTP95,
+		omniav1alpha1.LoadThresholdMetricTTFTP99:
+		return true
+	}
+	return false
+}
+
+func isRateMetric(m omniav1alpha1.LoadThresholdMetric) bool {
+	switch m {
+	case omniav1alpha1.LoadThresholdMetricErrorRate,
+		omniav1alpha1.LoadThresholdMetricPassRate,
+		omniav1alpha1.LoadThresholdMetricRateLimit:
+		return true
+	}
+	return false
+}
+
+// SummaryLine returns a one-line summary of threshold evaluation results,
+// e.g., "3/4 passed".
+func SummaryLine(results []Result) string {
+	passed := 0
+	for _, r := range results {
+		if r.Passed {
+			passed++
+		}
+	}
+	return fmt.Sprintf("%d/%d passed", passed, len(results))
+}

--- a/ee/pkg/arena/threshold/evaluator_test.go
+++ b/ee/pkg/arena/threshold/evaluator_test.go
@@ -1,0 +1,516 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package threshold
+
+import (
+	"math"
+	"testing"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+)
+
+func TestEvaluate_EmptyThresholds(t *testing.T) {
+	results, allPassed := Evaluate(nil, &queue.JobStats{})
+	if !allPassed {
+		t.Error("expected allPassed=true for empty thresholds")
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestEvaluate_LatencyAvg_Pass(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:           10,
+		TotalDurationMs: 20000, // 20s total → 2s avg
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricLatencyAvg,
+			Operator: omniav1alpha1.LoadThresholdOperatorLT,
+			Value:    "3s",
+		},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if !allPassed {
+		t.Error("expected allPassed=true")
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if !r.Passed {
+		t.Error("expected threshold to pass")
+	}
+	if r.ActualStr != "2.00s" {
+		t.Errorf("expected ActualStr=2.00s, got %s", r.ActualStr)
+	}
+}
+
+func TestEvaluate_LatencyAvg_Fail(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:           10,
+		TotalDurationMs: 50000, // 50s total → 5s avg
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricLatencyAvg,
+			Operator: omniav1alpha1.LoadThresholdOperatorLT,
+			Value:    "3s",
+		},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if allPassed {
+		t.Error("expected allPassed=false")
+	}
+	if results[0].Passed {
+		t.Error("expected threshold to fail")
+	}
+}
+
+func TestEvaluate_LatencyAvg_MillisecondTarget(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:           10,
+		TotalDurationMs: 3000, // 3s total → 300ms avg
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricLatencyAvg,
+			Operator: omniav1alpha1.LoadThresholdOperatorLT,
+			Value:    "500ms",
+		},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if !allPassed {
+		t.Error("expected allPassed=true")
+	}
+	r := results[0]
+	if r.ActualStr != "300ms" {
+		t.Errorf("expected ActualStr=300ms, got %s", r.ActualStr)
+	}
+}
+
+func TestEvaluate_ErrorRate_Pass(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:  100,
+		Passed: 99,
+		Failed: 1,
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricErrorRate,
+			Operator: omniav1alpha1.LoadThresholdOperatorLT,
+			Value:    "0.05",
+		},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if !allPassed {
+		t.Error("expected allPassed=true")
+	}
+	if results[0].Actual != 0.01 {
+		t.Errorf("expected actual=0.01, got %f", results[0].Actual)
+	}
+}
+
+func TestEvaluate_ErrorRate_Fail(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:  100,
+		Passed: 80,
+		Failed: 20,
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricErrorRate,
+			Operator: omniav1alpha1.LoadThresholdOperatorLT,
+			Value:    "0.05",
+		},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if allPassed {
+		t.Error("expected allPassed=false")
+	}
+	if results[0].Actual != 0.2 {
+		t.Errorf("expected actual=0.2, got %f", results[0].Actual)
+	}
+}
+
+func TestEvaluate_PassRate_Pass(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:  100,
+		Passed: 96,
+		Failed: 4,
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricPassRate,
+			Operator: omniav1alpha1.LoadThresholdOperatorGTE,
+			Value:    "0.95",
+		},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if !allPassed {
+		t.Error("expected allPassed=true")
+	}
+	if results[0].Actual != 0.96 {
+		t.Errorf("expected actual=0.96, got %f", results[0].Actual)
+	}
+}
+
+func TestEvaluate_TotalCost_Pass(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:     50,
+		TotalCost: 42.50,
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricTotalCost,
+			Operator: omniav1alpha1.LoadThresholdOperatorLTE,
+			Value:    "50.00",
+		},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if !allPassed {
+		t.Error("expected allPassed=true")
+	}
+	if results[0].Actual != 42.50 {
+		t.Errorf("expected actual=42.50, got %f", results[0].Actual)
+	}
+}
+
+func TestEvaluate_TotalCost_Fail(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:     50,
+		TotalCost: 75.00,
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{
+			Metric:   omniav1alpha1.LoadThresholdMetricTotalCost,
+			Operator: omniav1alpha1.LoadThresholdOperatorLTE,
+			Value:    "50.00",
+		},
+	}
+
+	_, allPassed := Evaluate(thresholds, stats)
+	if allPassed {
+		t.Error("expected allPassed=false")
+	}
+}
+
+func TestEvaluate_UnavailableMetrics(t *testing.T) {
+	stats := &queue.JobStats{Total: 10}
+	unavailableMetrics := []omniav1alpha1.LoadThresholdMetric{
+		omniav1alpha1.LoadThresholdMetricLatencyP50,
+		omniav1alpha1.LoadThresholdMetricLatencyP90,
+		omniav1alpha1.LoadThresholdMetricLatencyP95,
+		omniav1alpha1.LoadThresholdMetricLatencyP99,
+		omniav1alpha1.LoadThresholdMetricTTFTAvg,
+		omniav1alpha1.LoadThresholdMetricTTFTP50,
+		omniav1alpha1.LoadThresholdMetricTTFTP90,
+		omniav1alpha1.LoadThresholdMetricTTFTP95,
+		omniav1alpha1.LoadThresholdMetricTTFTP99,
+		omniav1alpha1.LoadThresholdMetricRateLimit,
+	}
+
+	for _, metric := range unavailableMetrics {
+		thresholds := []omniav1alpha1.LoadThreshold{
+			{Metric: metric, Operator: omniav1alpha1.LoadThresholdOperatorLT, Value: "1.0"},
+		}
+		results, allPassed := Evaluate(thresholds, stats)
+		if !allPassed {
+			t.Errorf("metric %s: expected allPassed=true for unavailable metric", metric)
+		}
+		if results[0].ActualStr != "unavailable" {
+			t.Errorf("metric %s: expected ActualStr=unavailable, got %s", metric, results[0].ActualStr)
+		}
+		if !math.IsNaN(results[0].Actual) {
+			t.Errorf("metric %s: expected NaN actual, got %f", metric, results[0].Actual)
+		}
+	}
+}
+
+func TestEvaluate_ZeroStats(t *testing.T) {
+	stats := &queue.JobStats{}
+
+	// latency_avg with zero total → unavailable
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{Metric: omniav1alpha1.LoadThresholdMetricLatencyAvg, Operator: omniav1alpha1.LoadThresholdOperatorLT, Value: "3s"},
+		{Metric: omniav1alpha1.LoadThresholdMetricErrorRate, Operator: omniav1alpha1.LoadThresholdOperatorLT, Value: "0.05"},
+		{Metric: omniav1alpha1.LoadThresholdMetricPassRate, Operator: omniav1alpha1.LoadThresholdOperatorGTE, Value: "0.95"},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if !allPassed {
+		t.Error("expected allPassed=true for zero stats (all unavailable)")
+	}
+	for _, r := range results {
+		if !r.Passed {
+			t.Errorf("metric %s: expected passed for zero stats", r.Metric)
+		}
+	}
+}
+
+func TestEvaluate_MixedPassFail(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:           100,
+		Passed:          90,
+		Failed:          10,
+		TotalDurationMs: 500000, // 5s avg
+		TotalCost:       30.00,
+	}
+
+	lt := omniav1alpha1.LoadThresholdOperatorLT
+	gte := omniav1alpha1.LoadThresholdOperatorGTE
+	lte := omniav1alpha1.LoadThresholdOperatorLTE
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{Metric: omniav1alpha1.LoadThresholdMetricLatencyAvg, Operator: lt, Value: "3s"},
+		{Metric: omniav1alpha1.LoadThresholdMetricErrorRate, Operator: lt, Value: "0.15"},
+		{Metric: omniav1alpha1.LoadThresholdMetricPassRate, Operator: gte, Value: "0.95"},
+		{Metric: omniav1alpha1.LoadThresholdMetricTotalCost, Operator: lte, Value: "50.00"},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if allPassed {
+		t.Error("expected allPassed=false")
+	}
+	if len(results) != 4 {
+		t.Fatalf("expected 4 results, got %d", len(results))
+	}
+
+	expected := []bool{false, true, false, true}
+	for i, r := range results {
+		if r.Passed != expected[i] {
+			t.Errorf("result[%d] (%s): expected passed=%v, got %v", i, r.Metric, expected[i], r.Passed)
+		}
+	}
+}
+
+func TestEvaluate_AllOperators(t *testing.T) {
+	stats := &queue.JobStats{
+		Total:     100,
+		Passed:    50,
+		Failed:    50,
+		TotalCost: 10.0,
+	}
+
+	tests := []struct {
+		op     omniav1alpha1.LoadThresholdOperator
+		value  string
+		passed bool
+	}{
+		{omniav1alpha1.LoadThresholdOperatorLT, "20.00", true},   // 10 < 20
+		{omniav1alpha1.LoadThresholdOperatorLT, "5.00", false},   // 10 < 5
+		{omniav1alpha1.LoadThresholdOperatorGT, "5.00", true},    // 10 > 5
+		{omniav1alpha1.LoadThresholdOperatorGT, "20.00", false},  // 10 > 20
+		{omniav1alpha1.LoadThresholdOperatorLTE, "10.00", true},  // 10 <= 10
+		{omniav1alpha1.LoadThresholdOperatorLTE, "5.00", false},  // 10 <= 5
+		{omniav1alpha1.LoadThresholdOperatorGTE, "10.00", true},  // 10 >= 10
+		{omniav1alpha1.LoadThresholdOperatorGTE, "20.00", false}, // 10 >= 20
+	}
+
+	for _, tt := range tests {
+		thresholds := []omniav1alpha1.LoadThreshold{
+			{Metric: omniav1alpha1.LoadThresholdMetricTotalCost, Operator: tt.op, Value: tt.value},
+		}
+		results, _ := Evaluate(thresholds, stats)
+		if results[0].Passed != tt.passed {
+			t.Errorf("op=%s value=%s: expected passed=%v, got %v", tt.op, tt.value, tt.passed, results[0].Passed)
+		}
+	}
+}
+
+func TestEvaluate_FloatTargetForLatency(t *testing.T) {
+	// Plain float target (assumed seconds) for latency metric
+	stats := &queue.JobStats{
+		Total:           10,
+		TotalDurationMs: 20000, // 2s avg
+	}
+	thresholds := []omniav1alpha1.LoadThreshold{
+		{Metric: omniav1alpha1.LoadThresholdMetricLatencyAvg, Operator: omniav1alpha1.LoadThresholdOperatorLT, Value: "3.0"},
+	}
+
+	results, allPassed := Evaluate(thresholds, stats)
+	if !allPassed {
+		t.Error("expected allPassed=true")
+	}
+	if !results[0].Passed {
+		t.Error("expected threshold to pass")
+	}
+}
+
+func TestResult_String(t *testing.T) {
+	r := Result{
+		Metric:    "latency_avg",
+		Operator:  "<",
+		Target:    "3s",
+		Actual:    4.2,
+		ActualStr: "4.20s",
+		Passed:    false,
+	}
+	got := r.String()
+	expected := "4.20s < 3s FAIL"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+
+	r.Passed = true
+	got = r.String()
+	expected = "4.20s < 3s PASS"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestSummaryLine(t *testing.T) {
+	results := []Result{
+		{Passed: true},
+		{Passed: false},
+		{Passed: true},
+		{Passed: true},
+	}
+	got := SummaryLine(results)
+	expected := "3/4 passed"
+	if got != expected {
+		t.Errorf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestCompare_UnknownOperator(t *testing.T) {
+	if compare(1.0, "==", 1.0) {
+		t.Error("expected false for unknown operator")
+	}
+}
+
+func TestFormatDuration_SubSecond(t *testing.T) {
+	got := formatDuration(0.250)
+	if got != "250ms" {
+		t.Errorf("expected 250ms, got %s", got)
+	}
+}
+
+func TestFormatDuration_Seconds(t *testing.T) {
+	got := formatDuration(2.5)
+	if got != "2.50s" {
+		t.Errorf("expected 2.50s, got %s", got)
+	}
+}
+
+func TestParseDurationOrFloat_Duration(t *testing.T) {
+	v, err := parseDurationOrFloat("500ms")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 0.5 {
+		t.Errorf("expected 0.5, got %f", v)
+	}
+}
+
+func TestParseDurationOrFloat_Float(t *testing.T) {
+	v, err := parseDurationOrFloat("2.5")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 2.5 {
+		t.Errorf("expected 2.5, got %f", v)
+	}
+}
+
+func TestParseDurationOrFloat_Invalid(t *testing.T) {
+	_, err := parseDurationOrFloat("not-a-number")
+	if err == nil {
+		t.Error("expected error for invalid input")
+	}
+}
+
+func TestParseTargetValue_RateMetric(t *testing.T) {
+	v, err := parseTargetValue(omniav1alpha1.LoadThresholdMetricErrorRate, "0.05")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v != 0.05 {
+		t.Errorf("expected 0.05, got %f", v)
+	}
+}
+
+func TestParseTargetValue_InvalidRate(t *testing.T) {
+	_, err := parseTargetValue(omniav1alpha1.LoadThresholdMetricErrorRate, "not-a-number")
+	if err == nil {
+		t.Error("expected error for invalid rate")
+	}
+}
+
+func TestEvaluateOne_ParseError(t *testing.T) {
+	stats := &queue.JobStats{Total: 10, TotalCost: 5.0}
+	threshold := omniav1alpha1.LoadThreshold{
+		Metric:   omniav1alpha1.LoadThresholdMetricTotalCost,
+		Operator: omniav1alpha1.LoadThresholdOperatorLT,
+		Value:    "not-a-number",
+	}
+
+	r := evaluateOne(threshold, stats)
+	if !r.Passed {
+		t.Error("expected passed=true for parse error")
+	}
+	if r.ActualStr != "parse error" {
+		t.Errorf("expected ActualStr='parse error', got %s", r.ActualStr)
+	}
+}
+
+func TestIsLatencyMetric(t *testing.T) {
+	if !isLatencyMetric(omniav1alpha1.LoadThresholdMetricLatencyAvg) {
+		t.Error("expected latency_avg to be latency metric")
+	}
+	if isLatencyMetric(omniav1alpha1.LoadThresholdMetricErrorRate) {
+		t.Error("expected error_rate to not be latency metric")
+	}
+}
+
+func TestIsTTFTMetric(t *testing.T) {
+	if !isTTFTMetric(omniav1alpha1.LoadThresholdMetricTTFTAvg) {
+		t.Error("expected ttft_avg to be TTFT metric")
+	}
+	if isTTFTMetric(omniav1alpha1.LoadThresholdMetricLatencyAvg) {
+		t.Error("expected latency_avg to not be TTFT metric")
+	}
+}
+
+func TestIsRateMetric(t *testing.T) {
+	if !isRateMetric(omniav1alpha1.LoadThresholdMetricErrorRate) {
+		t.Error("expected error_rate to be rate metric")
+	}
+	if !isRateMetric(omniav1alpha1.LoadThresholdMetricRateLimit) {
+		t.Error("expected rate_limit_rate to be rate metric")
+	}
+	if isRateMetric(omniav1alpha1.LoadThresholdMetricTotalCost) {
+		t.Error("expected total_cost to not be rate metric")
+	}
+}
+
+func TestFormatMetricValue_Rate(t *testing.T) {
+	got := formatMetricValue(omniav1alpha1.LoadThresholdMetricErrorRate, 0.05)
+	if got != "0.0500" {
+		t.Errorf("expected 0.0500, got %s", got)
+	}
+}
+
+func TestFormatMetricValue_Cost(t *testing.T) {
+	got := formatMetricValue(omniav1alpha1.LoadThresholdMetricTotalCost, 42.5)
+	if got != "42.50" {
+		t.Errorf("expected 42.50, got %s", got)
+	}
+}


### PR DESCRIPTION
## Summary

Evaluate load test metrics against configurable SLO thresholds after completion. If any threshold is violated, the ArenaJob fails — enabling CI/CD gating.

Closes #606

## Changes

- **New `ee/pkg/arena/threshold/` package**: `Evaluate()` checks thresholds against `JobStats` accumulators. Supports `latency_avg`, `error_rate`, `pass_rate`, `total_cost`. Percentile metrics return "unavailable" (need histograms, future work).
- **Controller integration**: `evaluateLoadTestThresholds()` called after aggregation. Writes per-threshold results to `JobResult.Summary`. Fails job if any threshold violated.

## Test plan
- [x] 30 tests with 100% coverage on evaluator
- [x] All metric types, operators, edge cases (zero stats, parse errors, NaN)
- [x] `go build` and `go test` pass