### PR TITLE
refactor: use session httpclient.Store in Doctor checks

### DIFF
--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/altairalabs/omnia/internal/doctor"
 	"github.com/altairalabs/omnia/internal/doctor/checks"
+	"github.com/altairalabs/omnia/internal/session/httpclient"
 	"github.com/altairalabs/omnia/pkg/k8s"
 	"github.com/altairalabs/omnia/pkg/logging"
 )
@@ -61,6 +62,9 @@ func main() {
 
 	agentFacadeURL := discoverServiceURL(*agentNamespace, *agentName, defaultAPIPort)
 
+	sessionStore := httpclient.NewStore(sessionAPIURL, log, httpclient.WithBufferCapacity(0))
+	defer sessionStore.Close() //nolint:errcheck
+
 	runner := doctor.NewRunner()
 
 	runner.Register(checks.InfrastructureChecks(map[string]string{
@@ -82,10 +86,11 @@ func main() {
 		AgentName:     *agentName,
 		Namespace:     *agentNamespace,
 		SessionAPIURL: sessionAPIURL,
+		SessionStore:  sessionStore,
 	})
 	runner.Register(agentChecker.Checks()...)
 
-	sessionChecker := checks.NewSessionChecker(sessionAPIURL, *agentNamespace, func() string {
+	sessionChecker := checks.NewSessionChecker(sessionAPIURL, *agentNamespace, sessionStore, func() string {
 		return agentChecker.LastSessionID
 	})
 	runner.Register(sessionChecker.Checks()...)

--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/altairalabs/omnia/internal/doctor"
 	"github.com/altairalabs/omnia/internal/doctor/checks"
+	memoryhttpclient "github.com/altairalabs/omnia/internal/memory/httpclient"
 	"github.com/altairalabs/omnia/internal/session/httpclient"
 	"github.com/altairalabs/omnia/pkg/k8s"
 	"github.com/altairalabs/omnia/pkg/logging"
@@ -100,7 +101,8 @@ func main() {
 		workspaceUID = checks.ResolveWorkspaceUID(k8sClient, *agentNamespace, log)
 	}
 
-	memoryChecker := checks.NewMemoryChecker(memoryAPIURL, workspaceUID, agentChecker)
+	memoryStore := memoryhttpclient.NewStore(memoryAPIURL, log)
+	memoryChecker := checks.NewMemoryChecker(memoryAPIURL, memoryStore, workspaceUID, agentChecker)
 	runner.Register(memoryChecker.Checks()...)
 
 	if *runOnce {

--- a/internal/doctor/checks/agent.go
+++ b/internal/doctor/checks/agent.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/altairalabs/omnia/internal/doctor"
+	"github.com/altairalabs/omnia/internal/session"
 )
 
 const (
@@ -34,7 +35,8 @@ type AgentConfig struct {
 	FacadeURL     string // e.g., http://tools-demo.omnia-demo.svc.cluster.local:8080
 	AgentName     string
 	Namespace     string
-	SessionAPIURL string // session-api URL for verifying tool calls after chat
+	SessionAPIURL string        // session-api URL for resolving latest session (list endpoint)
+	SessionStore  session.Store // session store for tool-call and provider-call queries
 }
 
 // AgentChecker runs WebSocket-based agent checks.
@@ -261,17 +263,15 @@ func (a *AgentChecker) checkToolCalling(ctx context.Context) doctor.TestResult {
 		}
 	}
 
-	// Verify tool calls via session-api (server-side tools aren't in WS stream).
-	if a.config.SessionAPIURL == "" {
+	// Verify tool calls via session store (server-side tools aren't in WS stream).
+	if a.config.SessionStore == nil {
 		return doctor.TestResult{
 			Status: doctor.StatusSkip,
-			Detail: "no session-api URL available",
+			Detail: "no session store available",
 		}
 	}
 
-	// The WS session may not be flushed to session-api yet. Query the most
-	// recent session for this namespace to find tool calls.
-	time.Sleep(3 * time.Second)
+	// Resolve the session ID — prefer the latest from session-api list (known persisted).
 	resolvedID := a.resolveLatestSession(ctx)
 	if resolvedID == "" {
 		resolvedID = sessionID
@@ -283,12 +283,12 @@ func (a *AgentChecker) checkToolCalling(ctx context.Context) doctor.TestResult {
 		}
 	}
 
-	toolCalls, err := a.fetchToolCalls(ctx, resolvedID)
+	toolCalls, err := a.config.SessionStore.GetToolCalls(ctx, resolvedID, 0, 0)
 	if err != nil {
 		return doctor.TestResult{
 			Status: doctor.StatusFail,
 			Error:  err.Error(),
-			Detail: "failed to fetch tool calls from session-api",
+			Detail: "failed to fetch tool calls from session store",
 		}
 	}
 
@@ -303,10 +303,10 @@ func (a *AgentChecker) checkToolCalling(ctx context.Context) doctor.TestResult {
 	var errors []string
 	for _, tc := range toolCalls {
 		names = append(names, tc.Name)
-		if tc.Status == "error" {
+		if tc.Status == session.ToolCallStatusError {
 			errMsg := tc.ErrorMessage
 			if errMsg == "" {
-				errMsg = tc.Result
+				errMsg = toolCallResultString(tc.Result)
 			}
 			errors = append(errors, fmt.Sprintf("%s: %s", tc.Name, truncate(errMsg, 100)))
 		}
@@ -352,38 +352,20 @@ func (a *AgentChecker) resolveLatestSession(ctx context.Context) string {
 	return result.Sessions[0].ID
 }
 
-// toolCallRecord is the shape returned by session-api /tool-calls endpoint.
-type toolCallRecord struct {
-	Name         string `json:"name"`
-	Status       string `json:"status"`
-	Result       string `json:"result,omitempty"`
-	ErrorMessage string `json:"errorMessage,omitempty"`
-}
-
-// fetchToolCalls queries session-api for tool calls in a given session.
-func (a *AgentChecker) fetchToolCalls(ctx context.Context, sessionID string) ([]toolCallRecord, error) {
-	url := fmt.Sprintf("%s/api/v1/sessions/%s/tool-calls", a.config.SessionAPIURL, sessionID)
-	client := &http.Client{Timeout: 10 * time.Second}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// toolCallResultString converts a session.ToolCall.Result (any) to a string
+// for display in error messages.
+func toolCallResultString(result any) string {
+	if result == nil {
+		return ""
+	}
+	if s, ok := result.(string); ok {
+		return s
+	}
+	data, err := json.Marshal(result)
 	if err != nil {
-		return nil, err
+		return fmt.Sprintf("%v", result)
 	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, nil // session or tool calls not found yet
-	}
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d", resp.StatusCode)
-	}
-	var calls []toolCallRecord
-	if err := json.NewDecoder(resp.Body).Decode(&calls); err != nil {
-		return nil, err
-	}
-	return calls, nil
+	return string(data)
 }
 
 // assembleText concatenates the Content fields from all chunk and done messages.

--- a/internal/doctor/checks/agent_test.go
+++ b/internal/doctor/checks/agent_test.go
@@ -350,6 +350,13 @@ func TestAssembleText(t *testing.T) {
 	assert.Equal(t, "foobarbaz", assembleText(msgs))
 }
 
+func TestToolCallResultString(t *testing.T) {
+	assert.Equal(t, "", toolCallResultString(nil))
+	assert.Equal(t, "hello", toolCallResultString("hello"))
+	assert.Equal(t, `{"key":"val"}`, toolCallResultString(map[string]string{"key": "val"}))
+	assert.Equal(t, "42", toolCallResultString(42))
+}
+
 func TestTruncate(t *testing.T) {
 	assert.Equal(t, "abc", truncate("abc", 10))
 	assert.Equal(t, "ab...", truncate("abcde", 2))

--- a/internal/doctor/checks/agent_test.go
+++ b/internal/doctor/checks/agent_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/altairalabs/omnia/internal/doctor"
+	"github.com/altairalabs/omnia/internal/session"
 )
 
 // testSessionID is the session ID returned by the mock facade.
@@ -80,6 +81,59 @@ func newCheckerForServer(srv *httptest.Server) *AgentChecker {
 		Namespace: "test-ns",
 	})
 }
+
+// MockStore is a minimal session.Store mock for doctor check tests.
+// Only GetToolCalls and GetProviderCalls are used; other methods panic.
+type MockStore struct {
+	ToolCalls        []session.ToolCall
+	ToolCallsErr     error
+	ProviderCalls    []session.ProviderCall
+	ProviderCallsErr error
+}
+
+func (m *MockStore) CreateSession(_ context.Context, _ session.CreateSessionOptions) (*session.Session, error) {
+	panic("not used")
+}
+func (m *MockStore) GetSession(_ context.Context, _ string) (*session.Session, error) {
+	panic("not used")
+}
+func (m *MockStore) DeleteSession(_ context.Context, _ string) error { panic("not used") }
+func (m *MockStore) AppendMessage(_ context.Context, _ string, _ session.Message) error {
+	panic("not used")
+}
+func (m *MockStore) GetMessages(_ context.Context, _ string) ([]session.Message, error) {
+	panic("not used")
+}
+func (m *MockStore) RefreshTTL(_ context.Context, _ string, _ time.Duration) error {
+	panic("not used")
+}
+func (m *MockStore) UpdateSessionStatus(_ context.Context, _ string, _ session.SessionStatusUpdate) error {
+	panic("not used")
+}
+func (m *MockStore) RecordToolCall(_ context.Context, _ string, _ session.ToolCall) error {
+	panic("not used")
+}
+func (m *MockStore) RecordProviderCall(_ context.Context, _ string, _ session.ProviderCall) error {
+	panic("not used")
+}
+func (m *MockStore) GetToolCalls(_ context.Context, _ string, _, _ int) ([]session.ToolCall, error) {
+	return m.ToolCalls, m.ToolCallsErr
+}
+func (m *MockStore) GetProviderCalls(_ context.Context, _ string, _, _ int) ([]session.ProviderCall, error) {
+	return m.ProviderCalls, m.ProviderCallsErr
+}
+func (m *MockStore) RecordEvalResult(_ context.Context, _ string, _ session.EvalResult) error {
+	panic("not used")
+}
+func (m *MockStore) RecordRuntimeEvent(_ context.Context, _ string, _ session.RuntimeEvent) error {
+	panic("not used")
+}
+func (m *MockStore) GetRuntimeEvents(_ context.Context, _ string, _, _ int) ([]session.RuntimeEvent, error) {
+	panic("not used")
+}
+func (m *MockStore) Close() error { return nil }
+
+var _ session.Store = (*MockStore)(nil)
 
 // --- Tests for facadeURL ---
 
@@ -179,15 +233,13 @@ func TestCheckToolCalling_Pass(t *testing.T) {
 	})
 	defer facadeSrv.Close()
 
-	// Mock session-api returns tool calls for the session.
-	sessionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"name":"search_places","status":"success"},{"name":"get_weather","status":"success"}]`))
-	}))
-	defer sessionSrv.Close()
-
 	c := newCheckerForServer(facadeSrv)
-	c.config.SessionAPIURL = sessionSrv.URL
+	c.config.SessionStore = &MockStore{
+		ToolCalls: []session.ToolCall{
+			{Name: "search_places", Status: session.ToolCallStatusSuccess},
+			{Name: "get_weather", Status: session.ToolCallStatusSuccess},
+		},
+	}
 	result := c.checkToolCalling(context.Background())
 	assert.Equal(t, doctor.StatusPass, result.Status)
 	assert.Contains(t, result.Detail, "search_places")
@@ -201,20 +253,14 @@ func TestCheckToolCalling_Fail_NoToolCalls(t *testing.T) {
 	})
 	defer facadeSrv.Close()
 
-	sessionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[]`))
-	}))
-	defer sessionSrv.Close()
-
 	c := newCheckerForServer(facadeSrv)
-	c.config.SessionAPIURL = sessionSrv.URL
+	c.config.SessionStore = &MockStore{ToolCalls: []session.ToolCall{}}
 	result := c.checkToolCalling(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "no tool calls")
 }
 
-func TestCheckToolCalling_Skip_NoSessionAPI(t *testing.T) {
+func TestCheckToolCalling_Skip_NoStore(t *testing.T) {
 	facadeSrv := serveMockFacade(t, mockFacadeHandler{
 		responses: []wsServerMessage{
 			{Type: wsMessageTypeDone, Content: "Done."},
@@ -223,7 +269,7 @@ func TestCheckToolCalling_Skip_NoSessionAPI(t *testing.T) {
 	defer facadeSrv.Close()
 
 	c := newCheckerForServer(facadeSrv)
-	// No SessionAPIURL set
+	// No SessionStore set
 	result := c.checkToolCalling(context.Background())
 	assert.Equal(t, doctor.StatusSkip, result.Status)
 }
@@ -242,47 +288,30 @@ func TestCheckToolCalling_Fail_ToolCallErrors(t *testing.T) {
 	})
 	defer facadeSrv.Close()
 
-	sessionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "tool-calls") {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`[{"name":"get_weather","status":"error","errorMessage":"validation failed: latitude invalid"}]`))
-		} else {
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"sessions":[{"id":"test-session-1"}]}`))
-		}
-	}))
-	defer sessionSrv.Close()
-
 	c := newCheckerForServer(facadeSrv)
-	c.config.SessionAPIURL = sessionSrv.URL
-	c.config.Namespace = "test"
+	c.config.SessionStore = &MockStore{
+		ToolCalls: []session.ToolCall{
+			{Name: "get_weather", Status: session.ToolCallStatusError, ErrorMessage: "validation failed: latitude invalid"},
+		},
+	}
 	result := c.checkToolCalling(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "validation failed")
 }
 
-func TestFetchToolCalls_HTTPError(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	}))
-	defer srv.Close()
+func TestCheckToolCalling_Fail_StoreError(t *testing.T) {
+	facadeSrv := serveMockFacade(t, mockFacadeHandler{
+		responses: []wsServerMessage{
+			{Type: wsMessageTypeDone, Content: "Done."},
+		},
+	})
+	defer facadeSrv.Close()
 
-	c := NewAgentChecker(AgentConfig{SessionAPIURL: srv.URL})
-	calls, err := c.fetchToolCalls(context.Background(), "test-id")
-	assert.Error(t, err)
-	assert.Nil(t, calls)
-}
-
-func TestFetchToolCalls_404ReturnsNil(t *testing.T) {
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-	}))
-	defer srv.Close()
-
-	c := NewAgentChecker(AgentConfig{SessionAPIURL: srv.URL})
-	calls, err := c.fetchToolCalls(context.Background(), "test-id")
-	assert.NoError(t, err)
-	assert.Nil(t, calls)
+	c := newCheckerForServer(facadeSrv)
+	c.config.SessionStore = &MockStore{ToolCallsErr: assert.AnError}
+	result := c.checkToolCalling(context.Background())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "failed to fetch tool calls")
 }
 
 func TestResolveLatestSession_Pass(t *testing.T) {

--- a/internal/doctor/checks/memory.go
+++ b/internal/doctor/checks/memory.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/altairalabs/omnia/internal/doctor"
+	"github.com/altairalabs/omnia/internal/session"
 )
 
 const (
@@ -313,9 +314,8 @@ func (m *MemoryChecker) checkMemoryToolsAvailable(ctx context.Context) doctor.Te
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "receive failed"}
 	}
 
-	// Check session-api for tool call errors first.
-	if m.agentChecker.config.SessionAPIURL != "" && sessionID != "" {
-		time.Sleep(2 * time.Second)
+	// Check session store for tool call errors first.
+	if m.agentChecker.config.SessionStore != nil && sessionID != "" {
 		if errDetail := m.checkToolCallErrors(ctx, sessionID, "memory__remember"); errDetail != "" {
 			return doctor.TestResult{Status: doctor.StatusFail, Detail: errDetail}
 		}
@@ -345,18 +345,22 @@ func (m *MemoryChecker) checkMemoryToolsAvailable(ctx context.Context) doctor.Te
 	}
 }
 
-// checkToolCallErrors queries session-api for tool calls and returns an error detail
+// checkToolCallErrors queries the session store for tool calls and returns an error detail
 // string if any call matching toolName has status "error". Returns "" if no errors.
 func (m *MemoryChecker) checkToolCallErrors(ctx context.Context, sessionID, toolName string) string {
-	toolCalls, err := m.agentChecker.fetchToolCalls(ctx, sessionID)
+	store := m.agentChecker.config.SessionStore
+	if store == nil {
+		return ""
+	}
+	toolCalls, err := store.GetToolCalls(ctx, sessionID, 0, 0)
 	if err != nil || len(toolCalls) == 0 {
 		return ""
 	}
 	for _, tc := range toolCalls {
-		if tc.Name == toolName && tc.Status == "error" {
+		if tc.Name == toolName && tc.Status == session.ToolCallStatusError {
 			errMsg := tc.ErrorMessage
 			if errMsg == "" {
-				errMsg = tc.Result
+				errMsg = toolCallResultString(tc.Result)
 			}
 			return fmt.Sprintf("%s tool call failed: %s", toolName, truncate(errMsg, 150))
 		}

--- a/internal/doctor/checks/memory.go
+++ b/internal/doctor/checks/memory.go
@@ -1,42 +1,43 @@
 package checks
 
 import (
-	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+
 	"github.com/altairalabs/omnia/internal/doctor"
+	memoryhttpclient "github.com/altairalabs/omnia/internal/memory/httpclient"
 	"github.com/altairalabs/omnia/internal/session"
 )
 
 const (
 	memoryAPITimeout = 10 * time.Second
 	memoryCategory   = "Memory"
-	memoryAPIPrefix  = "/api/v1/memories"
 	memoryTestType   = "doctor-test"
 	memoryTestValue  = "doctor smoke test value"
 	memoryTestMarker = "smoke-42"
-	workspaceParam   = "workspace"
 )
 
 // MemoryChecker runs REST API checks against the memory-api service, and
 // optionally agent tool-calling checks if an AgentChecker is provided.
 type MemoryChecker struct {
 	memoryAPIURL  string
+	memoryStore   *memoryhttpclient.Store
 	workspace     string
 	agentChecker  *AgentChecker
 	savedMemoryID string
 }
 
 // NewMemoryChecker creates a new MemoryChecker.
-func NewMemoryChecker(memoryAPIURL, workspace string, agentChecker *AgentChecker) *MemoryChecker {
+func NewMemoryChecker(memoryAPIURL string, memoryStore *memoryhttpclient.Store, workspace string, agentChecker *AgentChecker) *MemoryChecker {
 	return &MemoryChecker{
 		memoryAPIURL: memoryAPIURL,
+		memoryStore:  memoryStore,
 		workspace:    workspace,
 		agentChecker: agentChecker,
 	}
@@ -67,6 +68,11 @@ func memoryClient() *http.Client {
 	return &http.Client{Timeout: memoryAPITimeout}
 }
 
+// scope returns the scope map for memory operations.
+func (m *MemoryChecker) scope() map[string]string {
+	return map[string]string{"workspace_id": m.workspace}
+}
+
 // requireWorkspace returns a skip result if the workspace UID is empty.
 func (m *MemoryChecker) requireWorkspace() *doctor.TestResult {
 	if m.workspace == "" {
@@ -91,82 +97,26 @@ func (m *MemoryChecker) checkDocs(ctx context.Context) doctor.TestResult {
 	return doctor.TestResult{Status: doctor.StatusPass, Detail: "docs page served"}
 }
 
-// memorySaveRequest is the body sent to POST /api/v1/memories.
-type memorySaveRequest struct {
-	Type       string      `json:"type"`
-	Content    string      `json:"content"`
-	Confidence float64     `json:"confidence"`
-	Scope      memoryScope `json:"scope"`
-}
-
-// memoryScope identifies the workspace the memory belongs to.
-type memoryScope struct {
-	WorkspaceID string `json:"workspace_id"`
-}
-
-// memorySaveResponse is the expected response from POST /api/v1/memories.
-type memorySaveResponse struct {
-	Memory struct {
-		ID string `json:"id"`
-	} `json:"memory"`
-}
-
 // checkSave POSTs a test memory and stores the returned ID for later deletion.
 func (m *MemoryChecker) checkSave(ctx context.Context) doctor.TestResult {
 	if r := m.requireWorkspace(); r != nil {
 		return *r
 	}
-	payload := memorySaveRequest{
+	mem := &pkmemory.Memory{
 		Type:       memoryTestType,
 		Content:    memoryTestValue,
 		Confidence: 0.95,
-		Scope:      memoryScope{WorkspaceID: m.workspace},
+		Scope:      m.scope(),
 	}
-	data, err := json.Marshal(payload)
-	if err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: fmt.Sprintf("marshal: %v", err)}
-	}
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, m.memoryAPIURL+memoryAPIPrefix, bytes.NewReader(data))
-	if err != nil {
+	if err := m.memoryStore.Save(ctx, mem); err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
 	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := memoryClient().Do(req)
-	if err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusCreated {
-		return doctor.TestResult{
-			Status: doctor.StatusFail,
-			Detail: fmt.Sprintf("expected HTTP 201, got %d", resp.StatusCode),
-		}
-	}
-
-	var result memorySaveResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: fmt.Sprintf("decode response: %v", err)}
-	}
-	if result.Memory.ID == "" {
+	if mem.ID == "" {
 		return doctor.TestResult{Status: doctor.StatusFail, Detail: "response missing id field"}
 	}
 
-	m.savedMemoryID = result.Memory.ID
-	return doctor.TestResult{Status: doctor.StatusPass, Detail: fmt.Sprintf("saved memory id=%s", result.Memory.ID)}
-}
-
-// memorySearchResponse is the shape returned by GET /api/v1/memories/search.
-type memorySearchResponse struct {
-	Memories []memoryItem `json:"memories"`
-}
-
-// memoryItem is a single memory returned by list or search.
-type memoryItem struct {
-	ID      string `json:"id"`
-	Content string `json:"content"`
+	m.savedMemoryID = mem.ID
+	return doctor.TestResult{Status: doctor.StatusPass, Detail: fmt.Sprintf("saved memory id=%s", mem.ID)}
 }
 
 // checkRetrieve searches for the previously saved test memory.
@@ -174,32 +124,17 @@ func (m *MemoryChecker) checkRetrieve(ctx context.Context) doctor.TestResult {
 	if r := m.requireWorkspace(); r != nil {
 		return *r
 	}
-	url := fmt.Sprintf("%s%s/search?q=%s&%s=%s",
-		m.memoryAPIURL, memoryAPIPrefix,
-		"doctor+smoke",
-		workspaceParam, m.workspace,
-	)
-	body, err := fetchBody(ctx, memoryClient(), url)
+	memories, err := m.memoryStore.Retrieve(ctx, m.scope(), "doctor smoke", pkmemory.RetrieveOptions{})
 	if err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
 	}
-
-	var result memorySearchResponse
-	if err := json.Unmarshal([]byte(body), &result); err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: fmt.Sprintf("decode: %v", err)}
-	}
-	if len(result.Memories) == 0 {
+	if len(memories) == 0 {
 		return doctor.TestResult{Status: doctor.StatusFail, Detail: "search returned no results"}
 	}
 	return doctor.TestResult{
 		Status: doctor.StatusPass,
-		Detail: fmt.Sprintf("found %d result(s)", len(result.Memories)),
+		Detail: fmt.Sprintf("found %d result(s)", len(memories)),
 	}
-}
-
-// memoryListResponse is the shape returned by GET /api/v1/memories.
-type memoryListResponse struct {
-	Memories []memoryItem `json:"memories"`
 }
 
 // checkList lists memories for the workspace and verifies at least one exists.
@@ -207,22 +142,16 @@ func (m *MemoryChecker) checkList(ctx context.Context) doctor.TestResult {
 	if r := m.requireWorkspace(); r != nil {
 		return *r
 	}
-	url := fmt.Sprintf("%s%s?%s=%s", m.memoryAPIURL, memoryAPIPrefix, workspaceParam, m.workspace)
-	body, err := fetchBody(ctx, memoryClient(), url)
+	memories, err := m.memoryStore.List(ctx, m.scope(), pkmemory.ListOptions{})
 	if err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
 	}
-
-	var result memoryListResponse
-	if err := json.Unmarshal([]byte(body), &result); err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: fmt.Sprintf("decode: %v", err)}
-	}
-	if len(result.Memories) == 0 {
+	if len(memories) == 0 {
 		return doctor.TestResult{Status: doctor.StatusFail, Detail: "list returned 0 items"}
 	}
 	return doctor.TestResult{
 		Status: doctor.StatusPass,
-		Detail: fmt.Sprintf("%d item(s) in workspace", len(result.Memories)),
+		Detail: fmt.Sprintf("%d item(s) in workspace", len(memories)),
 	}
 }
 
@@ -235,24 +164,8 @@ func (m *MemoryChecker) checkDelete(ctx context.Context) doctor.TestResult {
 		}
 	}
 
-	url := fmt.Sprintf("%s%s/%s?%s=%s",
-		m.memoryAPIURL, memoryAPIPrefix, m.savedMemoryID, workspaceParam, m.workspace)
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
-	if err != nil {
+	if err := m.memoryStore.Delete(ctx, m.scope(), m.savedMemoryID); err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
-	}
-
-	resp, err := memoryClient().Do(req)
-	if err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return doctor.TestResult{
-			Status: doctor.StatusFail,
-			Detail: fmt.Sprintf("expected HTTP 200, got %d", resp.StatusCode),
-		}
 	}
 	return doctor.TestResult{Status: doctor.StatusPass, Detail: "memory deleted"}
 }
@@ -262,7 +175,7 @@ func (m *MemoryChecker) checkExport(ctx context.Context) doctor.TestResult {
 	if r := m.requireWorkspace(); r != nil {
 		return *r
 	}
-	url := fmt.Sprintf("%s%s/export?%s=%s", m.memoryAPIURL, memoryAPIPrefix, workspaceParam, m.workspace)
+	url := fmt.Sprintf("%s/api/v1/memories/export?workspace=%s", m.memoryAPIURL, m.workspace)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
@@ -322,26 +235,19 @@ func (m *MemoryChecker) checkMemoryToolsAvailable(ctx context.Context) doctor.Te
 	}
 
 	// Verify the memory was saved by searching the memory-api.
-	url := fmt.Sprintf("%s%s/search?q=%s&%s=%s",
-		m.memoryAPIURL, memoryAPIPrefix, memoryTestMarker, workspaceParam, m.workspace)
-	body, err := fetchBody(ctx, memoryClient(), url)
+	memories, err := m.memoryStore.Retrieve(ctx, m.scope(), memoryTestMarker, pkmemory.RetrieveOptions{})
 	if err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "search after remember failed"}
 	}
 
-	var result memorySearchResponse
-	if err := json.Unmarshal([]byte(body), &result); err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "decode search response"}
-	}
-
-	for _, mem := range result.Memories {
+	for _, mem := range memories {
 		if strings.Contains(mem.Content, memoryTestMarker) {
 			return doctor.TestResult{Status: doctor.StatusPass, Detail: "memory__remember persisted 'smoke-42'"}
 		}
 	}
 	return doctor.TestResult{
 		Status: doctor.StatusFail,
-		Detail: fmt.Sprintf("memory__remember did not persist 'smoke-42' (found %d memories)", len(result.Memories)),
+		Detail: fmt.Sprintf("memory__remember did not persist 'smoke-42' (found %d memories)", len(memories)),
 	}
 }
 

--- a/internal/doctor/checks/memory_test.go
+++ b/internal/doctor/checks/memory_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/altairalabs/omnia/internal/doctor"
+	"github.com/altairalabs/omnia/internal/session"
 )
 
 const (
@@ -448,13 +449,6 @@ func TestCheckMemoryToolsAvailable_Fail_ToolCallError(t *testing.T) {
 	})
 	defer facadeSrv.Close()
 
-	// Session-api returns a failed tool call with errorMessage.
-	sessionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"name":"memory__remember","status":"error","errorMessage":"validation error: metadata: Invalid type"}]`))
-	}))
-	defer sessionSrv.Close()
-
 	// Memory-api returns no results (remember failed).
 	memorySrv := (&mockMemoryServer{
 		searchHandler: func(w http.ResponseWriter, _ *http.Request) {
@@ -465,7 +459,11 @@ func TestCheckMemoryToolsAvailable_Fail_ToolCallError(t *testing.T) {
 	defer memorySrv.Close()
 
 	agentChecker := newCheckerForServer(facadeSrv)
-	agentChecker.config.SessionAPIURL = sessionSrv.URL
+	agentChecker.config.SessionStore = &MockStore{
+		ToolCalls: []session.ToolCall{
+			{Name: "memory__remember", Status: session.ToolCallStatusError, ErrorMessage: "validation error: metadata: Invalid type"},
+		},
+	}
 	c := NewMemoryChecker(memorySrv.URL, testWorkspace, agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)
@@ -480,13 +478,6 @@ func TestCheckMemoryToolsAvailable_Fail_ToolCallErrorFallbackResult(t *testing.T
 	})
 	defer facadeSrv.Close()
 
-	// Session-api returns error with result field but no errorMessage.
-	sessionSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`[{"name":"memory__remember","status":"error","result":"Tool execution failed: some error"}]`))
-	}))
-	defer sessionSrv.Close()
-
 	memorySrv := (&mockMemoryServer{
 		searchHandler: func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -496,7 +487,11 @@ func TestCheckMemoryToolsAvailable_Fail_ToolCallErrorFallbackResult(t *testing.T
 	defer memorySrv.Close()
 
 	agentChecker := newCheckerForServer(facadeSrv)
-	agentChecker.config.SessionAPIURL = sessionSrv.URL
+	agentChecker.config.SessionStore = &MockStore{
+		ToolCalls: []session.ToolCall{
+			{Name: "memory__remember", Status: session.ToolCallStatusError, Result: "Tool execution failed: some error"},
+		},
+	}
 	c := NewMemoryChecker(memorySrv.URL, testWorkspace, agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)

--- a/internal/doctor/checks/memory_test.go
+++ b/internal/doctor/checks/memory_test.go
@@ -7,10 +7,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+
 	"github.com/altairalabs/omnia/internal/doctor"
+	memoryhttpclient "github.com/altairalabs/omnia/internal/memory/httpclient"
 	"github.com/altairalabs/omnia/internal/session"
 )
 
@@ -121,7 +125,8 @@ func defaultExportHandler(w http.ResponseWriter, _ *http.Request) {
 
 // newCheckerForMemoryServer creates a MemoryChecker pointing at the given server.
 func newCheckerForMemoryServer(srv *httptest.Server) *MemoryChecker {
-	return NewMemoryChecker(srv.URL, testWorkspace, nil)
+	store := memoryhttpclient.NewStore(srv.URL, logr.Discard())
+	return NewMemoryChecker(srv.URL, store, testWorkspace, nil)
 }
 
 // --- MemoryAPIDocsServed ---
@@ -201,7 +206,7 @@ func TestCheckSave_Fail_MissingID(t *testing.T) {
 }
 
 func TestCheckSave_SendsCorrectPayload(t *testing.T) {
-	var captured memorySaveRequest
+	var captured pkmemory.Memory
 	srv := (&mockMemoryServer{
 		saveHandler: func(w http.ResponseWriter, r *http.Request) {
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
@@ -215,7 +220,7 @@ func TestCheckSave_SendsCorrectPayload(t *testing.T) {
 	assert.Equal(t, memoryTestType, captured.Type)
 	assert.Equal(t, memoryTestValue, captured.Content)
 	assert.InDelta(t, 0.95, captured.Confidence, 0.001)
-	assert.Equal(t, testWorkspace, captured.Scope.WorkspaceID)
+	assert.Equal(t, testWorkspace, captured.Scope["workspace_id"])
 }
 
 // --- MemoryRetrieve ---
@@ -365,7 +370,7 @@ func TestCheckExport_Fail_ServerError(t *testing.T) {
 // --- Checks() registration ---
 
 func TestChecks_NoAgentChecker_ReturnsRestOnly(t *testing.T) {
-	c := NewMemoryChecker("http://localhost:8080", "ws1", nil)
+	c := NewMemoryChecker("http://localhost:8080", nil, "ws1", nil)
 	checks := c.Checks()
 	require.Len(t, checks, 6)
 	names := make([]string, len(checks))
@@ -384,7 +389,7 @@ func TestChecks_NoAgentChecker_ReturnsRestOnly(t *testing.T) {
 
 func TestChecks_WithAgentChecker_ReturnsAllChecks(t *testing.T) {
 	agentChecker := NewAgentChecker(AgentConfig{})
-	c := NewMemoryChecker("http://localhost:8080", "ws1", agentChecker)
+	c := NewMemoryChecker("http://localhost:8080", nil, "ws1", agentChecker)
 	checks := c.Checks()
 	require.Len(t, checks, 8)
 	assert.Equal(t, "MemoryToolsAvailable", checks[6].Name)
@@ -412,7 +417,8 @@ func TestCheckMemoryToolsAvailable_Pass(t *testing.T) {
 	defer memorySrv.Close()
 
 	agentChecker := newCheckerForServer(facadeSrv)
-	c := NewMemoryChecker(memorySrv.URL, testWorkspace, agentChecker)
+	memStore := memoryhttpclient.NewStore(memorySrv.URL, logr.Discard())
+	c := NewMemoryChecker(memorySrv.URL, memStore, testWorkspace, agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusPass, result.Status)
 }
@@ -435,7 +441,8 @@ func TestCheckMemoryToolsAvailable_Fail_NotPersisted(t *testing.T) {
 	defer memorySrv.Close()
 
 	agentChecker := newCheckerForServer(facadeSrv)
-	c := NewMemoryChecker(memorySrv.URL, testWorkspace, agentChecker)
+	memStore := memoryhttpclient.NewStore(memorySrv.URL, logr.Discard())
+	c := NewMemoryChecker(memorySrv.URL, memStore, testWorkspace, agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "did not persist")
@@ -464,7 +471,8 @@ func TestCheckMemoryToolsAvailable_Fail_ToolCallError(t *testing.T) {
 			{Name: "memory__remember", Status: session.ToolCallStatusError, ErrorMessage: "validation error: metadata: Invalid type"},
 		},
 	}
-	c := NewMemoryChecker(memorySrv.URL, testWorkspace, agentChecker)
+	memStore := memoryhttpclient.NewStore(memorySrv.URL, logr.Discard())
+	c := NewMemoryChecker(memorySrv.URL, memStore, testWorkspace, agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "validation error")
@@ -492,7 +500,8 @@ func TestCheckMemoryToolsAvailable_Fail_ToolCallErrorFallbackResult(t *testing.T
 			{Name: "memory__remember", Status: session.ToolCallStatusError, Result: "Tool execution failed: some error"},
 		},
 	}
-	c := NewMemoryChecker(memorySrv.URL, testWorkspace, agentChecker)
+	memStore := memoryhttpclient.NewStore(memorySrv.URL, logr.Discard())
+	c := NewMemoryChecker(memorySrv.URL, memStore, testWorkspace, agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "Tool execution failed")
@@ -500,14 +509,15 @@ func TestCheckMemoryToolsAvailable_Fail_ToolCallErrorFallbackResult(t *testing.T
 
 func TestCheckMemoryToolsAvailable_Fail_ConnectionError(t *testing.T) {
 	agentChecker := NewAgentChecker(AgentConfig{FacadeURL: "http://127.0.0.1:1", AgentName: "x", Namespace: "y"})
-	c := NewMemoryChecker("http://localhost:9999", testWorkspace, agentChecker)
+	memStore := memoryhttpclient.NewStore("http://localhost:9999", logr.Discard())
+	c := NewMemoryChecker("http://localhost:9999", memStore, testWorkspace, agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }
 
 func TestCheckMemoryToolsAvailable_Skip_NoWorkspace(t *testing.T) {
 	agentChecker := NewAgentChecker(AgentConfig{})
-	c := NewMemoryChecker("http://localhost:8080", "", agentChecker)
+	c := NewMemoryChecker("http://localhost:8080", nil, "", agentChecker)
 	result := c.checkMemoryToolsAvailable(t.Context())
 	assert.Equal(t, doctor.StatusSkip, result.Status)
 }
@@ -522,7 +532,7 @@ func TestCheckMemoryRecall_Pass(t *testing.T) {
 	defer srv.Close()
 
 	agentChecker := newCheckerForServer(srv)
-	c := NewMemoryChecker("", testWorkspace, agentChecker)
+	c := NewMemoryChecker("", nil, testWorkspace, agentChecker)
 	result := c.checkMemoryRecall(t.Context())
 	assert.Equal(t, doctor.StatusPass, result.Status)
 }
@@ -536,7 +546,7 @@ func TestCheckMemoryRecall_Fail_ValueNotInResponse(t *testing.T) {
 	defer srv.Close()
 
 	agentChecker := newCheckerForServer(srv)
-	c := NewMemoryChecker("", testWorkspace, agentChecker)
+	c := NewMemoryChecker("", nil, testWorkspace, agentChecker)
 	result := c.checkMemoryRecall(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "smoke-42")
@@ -544,7 +554,7 @@ func TestCheckMemoryRecall_Fail_ValueNotInResponse(t *testing.T) {
 
 func TestCheckMemoryRecall_Fail_ConnectionError(t *testing.T) {
 	agentChecker := NewAgentChecker(AgentConfig{FacadeURL: "http://127.0.0.1:1", AgentName: "x", Namespace: "y"})
-	c := NewMemoryChecker("", testWorkspace, agentChecker)
+	c := NewMemoryChecker("", nil, testWorkspace, agentChecker)
 	result := c.checkMemoryRecall(t.Context())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }

--- a/internal/doctor/checks/sessions.go
+++ b/internal/doctor/checks/sessions.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/altairalabs/omnia/internal/doctor"
+	"github.com/altairalabs/omnia/internal/session"
 )
 
 const (
@@ -27,16 +28,18 @@ const (
 type SessionChecker struct {
 	sessionAPIURL string
 	namespace     string
+	store         session.Store // session store for provider-call queries
 	// GetSessionID returns the session ID from the most recent agent chat check.
 	GetSessionID  func() string
 	lastSessionID string // populated by checkSessionExists as fallback
 }
 
 // NewSessionChecker creates a new SessionChecker.
-func NewSessionChecker(sessionAPIURL, namespace string, getSessionID func() string) *SessionChecker {
+func NewSessionChecker(sessionAPIURL, namespace string, store session.Store, getSessionID func() string) *SessionChecker {
 	return &SessionChecker{
 		sessionAPIURL: sessionAPIURL,
 		namespace:     namespace,
+		store:         store,
 		GetSessionID:  getSessionID,
 	}
 }
@@ -217,25 +220,13 @@ func (s *SessionChecker) checkProviderCalls(ctx context.Context) doctor.TestResu
 		return doctor.TestResult{Status: doctor.StatusSkip, Detail: msgNoSessionAvailable}
 	}
 
-	path := fmt.Sprintf("%s/%s%s", sessionAPIPathSessions, sessionID, sessionAPIPathProviders)
-	resp, err := s.sessionHTTPGet(ctx, path)
+	if s.store == nil {
+		return doctor.TestResult{Status: doctor.StatusSkip, Detail: "no session store available"}
+	}
+
+	calls, err := s.store.GetProviderCalls(ctx, sessionID, 0, 0)
 	if err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "GET provider-calls failed"}
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode != http.StatusOK {
-		return doctor.TestResult{
-			Status: doctor.StatusFail,
-			Detail: fmt.Sprintf("GET provider-calls returned HTTP %d", resp.StatusCode),
-		}
-	}
-
-	var calls []struct {
-		InputTokens int64 `json:"inputTokens"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&calls); err != nil {
-		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "decoding provider-calls response"}
+		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "get provider calls failed"}
 	}
 
 	if len(calls) == 0 {
@@ -256,9 +247,7 @@ func (s *SessionChecker) checkProviderCalls(ctx context.Context) doctor.TestResu
 }
 
 // anyProviderCallHasTokens returns true if at least one call has InputTokens > 0.
-func anyProviderCallHasTokens(calls []struct {
-	InputTokens int64 `json:"inputTokens"`
-}) bool {
+func anyProviderCallHasTokens(calls []session.ProviderCall) bool {
 	for _, c := range calls {
 		if c.InputTokens > 0 {
 			return true

--- a/internal/doctor/checks/sessions.go
+++ b/internal/doctor/checks/sessions.go
@@ -16,10 +16,9 @@ import (
 const (
 	sessionTimeout = 10 * time.Second
 
-	sessionAPIPathSessions  = "/api/v1/sessions"
-	sessionAPIPathDocs      = "/docs"
-	sessionAPIPathMessages  = "/messages"
-	sessionAPIPathProviders = "/provider-calls"
+	sessionAPIPathSessions = "/api/v1/sessions"
+	sessionAPIPathDocs     = "/docs"
+	sessionAPIPathMessages = "/messages"
 
 	msgNoSessionAvailable = "no agent chat session available"
 )

--- a/internal/doctor/checks/sessions_test.go
+++ b/internal/doctor/checks/sessions_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/altairalabs/omnia/internal/doctor"
+	"github.com/altairalabs/omnia/internal/session"
 )
 
 const (
@@ -88,7 +89,7 @@ type messagesResponse struct {
 // --- TestSessionCheckerChecks ---
 
 func TestSessionCheckerChecks_ReturnsFour(t *testing.T) {
-	c := NewSessionChecker("http://localhost", testSessionNS, goodSessionID)
+	c := NewSessionChecker("http://localhost", testSessionNS, nil, goodSessionID)
 	checks := c.Checks()
 	require.Len(t, checks, 4)
 	assert.Equal(t, "SessionAPIDocsServed", checks[0].Name)
@@ -109,7 +110,7 @@ func TestSessionCheckDocs_Pass(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkDocs(context.Background())
 	assert.Equal(t, doctor.StatusPass, result.Status)
 }
@@ -121,7 +122,7 @@ func TestCheckDocs_Fail_NotFound(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkDocs(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "404")
@@ -134,14 +135,14 @@ func TestCheckDocs_Fail_MissingText(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkDocs(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "Session API")
 }
 
 func TestCheckDocs_Fail_ConnectionError(t *testing.T) {
-	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, goodSessionID)
+	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, nil, goodSessionID)
 	result := c.checkDocs(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.NotEmpty(t, result.Error)
@@ -160,7 +161,7 @@ func TestCheckSessionExists_Pass(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkSessionExists(context.Background())
 	assert.Equal(t, doctor.StatusPass, result.Status)
 	assert.Contains(t, result.Detail, "1")
@@ -174,7 +175,7 @@ func TestCheckSessionExists_Fail_EmptyList(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkSessionExists(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "no sessions")
@@ -186,13 +187,13 @@ func TestCheckSessionExists_Fail_HTTPError(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkSessionExists(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }
 
 func TestCheckSessionExists_Fail_ConnectionError(t *testing.T) {
-	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, goodSessionID)
+	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, nil, goodSessionID)
 	result := c.checkSessionExists(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }
@@ -206,7 +207,7 @@ func TestCheckSessionExists_Fail_BadJSON(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkSessionExists(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }
@@ -226,14 +227,14 @@ func TestCheckMessages_Pass(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkMessages(context.Background())
 	assert.Equal(t, doctor.StatusPass, result.Status)
 	assert.Contains(t, result.Detail, "2")
 }
 
 func TestCheckMessages_Skip_NoSession(t *testing.T) {
-	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, emptySessionID)
+	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, nil, emptySessionID)
 	result := c.checkMessages(context.Background())
 	assert.Equal(t, doctor.StatusSkip, result.Status)
 	assert.Equal(t, msgNoSessionAvailable, result.Detail)
@@ -251,7 +252,7 @@ func TestCheckMessages_Fail_MissingUserRole(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkMessages(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "hasUser=false")
@@ -269,7 +270,7 @@ func TestCheckMessages_Fail_MissingAssistantRole(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkMessages(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "hasAssistant=false")
@@ -281,13 +282,13 @@ func TestCheckMessages_Fail_HTTPError(t *testing.T) {
 	})
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkMessages(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }
 
 func TestCheckMessages_Fail_ConnectionError(t *testing.T) {
-	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, goodSessionID)
+	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, nil, goodSessionID)
 	result := c.checkMessages(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }
@@ -301,7 +302,7 @@ func TestCheckMessages_Fail_BadJSON(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker(srv.URL, testSessionNS, nil, goodSessionID)
 	result := c.checkMessages(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 }
@@ -309,88 +310,57 @@ func TestCheckMessages_Fail_BadJSON(t *testing.T) {
 // --- checkProviderCalls ---
 
 func TestCheckProviderCalls_Pass(t *testing.T) {
-	// provider-calls returns a bare JSON array
-	body := []map[string]interface{}{
-		{"inputTokens": 150, "outputTokens": 75},
+	store := &MockStore{
+		ProviderCalls: []session.ProviderCall{
+			{InputTokens: 150, OutputTokens: 75},
+		},
 	}
-	srv := defaultSessionAPIMux(t, sessionAPIMuxConfig{
-		providerStatus: http.StatusOK,
-		providerBody:   body,
-	})
-	defer srv.Close()
-
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker("http://localhost", testSessionNS, store, goodSessionID)
 	result := c.checkProviderCalls(context.Background())
 	assert.Equal(t, doctor.StatusPass, result.Status)
 	assert.Contains(t, result.Detail, "1 provider call")
 }
 
 func TestCheckProviderCalls_Skip_NoSession(t *testing.T) {
-	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, emptySessionID)
+	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, &MockStore{}, emptySessionID)
 	result := c.checkProviderCalls(context.Background())
 	assert.Equal(t, doctor.StatusSkip, result.Status)
 	assert.Equal(t, msgNoSessionAvailable, result.Detail)
 }
 
-func TestCheckProviderCalls_Fail_Empty(t *testing.T) {
-	body := []map[string]interface{}{}
-	srv := defaultSessionAPIMux(t, sessionAPIMuxConfig{
-		providerStatus: http.StatusOK,
-		providerBody:   body,
-	})
-	defer srv.Close()
+func TestCheckProviderCalls_Skip_NoStore(t *testing.T) {
+	c := NewSessionChecker("http://localhost", testSessionNS, nil, goodSessionID)
+	result := c.checkProviderCalls(context.Background())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+	assert.Contains(t, result.Detail, "no session store")
+}
 
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+func TestCheckProviderCalls_Fail_Empty(t *testing.T) {
+	store := &MockStore{ProviderCalls: []session.ProviderCall{}}
+	c := NewSessionChecker("http://localhost", testSessionNS, store, goodSessionID)
 	result := c.checkProviderCalls(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "no provider calls")
 }
 
 func TestCheckProviderCalls_Fail_ZeroTokens(t *testing.T) {
-	body := []map[string]interface{}{
-		{"inputTokens": 0, "outputTokens": 0},
+	store := &MockStore{
+		ProviderCalls: []session.ProviderCall{
+			{InputTokens: 0, OutputTokens: 0},
+		},
 	}
-	srv := defaultSessionAPIMux(t, sessionAPIMuxConfig{
-		providerStatus: http.StatusOK,
-		providerBody:   body,
-	})
-	defer srv.Close()
-
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+	c := NewSessionChecker("http://localhost", testSessionNS, store, goodSessionID)
 	result := c.checkProviderCalls(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
 	assert.Contains(t, result.Detail, "inputTokens > 0")
 }
 
-func TestCheckProviderCalls_Fail_HTTPError(t *testing.T) {
-	srv := defaultSessionAPIMux(t, sessionAPIMuxConfig{
-		providerStatus: http.StatusInternalServerError,
-	})
-	defer srv.Close()
-
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
+func TestCheckProviderCalls_Fail_StoreError(t *testing.T) {
+	store := &MockStore{ProviderCallsErr: assert.AnError}
+	c := NewSessionChecker("http://localhost", testSessionNS, store, goodSessionID)
 	result := c.checkProviderCalls(context.Background())
 	assert.Equal(t, doctor.StatusFail, result.Status)
-}
-
-func TestCheckProviderCalls_Fail_ConnectionError(t *testing.T) {
-	c := NewSessionChecker("http://127.0.0.1:1", testSessionNS, goodSessionID)
-	result := c.checkProviderCalls(context.Background())
-	assert.Equal(t, doctor.StatusFail, result.Status)
-}
-
-func TestCheckProviderCalls_Fail_BadJSON(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v1/sessions/"+testSessionAPIID+"/provider-calls", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write([]byte("not-json"))
-	})
-	srv := httptest.NewServer(mux)
-	defer srv.Close()
-
-	c := NewSessionChecker(srv.URL, testSessionNS, goodSessionID)
-	result := c.checkProviderCalls(context.Background())
-	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "get provider calls failed")
 }
 
 // --- classifyMessages unit test ---


### PR DESCRIPTION
## Summary
- Replace hand-rolled HTTP calls + `time.Sleep` retry hacks with the existing `httpclient.Store`
- The store already has retry logic, circuit breaker, and proper error handling
- All `time.Sleep` calls removed from doctor checks
- `toolCallRecord` type removed — uses `session.ToolCall` directly
- Provider call checks use `store.GetProviderCalls()` instead of raw HTTP
- Tests mock `session.Store` interface instead of HTTP servers

## Test plan
- [ ] All doctor unit tests pass
- [ ] Doctor 21/21 in-cluster