### PR TITLE
feat: compute cost from Provider CRD pricing in arena worker

### DIFF
--- a/ee/cmd/arena-worker/main_test.go
+++ b/ee/cmd/arena-worker/main_test.go
@@ -27,6 +27,7 @@ import (
 
 	pkproviders "github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/statestore"
+	v1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -580,7 +581,7 @@ func TestPopulateMetrics(t *testing.T) {
 			totalDuration: 1500 * time.Millisecond,
 		}
 
-		populateMetrics(result, agg, 7)
+		populateMetrics(result, agg, 7, nil)
 
 		if result.Metrics["totalDurationMs"] != 1500 {
 			t.Errorf("expected totalDurationMs=1500, got %v", result.Metrics["totalDurationMs"])
@@ -606,7 +607,7 @@ func TestPopulateMetrics_Tokens(t *testing.T) {
 			outputTokens: 50,
 		}
 
-		populateMetrics(result, agg, 1)
+		populateMetrics(result, agg, 1, nil)
 
 		assert.Equal(t, float64(100), result.Metrics[metricKeyInputTokens])
 		assert.Equal(t, float64(50), result.Metrics[metricKeyOutputTokens])
@@ -616,12 +617,131 @@ func TestPopulateMetrics_Tokens(t *testing.T) {
 		result := &ExecutionResult{Metrics: make(map[string]float64)}
 		agg := &runAggregator{passCount: 1}
 
-		populateMetrics(result, agg, 1)
+		populateMetrics(result, agg, 1, nil)
 
 		_, hasInput := result.Metrics[metricKeyInputTokens]
 		_, hasOutput := result.Metrics[metricKeyOutputTokens]
 		assert.False(t, hasInput, "should not set input tokens when zero")
 		assert.False(t, hasOutput, "should not set output tokens when zero")
+	})
+}
+
+func TestComputeCost(t *testing.T) {
+	t.Run("calculates cost from input and output tokens", func(t *testing.T) {
+		p := &providerPricing{inputCostPer1K: 0.003, outputCostPer1K: 0.015}
+		// 1000 input tokens * 0.003/1000 = 0.003
+		// 500 output tokens * 0.015/1000 = 0.0075
+		cost := p.computeCost(1000, 500)
+		assert.InDelta(t, 0.0105, cost, 1e-9)
+	})
+
+	t.Run("handles zero tokens", func(t *testing.T) {
+		p := &providerPricing{inputCostPer1K: 0.003, outputCostPer1K: 0.015}
+		assert.Equal(t, 0.0, p.computeCost(0, 0))
+	})
+
+	t.Run("handles input-only pricing", func(t *testing.T) {
+		p := &providerPricing{inputCostPer1K: 0.01}
+		cost := p.computeCost(2000, 500)
+		assert.InDelta(t, 0.02, cost, 1e-9)
+	})
+
+	t.Run("handles output-only pricing", func(t *testing.T) {
+		p := &providerPricing{outputCostPer1K: 0.06}
+		cost := p.computeCost(1000, 2000)
+		assert.InDelta(t, 0.12, cost, 1e-9)
+	})
+}
+
+func TestParsePricing(t *testing.T) {
+	t.Run("returns nil when pricing is nil", func(t *testing.T) {
+		assert.Nil(t, parsePricing(nil))
+	})
+
+	t.Run("returns nil when all values are zero", func(t *testing.T) {
+		zero := "0"
+		p := parsePricing(&v1alpha1.ProviderPricing{
+			InputCostPer1K:  &zero,
+			OutputCostPer1K: &zero,
+		})
+		assert.Nil(t, p)
+	})
+
+	t.Run("parses valid pricing", func(t *testing.T) {
+		input := "0.003"
+		output := "0.015"
+		p := parsePricing(&v1alpha1.ProviderPricing{
+			InputCostPer1K:  &input,
+			OutputCostPer1K: &output,
+		})
+		require.NotNil(t, p)
+		assert.InDelta(t, 0.003, p.inputCostPer1K, 1e-9)
+		assert.InDelta(t, 0.015, p.outputCostPer1K, 1e-9)
+	})
+
+	t.Run("ignores invalid strings", func(t *testing.T) {
+		bad := "notanumber"
+		output := "0.015"
+		p := parsePricing(&v1alpha1.ProviderPricing{
+			InputCostPer1K:  &bad,
+			OutputCostPer1K: &output,
+		})
+		require.NotNil(t, p)
+		assert.Equal(t, 0.0, p.inputCostPer1K)
+		assert.InDelta(t, 0.015, p.outputCostPer1K, 1e-9)
+	})
+
+	t.Run("parses partial pricing (input only)", func(t *testing.T) {
+		input := "0.005"
+		p := parsePricing(&v1alpha1.ProviderPricing{
+			InputCostPer1K: &input,
+		})
+		require.NotNil(t, p)
+		assert.InDelta(t, 0.005, p.inputCostPer1K, 1e-9)
+		assert.Equal(t, 0.0, p.outputCostPer1K)
+	})
+}
+
+func TestPopulateMetrics_Cost(t *testing.T) {
+	t.Run("writes cost when pricing and tokens are present", func(t *testing.T) {
+		result := &ExecutionResult{Metrics: make(map[string]float64)}
+		agg := &runAggregator{
+			passCount:    1,
+			inputTokens:  1000,
+			outputTokens: 500,
+		}
+		pricing := &providerPricing{inputCostPer1K: 0.003, outputCostPer1K: 0.015}
+
+		populateMetrics(result, agg, 1, pricing)
+
+		cost, ok := result.Metrics[metricKeyCost]
+		assert.True(t, ok, "cost metric should be present")
+		assert.InDelta(t, 0.0105, cost, 1e-9)
+	})
+
+	t.Run("omits cost when pricing is nil", func(t *testing.T) {
+		result := &ExecutionResult{Metrics: make(map[string]float64)}
+		agg := &runAggregator{
+			passCount:    1,
+			inputTokens:  1000,
+			outputTokens: 500,
+		}
+
+		populateMetrics(result, agg, 1, nil)
+
+		_, ok := result.Metrics[metricKeyCost]
+		assert.False(t, ok, "cost metric should not be present without pricing")
+	})
+
+	t.Run("omits cost when tokens are zero", func(t *testing.T) {
+		result := &ExecutionResult{Metrics: make(map[string]float64)}
+		agg := &runAggregator{passCount: 1}
+		pricing := &providerPricing{inputCostPer1K: 0.003, outputCostPer1K: 0.015}
+
+		populateMetrics(result, agg, 1, pricing)
+
+		_, ok := result.Metrics[metricKeyCost]
+		assert.False(t, ok, "cost metric should not be present with zero tokens")
 	})
 }
 
@@ -851,7 +971,7 @@ func TestBuildExecutionResult(t *testing.T) {
 		runIDs := []string{"run-1"}
 		startTime := time.Now()
 
-		result := buildExecutionResult(testLog(), mockStore, runIDs, startTime)
+		result := buildExecutionResult(testLog(), mockStore, runIDs, startTime, nil)
 
 		// Should return fail — unable to read run state means results are unknown
 		if result.Status != statusFail {
@@ -867,7 +987,7 @@ func TestBuildExecutionResult(t *testing.T) {
 		runIDs := []string{}
 		startTime := time.Now()
 
-		result := buildExecutionResult(testLog(), mockStore, runIDs, startTime)
+		result := buildExecutionResult(testLog(), mockStore, runIDs, startTime, nil)
 
 		if result.Status != statusFail {
 			t.Errorf("expected status %s, got %s", statusFail, result.Status)

--- a/ee/cmd/arena-worker/provider_groups.go
+++ b/ee/cmd/arena-worker/provider_groups.go
@@ -42,24 +42,25 @@ type resolvedFleetProvider struct {
 // resolveProvidersFromCRD resolves providers from CRD refs when ARENA_PROVIDER_GROUPS is set.
 // It reads each Provider/AgentRuntime CRD, builds PromptKit provider configs, and populates
 // LoadedProviders. Fleet providers are connected and returned for post-engine registration.
+// The returned pricing map contains parsed pricing for providers that have spec.pricing set.
 func resolveProvidersFromCRD(
 	ctx context.Context,
 	log logr.Logger,
 	c client.Client,
 	cfg *Config,
 	arenaCfg *config.Config,
-) ([]*resolvedFleetProvider, error) {
+) ([]*resolvedFleetProvider, map[string]*providerPricing, error) {
 	// Read the ArenaJob CRD to get spec.Providers
 	jobName := cfg.JobName
 	jobNamespace := cfg.JobNamespace
 
 	arenaJob, err := getArenaJob(ctx, c, jobName, jobNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read ArenaJob %s/%s: %w", jobNamespace, jobName, err)
+		return nil, nil, fmt.Errorf("failed to read ArenaJob %s/%s: %w", jobNamespace, jobName, err)
 	}
 
 	if len(arenaJob.Providers) == 0 {
-		return nil, fmt.Errorf("ArenaJob %s/%s has no providers", jobNamespace, jobName)
+		return nil, nil, fmt.Errorf("ArenaJob %s/%s has no providers", jobNamespace, jobName)
 	}
 
 	// Clear providers loaded from arena config file references.
@@ -71,21 +72,26 @@ func resolveProvidersFromCRD(
 	agentWSURLs := parseAgentWSURLs()
 
 	var fleetProviders []*resolvedFleetProvider
+	pricingMap := make(map[string]*providerPricing)
 
 	for groupName, pg := range arenaJob.Providers {
-		fps, err := resolveProviderGroup(ctx, log, c, jobNamespace, groupName, &pg, agentWSURLs, arenaCfg)
+		fps, groupPricing, err := resolveProviderGroup(ctx, log, c, jobNamespace, groupName, &pg, agentWSURLs, arenaCfg)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		fleetProviders = append(fleetProviders, fps...)
+		for id, p := range groupPricing {
+			pricingMap[id] = p
+		}
 	}
 
 	log.Info("providers resolved from CRDs",
 		"providerCount", len(arenaCfg.LoadedProviders),
 		"fleetCount", len(fleetProviders),
+		"hasPricing", len(pricingMap) > 0,
 	)
 
-	return fleetProviders, nil
+	return fleetProviders, pricingMap, nil
 }
 
 // resolveProviderGroup resolves a single provider group (array or map mode).
@@ -97,32 +103,61 @@ func resolveProviderGroup(
 	pg *arenaProviderGroup,
 	agentWSURLs map[string]string,
 	arenaCfg *config.Config,
-) ([]*resolvedFleetProvider, error) {
-	var fps []*resolvedFleetProvider
-
+) ([]*resolvedFleetProvider, map[string]*providerPricing, error) {
 	if pg.isMapMode() {
-		for configID, entry := range pg.mapping {
-			fp, err := resolveEntry(ctx, log, c, namespace, groupName, configID, &entry, agentWSURLs, arenaCfg)
-			if err != nil {
-				return nil, err
-			}
-			if fp != nil {
-				fps = append(fps, fp)
-			}
+		return resolveMapModeGroup(ctx, log, c, namespace, groupName, pg.mapping, agentWSURLs, arenaCfg)
+	}
+	return resolveArrayModeGroup(ctx, log, c, namespace, groupName, pg.entries, agentWSURLs, arenaCfg)
+}
+
+// resolveMapModeGroup resolves providers in map mode (configID -> entry).
+func resolveMapModeGroup(
+	ctx context.Context, log logr.Logger, c client.Client,
+	namespace, groupName string,
+	mapping map[string]arenaProviderEntry,
+	agentWSURLs map[string]string, arenaCfg *config.Config,
+) ([]*resolvedFleetProvider, map[string]*providerPricing, error) {
+	var fps []*resolvedFleetProvider
+	pricing := make(map[string]*providerPricing)
+
+	for configID, entry := range mapping {
+		fp, p, err := resolveEntry(ctx, log, c, namespace, groupName, configID, &entry, agentWSURLs, arenaCfg)
+		if err != nil {
+			return nil, nil, err
 		}
-	} else {
-		for _, entry := range pg.entries {
-			fp, err := resolveEntry(ctx, log, c, namespace, groupName, "", &entry, agentWSURLs, arenaCfg)
-			if err != nil {
-				return nil, err
-			}
-			if fp != nil {
-				fps = append(fps, fp)
-			}
+		if fp != nil {
+			fps = append(fps, fp)
+		}
+		if p != nil {
+			pricing[configID] = p
 		}
 	}
+	return fps, pricing, nil
+}
 
-	return fps, nil
+// resolveArrayModeGroup resolves providers in array mode (sequential entries).
+func resolveArrayModeGroup(
+	ctx context.Context, log logr.Logger, c client.Client,
+	namespace, groupName string,
+	entries []arenaProviderEntry,
+	agentWSURLs map[string]string, arenaCfg *config.Config,
+) ([]*resolvedFleetProvider, map[string]*providerPricing, error) {
+	var fps []*resolvedFleetProvider
+	pricing := make(map[string]*providerPricing)
+
+	for _, entry := range entries {
+		fp, p, err := resolveEntry(ctx, log, c, namespace, groupName, "", &entry, agentWSURLs, arenaCfg)
+		if err != nil {
+			return nil, nil, err
+		}
+		if fp != nil {
+			fps = append(fps, fp)
+		}
+		if p != nil && entry.ProviderRef != nil {
+			pricing[sanitizeID(entry.ProviderRef.Name)] = p
+		}
+	}
+	return fps, pricing, nil
 }
 
 // resolveEntry resolves a single provider/agent entry. When configID is non-empty,
@@ -135,23 +170,28 @@ func resolveEntry(
 	entry *arenaProviderEntry,
 	agentWSURLs map[string]string,
 	arenaCfg *config.Config,
-) (*resolvedFleetProvider, error) {
+) (*resolvedFleetProvider, *providerPricing, error) {
 	if entry.ProviderRef != nil {
 		if configID != "" {
-			return nil, resolveProviderRefEntryWithID(ctx, log, c, namespace, *entry.ProviderRef, configID, groupName, arenaCfg)
+			p, err := resolveProviderRefEntryWithID(ctx, log, c, namespace, *entry.ProviderRef, configID, groupName, arenaCfg)
+			return nil, p, err
 		}
-		return nil, resolveProviderRefEntry(ctx, log, c, namespace, *entry.ProviderRef, groupName, arenaCfg)
+		p, err := resolveProviderRefEntry(ctx, log, c, namespace, *entry.ProviderRef, groupName, arenaCfg)
+		return nil, p, err
 	}
 	if entry.AgentRef != nil {
 		if configID != "" {
-			return resolveAgentRefEntryWithID(ctx, log, entry.AgentRef.Name, configID, groupName, agentWSURLs, arenaCfg)
+			fp, err := resolveAgentRefEntryWithID(ctx, log, entry.AgentRef.Name, configID, groupName, agentWSURLs, arenaCfg)
+			return fp, nil, err
 		}
-		return resolveAgentRefEntry(ctx, log, entry.AgentRef.Name, groupName, agentWSURLs, arenaCfg)
+		fp, err := resolveAgentRefEntry(ctx, log, entry.AgentRef.Name, groupName, agentWSURLs, arenaCfg)
+		return fp, nil, err
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
 // resolveProviderRefEntry resolves a single Provider CRD and adds it to LoadedProviders.
+// Returns parsed pricing if the provider has spec.pricing configured.
 func resolveProviderRefEntry(
 	ctx context.Context,
 	log logr.Logger,
@@ -160,10 +200,10 @@ func resolveProviderRefEntry(
 	ref v1alpha1.ProviderRef,
 	groupName string,
 	arenaCfg *config.Config,
-) error {
+) (*providerPricing, error) {
 	provider, err := k8s.GetProvider(ctx, c, ref, namespace)
 	if err != nil {
-		return fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
+		return nil, fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
 	}
 
 	providerID := sanitizeID(provider.Name)
@@ -200,7 +240,7 @@ func resolveProviderRefEntry(
 		"hasCreds", credEnvVar != "" && os.Getenv(credEnvVar) != "",
 	)
 
-	return nil
+	return parsePricing(provider.Spec.Pricing), nil
 }
 
 // resolveAgentRefEntry resolves an AgentRuntime CRD and creates a fleet provider.
@@ -249,6 +289,7 @@ func resolveAgentRefEntry(
 
 // resolveProviderRefEntryWithID resolves a Provider CRD using an explicit config provider ID
 // instead of deriving it from sanitizeID(provider.Name). Used in map mode.
+// Returns parsed pricing if the provider has spec.pricing configured.
 func resolveProviderRefEntryWithID(
 	ctx context.Context,
 	log logr.Logger,
@@ -258,10 +299,10 @@ func resolveProviderRefEntryWithID(
 	configID string,
 	groupName string,
 	arenaCfg *config.Config,
-) error {
+) (*providerPricing, error) {
 	provider, err := k8s.GetProvider(ctx, c, ref, namespace)
 	if err != nil {
-		return fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
+		return nil, fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
 	}
 
 	pkProvider := &config.Provider{
@@ -293,7 +334,7 @@ func resolveProviderRefEntryWithID(
 		"group", groupName,
 	)
 
-	return nil
+	return parsePricing(provider.Spec.Pricing), nil
 }
 
 // resolveAgentRefEntryWithID resolves an AgentRuntime CRD using an explicit config provider ID.

--- a/ee/cmd/arena-worker/provider_groups_test.go
+++ b/ee/cmd/arena-worker/provider_groups_test.go
@@ -514,7 +514,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "my-openai"}
-		err := resolveProviderRefEntry(ctx, log, c, "default", ref, "judge", arenaCfg)
+		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "judge", arenaCfg)
 		require.NoError(t, err)
 
 		providerID := sanitizeID("my-openai")
@@ -548,7 +548,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "provider-with-cred"}
-		err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
+		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
 		require.NoError(t, err)
 
 		providerID := sanitizeID("provider-with-cred")
@@ -583,7 +583,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "provider-with-defaults"}
-		err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
+		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
 		require.NoError(t, err)
 
 		providerID := sanitizeID("provider-with-defaults")
@@ -601,7 +601,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "nonexistent"}
-		err := resolveProviderRefEntry(ctx, log, c, "default", ref, "group1", arenaCfg)
+		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "group1", arenaCfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "group1")
 		assert.Contains(t, err.Error(), "nonexistent")
@@ -628,11 +628,69 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "cross-ns-provider", Namespace: ptr.To("other-ns")}
-		err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
+		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
 		require.NoError(t, err)
 
 		providerID := sanitizeID("cross-ns-provider")
 		assert.Contains(t, arenaCfg.LoadedProviders, providerID)
+	})
+
+	t.Run("returns pricing when provider has spec.pricing", func(t *testing.T) {
+		provider := &v1alpha1.Provider{
+			Spec: v1alpha1.ProviderSpec{
+				Type:  "openai",
+				Model: "gpt-4o",
+				Pricing: &v1alpha1.ProviderPricing{
+					InputCostPer1K:  ptr.To("0.003"),
+					OutputCostPer1K: ptr.To("0.015"),
+				},
+			},
+		}
+		provider.Name = "priced-provider"
+		provider.Namespace = testNamespace
+
+		c := fake.NewClientBuilder().
+			WithScheme(k8s.Scheme()).
+			WithObjects(provider).
+			Build()
+
+		arenaCfg := &config.Config{
+			LoadedProviders: make(map[string]*config.Provider),
+			ProviderGroups:  make(map[string]string),
+		}
+
+		ref := v1alpha1.ProviderRef{Name: "priced-provider"}
+		pricing, err := resolveProviderRefEntry(ctx, log, c, testNamespace, ref, "default", arenaCfg)
+		require.NoError(t, err)
+		require.NotNil(t, pricing)
+		assert.InDelta(t, 0.003, pricing.inputCostPer1K, 1e-9)
+		assert.InDelta(t, 0.015, pricing.outputCostPer1K, 1e-9)
+	})
+
+	t.Run("returns nil pricing when provider has no spec.pricing", func(t *testing.T) {
+		provider := &v1alpha1.Provider{
+			Spec: v1alpha1.ProviderSpec{
+				Type:  "openai",
+				Model: "gpt-4o",
+			},
+		}
+		provider.Name = "no-pricing-provider"
+		provider.Namespace = testNamespace
+
+		c := fake.NewClientBuilder().
+			WithScheme(k8s.Scheme()).
+			WithObjects(provider).
+			Build()
+
+		arenaCfg := &config.Config{
+			LoadedProviders: make(map[string]*config.Provider),
+			ProviderGroups:  make(map[string]string),
+		}
+
+		ref := v1alpha1.ProviderRef{Name: "no-pricing-provider"}
+		pricing, err := resolveProviderRefEntry(ctx, log, c, testNamespace, ref, "default", arenaCfg)
+		require.NoError(t, err)
+		assert.Nil(t, pricing)
 	})
 }
 
@@ -767,7 +825,7 @@ func TestResolveProviderRefEntryWithID(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "nonexistent"}
-		err := resolveProviderRefEntryWithID(ctx, log, c, testNamespace, ref, "my-id", "grp", arenaCfg)
+		_, err := resolveProviderRefEntryWithID(ctx, log, c, testNamespace, ref, "my-id", "grp", arenaCfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nonexistent")
 	})
@@ -801,7 +859,7 @@ func TestResolveProviderRefEntryWithID(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "full-provider"}
-		err := resolveProviderRefEntryWithID(ctx, log, c, testNamespace, ref, "custom-id", "judge", arenaCfg)
+		_, err := resolveProviderRefEntryWithID(ctx, log, c, testNamespace, ref, "custom-id", "judge", arenaCfg)
 		require.NoError(t, err)
 
 		require.Contains(t, arenaCfg.LoadedProviders, "custom-id")
@@ -831,7 +889,7 @@ func TestResolveEntry(t *testing.T) {
 		}
 		entry := &arenaProviderEntry{}
 
-		fp, err := resolveEntry(ctx, log, nil, testNamespace, "group", "", entry, nil, arenaCfg)
+		fp, _, err := resolveEntry(ctx, log, nil, testNamespace, "group", "", entry, nil, arenaCfg)
 		require.NoError(t, err)
 		assert.Nil(t, fp)
 	})
@@ -848,7 +906,7 @@ func TestResolveEntry(t *testing.T) {
 			AgentRef: &v1alpha1.LocalObjectReference{Name: "agent-a"},
 		}
 
-		fp, err := resolveEntry(ctx, log, nil, testNamespace, "grp", "my-config-id", entry, agentWSURLs, arenaCfg)
+		fp, _, err := resolveEntry(ctx, log, nil, testNamespace, "grp", "my-config-id", entry, agentWSURLs, arenaCfg)
 		require.NoError(t, err)
 		require.NotNil(t, fp)
 		assert.Equal(t, "my-config-id", fp.id)
@@ -866,7 +924,7 @@ func TestResolveEntry(t *testing.T) {
 			AgentRef: &v1alpha1.LocalObjectReference{Name: "agent-b"},
 		}
 
-		fp, err := resolveEntry(ctx, log, nil, testNamespace, "grp", "", entry, agentWSURLs, arenaCfg)
+		fp, _, err := resolveEntry(ctx, log, nil, testNamespace, "grp", "", entry, agentWSURLs, arenaCfg)
 		require.NoError(t, err)
 		require.NotNil(t, fp)
 		assert.Equal(t, sanitizeID("agent-agent-b"), fp.id)
@@ -886,7 +944,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 		cfg := &Config{JobName: "missing", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		_, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		_, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "failed to read ArenaJob")
 	})
@@ -898,7 +956,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 		cfg := &Config{JobName: "empty-job", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		_, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		_, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "no providers")
 	})
@@ -944,7 +1002,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 			},
 		}
 
-		_, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		_, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.NoError(t, err)
 
 		// Arena config providers must be gone — only CRD providers remain
@@ -988,7 +1046,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 		cfg := &Config{JobName: "test-job", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		fps, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		fps, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.NoError(t, err)
 		assert.Empty(t, fps) // no fleet providers — only CRD providers
 
@@ -1016,7 +1074,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 		cfg := &Config{JobName: "test-job", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		_, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		_, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nonexistent-provider")
 	})
@@ -1041,7 +1099,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 		cfg := &Config{JobName: "agent-job", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		fps, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		fps, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.NoError(t, err)
 		require.Len(t, fps, 1)
 
@@ -1072,7 +1130,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 		cfg := &Config{JobName: "agent-job", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		_, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		_, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "my-agent")
 	})
@@ -1109,7 +1167,7 @@ func TestResolveProvidersFromCRD(t *testing.T) {
 		// arenaCfg has nil maps — function should initialise them
 		arenaCfg := &config.Config{}
 
-		_, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		_, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.NoError(t, err)
 		assert.NotNil(t, arenaCfg.LoadedProviders)
 		assert.NotNil(t, arenaCfg.ProviderGroups)
@@ -1856,7 +1914,7 @@ func TestResolveProvidersFromCRD_MapMode(t *testing.T) {
 		cfg := &Config{JobName: "map-agent-job", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		fps, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		fps, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.NoError(t, err)
 		require.Len(t, fps, 1)
 
@@ -1900,7 +1958,7 @@ func TestResolveProvidersFromCRD_MapMode(t *testing.T) {
 		cfg := &Config{JobName: "map-job", JobNamespace: testNamespace}
 		arenaCfg := &config.Config{}
 
-		fps, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
+		fps, _, err := resolveProvidersFromCRD(ctx, log, c, cfg, arenaCfg)
 		require.NoError(t, err)
 		assert.Empty(t, fps)
 

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -37,6 +37,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	v1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	"github.com/altairalabs/omnia/ee/pkg/arena/fleet"
 	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
 	"github.com/altairalabs/omnia/internal/session/httpclient"
@@ -519,7 +520,8 @@ func executeWorkItem(
 	}
 
 	var crdFleetProviders []*resolvedFleetProvider
-	crdFleetProviders, err = resolveProvidersFromCRD(ctx, log, k8sClient, cfg, arenaCfg)
+	var pricingMap map[string]*providerPricing
+	crdFleetProviders, pricingMap, err = resolveProvidersFromCRD(ctx, log, k8sClient, cfg, arenaCfg)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve providers from CRDs: %w", err)
 	}
@@ -656,8 +658,8 @@ func executeWorkItem(
 		return nil, fmt.Errorf("execution failed: %w", err)
 	}
 
-	// Build result from state store
-	result = buildExecutionResult(log, eng.GetStateStore(), runIDs, start)
+	// Build result from state store, with cost calculation from provider pricing.
+	result = buildExecutionResult(log, eng.GetStateStore(), runIDs, start, pricingMap[item.ProviderID])
 
 	// Extract TTFT from fleet providers — the engine doesn't propagate this,
 	// so we read it directly from the provider after execution completes.
@@ -852,8 +854,10 @@ func (a *runAggregator) processAssertions(runID string, assertions []arenastates
 }
 
 // buildExecutionResult constructs an ExecutionResult from the engine's state store.
+// If pricing is non-nil, cost is computed from token counts and written to metrics.
 func buildExecutionResult(
 	log logr.Logger, store statestore.Store, runIDs []string, startTime time.Time,
+	pricing *providerPricing,
 ) *ExecutionResult {
 	result := &ExecutionResult{
 		DurationMs: float64(time.Since(startTime).Milliseconds()),
@@ -878,7 +882,7 @@ func buildExecutionResult(
 	}
 
 	result.Assertions = agg.assertions
-	populateMetrics(result, agg, len(runIDs))
+	populateMetrics(result, agg, len(runIDs), pricing)
 	setResultStatus(result, agg)
 
 	return result
@@ -896,7 +900,8 @@ func buildFallbackResult(result *ExecutionResult, runIDs []string) *ExecutionRes
 }
 
 // populateMetrics sets the metrics on the result from aggregated data.
-func populateMetrics(result *ExecutionResult, agg *runAggregator, totalRuns int) {
+// If pricing is non-nil, it also computes and writes the total cost.
+func populateMetrics(result *ExecutionResult, agg *runAggregator, totalRuns int, pricing *providerPricing) {
 	result.Metrics["totalDurationMs"] = float64(agg.totalDuration.Milliseconds())
 	result.Metrics["runsExecuted"] = float64(totalRuns)
 	result.Metrics["runsPassed"] = float64(agg.passCount)
@@ -907,6 +912,13 @@ func populateMetrics(result *ExecutionResult, agg *runAggregator, totalRuns int)
 	}
 	if agg.outputTokens > 0 {
 		result.Metrics[metricKeyOutputTokens] = float64(agg.outputTokens)
+	}
+
+	if pricing != nil && (agg.inputTokens > 0 || agg.outputTokens > 0) {
+		cost := pricing.computeCost(agg.inputTokens, agg.outputTokens)
+		if cost > 0 {
+			result.Metrics[metricKeyCost] = cost
+		}
 	}
 }
 
@@ -929,8 +941,45 @@ func setResultStatus(result *ExecutionResult, agg *runAggregator) {
 const (
 	metricKeyInputTokens  = "totalInputTokens"
 	metricKeyOutputTokens = "totalOutputTokens"
+	metricKeyCost         = "totalCost"
 	metricKeyTTFT         = "ttftSeconds"
 )
+
+// providerPricing holds parsed pricing from a Provider CRD.
+type providerPricing struct {
+	inputCostPer1K  float64
+	outputCostPer1K float64
+}
+
+// computeCost calculates the total cost from token counts and pricing.
+func (p *providerPricing) computeCost(inputTokens, outputTokens int) float64 {
+	return float64(inputTokens)*p.inputCostPer1K/1000 + float64(outputTokens)*p.outputCostPer1K/1000
+}
+
+// parsePricing extracts pricing from a Provider CRD's spec.pricing field.
+// Returns nil if pricing is not configured or has no valid values.
+func parsePricing(pricing *v1alpha1.ProviderPricing) *providerPricing {
+	if pricing == nil {
+		return nil
+	}
+
+	p := &providerPricing{}
+	if pricing.InputCostPer1K != nil {
+		if v, err := strconv.ParseFloat(*pricing.InputCostPer1K, 64); err == nil {
+			p.inputCostPer1K = v
+		}
+	}
+	if pricing.OutputCostPer1K != nil {
+		if v, err := strconv.ParseFloat(*pricing.OutputCostPer1K, 64); err == nil {
+			p.outputCostPer1K = v
+		}
+	}
+
+	if p.inputCostPer1K == 0 && p.outputCostPer1K == 0 {
+		return nil
+	}
+	return p
+}
 
 // recordDetailedMetrics emits per-trial Prometheus metrics from an execution result.
 func recordDetailedMetrics(


### PR DESCRIPTION
## Summary

The worker now computes dollar cost from Provider CRD `spec.pricing` (inputCostPer1K/outputCostPer1K) and writes it to `result.Metrics["totalCost"]`. This enables budget safety and cost-based SLO thresholds to work with real data.

## Changes

- **`providerPricing` struct**: Parsed from Provider CRD pricing, with `computeCost(inputTokens, outputTokens)` method
- **`parsePricing`**: Parses `*ProviderPricing` string fields to float64, returns nil when absent/zero
- **Provider resolution**: `resolveProvidersFromCRD` now returns pricing map alongside providers
- **`populateMetrics`**: Accepts optional pricing, computes and writes `"totalCost"` when tokens and pricing are available

## Test plan
- [x] `TestComputeCost` — 4 cases
- [x] `TestParsePricing` — 5 cases (nil, zero, valid, invalid, partial)
- [x] `TestPopulateMetrics_Cost` — 3 cases
- [x] Provider resolution pricing extraction tests
- [x] All existing tests updated and passing