### PR TITLE
feat: enable cross-session memory on tools-demo agent

### DIFF
--- a/charts/omnia-demos/templates/resources.yaml
+++ b/charts/omnia-demos/templates/resources.yaml
@@ -846,6 +846,16 @@ spec:
     name: demo-tools
   evals:
     enabled: true
+  memory:
+    enabled: true
+    purpose: support_continuity
+    extraction:
+      enabled: true
+    retention:
+      defaultTTL: "720h"
+    retrieval:
+      strategy: keyword
+      limit: 5
   facade:
     type: websocket
     port: 8080


### PR DESCRIPTION
## Summary

Enable memory on the tools-demo AgentRuntime so it remembers user context across sessions.

```yaml
memory:
  enabled: true
  purpose: support_continuity
  extraction:
    enabled: true
  retention:
    defaultTTL: "720h"  # 30 days
  retrieval:
    strategy: keyword
    limit: 5
```

## How to test

1. `tilt up` with `ENABLE_DEMO=true`
2. Chat with the tools-demo agent in the console
3. Close the session
4. Start a new session — the agent should remember context from the previous conversation
5. View memories at `http://localhost:8083/api/v1/memories?workspace=demo`