### PR TITLE
feat: budget safety — stop Arena load tests on cost limit breach

### DIFF
--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -1330,7 +1330,12 @@ func (r *ArenaJobReconciler) updateStatusFromJob(ctx context.Context, arenaJob *
 		}
 	}
 
-	// If job is still running
+	// If job is still running, check budget and update progress
+	if arenaJob.Status.Phase == omniav1alpha1.ArenaJobPhaseRunning {
+		r.checkBudgetLimit(ctx, arenaJob)
+	}
+
+	// Update progress condition (unless budget breach already set phase to Failed)
 	if arenaJob.Status.Phase == omniav1alpha1.ArenaJobPhaseRunning {
 		SetCondition(&arenaJob.Status.Conditions, arenaJob.Generation, ArenaJobConditionTypeProgressing, metav1.ConditionTrue,
 			"JobRunning", fmt.Sprintf("Job running: %d/%d completed", job.Status.Succeeded, completions))
@@ -1389,6 +1394,71 @@ func (r *ArenaJobReconciler) writeThresholdResults(
 		summary[key] = r.String()
 	}
 	summary["thresholds_passed"] = threshold.SummaryLine(results)
+}
+
+// checkBudgetLimit checks if a running load test has exceeded its budget limit.
+// When the cost accumulator exceeds the configured budgetLimit, the job phase is
+// set to Failed and summary details are populated with cost information.
+// This is a no-op for non-loadtest jobs or jobs without a budget limit configured.
+func (r *ArenaJobReconciler) checkBudgetLimit(ctx context.Context, arenaJob *omniav1alpha1.ArenaJob) {
+	if arenaJob.Spec.LoadTest == nil || arenaJob.Spec.LoadTest.BudgetLimit == nil {
+		return
+	}
+	if r.Queue == nil {
+		return
+	}
+
+	log := logf.FromContext(ctx)
+	stats, err := r.Queue.GetStats(ctx, arenaJob.Name)
+	if err != nil {
+		log.V(1).Info("budget check skipped",
+			"reason", "failed to get stats",
+			"error", err)
+		return
+	}
+
+	currency := arenaJob.Spec.LoadTest.BudgetCurrency
+	if currency == "" {
+		currency = "USD"
+	}
+
+	result := checkBudget(*arenaJob.Spec.LoadTest.BudgetLimit, currency, stats)
+	if !result.Breached {
+		return
+	}
+
+	log.Info("budget limit exceeded",
+		"totalCost", stats.TotalCost,
+		"budgetLimit", *arenaJob.Spec.LoadTest.BudgetLimit,
+		"budgetCurrency", currency)
+
+	now := metav1.Now()
+	arenaJob.Status.Phase = omniav1alpha1.ArenaJobPhaseFailed
+	arenaJob.Status.CompletionTime = &now
+
+	if arenaJob.Status.Result == nil {
+		arenaJob.Status.Result = &omniav1alpha1.JobResult{}
+	}
+	if arenaJob.Status.Result.Summary == nil {
+		arenaJob.Status.Result.Summary = make(map[string]string)
+	}
+	for k, v := range result.Details {
+		arenaJob.Status.Result.Summary[k] = v
+	}
+
+	SetCondition(&arenaJob.Status.Conditions, arenaJob.Generation,
+		ArenaJobConditionTypeProgressing, metav1.ConditionFalse,
+		"BudgetExceeded", fmt.Sprintf("Cost %.2f %s exceeds budget limit %s %s",
+			stats.TotalCost, currency, *arenaJob.Spec.LoadTest.BudgetLimit, currency))
+	SetCondition(&arenaJob.Status.Conditions, arenaJob.Generation,
+		ArenaJobConditionTypeReady, metav1.ConditionFalse,
+		"BudgetExceeded", "Job stopped: budget limit exceeded")
+
+	if r.Recorder != nil {
+		r.Recorder.Event(arenaJob, corev1.EventTypeWarning, "BudgetExceeded",
+			fmt.Sprintf("Load test stopped: cost %.2f %s exceeds budget limit %s %s",
+				stats.TotalCost, currency, *arenaJob.Spec.LoadTest.BudgetLimit, currency))
+	}
 }
 
 // handleValidationError handles errors during validation.

--- a/ee/internal/controller/budget.go
+++ b/ee/internal/controller/budget.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package controller
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+)
+
+// BudgetResult holds the outcome of a budget check.
+type BudgetResult struct {
+	// Breached is true when TotalCost exceeds the configured limit.
+	Breached bool
+	// Details contains summary key-value pairs for the ArenaJob status.
+	// Populated only when Breached is true.
+	Details map[string]string
+}
+
+// checkBudget compares the current cost accumulator against a budget limit.
+// Returns a zero-value BudgetResult (Breached=false) when:
+//   - budgetLimit is empty or nil
+//   - budgetLimit cannot be parsed as a float64
+//   - stats is nil
+//   - cost is at or below the limit
+func checkBudget(budgetLimit string, budgetCurrency string, stats *queue.JobStats) BudgetResult {
+	if budgetLimit == "" {
+		return BudgetResult{}
+	}
+
+	limit, err := strconv.ParseFloat(budgetLimit, 64)
+	if err != nil {
+		return BudgetResult{}
+	}
+
+	if stats == nil {
+		return BudgetResult{}
+	}
+
+	if stats.TotalCost <= limit {
+		return BudgetResult{}
+	}
+
+	return BudgetResult{
+		Breached: true,
+		Details: map[string]string{
+			"budgetBreached": "true",
+			"totalCost":      fmt.Sprintf("%.2f", stats.TotalCost),
+			"budgetLimit":    fmt.Sprintf("%.2f", limit),
+			"budgetCurrency": budgetCurrency,
+		},
+	}
+}

--- a/ee/internal/controller/budget_test.go
+++ b/ee/internal/controller/budget_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+
+
+*/
+
+package controller
+
+import (
+	"testing"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+)
+
+func TestCheckBudget_UnderLimit(t *testing.T) {
+	stats := &queue.JobStats{TotalCost: 30.00}
+	result := checkBudget("50.00", "USD", stats)
+
+	if result.Breached {
+		t.Fatal("expected no breach when cost is under limit")
+	}
+	if result.Details != nil {
+		t.Fatal("expected nil details when not breached")
+	}
+}
+
+func TestCheckBudget_OverLimit(t *testing.T) {
+	stats := &queue.JobStats{TotalCost: 55.50}
+	result := checkBudget("50.00", "USD", stats)
+
+	if !result.Breached {
+		t.Fatal("expected breach when cost exceeds limit")
+	}
+	if result.Details["budgetBreached"] != "true" {
+		t.Fatalf("expected budgetBreached=true, got %q", result.Details["budgetBreached"])
+	}
+	if result.Details["totalCost"] != "55.50" {
+		t.Fatalf("expected totalCost=55.50, got %q", result.Details["totalCost"])
+	}
+	if result.Details["budgetLimit"] != "50.00" {
+		t.Fatalf("expected budgetLimit=50.00, got %q", result.Details["budgetLimit"])
+	}
+	if result.Details["budgetCurrency"] != "USD" {
+		t.Fatalf("expected budgetCurrency=USD, got %q", result.Details["budgetCurrency"])
+	}
+}
+
+func TestCheckBudget_ExactlyAtLimit(t *testing.T) {
+	stats := &queue.JobStats{TotalCost: 50.00}
+	result := checkBudget("50.00", "USD", stats)
+
+	if result.Breached {
+		t.Fatal("expected no breach when cost equals limit")
+	}
+}
+
+func TestCheckBudget_NoBudgetConfigured(t *testing.T) {
+	stats := &queue.JobStats{TotalCost: 999.99}
+	result := checkBudget("", "USD", stats)
+
+	if result.Breached {
+		t.Fatal("expected no breach when budget is empty")
+	}
+}
+
+func TestCheckBudget_InvalidBudgetString(t *testing.T) {
+	stats := &queue.JobStats{TotalCost: 100.00}
+	result := checkBudget("not-a-number", "USD", stats)
+
+	if result.Breached {
+		t.Fatal("expected no breach when budget string is invalid")
+	}
+}
+
+func TestCheckBudget_NilStats(t *testing.T) {
+	result := checkBudget("50.00", "USD", nil)
+
+	if result.Breached {
+		t.Fatal("expected no breach when stats is nil")
+	}
+}
+
+func TestCheckBudget_ZeroCost(t *testing.T) {
+	stats := &queue.JobStats{TotalCost: 0}
+	result := checkBudget("50.00", "USD", stats)
+
+	if result.Breached {
+		t.Fatal("expected no breach when cost is zero")
+	}
+}
+
+func TestCheckBudget_NonUSDCurrency(t *testing.T) {
+	stats := &queue.JobStats{TotalCost: 120.00}
+	result := checkBudget("100.00", "EUR", stats)
+
+	if !result.Breached {
+		t.Fatal("expected breach")
+	}
+	if result.Details["budgetCurrency"] != "EUR" {
+		t.Fatalf("expected budgetCurrency=EUR, got %q", result.Details["budgetCurrency"])
+	}
+}


### PR DESCRIPTION
## Summary

Monitor the cost accumulator during load test execution and stop the test if spending exceeds the configured budget limit.

Closes #664

## Changes

- **`budget.go`**: Pure `checkBudget()` function comparing cost accumulator against limit
- **Controller**: `checkBudgetLimit()` called during running phase reconciliation. On breach: sets phase to Failed, writes cost details to summary, emits warning event.

## Test plan
- [x] 8 unit tests covering all edge cases
- [x] `go build` and `go test` pass