### PR TITLE
fix: extractTokens handles separate input/output token keys

### DIFF
--- a/ee/pkg/arena/queue/complete_item_test.go
+++ b/ee/pkg/arena/queue/complete_item_test.go
@@ -328,6 +328,35 @@ func TestExtractTokensAndCost(t *testing.T) {
 	assertFloat64(t, "TotalCost", stats.TotalCost, 0.15)
 }
 
+func TestExtractTokensSeparateInputOutput(t *testing.T) {
+	q := NewMemoryQueueWithDefaults()
+	ctx := context.Background()
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "scen-a", ProviderID: "prov-x"},
+	}
+	mustPush(t, q, ctx, items)
+	mustPop(t, q, ctx)
+
+	// Worker writes separate input/output token keys (no "totalTokens" key).
+	result := &ItemResult{
+		Status:     "pass",
+		DurationMs: 100,
+		Metrics:    map[string]float64{"totalInputTokens": 500, "totalOutputTokens": 200},
+	}
+	if err := q.CompleteItem(ctx, completeTestJobID, "item-1", result); err != nil {
+		t.Fatalf("CompleteItem() error = %v", err)
+	}
+
+	stats, err := q.GetStats(ctx, completeTestJobID)
+	if err != nil {
+		t.Fatalf("GetStats() error = %v", err)
+	}
+
+	// Should sum input + output tokens.
+	assertInt64(t, "TotalTokens", stats.TotalTokens, 700)
+}
+
 func TestFailItemScenarioAndProviderStats(t *testing.T) {
 	q := NewMemoryQueueWithDefaults()
 	ctx := context.Background()

--- a/ee/pkg/arena/queue/queue.go
+++ b/ee/pkg/arena/queue/queue.go
@@ -279,14 +279,25 @@ type Options struct {
 	MaxRetries int
 }
 
-// extractTokens returns the token count from a metrics map,
-// checking both "totalTokens" and "tokens" keys.
+// extractTokens returns the token count from a metrics map.
+// Checks "totalTokens", "tokens", and the sum of "totalInputTokens" + "totalOutputTokens".
 func extractTokens(metrics map[string]float64) int64 {
 	if v, ok := metrics["totalTokens"]; ok {
 		return int64(v)
 	}
 	if v, ok := metrics["tokens"]; ok {
 		return int64(v)
+	}
+	// Sum input + output tokens if reported separately.
+	var total float64
+	if v, ok := metrics["totalInputTokens"]; ok {
+		total += v
+	}
+	if v, ok := metrics["totalOutputTokens"]; ok {
+		total += v
+	}
+	if total > 0 {
+		return int64(total)
 	}
 	return 0
 }


### PR DESCRIPTION
## Summary

The worker writes `totalInputTokens` and `totalOutputTokens` as separate metric keys, but `extractTokens` only checked `totalTokens` and `tokens`. This meant queue accumulators never picked up token counts from the worker, so `JobStats.TotalTokens` was always 0.

## Fix

`extractTokens` now sums `totalInputTokens` + `totalOutputTokens` when the combined key is absent.

## Test plan
- [x] New test `TestExtractTokensSeparateInputOutput` verifies summing
- [x] Existing token extraction tests still pass