### PR TITLE
fix: doctor code review cleanup

### DIFF
--- a/charts/omnia/templates/doctor/deployment.yaml
+++ b/charts/omnia/templates/doctor/deployment.yaml
@@ -21,6 +21,8 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: doctor
           image: {{ include "omnia.doctor.image" . }}

--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -98,11 +98,6 @@ func main() {
 	memoryChecker := checks.NewMemoryChecker(memoryAPIURL, workspaceUID, agentChecker)
 	runner.Register(memoryChecker.Checks()...)
 
-	// Observability: Prometheus scrapes metrics via pod annotations (port 9090),
-	// not via the K8s service. Doctor checks the /healthz probe instead;
-	// metrics scraping is validated by the Prometheus service monitor.
-	// TODO: add pod-level metrics check in v2
-
 	if *runOnce {
 		runOnceMode(runner, log, *exitCode)
 		return

--- a/internal/doctor/checks/memory.go
+++ b/internal/doctor/checks/memory.go
@@ -395,16 +395,6 @@ func (m *MemoryChecker) checkMemoryRecall(ctx context.Context) doctor.TestResult
 	}
 }
 
-// hasNamedToolCall returns true if any message is a tool_call with the given name.
-func hasNamedToolCall(msgs []wsServerMessage, name string) bool {
-	for _, m := range msgs {
-		if m.Type == wsMessageTypeToolCall && m.ToolCall != nil && m.ToolCall.Name == name {
-			return true
-		}
-	}
-	return false
-}
-
 // fetchBody performs a GET and returns the response body as a string.
 // It returns an error for non-200 responses.
 func fetchBody(ctx context.Context, client *http.Client, url string) (string, error) {

--- a/internal/doctor/checks/memory_test.go
+++ b/internal/doctor/checks/memory_test.go
@@ -604,16 +604,3 @@ func (t *bodyErrorTransport) RoundTrip(req *http.Request) (*http.Response, error
 	resp.Body = errReader{}
 	return resp, nil
 }
-
-// --- hasNamedToolCall helper ---
-
-func TestHasNamedToolCall(t *testing.T) {
-	assert.False(t, hasNamedToolCall(nil, "foo"))
-	assert.False(t, hasNamedToolCall([]wsServerMessage{{Type: wsMessageTypeChunk}}, "foo"))
-	assert.False(t, hasNamedToolCall([]wsServerMessage{
-		{Type: wsMessageTypeToolCall, ToolCall: &wsToolCallInfo{Name: "bar"}},
-	}, "foo"))
-	assert.True(t, hasNamedToolCall([]wsServerMessage{
-		{Type: wsMessageTypeToolCall, ToolCall: &wsToolCallInfo{Name: "foo"}},
-	}, "foo"))
-}

--- a/internal/doctor/result.go
+++ b/internal/doctor/result.go
@@ -5,7 +5,6 @@ import "time"
 type Status string
 
 const (
-	StatusPending Status = "pending"
 	StatusRunning Status = "running"
 	StatusPass    Status = "pass"
 	StatusFail    Status = "fail"

--- a/internal/doctor/server.go
+++ b/internal/doctor/server.go
@@ -51,16 +51,6 @@ func (s *Server) Handler() http.Handler {
 	return mux
 }
 
-// ListenAndServe starts the HTTP server.
-func (s *Server) ListenAndServe() error {
-	srv := &http.Server{
-		Addr:    s.addr,
-		Handler: s.Handler(),
-	}
-	s.log.Info("server starting", "addr", s.addr)
-	return srv.ListenAndServe()
-}
-
 func (s *Server) handleIndex(w http.ResponseWriter, _ *http.Request) {
 	data, err := templateFS.ReadFile("templates/index.html")
 	if err != nil {

--- a/internal/doctor/server_test.go
+++ b/internal/doctor/server_test.go
@@ -3,8 +3,6 @@ package doctor
 import (
 	"context"
 	"encoding/json"
-	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -186,33 +184,5 @@ func TestNewServer(t *testing.T) {
 	}
 	if s.addr != ":9090" {
 		t.Errorf("expected addr :9090, got %s", s.addr)
-	}
-}
-
-func TestServer_ListenAndServe(t *testing.T) {
-	srv := testServer()
-	// Override to use a random port.
-	s := &http.Server{
-		Addr:    "127.0.0.1:0",
-		Handler: srv.Handler(),
-	}
-
-	// Use a listener to get the actual port.
-	ln, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-
-	go func() { _ = s.Serve(ln) }()
-	defer func() { _ = s.Close() }()
-
-	resp, err := http.Get("http://" + ln.Addr().String() + "/healthz")
-	if err != nil {
-		t.Fatalf("GET /healthz: %v", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	body, _ := io.ReadAll(resp.Body)
-	if string(body) != "ok" {
-		t.Errorf("expected 'ok', got %q", string(body))
 	}
 }


### PR DESCRIPTION
## Summary
- Remove dead code: `ListenAndServe()`, `hasNamedToolCall`, `StatusPending`
- Add `seccompProfile: RuntimeDefault` to doctor deployment (PodSecurity restricted)
- Remove stale observability TODO comment

## Test plan
- [ ] All existing doctor tests pass
- [ ] Helm lint passes
- [ ] Doctor pod deploys in restricted namespace