### PR TITLE
fix: use DNS-compatible handler name in client tool E2E test

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -2057,7 +2057,7 @@ metadata:
   namespace: test-agents
 spec:
   handlers:
-  - name: get_location
+  - name: get-location
     type: client
     clientConfig:
       consentMessage: "Allow location access?"


### PR DESCRIPTION
## Summary

The client tool E2E test used `get_location` as the handler name, which contains an underscore. The ToolRegistry CRD validates handler names against `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$` (Kubernetes DNS naming). Renamed to `get-location`.

The tool name (`get_location`) is unchanged — tool names don't have this restriction since they're used by the LLM, not by Kubernetes.

The Arena E2E failure (job progress tracking) is a separate pre-existing issue — likely a timing/reconciliation race condition in the controller.

## Test plan

- [ ] Core E2E: client tool test should pass (ToolRegistry creation no longer fails)