### PR TITLE
fix: replace fixed sleeps with retry loops in Doctor checks

### DIFF
--- a/internal/doctor/checks/agent.go
+++ b/internal/doctor/checks/agent.go
@@ -269,9 +269,8 @@ func (a *AgentChecker) checkToolCalling(ctx context.Context) doctor.TestResult {
 		}
 	}
 
-	// The WS session may not be flushed to session-api yet. Query the most
-	// recent session for this namespace to find tool calls.
-	time.Sleep(3 * time.Second)
+	// The runtime event store writes tool calls to session-api asynchronously
+	// (fire-and-forget goroutines). Poll until they appear or timeout.
 	resolvedID := a.resolveLatestSession(ctx)
 	if resolvedID == "" {
 		resolvedID = sessionID
@@ -283,11 +282,21 @@ func (a *AgentChecker) checkToolCalling(ctx context.Context) doctor.TestResult {
 		}
 	}
 
-	toolCalls, err := a.fetchToolCalls(ctx, resolvedID)
-	if err != nil {
+	var toolCalls []toolCallRecord
+	var fetchErr error
+	for attempt := range 5 {
+		toolCalls, fetchErr = a.fetchToolCalls(ctx, resolvedID)
+		if fetchErr == nil && len(toolCalls) > 0 {
+			break
+		}
+		if attempt < 4 {
+			time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+		}
+	}
+	if fetchErr != nil {
 		return doctor.TestResult{
 			Status: doctor.StatusFail,
-			Error:  err.Error(),
+			Error:  fetchErr.Error(),
 			Detail: "failed to fetch tool calls from session-api",
 		}
 	}

--- a/internal/doctor/checks/memory.go
+++ b/internal/doctor/checks/memory.go
@@ -313,11 +313,20 @@ func (m *MemoryChecker) checkMemoryToolsAvailable(ctx context.Context) doctor.Te
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "receive failed"}
 	}
 
-	// Check session-api for tool call errors first.
+	// Check session-api for tool call errors. The runtime event store writes
+	// asynchronously, so poll until the tool call record appears.
 	if m.agentChecker.config.SessionAPIURL != "" && sessionID != "" {
-		time.Sleep(2 * time.Second)
-		if errDetail := m.checkToolCallErrors(ctx, sessionID, "memory__remember"); errDetail != "" {
-			return doctor.TestResult{Status: doctor.StatusFail, Detail: errDetail}
+		for attempt := range 5 {
+			if errDetail := m.checkToolCallErrors(ctx, sessionID, "memory__remember"); errDetail != "" {
+				return doctor.TestResult{Status: doctor.StatusFail, Detail: errDetail}
+			}
+			calls, _ := m.agentChecker.fetchToolCalls(ctx, sessionID)
+			if len(calls) > 0 {
+				break
+			}
+			if attempt < 4 {
+				time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Replace `time.Sleep(3s)` and `time.Sleep(2s)` with retry loops
- The runtime event store writes tool calls via async goroutines — session-api data isn't immediately available after a WebSocket response completes
- New approach: poll session-api with progressive backoff (500ms, 1s, 1.5s, 2s) up to 5 attempts
- Typically resolves on first try, reducing average check latency from 3s to <1s

## Test plan
- [ ] Doctor checks pass in-cluster (21/21)
- [ ] Unit tests pass