### PR TITLE
feat: ArenaJob to session correlation for fleet conversations

### DIFF
--- a/ee/cmd/arena-worker/session_recording.go
+++ b/ee/cmd/arena-worker/session_recording.go
@@ -33,6 +33,7 @@ type arenaSessionMetadata struct {
 	Scenario      string
 	ProviderID    string
 	JobType       string
+	TrialIndex    string
 }
 
 // arenaSessionManager lazily creates PostgreSQL sessions for arena engine runs.
@@ -99,24 +100,38 @@ func (m *arenaSessionManager) OnEvent(event *events.Event) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	tags := []string{
+		"source:arena",
+		"arena-job:" + m.meta.JobName,
+		"scenario:" + m.meta.Scenario,
+		"provider:" + m.meta.ProviderID,
+	}
+	if m.meta.TrialIndex != "" {
+		tags = append(tags, "trial:"+m.meta.TrialIndex)
+	}
+
+	initialState := map[string]string{
+		"arena.job":           m.meta.JobName,
+		"arena.job.name":      m.meta.JobName,
+		"arena.job.namespace": m.meta.Namespace,
+		"arena.scenario":      m.meta.Scenario,
+		"arena.scenario.id":   m.meta.Scenario,
+		"arena.provider":      m.meta.ProviderID,
+		"arena.provider.id":   m.meta.ProviderID,
+		"arena.type":          m.meta.JobType,
+		"arena.run_id":        runSessionID,
+	}
+	if m.meta.TrialIndex != "" {
+		initialState["arena.trial.index"] = m.meta.TrialIndex
+	}
+
 	_, err := m.store.CreateSession(ctx, session.CreateSessionOptions{
 		ID:            pgID,
 		AgentName:     m.meta.JobName,
 		Namespace:     m.meta.Namespace,
 		WorkspaceName: m.meta.WorkspaceName,
-		Tags: []string{
-			"source:arena",
-			"arena-job:" + m.meta.JobName,
-			"scenario:" + m.meta.Scenario,
-			"provider:" + m.meta.ProviderID,
-		},
-		InitialState: map[string]string{
-			"arena.job":      m.meta.JobName,
-			"arena.scenario": m.meta.Scenario,
-			"arena.provider": m.meta.ProviderID,
-			"arena.type":     m.meta.JobType,
-			"arena.run_id":   runSessionID,
-		},
+		Tags:          tags,
+		InitialState:  initialState,
 	})
 	if err != nil {
 		m.log.Error(err, "failed to create arena session",
@@ -137,6 +152,19 @@ func (m *arenaSessionManager) OnEvent(event *events.Event) {
 
 	event.SessionID = pgID
 	es.OnEvent(event)
+}
+
+// SessionIDs returns all PostgreSQL session IDs created by this manager.
+func (m *arenaSessionManager) SessionIDs() []string {
+	var ids []string
+	m.sessions.Range(func(_, value any) bool {
+		ms := value.(*managedSession)
+		if ms.pgSessionID != "" {
+			ids = append(ids, ms.pgSessionID)
+		}
+		return true
+	})
+	return ids
 }
 
 // CompleteAll marks all lazily created sessions as completed or errored

--- a/ee/cmd/arena-worker/session_recording_test.go
+++ b/ee/cmd/arena-worker/session_recording_test.go
@@ -364,6 +364,122 @@ func TestArenaSessionManager_OnEvent_CreateSessionError(t *testing.T) {
 	assert.Empty(t, store.getCreatedSessions(), "no sessions created when store fails")
 }
 
+func TestArenaSessionManager_SessionIDs(t *testing.T) {
+	t.Run("returns empty for no sessions", func(t *testing.T) {
+		store := newMockStore()
+		mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{})
+		assert.Empty(t, mgr.SessionIDs())
+	})
+
+	t.Run("returns all created session IDs", func(t *testing.T) {
+		store := newMockStore()
+		mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+			JobName:   "test-job",
+			Namespace: "default",
+		})
+
+		mgr.OnEvent(&events.Event{
+			Type:      events.EventProviderCallCompleted,
+			SessionID: "run-a",
+			Timestamp: time.Now(),
+			Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+		})
+		mgr.OnEvent(&events.Event{
+			Type:      events.EventProviderCallCompleted,
+			SessionID: "run-b",
+			Timestamp: time.Now(),
+			Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+		})
+
+		time.Sleep(100 * time.Millisecond)
+
+		ids := mgr.SessionIDs()
+		assert.Len(t, ids, 2)
+		assert.Contains(t, ids, runIDToUUID("run-a"))
+		assert.Contains(t, ids, runIDToUUID("run-b"))
+	})
+}
+
+func TestArenaSessionManager_MetadataTags(t *testing.T) {
+	t.Run("includes arena job metadata in tags and initial state", func(t *testing.T) {
+		store := newMockStore()
+		mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+			JobName:       "my-arena-job",
+			Namespace:     "prod-ns",
+			WorkspaceName: "my-workspace",
+			Scenario:      "support-scenario",
+			ProviderID:    "gpt-4o",
+			JobType:       "arena",
+			TrialIndex:    "3",
+		})
+
+		mgr.OnEvent(&events.Event{
+			Type:      events.EventProviderCallCompleted,
+			SessionID: "run-meta",
+			Timestamp: time.Now(),
+			Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+		})
+
+		time.Sleep(100 * time.Millisecond)
+
+		sessions := store.getCreatedSessions()
+		require.Len(t, sessions, 1)
+
+		s := sessions[0]
+
+		// Verify tags
+		assert.Contains(t, s.Tags, "source:arena")
+		assert.Contains(t, s.Tags, "arena-job:my-arena-job")
+		assert.Contains(t, s.Tags, "scenario:support-scenario")
+		assert.Contains(t, s.Tags, "provider:gpt-4o")
+		assert.Contains(t, s.Tags, "trial:3")
+
+		// Verify initial state includes new metadata keys
+		assert.Equal(t, "my-arena-job", s.InitialState["arena.job.name"])
+		assert.Equal(t, "prod-ns", s.InitialState["arena.job.namespace"])
+		assert.Equal(t, "support-scenario", s.InitialState["arena.scenario.id"])
+		assert.Equal(t, "gpt-4o", s.InitialState["arena.provider.id"])
+		assert.Equal(t, "3", s.InitialState["arena.trial.index"])
+
+		// Verify backward-compatible keys still present
+		assert.Equal(t, "my-arena-job", s.InitialState["arena.job"])
+		assert.Equal(t, "support-scenario", s.InitialState["arena.scenario"])
+		assert.Equal(t, "gpt-4o", s.InitialState["arena.provider"])
+		assert.Equal(t, "arena", s.InitialState["arena.type"])
+		assert.Equal(t, "run-meta", s.InitialState["arena.run_id"])
+	})
+
+	t.Run("omits trial tag and state when trial index is empty", func(t *testing.T) {
+		store := newMockStore()
+		mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+			JobName:    "job-no-trial",
+			Namespace:  "default",
+			Scenario:   "s1",
+			ProviderID: "p1",
+			JobType:    "arena",
+		})
+
+		mgr.OnEvent(&events.Event{
+			Type:      events.EventProviderCallCompleted,
+			SessionID: "run-no-trial",
+			Timestamp: time.Now(),
+			Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+		})
+
+		time.Sleep(100 * time.Millisecond)
+
+		sessions := store.getCreatedSessions()
+		require.Len(t, sessions, 1)
+
+		s := sessions[0]
+		for _, tag := range s.Tags {
+			assert.NotContains(t, tag, "trial:")
+		}
+		_, hasTrial := s.InitialState["arena.trial.index"]
+		assert.False(t, hasTrial)
+	})
+}
+
 func TestArenaSessionManager_CompleteAll_UpdateError(t *testing.T) {
 	store := &mockSessionStore{
 		statusUpdates: make(map[string]session.SessionStatusUpdate),

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -14,6 +14,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -143,6 +144,7 @@ type ExecutionResult struct {
 	Error      string             `json:"error,omitempty"`
 	Metrics    map[string]float64 `json:"metrics,omitempty"`
 	Assertions []AssertionResult  `json:"assertions,omitempty"`
+	SessionID  string             `json:"sessionId,omitempty"`
 }
 
 // AssertionResult represents a single assertion result.
@@ -466,6 +468,7 @@ func toItemResult(result *ExecutionResult) *queue.ItemResult {
 		Error:      result.Error,
 		Metrics:    result.Metrics,
 		Assertions: assertions,
+		SessionID:  result.SessionID,
 	}
 }
 
@@ -574,8 +577,9 @@ func executeWorkItem(
 
 	// Wire session recording if session-api is configured.
 	// Events from all engine runs are forwarded to session-api via OmniaEventStore.
+	var sessionMgr *arenaSessionManager
 	if cfg.SessionAPIURL != "" {
-		sessionMgr := newArenaSessionManager(
+		sessionMgr = newArenaSessionManager(
 			httpclient.NewStore(cfg.SessionAPIURL, log),
 			log,
 			arenaSessionMetadata{
@@ -585,6 +589,7 @@ func executeWorkItem(
 				Scenario:      item.ScenarioID,
 				ProviderID:    item.ProviderID,
 				JobType:       cfg.JobType,
+				TrialIndex:    extractTrialIndex(item),
 			},
 		)
 		bus := events.NewEventBus()
@@ -658,6 +663,9 @@ func executeWorkItem(
 	// so we read it directly from the provider after execution completes.
 	extractFleetTTFT(providerRegistry, crdFleetProviders, result)
 
+	// Extract session ID for job-to-session correlation.
+	result.SessionID = extractSessionID(sessionMgr, providerRegistry, crdFleetProviders)
+
 	return result, nil
 }
 
@@ -690,6 +698,57 @@ func extractFleetTTFT(
 			return // use the first non-zero value
 		}
 	}
+}
+
+// extractSessionID returns the first available session ID from the session manager
+// (direct providers) or fleet provider connections.
+func extractSessionID(
+	sessionMgr *arenaSessionManager,
+	registry *pkproviders.Registry,
+	fleetProviders []*resolvedFleetProvider,
+) string {
+	// Prefer session IDs from the session manager (direct providers with recording).
+	if sessionMgr != nil {
+		if ids := sessionMgr.SessionIDs(); len(ids) > 0 {
+			return ids[0]
+		}
+	}
+
+	// Fall back to fleet provider session IDs.
+	for _, fp := range fleetProviders {
+		prov, ok := registry.Get(fp.id)
+		if !ok {
+			continue
+		}
+		fleetProv, ok := prov.(*fleet.Provider)
+		if !ok {
+			continue
+		}
+		if sid := fleetProv.SessionID(); sid != "" {
+			return sid
+		}
+		for _, sid := range fleetProv.ConversationSessionIDs() {
+			if sid != "" {
+				return sid
+			}
+		}
+	}
+	return ""
+}
+
+// extractTrialIndex parses the trialIndex from a work item's Config JSON.
+func extractTrialIndex(item *queue.WorkItem) string {
+	if len(item.Config) == 0 {
+		return ""
+	}
+	var cfg map[string]interface{}
+	if err := json.Unmarshal(item.Config, &cfg); err != nil {
+		return ""
+	}
+	if v, ok := cfg["trialIndex"]; ok {
+		return fmt.Sprintf("%v", v)
+	}
+	return ""
 }
 
 // findArenaConfigFile looks for the arena config file in the bundle directory.

--- a/ee/cmd/arena-worker/worker_test.go
+++ b/ee/cmd/arena-worker/worker_test.go
@@ -12,11 +12,16 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/AltairaLabs/PromptKit/pkg/config"
+	"github.com/AltairaLabs/PromptKit/runtime/events"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
+
+	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
 )
 
 func TestApplyToolOverrides(t *testing.T) {
@@ -479,6 +484,118 @@ spec:
 		// Just verify it doesn't error with verbose mode
 		err := applyToolOverrides(testLog(), cfg, overrides)
 		require.NoError(t, err)
+	})
+}
+
+func TestToItemResult_CopiesSessionID(t *testing.T) {
+	t.Run("copies session ID when present", func(t *testing.T) {
+		result := &ExecutionResult{
+			Status:     statusPass,
+			DurationMs: 1234.5,
+			Metrics:    map[string]float64{"tokens": 100},
+			SessionID:  "abc-123-def",
+		}
+		ir := toItemResult(result)
+		assert.Equal(t, "abc-123-def", ir.SessionID)
+		assert.Equal(t, statusPass, ir.Status)
+		assert.Equal(t, 1234.5, ir.DurationMs)
+	})
+
+	t.Run("empty session ID when not set", func(t *testing.T) {
+		result := &ExecutionResult{
+			Status:     statusFail,
+			DurationMs: 500,
+			Error:      "something failed",
+		}
+		ir := toItemResult(result)
+		assert.Empty(t, ir.SessionID)
+		assert.Equal(t, statusFail, ir.Status)
+		assert.Equal(t, "something failed", ir.Error)
+	})
+
+	t.Run("copies assertions alongside session ID", func(t *testing.T) {
+		result := &ExecutionResult{
+			Status:    statusPass,
+			SessionID: "session-456",
+			Assertions: []AssertionResult{
+				{Name: "a1", Passed: true, Message: "ok"},
+				{Name: "a2", Passed: false, Message: "failed"},
+			},
+		}
+		ir := toItemResult(result)
+		assert.Equal(t, "session-456", ir.SessionID)
+		require.Len(t, ir.Assertions, 2)
+		assert.Equal(t, "a1", ir.Assertions[0].Name)
+		assert.True(t, ir.Assertions[0].Passed)
+		assert.Equal(t, "a2", ir.Assertions[1].Name)
+		assert.False(t, ir.Assertions[1].Passed)
+	})
+}
+
+func TestExtractTrialIndex(t *testing.T) {
+	t.Run("extracts trial index from config", func(t *testing.T) {
+		item := &queue.WorkItem{
+			Config: []byte(`{"trialIndex": 2, "totalTrials": 5}`),
+		}
+		assert.Equal(t, "2", extractTrialIndex(item))
+	})
+
+	t.Run("returns empty for nil config", func(t *testing.T) {
+		item := &queue.WorkItem{}
+		assert.Empty(t, extractTrialIndex(item))
+	})
+
+	t.Run("returns empty for empty config", func(t *testing.T) {
+		item := &queue.WorkItem{Config: []byte{}}
+		assert.Empty(t, extractTrialIndex(item))
+	})
+
+	t.Run("returns empty when trialIndex not present", func(t *testing.T) {
+		item := &queue.WorkItem{
+			Config: []byte(`{"totalTrials": 5}`),
+		}
+		assert.Empty(t, extractTrialIndex(item))
+	})
+
+	t.Run("returns empty for invalid JSON", func(t *testing.T) {
+		item := &queue.WorkItem{
+			Config: []byte(`not json`),
+		}
+		assert.Empty(t, extractTrialIndex(item))
+	})
+
+	t.Run("handles zero trial index", func(t *testing.T) {
+		item := &queue.WorkItem{
+			Config: []byte(`{"trialIndex": 0}`),
+		}
+		assert.Equal(t, "0", extractTrialIndex(item))
+	})
+}
+
+func TestExtractSessionID(t *testing.T) {
+	t.Run("returns empty when no sources available", func(t *testing.T) {
+		assert.Empty(t, extractSessionID(nil, nil, nil))
+	})
+
+	t.Run("returns session ID from session manager", func(t *testing.T) {
+		store := newMockStore()
+		mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+			JobName:   "test-job",
+			Namespace: "default",
+		})
+
+		// Create a session via event
+		mgr.OnEvent(&events.Event{
+			Type:      events.EventProviderCallCompleted,
+			SessionID: "run-001",
+			Timestamp: time.Now(),
+			Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+		})
+		time.Sleep(50 * time.Millisecond)
+
+		sid := extractSessionID(mgr, nil, nil)
+		assert.NotEmpty(t, sid)
+		assert.Equal(t, runIDToUUID("run-001"), sid)
 	})
 }
 

--- a/ee/pkg/arena/fleet/provider.go
+++ b/ee/pkg/arena/fleet/provider.go
@@ -287,6 +287,18 @@ func (p *Provider) SessionID() string {
 	return ""
 }
 
+// ConversationSessionIDs returns a map of conversation ID to facade session ID
+// for all pooled connections. This enables correlating arena runs with sessions.
+func (p *Provider) ConversationSessionIDs() map[string]string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	result := make(map[string]string, len(p.conns))
+	for cid, entry := range p.conns {
+		result[cid] = entry.sessionID
+	}
+	return result
+}
+
 // Close closes all connections (pooled and fallback).
 func (p *Provider) Close() error {
 	p.mu.Lock()

--- a/ee/pkg/arena/fleet/provider_test.go
+++ b/ee/pkg/arena/fleet/provider_test.go
@@ -747,3 +747,37 @@ func TestProvider_Predict_SendsOnlyLastUserMessage(t *testing.T) {
 	// Verify only the last user message was sent over the wire
 	assert.Equal(t, "second message", receivedContent)
 }
+
+func TestProvider_ConversationSessionIDs(t *testing.T) {
+	t.Run("empty when no conversations", func(t *testing.T) {
+		p := NewProvider("test", "ws://unused", nil)
+		ids := p.ConversationSessionIDs()
+		assert.Empty(t, ids)
+	})
+
+	t.Run("returns session IDs for pooled connections", func(t *testing.T) {
+		p := NewProvider("test", "ws://unused", nil)
+		// Manually populate conns map for testing
+		p.mu.Lock()
+		p.conns["conv-1"] = &connEntry{sessionID: "session-aaa"}
+		p.conns["conv-2"] = &connEntry{sessionID: "session-bbb"}
+		p.mu.Unlock()
+
+		ids := p.ConversationSessionIDs()
+		assert.Len(t, ids, 2)
+		assert.Equal(t, "session-aaa", ids["conv-1"])
+		assert.Equal(t, "session-bbb", ids["conv-2"])
+	})
+
+	t.Run("does not include fallback connection", func(t *testing.T) {
+		p := NewProvider("test", "ws://unused", nil)
+		p.mu.Lock()
+		p.fallback = &connEntry{sessionID: "fallback-session"}
+		p.conns["conv-1"] = &connEntry{sessionID: "session-ccc"}
+		p.mu.Unlock()
+
+		ids := p.ConversationSessionIDs()
+		assert.Len(t, ids, 1)
+		assert.Equal(t, "session-ccc", ids["conv-1"])
+	})
+}


### PR DESCRIPTION
## Summary

Link Arena trial executions to session transcripts. Sessions tagged with ArenaJob metadata, session IDs flow through to work item results.

Closes #607

## Changes

- **Worker**: `SessionID` on `ExecutionResult`, extracted from fleet provider or session manager. Propagated to `queue.ItemResult`.
- **Session recording**: Enhanced tags with `arena.job.name`, `arena.scenario.id`, `arena.provider.id`, `arena.trial.index`.
- **Fleet provider**: `ConversationSessionIDs()` method.

## Test plan
- [x] SessionID propagation, trial index parsing, session extraction tests
- [x] Metadata tag and fleet provider tests
- [x] `go build` and `go test` pass