### PR TITLE
feat: PgBouncer sidecar for dev Postgres

### DIFF
--- a/charts/omnia/templates/session-api/dev-postgres.yaml
+++ b/charts/omnia/templates/session-api/dev-postgres.yaml
@@ -1,8 +1,11 @@
 {{- if and .Values.sessionApi.enabled .Values.sessionApi.postgres.dev.enabled }}
+{{- $pgbouncerEnabled := .Values.sessionApi.postgres.pgbouncer.enabled }}
+{{- $clientPort := ternary 6432 5432 $pgbouncerEnabled }}
 # =============================================================================
 # Dev-only Postgres — NOT for production use.
 # Provides the omnia-postgres Secret and a single-node Postgres StatefulSet
 # so that session-api can start without external infrastructure.
+# When pgbouncer.enabled=true, a PgBouncer sidecar pools connections.
 # =============================================================================
 apiVersion: v1
 kind: Secret
@@ -11,7 +14,40 @@ metadata:
   labels:
     {{- include "omnia.sessionApi.labels" . | nindent 4 }}
 stringData:
-  {{ .Values.sessionApi.postgres.secretKey }}: "postgres://omnia:omnia@{{ include "omnia.fullname" . }}-postgres:5432/omnia?sslmode=disable"
+  {{ .Values.sessionApi.postgres.secretKey }}: "postgres://omnia:omnia@{{ include "omnia.fullname" . }}-postgres:{{ $clientPort }}/omnia?sslmode=disable"
+{{- if $pgbouncerEnabled }}
+---
+# PgBouncer configuration for the dev Postgres sidecar.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "omnia.fullname" . }}-pgbouncer
+  labels:
+    {{- include "omnia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+data:
+  pgbouncer.ini: |
+    [databases]
+    omnia = host=127.0.0.1 port=5432 dbname=omnia
+
+    [pgbouncer]
+    listen_addr = 0.0.0.0
+    listen_port = 6432
+    auth_type = md5
+    auth_file = /etc/pgbouncer/userlist.txt
+    pool_mode = {{ .Values.sessionApi.postgres.pgbouncer.poolMode }}
+    default_pool_size = {{ .Values.sessionApi.postgres.pgbouncer.defaultPoolSize }}
+    max_client_conn = {{ .Values.sessionApi.postgres.pgbouncer.maxClientConn }}
+    max_db_connections = {{ .Values.sessionApi.postgres.pgbouncer.maxDbConnections }}
+    ignore_startup_parameters = extra_float_digits
+    # Log connections/disconnections for debugging
+    log_connections = 1
+    log_disconnections = 1
+    # Stats available via SHOW STATS
+    stats_period = 60
+  userlist.txt: |
+    "omnia" "md55b67425b5ec6058d90ce3e21f576a7cf"
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
@@ -23,10 +59,10 @@ metadata:
 spec:
   type: ClusterIP
   ports:
-    - port: 5432
-      targetPort: 5432
+    - port: {{ $clientPort }}
+      targetPort: {{ $clientPort }}
       protocol: TCP
-      name: postgres
+      name: {{ ternary "pgbouncer" "postgres" $pgbouncerEnabled }}
   selector:
     app.kubernetes.io/name: {{ include "omnia.name" . }}-postgres
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -82,6 +118,33 @@ spec:
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
+{{- if $pgbouncerEnabled }}
+        - name: pgbouncer
+          image: bitnami/pgbouncer:1
+          ports:
+            - containerPort: 6432
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            limits:
+              cpu: 200m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          volumeMounts:
+            - name: pgbouncer-config
+              mountPath: /etc/pgbouncer
+              readOnly: true
+      volumes:
+        - name: pgbouncer-config
+          configMap:
+            name: {{ include "omnia.fullname" . }}-pgbouncer
+{{- end }}
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -730,13 +730,14 @@ sessionApi:
     # -- Deploy a dev-only single-node Postgres (NOT for production)
     dev:
       enabled: false
-    # -- PgBouncer connection pooling (recommended for production)
-    # IMPORTANT: These values are NOT consumed by any Helm template. They exist
-    # as a reference for operators deploying an external PgBouncer (e.g., via
-    # PgBouncer operator or a sidecar). No chart-managed PgBouncer is created.
+    # -- PgBouncer connection pooling sidecar for the dev Postgres.
+    # When dev.enabled=true and pgbouncer.enabled=true, a PgBouncer sidecar is
+    # added to the dev Postgres StatefulSet. The connection string in the Secret
+    # points to PgBouncer (port 6432) instead of Postgres directly.
+    # For production, use your cloud provider's connection pooling (RDS Proxy, etc.).
     pgbouncer:
-      # -- Enable PgBouncer connection pooling
-      enabled: false
+      # -- Enable PgBouncer sidecar (only applies when dev.enabled=true)
+      enabled: true
       # -- PgBouncer pool mode (session, transaction, or statement)
       poolMode: transaction
       # -- Default pool size per user/database pair


### PR DESCRIPTION
## Summary

Add a PgBouncer sidecar to the dev Postgres StatefulSet for OOTB connection pooling on evaluation installs.

- PgBouncer runs as a sidecar in the dev Postgres pod (bitnami/pgbouncer:1)
- Connection string in the Secret points to PgBouncer (port 6432) instead of Postgres (5432)
- Transaction pool mode with configurable pool size (default: 20 pool, 200 max clients, 50 max DB conns)
- Enabled by default when `sessionApi.postgres.dev.enabled=true`
- Can be disabled with `sessionApi.postgres.pgbouncer.enabled=false` (falls back to direct Postgres)
- For production, use cloud provider connection pooling (RDS Proxy, Cloud SQL proxy, etc.)

Addresses the connection exhaustion root cause from #683 — multiple session-api replicas each opening 50-connection pools would overwhelm the dev Postgres without PgBouncer.

## Test plan

- [x] `helm template` renders correctly with pgbouncer enabled (port 6432, ConfigMap, sidecar)
- [x] `helm template` renders correctly with pgbouncer disabled (port 5432, no sidecar)
- [x] `helm lint` passes
- [ ] Deploy to dev cluster and verify PgBouncer accepts connections
- [ ] Run arena load test with 100 VUs and verify all sessions created