### PR TITLE
fix: Helm template comment broke deployment YAML

### DIFF
--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -72,7 +72,6 @@ spec:
             {{- if .Values.operator.apiBindAddress }}
             - --api-bind-address={{ .Values.operator.apiBindAddress }}
             {{- end }}
-            {{- /* Memory config: runtime reads the CRD directly and derives memory-api URL from session-api URL */ -}}
           ports:
             {{- if .Values.operator.apiBindAddress }}
             - name: api


### PR DESCRIPTION
A Go template comment with trailing whitespace stripping concatenated args with ports block, causing E2E helm upgrade failure.