### PR TITLE
fix: retry session creation on transient errors under load

### DIFF
--- a/ee/cmd/arena-worker/session_recording.go
+++ b/ee/cmd/arena-worker/session_recording.go
@@ -103,9 +103,6 @@ func (m *arenaSessionManager) OnEvent(event *events.Event) {
 	}
 
 	// We won the race — create the session and event store.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	tags := []string{
 		"source:arena",
 		"arena-job:" + m.meta.JobName,
@@ -131,14 +128,16 @@ func (m *arenaSessionManager) OnEvent(event *events.Event) {
 		initialState["arena.trial.index"] = m.meta.TrialIndex
 	}
 
-	_, err := m.store.CreateSession(ctx, session.CreateSessionOptions{
+	opts := session.CreateSessionOptions{
 		ID:            pgID,
 		AgentName:     m.meta.JobName,
 		Namespace:     m.meta.Namespace,
 		WorkspaceName: m.meta.WorkspaceName,
 		Tags:          tags,
 		InitialState:  initialState,
-	})
+	}
+
+	_, err := m.createSessionWithRetry(opts)
 	if err != nil {
 		m.log.Error(err, "failed to create arena session",
 			"runID", runSessionID, "pgSessionID", pgID)
@@ -158,6 +157,36 @@ func (m *arenaSessionManager) OnEvent(event *events.Event) {
 
 	event.SessionID = pgID
 	es.OnEvent(event)
+}
+
+const (
+	sessionCreateMaxRetries = 3
+	sessionCreateBaseWait   = 500 * time.Millisecond
+	sessionCreateTimeout    = 10 * time.Second
+)
+
+// createSessionWithRetry attempts to create a session with exponential backoff.
+// Transient errors (timeouts, server errors) are retried up to sessionCreateMaxRetries times.
+func (m *arenaSessionManager) createSessionWithRetry(opts session.CreateSessionOptions) (*session.Session, error) {
+	var lastErr error
+	for attempt := range sessionCreateMaxRetries {
+		if attempt > 0 {
+			wait := sessionCreateBaseWait << uint(attempt-1)
+			m.log.V(1).Info("retrying session creation",
+				"pgSessionID", opts.ID, "attempt", attempt+1, "backoff", wait.String())
+			time.Sleep(wait)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), sessionCreateTimeout)
+		sess, err := m.store.CreateSession(ctx, opts)
+		cancel()
+
+		if err == nil {
+			return sess, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
 }
 
 // SessionIDs returns all PostgreSQL session IDs created by this manager.

--- a/ee/cmd/arena-worker/session_recording_test.go
+++ b/ee/cmd/arena-worker/session_recording_test.go
@@ -129,6 +129,27 @@ func (f *failingSessionStore) CreateSession(
 	return nil, errors.New("connection refused")
 }
 
+// failThenSucceedStore fails the first N calls, then succeeds.
+type failThenSucceedStore struct {
+	mockSessionStore
+	mu        sync.Mutex
+	failCount int
+	calls     int
+}
+
+func (f *failThenSucceedStore) CreateSession(
+	ctx context.Context, opts session.CreateSessionOptions,
+) (*session.Session, error) {
+	f.mu.Lock()
+	f.calls++
+	shouldFail := f.calls <= f.failCount
+	f.mu.Unlock()
+	if shouldFail {
+		return nil, errors.New("connection refused")
+	}
+	return f.mockSessionStore.CreateSession(ctx, opts)
+}
+
 func TestRunIDToUUID(t *testing.T) {
 	// Deterministic: same input → same output
 	id1 := runIDToUUID("2026-03-21T15-04-05Z_openai_us-east_support_a1b2c3d4_0001")
@@ -362,6 +383,31 @@ func TestArenaSessionManager_OnEvent_CreateSessionError(t *testing.T) {
 
 	// No sessions should have been created since CreateSession always fails
 	assert.Empty(t, store.getCreatedSessions(), "no sessions created when store fails")
+}
+
+func TestArenaSessionManager_OnEvent_RetriesAndSucceeds(t *testing.T) {
+	store := &failThenSucceedStore{
+		mockSessionStore: *newMockStore(),
+		failCount:        2, // fail first 2 attempts, succeed on 3rd
+	}
+	mgr := newArenaSessionManager(store, logr.Discard(), arenaSessionMetadata{
+		JobName:    "test-job",
+		Namespace:  "default",
+		ProviderID: "openai",
+	}, "test-item")
+
+	mgr.OnEvent(&events.Event{
+		Type:      events.EventProviderCallCompleted,
+		SessionID: "run-retry",
+		Timestamp: time.Now(),
+		Data:      &events.ProviderCallCompletedData{Provider: "openai"},
+	})
+
+	time.Sleep(100 * time.Millisecond)
+
+	sessions := store.getCreatedSessions()
+	require.Len(t, sessions, 1, "should succeed after retries")
+	assert.Equal(t, 3, store.calls, "should have attempted 3 times")
 }
 
 func TestArenaSessionManager_SessionIDs(t *testing.T) {

--- a/internal/session/httpclient/store.go
+++ b/internal/session/httpclient/store.go
@@ -706,8 +706,14 @@ func (s *Store) doRequest(ctx context.Context, method, path string, body []byte)
 }
 
 // isRetryableStatus returns true for HTTP status codes that indicate a transient server issue.
+// Includes 500 because database restarts (e.g., Postgres pool exhaustion under load)
+// return 500 but are recoverable after a short wait.
 func isRetryableStatus(code int) bool {
-	return code == http.StatusBadGateway || code == http.StatusServiceUnavailable || code == http.StatusGatewayTimeout
+	return code == http.StatusInternalServerError ||
+		code == http.StatusBadGateway ||
+		code == http.StatusServiceUnavailable ||
+		code == http.StatusGatewayTimeout ||
+		code == http.StatusTooManyRequests
 }
 
 // drainAndClose reads remaining body bytes and closes it.

--- a/internal/session/httpclient/store_test.go
+++ b/internal/session/httpclient/store_test.go
@@ -318,8 +318,10 @@ func TestGetSession_NotFound(t *testing.T) {
 }
 
 func TestGetSession_ServerError(t *testing.T) {
-	// Server returns 500 with valid JSON error.
+	// Server returns 500 with valid JSON error — retried then fails.
+	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(sessionapi.ErrorResponse{Error: "database down"})
@@ -335,8 +337,8 @@ func TestGetSession_ServerError(t *testing.T) {
 	if !strings.Contains(err.Error(), "500") {
 		t.Fatalf("expected error with status 500, got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "database down") {
-		t.Fatalf("expected error message, got: %v", err)
+	if attempts.Load() != maxRetries {
+		t.Fatalf("expected %d attempts (500 is retryable), got %d", maxRetries, attempts.Load())
 	}
 }
 
@@ -381,7 +383,10 @@ func TestAppendMessage_NotFound(t *testing.T) {
 }
 
 func TestAppendMessage_ServerError(t *testing.T) {
+	// 500 is retried; after exhausting retries, buffered writes absorb the error.
+	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(sessionapi.ErrorResponse{Error: "internal error"})
@@ -393,11 +398,12 @@ func TestAppendMessage_ServerError(t *testing.T) {
 	err := store.AppendMessage(context.Background(), "x", session.Message{
 		ID: "m1", Role: session.RoleUser, Content: "hi",
 	})
-	if err == nil {
-		t.Fatal("expected error")
+	// After retries exhaust, the write is buffered (returns nil).
+	if err != nil {
+		t.Fatalf("expected nil (buffered), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "500") {
-		t.Fatalf("expected 500 error, got: %v", err)
+	if attempts.Load() != maxRetries {
+		t.Fatalf("expected %d attempts, got %d", maxRetries, attempts.Load())
 	}
 }
 
@@ -440,7 +446,10 @@ func TestUpdateSessionStatus_NotFound(t *testing.T) {
 }
 
 func TestUpdateSessionStatus_ServerError(t *testing.T) {
+	// 500 is retried; after exhausting retries, buffered writes absorb the error.
+	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(sessionapi.ErrorResponse{Error: "internal error"})
@@ -452,11 +461,11 @@ func TestUpdateSessionStatus_ServerError(t *testing.T) {
 	err := store.UpdateSessionStatus(context.Background(), "x", session.SessionStatusUpdate{
 		SetStatus: session.SessionStatusActive,
 	})
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("expected nil (buffered), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "500") {
-		t.Fatalf("expected 500 error, got: %v", err)
+	if attempts.Load() != maxRetries {
+		t.Fatalf("expected %d attempts, got %d", maxRetries, attempts.Load())
 	}
 }
 
@@ -495,7 +504,10 @@ func TestRefreshTTL_NotFound(t *testing.T) {
 }
 
 func TestRefreshTTL_ServerError(t *testing.T) {
+	// 500 is retried; after exhausting retries, buffered writes absorb the error.
+	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		attempts.Add(1)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		_ = json.NewEncoder(w).Encode(sessionapi.ErrorResponse{Error: "internal error"})
@@ -505,11 +517,11 @@ func TestRefreshTTL_ServerError(t *testing.T) {
 	store := NewStore(srv.URL, logr.Discard())
 	t.Cleanup(func() { _ = store.Close() })
 	err := store.RefreshTTL(context.Background(), "x", time.Hour)
-	if err == nil {
-		t.Fatal("expected error")
+	if err != nil {
+		t.Fatalf("expected nil (buffered), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "500") {
-		t.Fatalf("expected 500 error, got: %v", err)
+	if attempts.Load() != maxRetries {
+		t.Fatalf("expected %d attempts, got %d", maxRetries, attempts.Load())
 	}
 }
 
@@ -575,16 +587,17 @@ func TestServerErrorResponses(t *testing.T) {
 		t.Fatal("GetSession: expected error")
 	}
 
-	if err := store.AppendMessage(ctx, "x", session.Message{ID: "m1", Role: session.RoleUser, Content: "hi"}); err == nil {
-		t.Fatal("AppendMessage: expected error")
+	// Buffered writes return nil after retries exhaust (error absorbed by buffer).
+	if err := store.AppendMessage(ctx, "x", session.Message{ID: "m1", Role: session.RoleUser, Content: "hi"}); err != nil {
+		t.Fatalf("AppendMessage: expected nil (buffered), got: %v", err)
 	}
 
-	if err := store.UpdateSessionStatus(ctx, "x", session.SessionStatusUpdate{SetStatus: session.SessionStatusActive}); err == nil {
-		t.Fatal("UpdateSessionStatus: expected error")
+	if err := store.UpdateSessionStatus(ctx, "x", session.SessionStatusUpdate{SetStatus: session.SessionStatusActive}); err != nil {
+		t.Fatalf("UpdateSessionStatus: expected nil (buffered), got: %v", err)
 	}
 
-	if err := store.RefreshTTL(ctx, "x", time.Hour); err == nil {
-		t.Fatal("RefreshTTL: expected error")
+	if err := store.RefreshTTL(ctx, "x", time.Hour); err != nil {
+		t.Fatalf("RefreshTTL: expected nil (buffered), got: %v", err)
 	}
 }
 
@@ -832,8 +845,7 @@ func TestCircuitBreaker_OpensAfterRepeatedFailures(t *testing.T) {
 	var attempts atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		attempts.Add(1)
-		// Use a retryable status so doWithRetryInner returns an error
-		// (non-retryable statuses like 500 return (resp, nil) which gobreaker counts as success).
+		// Use a retryable status so doWithRetryInner returns an error.
 		w.WriteHeader(http.StatusBadGateway)
 	}))
 	defer srv.Close()


### PR DESCRIPTION
## Summary

Fixes #683 — 100 VU load test only produced 12 out of 100 sessions because Postgres crashed under burst load and 500 errors were not retried.

- Add HTTP 500 and 429 to retryable status codes in session httpclient — Postgres restarts return 500 which is recoverable
- Add retry with exponential backoff (500ms/1s/2s) in arena session manager's `createSessionWithRetry` — previously gave up on first failure
- Update httpclient tests: buffered writes now absorb 500 errors after retry exhaustion instead of surfacing them

## Test plan

- [x] `go test ./internal/session/httpclient/...` — all pass, retry behavior verified
- [x] `go test ./ee/cmd/arena-worker/...` — new `TestArenaSessionManager_OnEvent_RetriesAndSucceeds` verifies fail-then-succeed path
- [ ] Run 100 VU load test and verify session count matches work item count