### PR TITLE
fix: use pgvector postgres image in E2E tests and dev postgres

### DIFF
--- a/charts/omnia/templates/session-api/dev-postgres.yaml
+++ b/charts/omnia/templates/session-api/dev-postgres.yaml
@@ -90,7 +90,7 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: postgres:17-alpine
+          image: pgvector/pgvector:pg17
           env:
             - name: POSTGRES_USER
               value: omnia

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -376,7 +376,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: postgres
-        image: postgres:17-alpine
+        image: pgvector/pgvector:pg17
         ports:
         - containerPort: 5432
         env:

--- a/test/e2e/eval_worker_e2e_test.go
+++ b/test/e2e/eval_worker_e2e_test.go
@@ -257,7 +257,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: postgres
-        image: postgres:16-alpine
+        image: pgvector/pgvector:pg16
         ports:
         - containerPort: 5432
         env:


### PR DESCRIPTION
## Summary

Migration 000025 (from #690) added `CREATE EXTENSION IF NOT EXISTS vector` which requires the pgvector extension to be installed in the Postgres image. Three places used vanilla `postgres:*-alpine` images without pgvector:

- `test/e2e/e2e_test.go` — `postgres:17-alpine` → `pgvector/pgvector:pg17`
- `test/e2e/eval_worker_e2e_test.go` — `postgres:16-alpine` → `pgvector/pgvector:pg16`
- `charts/omnia/templates/session-api/dev-postgres.yaml` — `postgres:17-alpine` → `pgvector/pgvector:pg17`

This caused the Core E2E `BeforeAll` to fail — session-api pod never became Ready because migrations failed on the missing vector extension.

## Test plan

- [ ] Core E2E tests pass (session-api pod starts successfully)
- [ ] Eval worker E2E tests pass
- [ ] Dev postgres (via Tilt) runs migrations successfully