### PR TITLE
fix: make arena stats accumulators idempotent

### DIFF
--- a/ee/pkg/arena/queue/memory.go
+++ b/ee/pkg/arena/queue/memory.go
@@ -31,13 +31,14 @@ type MemoryQueue struct {
 
 // jobState holds the state for a single job's work items.
 type jobState struct {
-	mu         sync.Mutex
-	pending    []*WorkItem          // Items waiting to be processed
-	processing map[string]*WorkItem // Items currently being processed (by itemID)
-	completed  map[string]*WorkItem // Successfully completed items
-	failed     map[string]*WorkItem // Failed items
-	startedAt  *time.Time
-	stats      *JobStats // Accumulated statistics
+	mu           sync.Mutex
+	pending      []*WorkItem          // Items waiting to be processed
+	processing   map[string]*WorkItem // Items currently being processed (by itemID)
+	completed    map[string]*WorkItem // Successfully completed items
+	failed       map[string]*WorkItem // Failed items
+	statsCounted map[string]bool      // Item IDs already counted in stats (idempotency guard)
+	startedAt    *time.Time
+	stats        *JobStats // Accumulated statistics
 }
 
 // NewMemoryQueue creates a new in-memory work queue with the given options.
@@ -285,10 +286,11 @@ func (q *MemoryQueue) getOrCreateJobState(jobID string) *jobState {
 	state, exists := q.jobs[jobID]
 	if !exists {
 		state = &jobState{
-			pending:    make([]*WorkItem, 0),
-			processing: make(map[string]*WorkItem),
-			completed:  make(map[string]*WorkItem),
-			failed:     make(map[string]*WorkItem),
+			pending:      make([]*WorkItem, 0),
+			processing:   make(map[string]*WorkItem),
+			completed:    make(map[string]*WorkItem),
+			failed:       make(map[string]*WorkItem),
+			statsCounted: make(map[string]bool),
 			stats: &JobStats{
 				ByScenario: make(map[string]*GroupStats),
 				ByProvider: make(map[string]*GroupStats),
@@ -376,7 +378,12 @@ func (q *MemoryQueue) CompleteItem(ctx context.Context, jobID string, itemID str
 	state.mu.Lock()
 	defer state.mu.Unlock()
 
-	// Get item to extract scenarioID/providerID
+	// Idempotent: skip stats if this item was already counted.
+	if state.statsCounted[itemID] {
+		return nil
+	}
+	state.statsCounted[itemID] = true
+
 	item := state.completed[itemID]
 	q.updateMemoryStats(state.stats, item, result)
 
@@ -417,8 +424,11 @@ func (q *MemoryQueue) FailItem(ctx context.Context, jobID string, itemID string,
 	delete(state.processing, itemID)
 	state.failed[itemID] = item
 
-	// Update failure accumulators
-	q.incrementFailureStats(state.stats, item)
+	// Idempotent: skip stats if this item was already counted.
+	if !state.statsCounted[itemID] {
+		state.statsCounted[itemID] = true
+		q.incrementFailureStats(state.stats, item)
+	}
 
 	return nil
 }

--- a/ee/pkg/arena/queue/redis.go
+++ b/ee/pkg/arena/queue/redis.go
@@ -784,11 +784,20 @@ func (q *RedisQueue) CompleteItem(ctx context.Context, jobID string, itemID stri
 	item.CompletedAt = &now
 	item.Result = resultJSON
 
+	// Check idempotency: skip stats increment if this item was already counted
+	// (e.g., due to re-enqueue after partial failure or duplicate processing).
+	alreadyCounted, markErr := q.markStatsCounted(ctx, jobID, itemID)
+	if markErr != nil {
+		// Non-fatal: if we can't check, increment anyway to avoid lost stats.
+		// This is the pre-fix behavior and only triggers on Redis errors.
+		alreadyCounted = false
+	}
+
 	// Build and execute the accumulator pipeline
 	pipe := q.client.Pipeline()
 	q.saveItemPipe(ctx, pipe, item)
 	q.addToCompletedSetPipe(ctx, pipe, jobID, itemID)
-	q.incrementStatsPipe(ctx, pipe, jobID, item, result)
+	q.incrementStatsPipe(ctx, pipe, jobID, item, result, alreadyCounted)
 	_, err = pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to execute complete pipeline: %w", err)
@@ -831,11 +840,18 @@ func (q *RedisQueue) FailItem(ctx context.Context, jobID string, itemID string, 
 		item.Error = failErr.Error()
 	}
 
+	alreadyCounted, markErr := q.markStatsCounted(ctx, jobID, itemID)
+	if markErr != nil {
+		alreadyCounted = false
+	}
+
 	// Build and execute the failure pipeline
 	pipe := q.client.Pipeline()
 	q.saveItemPipe(ctx, pipe, item)
 	q.addToFailedSetPipe(ctx, pipe, jobID, itemID)
-	q.incrementFailureStatsPipe(ctx, pipe, jobID, item)
+	if !alreadyCounted {
+		q.incrementFailureStatsPipe(ctx, pipe, jobID, item)
+	}
 	_, err = pipe.Exec(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to execute fail pipeline: %w", err)
@@ -904,10 +920,22 @@ func (q *RedisQueue) scanGroupStats(
 	}
 }
 
+// statsCountedKey returns the Redis key for the set of item IDs that have been counted in stats.
+func (q *RedisQueue) statsCountedKey(jobID string) string {
+	return jobKeyPrefix + jobID + ":stats:counted"
+}
+
 // incrementStatsPipe adds accumulator increment commands to a pipeline for a completed item.
+// Idempotent: only increments if the item has not already been counted.
+// The caller must call markStatsCounted first and pass alreadyCounted=true to skip.
 func (q *RedisQueue) incrementStatsPipe(
 	ctx context.Context, pipe redis.Pipeliner, jobID string, item *WorkItem, result *ItemResult,
+	alreadyCounted bool,
 ) {
+	if alreadyCounted {
+		return
+	}
+
 	mainKey := q.statsKey(jobID)
 	tokens := extractTokens(result.Metrics)
 	cost := extractCost(result.Metrics)
@@ -923,6 +951,18 @@ func (q *RedisQueue) incrementStatsPipe(
 		provKey := q.statsProviderKey(jobID, item.ProviderID)
 		q.incrStatsFields(ctx, pipe, provKey, result.Status, result.DurationMs, tokens, cost)
 	}
+}
+
+// markStatsCounted atomically adds the item ID to the stats-counted set.
+// Returns true if the item was already counted (SADD returned 0).
+func (q *RedisQueue) markStatsCounted(ctx context.Context, jobID, itemID string) (bool, error) {
+	countedKey := q.statsCountedKey(jobID)
+	added, err := q.client.SAdd(ctx, countedKey, itemID).Result()
+	if err != nil {
+		return false, err
+	}
+	q.client.Expire(ctx, countedKey, q.itemTTL)
+	return added == 0, nil
 }
 
 // incrStatsFields adds HINCRBY/HINCRBYFLOAT commands for a stats hash.

--- a/ee/pkg/arena/queue/redis_test.go
+++ b/ee/pkg/arena/queue/redis_test.go
@@ -13,6 +13,7 @@ package queue
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -859,4 +860,223 @@ func TestRedisQueue_GetItems_Closed(t *testing.T) {
 
 	_, err = q.GetFailedItems(ctx, "job-1")
 	assert.Equal(t, ErrQueueClosed, err)
+}
+
+// TestRedisQueue_NackRetryDoubleCount reproduces issue #682:
+// an item that is Nack'd (requeued) and then completed on retry
+// should be counted exactly once in the stats accumulators.
+func TestRedisQueue_NackRetryDoubleCount(t *testing.T) {
+	client := getTestRedisClient(t)
+	defer cleanupRedisKeys(t, client)
+	defer func() { _ = client.Close() }()
+
+	q := NewRedisQueueFromClient(client, Options{
+		VisibilityTimeout: 5 * time.Minute,
+		MaxRetries:        3,
+	})
+	defer func() { _ = q.Close() }()
+
+	ctx := context.Background()
+	jobID := "test-double-count"
+
+	// Push a single item
+	items := []WorkItem{{ID: "item-1", ScenarioID: "simple-qa", ProviderID: "tools-demo"}}
+	require.NoError(t, q.Push(ctx, jobID, items))
+
+	// Pop → Nack (simulates session-api failure causing retry)
+	item1, err := q.Pop(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, "item-1", item1.ID)
+
+	require.NoError(t, q.Nack(ctx, jobID, "item-1", errors.New("session-api timeout")))
+
+	// Pop again (retried item)
+	item2, err := q.Pop(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, "item-1", item2.ID)
+	assert.Equal(t, 2, item2.Attempt) // second attempt
+
+	// Complete on retry
+	result := &ItemResult{Status: "pass", DurationMs: 100}
+	require.NoError(t, q.CompleteItem(ctx, jobID, "item-1", result))
+
+	// Stats should show 1 item, not 2
+	stats, err := q.GetStats(ctx, jobID)
+	require.NoError(t, err)
+
+	t.Logf("Stats: total=%d, passed=%d, failed=%d", stats.Total, stats.Passed, stats.Failed)
+	t.Logf("ByScenario: %+v", stats.ByScenario)
+	t.Logf("ByProvider: %+v", stats.ByProvider)
+
+	assert.Equal(t, int64(1), stats.Passed+stats.Failed,
+		"item completed once should count as 1 total, not %d", stats.Passed+stats.Failed)
+
+	scenStats := stats.ByScenario["simple-qa"]
+	if scenStats != nil {
+		assert.Equal(t, int64(1), scenStats.Total,
+			"scenario should count 1, not %d", scenStats.Total)
+	}
+}
+
+// TestRedisQueue_MultipleNackRetryStats tests that multiple retries
+// don't accumulate stats beyond the expected count.
+func TestRedisQueue_MultipleNackRetryStats(t *testing.T) {
+	client := getTestRedisClient(t)
+	defer cleanupRedisKeys(t, client)
+	defer func() { _ = client.Close() }()
+
+	q := NewRedisQueueFromClient(client, Options{
+		VisibilityTimeout: 5 * time.Minute,
+		MaxRetries:        3,
+	})
+	defer func() { _ = q.Close() }()
+
+	ctx := context.Background()
+	jobID := "test-multi-retry"
+
+	const numItems = 10
+	items := make([]WorkItem, numItems)
+	for i := range numItems {
+		items[i] = WorkItem{
+			ID:         fmt.Sprintf("item-%d", i),
+			ScenarioID: "simple-qa",
+			ProviderID: "tools-demo",
+		}
+	}
+	require.NoError(t, q.Push(ctx, jobID, items))
+
+	// Pop all → Nack all (simulate transient failure)
+	for i := range numItems {
+		item, err := q.Pop(ctx, jobID)
+		require.NoError(t, err)
+		require.NoError(t, q.Nack(ctx, jobID, item.ID, errors.New("transient")))
+		_ = i
+	}
+
+	// Pop all again → Complete all (retry succeeds)
+	for range numItems {
+		item, err := q.Pop(ctx, jobID)
+		require.NoError(t, err)
+		result := &ItemResult{Status: "pass", DurationMs: 50}
+		require.NoError(t, q.CompleteItem(ctx, jobID, item.ID, result))
+	}
+
+	stats, err := q.GetStats(ctx, jobID)
+	require.NoError(t, err)
+
+	total := stats.Passed + stats.Failed
+	t.Logf("Stats after retry: total=%d (expected %d)", total, numItems)
+	assert.Equal(t, int64(numItems), total,
+		"stats should count %d items, not %d (double-count bug)", numItems, total)
+}
+
+// TestRedisQueue_DoubleCompleteViaRequeue reproduces the exact failure mode
+// from issue #682: an item is completed successfully, but due to a race
+// (e.g., CompleteItem pipeline partially fails, visibility timeout requeues),
+// the item ends up being completed a second time. Stats must not double-count.
+func TestRedisQueue_DoubleCompleteViaRequeue(t *testing.T) {
+	client := getTestRedisClient(t)
+	defer cleanupRedisKeys(t, client)
+	defer func() { _ = client.Close() }()
+
+	q := NewRedisQueueFromClient(client, Options{
+		VisibilityTimeout: 100 * time.Millisecond, // short timeout for test
+		MaxRetries:        3,
+	})
+	defer func() { _ = q.Close() }()
+
+	ctx := context.Background()
+	jobID := "test-double-complete"
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "simple-qa", ProviderID: "tools-demo"},
+	}
+	require.NoError(t, q.Push(ctx, jobID, items))
+
+	// Pop the item (moves to processing ZSET with short visibility timeout)
+	item, err := q.Pop(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, "item-1", item.ID)
+
+	// Complete the item → stats should be 1
+	result := &ItemResult{Status: "pass", DurationMs: 100}
+	require.NoError(t, q.CompleteItem(ctx, jobID, "item-1", result))
+
+	stats, err := q.GetStats(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stats.Passed, "first completion: passed=1")
+
+	// Simulate the race: re-push the same item (as if requeued after timeout)
+	// This is what happens when Push is called again or RequeueTimedOutItems fires
+	require.NoError(t, q.Push(ctx, jobID, items))
+
+	// Pop and complete again
+	item2, err := q.Pop(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, "item-1", item2.ID)
+
+	result2 := &ItemResult{Status: "pass", DurationMs: 50}
+	require.NoError(t, q.CompleteItem(ctx, jobID, "item-1", result2))
+
+	// Stats should STILL be 1, not 2
+	stats2, err := q.GetStats(ctx, jobID)
+	require.NoError(t, err)
+	total := stats2.Passed + stats2.Failed
+	t.Logf("Stats after double-complete: total=%d, passed=%d (want 1)", total, stats2.Passed)
+	assert.Equal(t, int64(1), stats2.Passed,
+		"double-complete should not inflate stats: got passed=%d, want 1", stats2.Passed)
+}
+
+// TestRedisQueue_VisibilityTimeoutRequeueDoubleCount simulates the visibility
+// timeout path: item is popped, takes too long, gets requeued by
+// RequeueTimedOutItems, then completed by both the original and retry workers.
+func TestRedisQueue_VisibilityTimeoutRequeueDoubleCount(t *testing.T) {
+	client := getTestRedisClient(t)
+	defer cleanupRedisKeys(t, client)
+	defer func() { _ = client.Close() }()
+
+	q := NewRedisQueueFromClient(client, Options{
+		VisibilityTimeout: 100 * time.Millisecond, // very short
+		MaxRetries:        3,
+	})
+	defer func() { _ = q.Close() }()
+
+	ctx := context.Background()
+	jobID := "test-visibility-double"
+
+	items := []WorkItem{
+		{ID: "item-1", ScenarioID: "simple-qa", ProviderID: "tools-demo"},
+	}
+	require.NoError(t, q.Push(ctx, jobID, items))
+
+	// Worker A pops the item
+	item, err := q.Pop(ctx, jobID)
+	require.NoError(t, err)
+
+	// Wait for visibility timeout to expire
+	time.Sleep(200 * time.Millisecond)
+
+	// Controller/maintenance requeues timed-out items
+	requeued, err := q.RequeueTimedOutItems(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, 1, requeued, "should requeue 1 timed-out item")
+
+	// Worker B pops the requeued item
+	item2, err := q.Pop(ctx, jobID)
+	require.NoError(t, err)
+	assert.Equal(t, item.ID, item2.ID)
+
+	// Worker B completes first
+	result := &ItemResult{Status: "pass", DurationMs: 50}
+	require.NoError(t, q.CompleteItem(ctx, jobID, item2.ID, result))
+
+	// Worker A tries to complete (stale) — should get ErrItemNotFound
+	err = q.CompleteItem(ctx, jobID, item.ID, result)
+	assert.Equal(t, ErrItemNotFound, err, "stale worker should get ErrItemNotFound")
+
+	// Stats should be 1, not 2
+	stats, err := q.GetStats(ctx, jobID)
+	require.NoError(t, err)
+	t.Logf("Stats after visibility timeout race: total=%d, passed=%d", stats.Passed+stats.Failed, stats.Passed)
+	assert.Equal(t, int64(1), stats.Passed, "visibility timeout race should not double-count")
 }


### PR DESCRIPTION
## Summary

Fixes #682 — stats HINCRBY counters were not guarded against duplicate counting. When items were re-enqueued (session-api failures, visibility timeout redelivery), `CompleteItem` incremented stats again for the same item.

- Add `stats:counted` Redis SET (SADD) checked before incrementing stats in `CompleteItem` and `FailItem`
- If item was already counted, stats increment is skipped entirely
- Same guard added to memory queue (`statsCounted map[string]bool`)
- Graceful degradation: if SADD fails (Redis error), falls back to pre-fix behavior

### Reproducer

`TestRedisQueue_DoubleCompleteViaRequeue`: pushes same item twice, completes both — stats correctly show 1, not 2 (was 2 before fix).

## Test plan

- [x] `TestRedisQueue_DoubleCompleteViaRequeue` — reproduces and verifies fix
- [x] `TestRedisQueue_VisibilityTimeoutRequeueDoubleCount` — visibility timeout race
- [x] `TestRedisQueue_NackRetryDoubleCount` — Nack+retry path
- [x] `TestRedisQueue_MultipleNackRetryStats` — 10 items all retried once
- [x] Full queue test suite passes (Redis + memory)
- [x] `go build ./...` clean