### PR TITLE
feat: wire privacy infrastructure to memory system

### DIFF
--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -150,6 +150,9 @@ func main() {
 	memoryChecker := checks.NewMemoryChecker(memoryAPIURL, memoryStore, workspaceUID, agentChecker)
 	runner.Register(memoryChecker.Checks()...)
 
+	privacyChecker := checks.NewPrivacyChecker(memoryAPIURL, workspaceUID)
+	runner.Register(privacyChecker.Checks()...)
+
 	// Agent → Sessions must run sequentially (Sessions reads Agent's LastSessionID).
 	runner.SequentialGroup("agent-sessions", "Agent", "Sessions")
 

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -37,7 +37,14 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	eev1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/privacy"
+	"github.com/altairalabs/omnia/ee/pkg/redaction"
 	"github.com/altairalabs/omnia/internal/memory"
 	memoryapi "github.com/altairalabs/omnia/internal/memory/api"
 	sessionapi "github.com/altairalabs/omnia/internal/session/api"
@@ -244,7 +251,7 @@ func run() error {
 	}
 
 	// --- Build API mux ---
-	apiMux, cleanup := buildAPIMux(store, embeddingSvc, svcCfg, eventPublisher, log)
+	apiMux, cleanup := buildAPIMux(store, embeddingSvc, svcCfg, eventPublisher, f.enterprise, pool, log)
 	defer cleanup()
 
 	// --- Servers ---
@@ -278,9 +285,17 @@ func run() error {
 }
 
 // buildAPIMux assembles the HTTP handler with all memory-api routes, wrapped
-// with rate limiting, metrics, and tracing middleware. Returns the handler and
-// a cleanup function.
-func buildAPIMux(store memory.Store, embeddingSvc *memory.EmbeddingService, cfg memoryapi.MemoryServiceConfig, publisher memoryapi.MemoryEventPublisher, log logr.Logger) (http.Handler, func()) {
+// with rate limiting, privacy (enterprise), metrics, and tracing middleware.
+// Returns the handler and a cleanup function.
+func buildAPIMux(
+	store memory.Store,
+	embeddingSvc *memory.EmbeddingService,
+	cfg memoryapi.MemoryServiceConfig,
+	publisher memoryapi.MemoryEventPublisher,
+	enterprise bool,
+	pool *pgxpool.Pool,
+	log logr.Logger,
+) (http.Handler, func()) {
 	httpMetrics := memoryapi.NewHTTPMetrics(nil)
 
 	svc := memoryapi.NewMemoryService(store, embeddingSvc, cfg, log)
@@ -294,6 +309,11 @@ func buildAPIMux(store memory.Store, embeddingSvc *memory.EmbeddingService, cfg 
 
 	var apiHandler http.Handler = mux
 
+	// Enterprise privacy middleware (opt-out + PII redaction).
+	if enterprise {
+		apiHandler = wrapPrivacyMiddleware(apiHandler, pool, log)
+	}
+
 	// Rate limiting middleware (per-client-IP token bucket).
 	rlCfg := sessionapi.RateLimitConfigFromEnv()
 	rlMiddleware, rlStop := sessionapi.NewRateLimitMiddleware(rlCfg)
@@ -305,6 +325,54 @@ func buildAPIMux(store memory.Store, embeddingSvc *memory.EmbeddingService, cfg 
 		}),
 	)
 	return rlMiddleware(httpMetrics.MetricsMiddleware(traced)), rlStop
+}
+
+// wrapPrivacyMiddleware creates and wires the enterprise privacy middleware.
+// When the K8s API is unreachable (e.g., in tests), the middleware is skipped
+// and the original handler is returned unchanged.
+func wrapPrivacyMiddleware(next http.Handler, pool *pgxpool.Pool, log logr.Logger) http.Handler {
+	kubeConfig, err := rest.InClusterConfig()
+	if err != nil {
+		log.Info("memory privacy middleware skipped", "reason", "no in-cluster kubeconfig")
+		return next
+	}
+
+	scheme := runtime.NewScheme()
+	utilruntime.Must(eev1alpha1.AddToScheme(scheme))
+	k8sClient, err := client.New(kubeConfig, client.Options{Scheme: scheme})
+	if err != nil {
+		log.Error(err, "memory privacy middleware skipped", "reason", "k8s client creation failed")
+		return next
+	}
+
+	watcher := privacy.NewPolicyWatcher(k8sClient, log)
+
+	// Start the watcher asynchronously; it syncs the policy cache in the background.
+	go func() {
+		if startErr := watcher.Start(context.Background()); startErr != nil {
+			log.Error(startErr, "memory policy watcher start failed")
+		}
+	}()
+
+	prefStore := privacy.NewPreferencesStore(pool)
+	redactor := redaction.NewRedactor()
+
+	checkOptOut := memoryapi.OptOutChecker(func(ctx context.Context, userID, workspace string) bool {
+		return privacy.ShouldRemember(ctx, prefStore, userID, workspace, "")
+	})
+
+	contentRedactor := memoryapi.ContentRedactor(func(ctx context.Context, workspace, content string) (string, error) {
+		policy := watcher.GetEffectivePolicy(workspace, "")
+		if policy == nil || policy.Recording.PII == nil || !policy.Recording.PII.Redact {
+			return content, nil
+		}
+		redacted, _, err := redactor.Redact(ctx, content, policy.Recording.PII)
+		return redacted, err
+	})
+
+	mw := memoryapi.NewMemoryPrivacyMiddleware(checkOptOut, contentRedactor, log)
+	log.Info("memory privacy middleware enabled")
+	return mw.Wrap(next)
 }
 
 // traceLogMiddleware injects the OTel trace ID into the logging context.

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -334,11 +334,13 @@ func buildAPIMux(
 
 	// Enterprise audit logging.
 	var auditClose func() error
+	var auditHandler *eeaudit.Handler
 	if enterprise {
 		auditMetrics := eemetrics.NewAuditMetrics()
 		auditLogger := eeaudit.NewLogger(pool, log, auditMetrics, eeaudit.LoggerConfig{})
 		auditClose = auditLogger.Close
 		svc.SetAuditLogger(&auditLoggerAdapter{inner: auditLogger})
+		auditHandler = eeaudit.NewHandler(auditLogger, log)
 		log.Info("memory audit logging enabled")
 	}
 
@@ -346,6 +348,9 @@ func buildAPIMux(
 
 	mux := http.NewServeMux()
 	handler.RegisterRoutes(mux)
+	if auditHandler != nil {
+		auditHandler.RegisterMemoryRoutes(mux)
+	}
 
 	// AuditMiddleware always applied — populates request context with IP/UA.
 	// The service only emits events when an audit logger is configured.

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -43,6 +43,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	eev1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	eeaudit "github.com/altairalabs/omnia/ee/pkg/audit"
+	eemetrics "github.com/altairalabs/omnia/ee/pkg/metrics"
 	"github.com/altairalabs/omnia/ee/pkg/privacy"
 	"github.com/altairalabs/omnia/ee/pkg/redaction"
 	"github.com/altairalabs/omnia/internal/memory"
@@ -53,6 +55,33 @@ import (
 	"github.com/altairalabs/omnia/pkg/logctx"
 	"github.com/altairalabs/omnia/pkg/logging"
 )
+
+// auditLoggerAdapter adapts ee/pkg/audit.Logger to memoryapi.MemoryAuditLogger.
+// It converts MemoryAuditEntry fields into the session/api.AuditEntry shape,
+// placing memory-specific fields (MemoryID, Kind) in Metadata.
+type auditLoggerAdapter struct {
+	inner *eeaudit.Logger
+}
+
+func (a *auditLoggerAdapter) LogEvent(ctx context.Context, entry *memoryapi.MemoryAuditEntry) {
+	meta := entry.Metadata
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+	if entry.MemoryID != "" {
+		meta["memoryId"] = entry.MemoryID
+	}
+	if entry.Kind != "" {
+		meta["kind"] = entry.Kind
+	}
+	a.inner.LogEvent(ctx, &sessionapi.AuditEntry{
+		EventType: entry.EventType,
+		Workspace: entry.WorkspaceID,
+		IPAddress: entry.IPAddress,
+		UserAgent: entry.UserAgent,
+		Metadata:  meta,
+	})
+}
 
 // flags groups all CLI flags for the memory-api binary.
 type flags struct {
@@ -302,12 +331,25 @@ func buildAPIMux(
 	if publisher != nil {
 		svc.SetEventPublisher(publisher)
 	}
+
+	// Enterprise audit logging.
+	var auditClose func() error
+	if enterprise {
+		auditMetrics := eemetrics.NewAuditMetrics()
+		auditLogger := eeaudit.NewLogger(pool, log, auditMetrics, eeaudit.LoggerConfig{})
+		auditClose = auditLogger.Close
+		svc.SetAuditLogger(&auditLoggerAdapter{inner: auditLogger})
+		log.Info("memory audit logging enabled")
+	}
+
 	handler := memoryapi.NewHandler(svc, log)
 
 	mux := http.NewServeMux()
 	handler.RegisterRoutes(mux)
 
-	var apiHandler http.Handler = mux
+	// AuditMiddleware always applied — populates request context with IP/UA.
+	// The service only emits events when an audit logger is configured.
+	apiHandler := memoryapi.AuditMiddleware(mux)
 
 	// Enterprise privacy middleware (opt-out + PII redaction).
 	if enterprise {
@@ -324,7 +366,13 @@ func buildAPIMux(
 			return r.URL.Path != "/healthz"
 		}),
 	)
-	return rlMiddleware(httpMetrics.MetricsMiddleware(traced)), rlStop
+	cleanup := func() {
+		rlStop()
+		if auditClose != nil {
+			_ = auditClose()
+		}
+	}
+	return rlMiddleware(httpMetrics.MetricsMiddleware(traced)), cleanup
 }
 
 // wrapPrivacyMiddleware creates and wires the enterprise privacy middleware.

--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -436,7 +436,7 @@ func buildAPIMux(pool *pgxpool.Pool, registry *providers.Registry, f *flags, log
 	// Privacy middleware (enterprise only): PII redaction + user opt-out.
 	var apiHandler http.Handler = mux
 	if f.enterprise {
-		apiHandler = wrapPrivacyMiddleware(apiHandler, registry, pool, log)
+		apiHandler = wrapPrivacyMiddleware(apiHandler, registry, pool, auditLogger, log)
 	}
 
 	// Rate limiting middleware (per-client-IP token bucket).
@@ -710,6 +710,7 @@ func wrapPrivacyMiddleware(
 	next http.Handler,
 	registry *providers.Registry,
 	pool *pgxpool.Pool,
+	auditLogger *audit.Logger,
 	log logr.Logger,
 ) http.Handler {
 	kubeConfig, err := rest.InClusterConfig()
@@ -741,6 +742,9 @@ func wrapPrivacyMiddleware(
 	prefStore := privacy.NewPreferencesStore(pool)
 
 	middleware := privacy.NewPrivacyMiddleware(watcher, sessionCache, redactor, prefStore, log)
+	if auditLogger != nil {
+		middleware.SetAuditLogger(auditLogger)
+	}
 	log.Info("privacy middleware enabled")
 	return middleware.Wrap(next)
 }

--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -469,6 +469,11 @@ func registerEnterpriseRoutes(mux *http.ServeMux, pool *pgxpool.Pool, registry *
 		deleter := privacy.NewWarmStoreSessionDeleter(warm)
 		deletionSvc := privacy.NewDeletionService(deletionStore, deleter, auditLogger, log)
 		deletionSvc.SetMediaDeleter(buildMediaDeleter(f, log))
+		if memoryAPIURL := os.Getenv("OMNIA_MEMORY_API_URL"); memoryAPIURL != "" {
+			memDeleter := privacy.NewMemoryHTTPDeleter(memoryAPIURL, log)
+			deletionSvc.SetMemoryDeleter(memDeleter)
+			log.Info("memory deleter enabled", "memoryAPIURL", memoryAPIURL)
+		}
 		deletionHandler := privacy.NewDeletionHandler(deletionSvc, log)
 		deletionHandler.RegisterRoutes(mux)
 	}

--- a/ee/pkg/audit/handler.go
+++ b/ee/pkg/audit/handler.go
@@ -43,6 +43,11 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/audit/sessions", h.handleQuery)
 }
 
+// RegisterMemoryRoutes registers the memory audit query route on the given mux.
+func (h *Handler) RegisterMemoryRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /api/v1/audit/memories", h.handleQuery)
+}
+
 // handleQuery returns paginated audit log entries matching the query filters.
 func (h *Handler) handleQuery(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()

--- a/ee/pkg/audit/handler_test.go
+++ b/ee/pkg/audit/handler_test.go
@@ -117,6 +117,41 @@ func TestRegisterRoutes(t *testing.T) {
 	h.RegisterRoutes(mux)
 }
 
+func TestRegisterMemoryRoutes(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	// Should not panic.
+	h.RegisterMemoryRoutes(mux)
+}
+
+func TestRegisterMemoryRoutes_Success(t *testing.T) {
+	mq := &mockQuerier{
+		result: &QueryResult{
+			Entries: []*Entry{{ID: 2, EventType: "memory_stored"}},
+			Total:   1,
+			HasMore: false,
+		},
+	}
+	h := &Handler{logger: mq, log: logr.Discard()}
+
+	mux := http.NewServeMux()
+	h.RegisterMemoryRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/memories?workspace=ws1", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var result QueryResult
+	err := json.NewDecoder(rec.Body).Decode(&result)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), result.Total)
+	assert.Len(t, result.Entries, 1)
+	assert.Equal(t, "ws1", mq.opts.Workspace)
+}
+
 func TestHandleQuery_Success(t *testing.T) {
 	mq := &mockQuerier{
 		result: &QueryResult{

--- a/ee/pkg/privacy/memory_deleter.go
+++ b/ee/pkg/privacy/memory_deleter.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/altairalabs/omnia/pkg/logging"
+)
+
+// defaultMemoryBatchSize is the number of memories deleted per batch call.
+const defaultMemoryBatchSize = 500
+
+// memoryBatchDeleteResponse is the response from the batch delete endpoint.
+type memoryBatchDeleteResponse struct {
+	Deleted int `json:"deleted"`
+}
+
+// MemoryHTTPDeleter implements MemoryDeleter by calling the memory-api batch
+// delete endpoint in a loop until all memories for a user are removed.
+type MemoryHTTPDeleter struct {
+	baseURL   string
+	client    *http.Client
+	batchSize int
+	log       logr.Logger
+}
+
+// NewMemoryHTTPDeleter creates a MemoryHTTPDeleter that targets the given baseURL.
+func NewMemoryHTTPDeleter(baseURL string, log logr.Logger) *MemoryHTTPDeleter {
+	return &MemoryHTTPDeleter{
+		baseURL:   baseURL,
+		client:    &http.Client{Timeout: 30 * time.Second},
+		batchSize: defaultMemoryBatchSize,
+		log:       log.WithName("memory-http-deleter"),
+	}
+}
+
+// DeleteAllMemories deletes all memories for userID in workspace by calling the
+// batch delete endpoint repeatedly until deleted == 0.
+func (d *MemoryHTTPDeleter) DeleteAllMemories(ctx context.Context, userID, workspace string) error {
+	for {
+		n, err := d.deleteBatch(ctx, userID, workspace)
+		if err != nil {
+			return err
+		}
+		d.log.V(1).Info("memory batch deleted", "count", n, "userHash", logging.HashID(userID))
+		if n == 0 {
+			return nil
+		}
+	}
+}
+
+// deleteBatch sends a single DELETE request and returns the number of deleted memories.
+func (d *MemoryHTTPDeleter) deleteBatch(ctx context.Context, userID, workspace string) (int, error) {
+	url := fmt.Sprintf(
+		"%s/api/v1/memories/batch?workspace=%s&user_id=%s&limit=%d",
+		d.baseURL, workspace, userID, d.batchSize,
+	)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("building memory delete request: %w", err)
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("memory delete request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("memory delete returned status %d", resp.StatusCode)
+	}
+
+	var result memoryBatchDeleteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return 0, fmt.Errorf("decoding memory delete response: %w", err)
+	}
+
+	return result.Deleted, nil
+}

--- a/ee/pkg/privacy/memory_deleter_test.go
+++ b/ee/pkg/privacy/memory_deleter_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestMemoryHTTPDeleter_DeleteAllMemories(t *testing.T) {
+	t.Run("single batch returns zero — terminates immediately", func(t *testing.T) {
+		calls := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			calls++
+			mustWriteJSON(t, w, memoryBatchDeleteResponse{Deleted: 0})
+		}))
+		defer srv.Close()
+
+		d := NewMemoryHTTPDeleter(srv.URL, zap.New())
+		if err := d.DeleteAllMemories(context.Background(), "user-1", "ws-a"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if calls != 1 {
+			t.Fatalf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("multiple batches — loops until deleted is zero", func(t *testing.T) {
+		responses := []int{500, 200, 0}
+		idx := 0
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mustWriteJSON(t, w, memoryBatchDeleteResponse{Deleted: responses[idx]})
+			idx++
+		}))
+		defer srv.Close()
+
+		d := NewMemoryHTTPDeleter(srv.URL, zap.New())
+		if err := d.DeleteAllMemories(context.Background(), "user-2", "ws-b"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if idx != 3 {
+			t.Fatalf("expected 3 calls, got %d", idx)
+		}
+	})
+
+	t.Run("HTTP transport error returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+		srv.Close() // close immediately so the request fails
+
+		d := NewMemoryHTTPDeleter(srv.URL, zap.New())
+		err := d.DeleteAllMemories(context.Background(), "user-3", "ws-c")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("non-200 status code returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer srv.Close()
+
+		d := NewMemoryHTTPDeleter(srv.URL, zap.New())
+		err := d.DeleteAllMemories(context.Background(), "user-4", "ws-d")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("invalid JSON response returns error", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("not-json"))
+		}))
+		defer srv.Close()
+
+		d := NewMemoryHTTPDeleter(srv.URL, zap.New())
+		err := d.DeleteAllMemories(context.Background(), "user-5", "ws-e")
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+
+	t.Run("request uses correct method and query parameters", func(t *testing.T) {
+		var gotMethod, gotPath, gotQuery string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotMethod = r.Method
+			gotPath = r.URL.Path
+			gotQuery = r.URL.RawQuery
+			mustWriteJSON(t, w, memoryBatchDeleteResponse{Deleted: 0})
+		}))
+		defer srv.Close()
+
+		d := NewMemoryHTTPDeleter(srv.URL, zap.New())
+		if err := d.DeleteAllMemories(context.Background(), "user-6", "ws-f"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if gotMethod != http.MethodDelete {
+			t.Errorf("expected DELETE, got %s", gotMethod)
+		}
+		if gotPath != "/api/v1/memories/batch" {
+			t.Errorf("unexpected path: %s", gotPath)
+		}
+		if gotQuery == "" {
+			t.Error("expected query parameters, got none")
+		}
+	})
+}
+
+// mustWriteJSON writes v as JSON to w, failing t on error.
+func mustWriteJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("writing JSON response: %v", err)
+	}
+}

--- a/ee/pkg/privacy/middleware.go
+++ b/ee/pkg/privacy/middleware.go
@@ -14,7 +14,9 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/altairalabs/omnia/ee/pkg/audit"
 	"github.com/altairalabs/omnia/ee/pkg/redaction"
+	"github.com/altairalabs/omnia/internal/session/api"
 )
 
 // UserIDHeader is the HTTP header carrying the originating user's identity.
@@ -31,6 +33,7 @@ type PrivacyMiddleware struct {
 	sessionCache  *SessionMetadataCache
 	redactor      redaction.Redactor
 	prefStore     PreferencesStore
+	auditLogger   api.AuditLogger
 	log           logr.Logger
 }
 
@@ -51,11 +54,19 @@ func NewPrivacyMiddleware(
 	}
 }
 
+// SetAuditLogger configures an optional audit logger. When set, the middleware
+// emits session_accessed events for GET requests and session_created events
+// for write requests that are not blocked by opt-out or redaction failure.
+func (m *PrivacyMiddleware) SetAuditLogger(logger api.AuditLogger) {
+	m.auditLogger = logger
+}
+
 // Wrap returns an http.Handler that enforces privacy policy before delegating
 // to the next handler.
 func (m *PrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !isWriteMethod(r.Method) {
+			m.emitAccessEvent(r)
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -77,6 +88,7 @@ func (m *PrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 
 		policy := m.policyWatcher.GetEffectivePolicy(ns, agent)
 		if policy == nil {
+			m.emitWriteEvent(r, sessionID)
 			next.ServeHTTP(w, r)
 			return
 		}
@@ -90,8 +102,41 @@ func (m *PrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 			return // 500 already sent
 		}
 
+		m.emitWriteEvent(r, sessionID)
 		next.ServeHTTP(w, r)
 	})
+}
+
+// emitAccessEvent emits a session_accessed audit event for GET requests.
+// Only fires when the audit logger is set and the path contains a session ID.
+func (m *PrivacyMiddleware) emitAccessEvent(r *http.Request) {
+	if m.auditLogger == nil {
+		return
+	}
+	sessionID := extractSessionID(r.URL.Path)
+	if sessionID == "" {
+		return
+	}
+	ctx := r.Context()
+	entry := &api.AuditEntry{
+		EventType: audit.EventSessionAccessed,
+		SessionID: sessionID,
+	}
+	go m.auditLogger.LogEvent(ctx, entry)
+}
+
+// emitWriteEvent emits a session_created audit event for write requests.
+// Only fires when the audit logger is set.
+func (m *PrivacyMiddleware) emitWriteEvent(r *http.Request, sessionID string) {
+	if m.auditLogger == nil {
+		return
+	}
+	ctx := r.Context()
+	entry := &api.AuditEntry{
+		EventType: audit.EventSessionCreated,
+		SessionID: sessionID,
+	}
+	go m.auditLogger.LogEvent(ctx, entry)
 }
 
 // isWriteMethod returns true for HTTP methods that carry a request body.

--- a/ee/pkg/privacy/middleware_test.go
+++ b/ee/pkg/privacy/middleware_test.go
@@ -14,14 +14,49 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/audit"
 	"github.com/altairalabs/omnia/ee/pkg/redaction"
+	"github.com/altairalabs/omnia/internal/session/api"
 )
+
+// mockAuditLogger captures LogEvent calls for test assertions.
+type mockAuditLogger struct {
+	mu      sync.Mutex
+	entries []*api.AuditEntry
+}
+
+func (m *mockAuditLogger) LogEvent(_ context.Context, entry *api.AuditEntry) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.entries = append(m.entries, entry)
+}
+
+func (m *mockAuditLogger) Close() error { return nil }
+
+func (m *mockAuditLogger) waitForEntry(t *testing.T) []*api.AuditEntry {
+	t.Helper()
+	deadline := time.Now().Add(100 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		m.mu.Lock()
+		n := len(m.entries)
+		m.mu.Unlock()
+		if n > 0 {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]*api.AuditEntry(nil), m.entries...)
+}
 
 // mockSessionLookup always returns a fixed namespace/agent.
 type mockSessionLookup struct {
@@ -308,4 +343,133 @@ func TestSessionMetadataCache_Eviction(t *testing.T) {
 	ns, _, err := cache.Resolve(context.Background(), "s1")
 	assert.NoError(t, err)
 	assert.Equal(t, "ns1", ns)
+}
+
+func TestPrivacyMiddleware_AuditGETEmitsSessionAccessed(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	lookup := &mockSessionLookup{ns: "default", agent: "test-agent"}
+	cache := NewSessionMetadataCache(lookup, 100)
+	watcher := &PolicyWatcher{}
+	mw := NewPrivacyMiddleware(watcher, cache, nil, nil, logr.Discard())
+
+	auditLog := &mockAuditLogger{}
+	mw.SetAuditLogger(auditLog)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/abc-123/messages", nil)
+	rr := httptest.NewRecorder()
+	mw.Wrap(handler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	entries := auditLog.waitForEntry(t)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, audit.EventSessionAccessed, entries[0].EventType)
+	assert.Equal(t, "abc-123", entries[0].SessionID)
+}
+
+func TestPrivacyMiddleware_AuditPOSTEmitsSessionCreated(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	lookup := &mockSessionLookup{ns: "default", agent: "test-agent"}
+	cache := NewSessionMetadataCache(lookup, 100)
+	watcher := &PolicyWatcher{} // no policy — passes through
+	mw := NewPrivacyMiddleware(watcher, cache, nil, nil, logr.Discard())
+
+	auditLog := &mockAuditLogger{}
+	mw.SetAuditLogger(auditLog)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/abc-123/messages",
+		strings.NewReader(`{"content":"hello"}`))
+	rr := httptest.NewRecorder()
+	mw.Wrap(handler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	entries := auditLog.waitForEntry(t)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, audit.EventSessionCreated, entries[0].EventType)
+	assert.Equal(t, "abc-123", entries[0].SessionID)
+}
+
+func TestPrivacyMiddleware_AuditNilLoggerGETPassesThrough(t *testing.T) {
+	called := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	lookup := &mockSessionLookup{ns: "default", agent: "test-agent"}
+	cache := NewSessionMetadataCache(lookup, 100)
+	watcher := &PolicyWatcher{}
+	mw := NewPrivacyMiddleware(watcher, cache, nil, nil, logr.Discard())
+	// auditLogger intentionally not set (nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions/abc-123/messages", nil)
+	rr := httptest.NewRecorder()
+	mw.Wrap(handler).ServeHTTP(rr, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+func TestPrivacyMiddleware_AuditGETNoSessionIDNoEvent(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	watcher := &PolicyWatcher{}
+	mw := NewPrivacyMiddleware(watcher, nil, nil, nil, logr.Discard())
+
+	auditLog := &mockAuditLogger{}
+	mw.SetAuditLogger(auditLog)
+
+	// Path with no session ID
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/sessions", nil)
+	rr := httptest.NewRecorder()
+	mw.Wrap(handler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	// Wait briefly to ensure no goroutine fires
+	time.Sleep(20 * time.Millisecond)
+	auditLog.mu.Lock()
+	defer auditLog.mu.Unlock()
+	assert.Empty(t, auditLog.entries)
+}
+
+func TestPrivacyMiddleware_AuditOptOutNoEvent(t *testing.T) {
+	handler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+
+	lookup := &mockSessionLookup{ns: "default", agent: "test-agent"}
+	cache := NewSessionMetadataCache(lookup, 100)
+
+	watcher := &PolicyWatcher{}
+	watcher.policies.Store("test", &omniav1alpha1.SessionPrivacyPolicy{
+		Spec: omniav1alpha1.SessionPrivacyPolicySpec{
+			Level:      omniav1alpha1.PolicyLevelGlobal,
+			Recording:  omniav1alpha1.RecordingConfig{Enabled: true},
+			UserOptOut: &omniav1alpha1.UserOptOutConfig{Enabled: true},
+		},
+	})
+
+	prefStore := optOutPrefStore()
+	mw := NewPrivacyMiddleware(watcher, cache, nil, prefStore, logr.Discard())
+
+	auditLog := &mockAuditLogger{}
+	mw.SetAuditLogger(auditLog)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions/abc-123/messages",
+		strings.NewReader(`{}`))
+	req.Header.Set(UserIDHeader, "user-1")
+	rr := httptest.NewRecorder()
+	mw.Wrap(handler).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNoContent, rr.Code)
+	// Wait briefly to confirm no event fired
+	time.Sleep(20 * time.Millisecond)
+	auditLog.mu.Lock()
+	defer auditLog.mu.Unlock()
+	assert.Empty(t, auditLog.entries, "opt-out should not emit audit event")
 }

--- a/ee/pkg/redaction/redactor.go
+++ b/ee/pkg/redaction/redactor.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package redaction
+
+import (
+	"context"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+)
+
+// TextRedactor strips PII from text.
+// Implemented by PatternRedactor (configured with PIIConfig) and NoOpRedactor (passthrough).
+// Satisfies the internal/memory.Redactor interface structurally.
+type TextRedactor interface {
+	RedactText(ctx context.Context, text string) (string, error)
+}
+
+// PatternRedactor is a TextRedactor that applies a fixed PIIConfig on every call.
+// It validates and pre-compiles patterns at construction time.
+type PatternRedactor struct {
+	inner Redactor
+	pii   *omniav1alpha1.PIIConfig
+}
+
+// NoOpRedactor is a passthrough TextRedactor that performs no redaction.
+type NoOpRedactor struct{}
+
+// RedactText returns text unchanged.
+func (NoOpRedactor) RedactText(_ context.Context, text string) (string, error) {
+	return text, nil
+}
+
+// NewPatternRedactor constructs a TextRedactor from a PIIConfig.
+// If config is nil, has Redact=false, or has no patterns, a NoOpRedactor is returned.
+// Pattern names are validated at construction; an error is returned for unknown or
+// invalid custom patterns.
+func NewPatternRedactor(config *omniav1alpha1.PIIConfig) (TextRedactor, error) {
+	if config == nil || !config.Redact || len(config.Patterns) == 0 {
+		return NoOpRedactor{}, nil
+	}
+
+	// Eagerly validate patterns so callers surface errors at construction, not at first call.
+	if _, err := resolvePatterns(config.Patterns); err != nil {
+		return nil, err
+	}
+
+	return &PatternRedactor{
+		inner: NewRedactor(),
+		pii:   config,
+	}, nil
+}
+
+// RedactText applies the configured PIIConfig to text and returns the redacted result.
+func (r *PatternRedactor) RedactText(ctx context.Context, text string) (string, error) {
+	redacted, _, err := r.inner.Redact(ctx, text, r.pii)
+	return redacted, err
+}

--- a/ee/pkg/redaction/redactor_test.go
+++ b/ee/pkg/redaction/redactor_test.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package redaction_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/redaction"
+)
+
+func piiConfig(patterns []string, strategy omniav1alpha1.RedactionStrategy) *omniav1alpha1.PIIConfig {
+	return &omniav1alpha1.PIIConfig{
+		Redact:   true,
+		Patterns: patterns,
+		Strategy: strategy,
+	}
+}
+
+// TestNewPatternRedactor_NilConfig verifies that a nil config returns a NoOpRedactor.
+func TestNewPatternRedactor_NilConfig(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := "My SSN is 123-45-6789"
+	got, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != text {
+		t.Errorf("expected passthrough, got %q", got)
+	}
+}
+
+// TestNewPatternRedactor_RedactFalse verifies that Redact=false returns a NoOpRedactor.
+func TestNewPatternRedactor_RedactFalse(t *testing.T) {
+	cfg := &omniav1alpha1.PIIConfig{
+		Redact:   false,
+		Patterns: []string{"ssn"},
+	}
+	r, err := redaction.NewPatternRedactor(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := "My SSN is 123-45-6789"
+	got, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != text {
+		t.Errorf("expected passthrough, got %q", got)
+	}
+}
+
+// TestNewPatternRedactor_EmptyPatterns verifies that empty patterns returns a NoOpRedactor.
+func TestNewPatternRedactor_EmptyPatterns(t *testing.T) {
+	cfg := &omniav1alpha1.PIIConfig{
+		Redact:   true,
+		Patterns: []string{},
+	}
+	r, err := redaction.NewPatternRedactor(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := "My SSN is 123-45-6789"
+	got, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != text {
+		t.Errorf("expected passthrough, got %q", got)
+	}
+}
+
+// TestNewPatternRedactor_UnknownPattern verifies that an unknown built-in name returns an error.
+func TestNewPatternRedactor_UnknownPattern(t *testing.T) {
+	cfg := piiConfig([]string{"nonexistent_pattern"}, omniav1alpha1.RedactionStrategyReplace)
+	_, err := redaction.NewPatternRedactor(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown pattern, got nil")
+	}
+}
+
+// TestNewPatternRedactor_InvalidCustomPattern verifies that an invalid custom regex returns an error.
+func TestNewPatternRedactor_InvalidCustomPattern(t *testing.T) {
+	cfg := piiConfig([]string{"custom:[invalid("}, omniav1alpha1.RedactionStrategyReplace)
+	_, err := redaction.NewPatternRedactor(cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid custom regex, got nil")
+	}
+}
+
+// TestPatternRedactor_SSN verifies SSN redaction with replace strategy.
+func TestPatternRedactor_SSN(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"ssn"}, omniav1alpha1.RedactionStrategyReplace))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := r.RedactText(context.Background(), "My SSN is 123-45-6789 and that's sensitive.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "123-45-6789") {
+		t.Errorf("SSN not redacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_SSN]") {
+		t.Errorf("expected [REDACTED_SSN] token, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_CreditCard verifies credit card redaction.
+func TestPatternRedactor_CreditCard(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"credit_card"}, omniav1alpha1.RedactionStrategyReplace))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := r.RedactText(context.Background(), "Card: 4111-1111-1111-1111")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "4111") {
+		t.Errorf("credit card not redacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_CC]") {
+		t.Errorf("expected [REDACTED_CC] token, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_Email verifies email redaction.
+func TestPatternRedactor_Email(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"email"}, omniav1alpha1.RedactionStrategyReplace))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := r.RedactText(context.Background(), "Contact user@example.com for details.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "user@example.com") {
+		t.Errorf("email not redacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_EMAIL]") {
+		t.Errorf("expected [REDACTED_EMAIL] token, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_Phone verifies phone number redaction.
+func TestPatternRedactor_Phone(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"phone_number"}, omniav1alpha1.RedactionStrategyReplace))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := r.RedactText(context.Background(), "Call 555-867-5309 now.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "555-867-5309") {
+		t.Errorf("phone not redacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_PHONE]") {
+		t.Errorf("expected [REDACTED_PHONE] token, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_IPAddress verifies IP address redaction.
+func TestPatternRedactor_IPAddress(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"ip_address"}, omniav1alpha1.RedactionStrategyReplace))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := r.RedactText(context.Background(), "Request from 192.168.1.1.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "192.168.1.1") {
+		t.Errorf("IP not redacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_IP]") {
+		t.Errorf("expected [REDACTED_IP] token, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_HashStrategy verifies that hash strategy produces deterministic output.
+func TestPatternRedactor_HashStrategy(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"email"}, omniav1alpha1.RedactionStrategyHash))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := "Contact user@example.com for details."
+	got1, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error on first call: %v", err)
+	}
+	got2, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error on second call: %v", err)
+	}
+	if got1 != got2 {
+		t.Errorf("hash strategy is not deterministic: %q != %q", got1, got2)
+	}
+	if strings.Contains(got1, "user@example.com") {
+		t.Errorf("email not redacted: %q", got1)
+	}
+	if !strings.Contains(got1, "[HASH_EMAIL:") {
+		t.Errorf("expected [HASH_EMAIL:...] token, got: %q", got1)
+	}
+}
+
+// TestPatternRedactor_MaskStrategy verifies that mask strategy preserves last 4 chars.
+func TestPatternRedactor_MaskStrategy(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"ssn"}, omniav1alpha1.RedactionStrategyMask))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// SSN "123-45-6789" — last 4 chars are "6789"
+	got, err := r.RedactText(context.Background(), "SSN: 123-45-6789")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "123-45") {
+		t.Errorf("SSN prefix not masked: %q", got)
+	}
+	if !strings.Contains(got, "6789") {
+		t.Errorf("expected last 4 chars preserved, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_CustomPattern verifies custom regex via "custom:" prefix.
+func TestPatternRedactor_CustomPattern(t *testing.T) {
+	// Custom pattern matching employee IDs like EMP-12345
+	cfg := piiConfig([]string{"custom:EMP-\\d{5}"}, omniav1alpha1.RedactionStrategyReplace)
+	r, err := redaction.NewPatternRedactor(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := r.RedactText(context.Background(), "Employee EMP-99999 filed a report.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "EMP-99999") {
+		t.Errorf("custom pattern not redacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_CUSTOM]") {
+		t.Errorf("expected [REDACTED_CUSTOM] token, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_MultiplePatterns verifies multiple patterns in a single text.
+func TestPatternRedactor_MultiplePatterns(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig(
+		[]string{"ssn", "email"},
+		omniav1alpha1.RedactionStrategyReplace,
+	))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := "SSN: 123-45-6789. Email: user@example.com."
+	got, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(got, "123-45-6789") {
+		t.Errorf("SSN not redacted: %q", got)
+	}
+	if strings.Contains(got, "user@example.com") {
+		t.Errorf("email not redacted: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_SSN]") {
+		t.Errorf("expected [REDACTED_SSN] token, got: %q", got)
+	}
+	if !strings.Contains(got, "[REDACTED_EMAIL]") {
+		t.Errorf("expected [REDACTED_EMAIL] token, got: %q", got)
+	}
+}
+
+// TestPatternRedactor_NoPIIInText verifies that text without PII is returned unchanged.
+func TestPatternRedactor_NoPIIInText(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"ssn", "email"}, omniav1alpha1.RedactionStrategyReplace))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text := "This text contains no personally identifiable information."
+	got, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != text {
+		t.Errorf("expected unchanged text, got %q", got)
+	}
+}
+
+// TestPatternRedactor_EmptyText verifies that empty text is returned as-is.
+func TestPatternRedactor_EmptyText(t *testing.T) {
+	r, err := redaction.NewPatternRedactor(piiConfig([]string{"ssn"}, omniav1alpha1.RedactionStrategyReplace))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := r.RedactText(context.Background(), "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+// TestNoOpRedactor_PassthroughDirectly exercises NoOpRedactor directly.
+func TestNoOpRedactor_PassthroughDirectly(t *testing.T) {
+	var r redaction.NoOpRedactor
+	text := "some text with 123-45-6789"
+	got, err := r.RedactText(context.Background(), text)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != text {
+		t.Errorf("expected passthrough, got %q", got)
+	}
+}

--- a/internal/doctor/checks/privacy.go
+++ b/internal/doctor/checks/privacy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/altairalabs/omnia/internal/doctor"
 )
@@ -224,9 +225,52 @@ func (p *PrivacyChecker) checkDeletionCascade(ctx context.Context) doctor.TestRe
 	return doctor.TestResult{Status: doctor.StatusPass, Detail: "memory absent after batch delete"}
 }
 
-// checkAuditLogWritten is deferred until the audit query endpoint is added.
-func (p *PrivacyChecker) checkAuditLogWritten(_ context.Context) doctor.TestResult {
-	return doctor.TestResult{Status: doctor.StatusSkip, Detail: "audit endpoint not available"}
+// checkAuditLogWritten saves a memory and queries the audit endpoint to verify
+// a memory_created event was recorded. Skips if the audit endpoint is not available.
+func (p *PrivacyChecker) checkAuditLogWritten(ctx context.Context) doctor.TestResult {
+	if r := p.requireWorkspace(); r != nil {
+		return *r
+	}
+
+	// Probe the audit endpoint first.
+	auditURL := p.memoryAPIURL + "/api/v1/audit/memories?workspace=" + p.workspace + "&limit=1"
+	probeResp, err := fetchBody(ctx, memoryClient(), auditURL)
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusSkip, Detail: "audit endpoint not available", Error: err.Error()}
+	}
+	_ = probeResp
+
+	// Save a test memory to generate an audit event.
+	_, status, err := p.saveMemory(ctx, "audit log test "+time.Now().Format(time.RFC3339Nano), nil)
+	if err != nil || status != http.StatusCreated {
+		return doctor.TestResult{Status: doctor.StatusFail, Detail: "save failed before audit check", Error: errString(err)}
+	}
+
+	// Brief pause to let the async audit logger flush.
+	time.Sleep(2 * time.Second)
+
+	// Query for memory_created events.
+	queryURL := p.memoryAPIURL + "/api/v1/audit/memories?workspace=" + p.workspace + "&eventTypes=memory_created&limit=5"
+	body, err := fetchBody(ctx, memoryClient(), queryURL)
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusFail, Detail: "audit query failed", Error: err.Error()}
+	}
+
+	var result struct {
+		Entries []map[string]any `json:"entries"`
+		Total   int64            `json:"total"`
+	}
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return doctor.TestResult{Status: doctor.StatusFail, Detail: "invalid audit response", Error: err.Error()}
+	}
+
+	if result.Total == 0 {
+		return doctor.TestResult{Status: doctor.StatusFail, Detail: "no memory_created audit events found"}
+	}
+	return doctor.TestResult{
+		Status: doctor.StatusPass,
+		Detail: fmt.Sprintf("found %d memory_created audit event(s)", result.Total),
+	}
 }
 
 // errString returns the error message or an empty string if err is nil.

--- a/internal/doctor/checks/privacy.go
+++ b/internal/doctor/checks/privacy.go
@@ -1,0 +1,238 @@
+package checks
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/altairalabs/omnia/internal/doctor"
+)
+
+const (
+	privacyCategory         = "Privacy"
+	privacyTestSSN          = "123-45-6789"
+	privacyOptOutHeader     = "X-Privacy-Opt-Out"
+	privacyBatchDeletePath  = "/api/v1/memories/batch"
+	privacyMemoriesPath     = "/api/v1/memories"
+	privacyMemorySearchPath = "/api/v1/memories/search"
+)
+
+// PrivacyChecker runs privacy-related checks against the memory-api service.
+type PrivacyChecker struct {
+	memoryAPIURL string
+	workspace    string
+}
+
+// NewPrivacyChecker creates a new PrivacyChecker.
+func NewPrivacyChecker(memoryAPIURL, workspace string) *PrivacyChecker {
+	return &PrivacyChecker{
+		memoryAPIURL: memoryAPIURL,
+		workspace:    workspace,
+	}
+}
+
+// Checks returns the list of privacy checks to run.
+func (p *PrivacyChecker) Checks() []doctor.Check {
+	return []doctor.Check{
+		{Name: "MemoryPIIRedaction", Category: privacyCategory, Run: p.checkPIIRedaction},
+		{Name: "MemoryOptOutRespected", Category: privacyCategory, Run: p.checkOptOutRespected},
+		{Name: "MemoryDeletionCascade", Category: privacyCategory, Run: p.checkDeletionCascade},
+		{Name: "AuditLogWritten", Category: privacyCategory, Run: p.checkAuditLogWritten},
+	}
+}
+
+// requireWorkspace returns a skip result if workspace is empty.
+func (p *PrivacyChecker) requireWorkspace() *doctor.TestResult {
+	if p.workspace == "" {
+		r := doctor.TestResult{Status: doctor.StatusSkip, Detail: "workspace UID not resolved"}
+		return &r
+	}
+	return nil
+}
+
+// saveMemory POSTs a memory with the given content and optional extra headers.
+// Returns the memory ID on success, or an error.
+func (p *PrivacyChecker) saveMemory(ctx context.Context, content string, extraHeaders map[string]string) (string, int, error) {
+	payload := map[string]interface{}{
+		"type":       "doctor-privacy-test",
+		"content":    content,
+		"confidence": 0.9,
+		"scope":      map[string]string{"workspace_id": p.workspace},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", 0, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.memoryAPIURL+privacyMemoriesPath, bytes.NewReader(body))
+	if err != nil {
+		return "", 0, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range extraHeaders {
+		req.Header.Set(k, v)
+	}
+
+	resp, err := memoryClient().Do(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		return "", resp.StatusCode, nil
+	}
+
+	var result struct {
+		Memory struct {
+			ID string `json:"id"`
+		} `json:"memory"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", resp.StatusCode, err
+	}
+	return result.Memory.ID, resp.StatusCode, nil
+}
+
+// searchMemories queries the memory search endpoint for a query string.
+// Returns the raw JSON body contents of the memories array items.
+func (p *PrivacyChecker) searchMemories(ctx context.Context, query string) ([]map[string]interface{}, error) {
+	params := url.Values{"workspace": {p.workspace}, "q": {query}}
+	searchURL := p.memoryAPIURL + privacyMemorySearchPath + "?" + params.Encode()
+	body, err := fetchBody(ctx, memoryClient(), searchURL)
+	if err != nil {
+		return nil, err
+	}
+
+	var result struct {
+		Memories []map[string]interface{} `json:"memories"`
+	}
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return nil, err
+	}
+	return result.Memories, nil
+}
+
+// checkPIIRedaction saves a memory containing a test SSN, retrieves it, and
+// verifies the SSN is not present in the returned content.
+func (p *PrivacyChecker) checkPIIRedaction(ctx context.Context) doctor.TestResult {
+	if r := p.requireWorkspace(); r != nil {
+		return *r
+	}
+
+	_, status, err := p.saveMemory(ctx, "patient ssn is "+privacyTestSSN, nil)
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
+	}
+	if status != http.StatusCreated {
+		return doctor.TestResult{Status: doctor.StatusFail, Detail: fmt.Sprintf("expected HTTP 201, got %d", status)}
+	}
+
+	memories, err := p.searchMemories(ctx, privacyTestSSN)
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusSkip, Detail: "memory-api search unavailable", Error: err.Error()}
+	}
+
+	for _, mem := range memories {
+		content, _ := mem["content"].(string)
+		if strings.Contains(content, privacyTestSSN) {
+			return doctor.TestResult{
+				Status: doctor.StatusFail,
+				Detail: "SSN found unredacted in retrieved memory content",
+			}
+		}
+	}
+	return doctor.TestResult{Status: doctor.StatusPass, Detail: "SSN not present in retrieved memory content"}
+}
+
+// checkOptOutRespected saves a memory with the opt-out header and verifies it
+// is rejected (HTTP 204). If the memory is saved (HTTP 201), enterprise privacy
+// middleware is not present — the check is skipped.
+func (p *PrivacyChecker) checkOptOutRespected(ctx context.Context) doctor.TestResult {
+	if r := p.requireWorkspace(); r != nil {
+		return *r
+	}
+
+	_, status, err := p.saveMemory(ctx, "opt-out test content", map[string]string{privacyOptOutHeader: "true"})
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
+	}
+
+	switch status {
+	case http.StatusNoContent:
+		return doctor.TestResult{Status: doctor.StatusPass, Detail: "opt-out header respected: save rejected with 204"}
+	case http.StatusCreated:
+		return doctor.TestResult{Status: doctor.StatusSkip, Detail: "enterprise privacy middleware not detected"}
+	default:
+		return doctor.TestResult{
+			Status: doctor.StatusFail,
+			Detail: fmt.Sprintf("unexpected HTTP %d (expected 204 or 201)", status),
+		}
+	}
+}
+
+// checkDeletionCascade saves a test memory, batch-deletes it, and verifies it
+// is gone. Skips if the batch delete endpoint is not available (HTTP 404).
+func (p *PrivacyChecker) checkDeletionCascade(ctx context.Context) doctor.TestResult {
+	if r := p.requireWorkspace(); r != nil {
+		return *r
+	}
+
+	memID, status, err := p.saveMemory(ctx, "deletion cascade test", nil)
+	if err != nil || status != http.StatusCreated {
+		return doctor.TestResult{Status: doctor.StatusFail, Detail: "save failed before batch delete", Error: errString(err)}
+	}
+
+	batchURL := fmt.Sprintf("%s%s?workspace=%s&user_id=%s&limit=100",
+		p.memoryAPIURL, privacyBatchDeletePath, p.workspace, memID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, batchURL, nil)
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
+	}
+
+	resp, err := memoryClient().Do(req)
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return doctor.TestResult{Status: doctor.StatusSkip, Detail: "batch delete endpoint not available"}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return doctor.TestResult{
+			Status: doctor.StatusFail,
+			Detail: fmt.Sprintf("batch delete returned HTTP %d", resp.StatusCode),
+		}
+	}
+
+	// Verify the memory is gone.
+	memories, err := p.searchMemories(ctx, "deletion cascade test")
+	if err != nil {
+		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error(), Detail: "search after batch delete failed"}
+	}
+	if len(memories) > 0 {
+		return doctor.TestResult{
+			Status: doctor.StatusFail,
+			Detail: fmt.Sprintf("memory still present after batch delete (%d result(s))", len(memories)),
+		}
+	}
+	return doctor.TestResult{Status: doctor.StatusPass, Detail: "memory absent after batch delete"}
+}
+
+// checkAuditLogWritten is deferred until the audit query endpoint is added.
+func (p *PrivacyChecker) checkAuditLogWritten(_ context.Context) doctor.TestResult {
+	return doctor.TestResult{Status: doctor.StatusSkip, Detail: "audit endpoint not available"}
+}
+
+// errString returns the error message or an empty string if err is nil.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/doctor/checks/privacy_test.go
+++ b/internal/doctor/checks/privacy_test.go
@@ -1,0 +1,328 @@
+package checks
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/doctor"
+)
+
+// newPrivacyCheckerForServer creates a PrivacyChecker pointing at the given test server.
+func newPrivacyCheckerForServer(srv *httptest.Server) *PrivacyChecker {
+	return NewPrivacyChecker(srv.URL, testWorkspace)
+}
+
+// privacySaveBody captures a decoded save request body for assertions.
+type privacySaveBody struct {
+	Type    string                 `json:"type"`
+	Content string                 `json:"content"`
+	Scope   map[string]interface{} `json:"scope"`
+}
+
+// mockPrivacyServer builds a minimal httptest.Server for privacy check tests.
+// handlers map path strings to handler funcs; the save endpoint dispatches on method.
+type mockPrivacyServer struct {
+	saveHandler        http.HandlerFunc
+	searchHandler      http.HandlerFunc
+	batchDeleteHandler http.HandlerFunc
+}
+
+func (m *mockPrivacyServer) serve(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	saveH := m.saveHandler
+	if saveH == nil {
+		saveH = func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"memory":{"id":"priv-test-id"}}`))
+		}
+	}
+
+	searchH := m.searchHandler
+	if searchH == nil {
+		searchH = func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"memories":[],"total":0}`))
+		}
+	}
+
+	mux.HandleFunc(privacyMemoriesPath, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			saveH(w, r)
+			return
+		}
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	})
+
+	mux.HandleFunc(privacyMemorySearchPath, searchH)
+
+	if m.batchDeleteHandler != nil {
+		mux.HandleFunc(privacyBatchDeletePath, m.batchDeleteHandler)
+	}
+
+	return httptest.NewServer(mux)
+}
+
+// --- MemoryPIIRedaction ---
+
+func TestCheckPIIRedaction_Pass(t *testing.T) {
+	// Save succeeds; search returns content without SSN.
+	srv := (&mockPrivacyServer{
+		searchHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"memories":[{"id":"m1","content":"patient ssn is [REDACTED]"}],"total":1}`))
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkPIIRedaction(t.Context())
+	assert.Equal(t, doctor.StatusPass, result.Status)
+	assert.Contains(t, result.Detail, "not present")
+}
+
+func TestCheckPIIRedaction_Fail_SSNPresent(t *testing.T) {
+	// Search returns content still containing the SSN.
+	srv := (&mockPrivacyServer{
+		searchHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			body, _ := json.Marshal(map[string]interface{}{
+				"memories": []map[string]interface{}{
+					{"id": "m1", "content": "patient ssn is " + privacyTestSSN},
+				},
+				"total": 1,
+			})
+			_, _ = w.Write(body)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkPIIRedaction(t.Context())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "unredacted")
+}
+
+func TestCheckPIIRedaction_Fail_SaveError(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		saveHandler: func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkPIIRedaction(t.Context())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+}
+
+func TestCheckPIIRedaction_Skip_NoWorkspace(t *testing.T) {
+	c := NewPrivacyChecker("http://localhost:8080", "")
+	result := c.checkPIIRedaction(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+	assert.Contains(t, result.Detail, "workspace UID not resolved")
+}
+
+func TestCheckPIIRedaction_Skip_SearchUnavailable(t *testing.T) {
+	// Save succeeds but search returns 500 — should skip (search unavailable).
+	srv := (&mockPrivacyServer{
+		searchHandler: func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "search down", http.StatusInternalServerError)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkPIIRedaction(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+	assert.Contains(t, result.Detail, "unavailable")
+}
+
+func TestCheckPIIRedaction_SendsSSNInContent(t *testing.T) {
+	var captured privacySaveBody
+	srv := (&mockPrivacyServer{
+		saveHandler: func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte(`{"memory":{"id":"x"}}`))
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	_ = newPrivacyCheckerForServer(srv).checkPIIRedaction(t.Context())
+	assert.Contains(t, captured.Content, privacyTestSSN)
+}
+
+// --- MemoryOptOutRespected ---
+
+func TestCheckOptOutRespected_Pass(t *testing.T) {
+	// Server returns 204 — opt-out header respected.
+	srv := (&mockPrivacyServer{
+		saveHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkOptOutRespected(t.Context())
+	assert.Equal(t, doctor.StatusPass, result.Status)
+	assert.Contains(t, result.Detail, "204")
+}
+
+func TestCheckOptOutRespected_Skip_EnterpriseNotDetected(t *testing.T) {
+	// Server returns 201 — memory saved, no enterprise middleware.
+	srv := (&mockPrivacyServer{}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkOptOutRespected(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+	assert.Contains(t, result.Detail, "enterprise")
+}
+
+func TestCheckOptOutRespected_Fail_UnexpectedStatus(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		saveHandler: func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "oops", http.StatusInternalServerError)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkOptOutRespected(t.Context())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "unexpected")
+}
+
+func TestCheckOptOutRespected_Skip_NoWorkspace(t *testing.T) {
+	c := NewPrivacyChecker("http://localhost:8080", "")
+	result := c.checkOptOutRespected(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+}
+
+func TestCheckOptOutRespected_SendsOptOutHeader(t *testing.T) {
+	var capturedHeader string
+	srv := (&mockPrivacyServer{
+		saveHandler: func(w http.ResponseWriter, r *http.Request) {
+			capturedHeader = r.Header.Get(privacyOptOutHeader)
+			w.WriteHeader(http.StatusNoContent)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	_ = newPrivacyCheckerForServer(srv).checkOptOutRespected(t.Context())
+	assert.Equal(t, "true", capturedHeader)
+}
+
+// --- MemoryDeletionCascade ---
+
+func TestCheckDeletionCascade_Pass(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		batchDeleteHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"deleted":1}`))
+		},
+		// search after delete returns empty.
+		searchHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"memories":[],"total":0}`))
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkDeletionCascade(t.Context())
+	assert.Equal(t, doctor.StatusPass, result.Status)
+	assert.Contains(t, result.Detail, "absent")
+}
+
+func TestCheckDeletionCascade_Skip_BatchEndpointNotFound(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		batchDeleteHandler: func(w http.ResponseWriter, _ *http.Request) {
+			http.NotFound(w, nil)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkDeletionCascade(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+	assert.Contains(t, result.Detail, "batch delete endpoint not available")
+}
+
+func TestCheckDeletionCascade_Fail_MemoryStillPresent(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		batchDeleteHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"deleted":0}`))
+		},
+		searchHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"memories":[{"id":"m1","content":"deletion cascade test"}],"total":1}`))
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkDeletionCascade(t.Context())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "still present")
+}
+
+func TestCheckDeletionCascade_Fail_SaveFails(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		saveHandler: func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "save error", http.StatusInternalServerError)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkDeletionCascade(t.Context())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "save failed")
+}
+
+func TestCheckDeletionCascade_Fail_BatchDeleteError(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		batchDeleteHandler: func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "delete error", http.StatusInternalServerError)
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkDeletionCascade(t.Context())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+}
+
+func TestCheckDeletionCascade_Skip_NoWorkspace(t *testing.T) {
+	c := NewPrivacyChecker("http://localhost:8080", "")
+	result := c.checkDeletionCascade(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+}
+
+// --- AuditLogWritten ---
+
+func TestCheckAuditLogWritten_AlwaysSkip(t *testing.T) {
+	c := NewPrivacyChecker("http://localhost:8080", testWorkspace)
+	result := c.checkAuditLogWritten(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
+	assert.Contains(t, result.Detail, "audit endpoint not available")
+}
+
+// --- Checks() registration ---
+
+func TestPrivacyChecker_Checks_ReturnsFour(t *testing.T) {
+	c := NewPrivacyChecker("http://localhost:8080", "ws1")
+	cs := c.Checks()
+	require.Len(t, cs, 4)
+	names := make([]string, len(cs))
+	for i, ch := range cs {
+		names[i] = ch.Name
+	}
+	assert.Equal(t, []string{
+		"MemoryPIIRedaction",
+		"MemoryOptOutRespected",
+		"MemoryDeletionCascade",
+		"AuditLogWritten",
+	}, names)
+	for _, ch := range cs {
+		assert.Equal(t, privacyCategory, ch.Category)
+	}
+}

--- a/internal/doctor/checks/privacy_test.go
+++ b/internal/doctor/checks/privacy_test.go
@@ -30,6 +30,7 @@ type mockPrivacyServer struct {
 	saveHandler        http.HandlerFunc
 	searchHandler      http.HandlerFunc
 	batchDeleteHandler http.HandlerFunc
+	auditHandler       http.HandlerFunc
 }
 
 func (m *mockPrivacyServer) serve(t *testing.T) *httptest.Server {
@@ -64,6 +65,10 @@ func (m *mockPrivacyServer) serve(t *testing.T) *httptest.Server {
 
 	if m.batchDeleteHandler != nil {
 		mux.HandleFunc(privacyBatchDeletePath, m.batchDeleteHandler)
+	}
+
+	if m.auditHandler != nil {
+		mux.HandleFunc("/api/v1/audit/memories", m.auditHandler)
 	}
 
 	return httptest.NewServer(mux)
@@ -299,11 +304,48 @@ func TestCheckDeletionCascade_Skip_NoWorkspace(t *testing.T) {
 
 // --- AuditLogWritten ---
 
-func TestCheckAuditLogWritten_AlwaysSkip(t *testing.T) {
-	c := NewPrivacyChecker("http://localhost:8080", testWorkspace)
-	result := c.checkAuditLogWritten(t.Context())
+func TestCheckAuditLogWritten_Pass(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		auditHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"entries":[{"eventType":"memory_created"}],"total":1,"hasMore":false}`))
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkAuditLogWritten(t.Context())
+	assert.Equal(t, doctor.StatusPass, result.Status)
+	assert.Contains(t, result.Detail, "memory_created")
+}
+
+func TestCheckAuditLogWritten_Fail_NoEvents(t *testing.T) {
+	srv := (&mockPrivacyServer{
+		auditHandler: func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"entries":[],"total":0,"hasMore":false}`))
+		},
+	}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkAuditLogWritten(t.Context())
+	assert.Equal(t, doctor.StatusFail, result.Status)
+	assert.Contains(t, result.Detail, "no memory_created")
+}
+
+func TestCheckAuditLogWritten_Skip_EndpointNotAvailable(t *testing.T) {
+	// No audit handler registered → 404 → skip.
+	srv := (&mockPrivacyServer{}).serve(t)
+	defer srv.Close()
+
+	result := newPrivacyCheckerForServer(srv).checkAuditLogWritten(t.Context())
 	assert.Equal(t, doctor.StatusSkip, result.Status)
 	assert.Contains(t, result.Detail, "audit endpoint not available")
+}
+
+func TestCheckAuditLogWritten_Skip_NoWorkspace(t *testing.T) {
+	c := NewPrivacyChecker("http://localhost:8080", "")
+	result := c.checkAuditLogWritten(t.Context())
+	assert.Equal(t, doctor.StatusSkip, result.Status)
 }
 
 // --- Checks() registration ---

--- a/internal/memory/api/audit_middleware.go
+++ b/internal/memory/api/audit_middleware.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// requestMetaKey is the context key for RequestMeta.
+type requestMetaKey struct{}
+
+// RequestMeta holds request metadata extracted from HTTP headers.
+type RequestMeta struct {
+	IPAddress string
+	UserAgent string
+}
+
+// withRequestMeta returns a new context carrying the given RequestMeta.
+func withRequestMeta(ctx context.Context, meta RequestMeta) context.Context {
+	return context.WithValue(ctx, requestMetaKey{}, meta)
+}
+
+// requestMetaFromCtx extracts RequestMeta from the context.
+// Returns a zero value and false if not present.
+func requestMetaFromCtx(ctx context.Context) (RequestMeta, bool) {
+	meta, ok := ctx.Value(requestMetaKey{}).(RequestMeta)
+	return meta, ok
+}
+
+// AuditMiddleware extracts the client IP address and User-Agent from each
+// incoming HTTP request and injects them into the request context as
+// RequestMeta so that downstream handlers can include them in audit entries.
+func AuditMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		meta := RequestMeta{
+			IPAddress: extractIP(r),
+			UserAgent: r.Header.Get("User-Agent"),
+		}
+		ctx := withRequestMeta(r.Context(), meta)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// extractIP returns the best-effort client IP address from the request.
+// Priority: X-Forwarded-For (first entry) > X-Real-IP > RemoteAddr.
+func extractIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		// X-Forwarded-For may be a comma-separated list; take the first entry.
+		parts := strings.SplitN(xff, ",", 2)
+		if ip := strings.TrimSpace(parts[0]); ip != "" {
+			return ip
+		}
+	}
+	if realIP := r.Header.Get("X-Real-IP"); realIP != "" {
+		return strings.TrimSpace(realIP)
+	}
+	// Strip port from RemoteAddr (format: "host:port").
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil {
+		return host
+	}
+	return r.RemoteAddr
+}

--- a/internal/memory/api/audit_middleware_test.go
+++ b/internal/memory/api/audit_middleware_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractIP_XForwardedFor(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "203.0.113.5, 10.0.0.1, 192.168.1.1")
+	assert.Equal(t, "203.0.113.5", extractIP(r))
+}
+
+func TestExtractIP_XForwardedFor_Single(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "203.0.113.5")
+	assert.Equal(t, "203.0.113.5", extractIP(r))
+}
+
+func TestExtractIP_XRealIP(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Real-IP", "203.0.113.10")
+	assert.Equal(t, "203.0.113.10", extractIP(r))
+}
+
+func TestExtractIP_RemoteAddr(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "192.0.2.1:54321"
+	assert.Equal(t, "192.0.2.1", extractIP(r))
+}
+
+func TestExtractIP_RemoteAddrNoPort(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.RemoteAddr = "192.0.2.1"
+	// net.SplitHostPort fails — falls back to raw RemoteAddr
+	assert.Equal(t, "192.0.2.1", extractIP(r))
+}
+
+func TestExtractIP_XForwardedForHasPriority(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r.Header.Set("X-Forwarded-For", "203.0.113.5")
+	r.Header.Set("X-Real-IP", "10.0.0.1")
+	// X-Forwarded-For wins
+	assert.Equal(t, "203.0.113.5", extractIP(r))
+}
+
+func TestAuditMiddleware_PopulatesContext(t *testing.T) {
+	var capturedMeta RequestMeta
+	var metaPresent bool
+
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedMeta, metaPresent = requestMetaFromCtx(r.Context())
+	})
+
+	mw := AuditMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/memories", nil)
+	req.Header.Set("X-Forwarded-For", "1.2.3.4")
+	req.Header.Set("User-Agent", "test-agent/1.0")
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	require.True(t, metaPresent, "RequestMeta should be present in context")
+	assert.Equal(t, "1.2.3.4", capturedMeta.IPAddress)
+	assert.Equal(t, "test-agent/1.0", capturedMeta.UserAgent)
+}
+
+func TestAuditMiddleware_NoHeaders(t *testing.T) {
+	var capturedMeta RequestMeta
+	var metaPresent bool
+
+	inner := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		capturedMeta, metaPresent = requestMetaFromCtx(r.Context())
+	})
+
+	mw := AuditMiddleware(inner)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/memories", nil)
+	req.RemoteAddr = "192.0.2.99:1234"
+
+	rr := httptest.NewRecorder()
+	mw.ServeHTTP(rr, req)
+
+	require.True(t, metaPresent)
+	assert.Equal(t, "192.0.2.99", capturedMeta.IPAddress)
+	assert.Empty(t, capturedMeta.UserAgent)
+}
+
+func TestRequestMetaFromCtx_NotPresent(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	meta, ok := requestMetaFromCtx(req.Context())
+	assert.False(t, ok)
+	assert.Empty(t, meta.IPAddress)
+	assert.Empty(t, meta.UserAgent)
+}

--- a/internal/memory/api/event_publisher_test.go
+++ b/internal/memory/api/event_publisher_test.go
@@ -77,6 +77,10 @@ func (m *mockMemoryStore) ExportAll(_ context.Context, _ map[string]string) ([]*
 	return nil, nil
 }
 
+func (m *mockMemoryStore) BatchDelete(_ context.Context, _ map[string]string, _ int) (int, error) {
+	return 0, nil
+}
+
 // --- mockMemoryEventPublisher -----------------------------------------------
 
 // mockMemoryEventPublisher records published events and can be configured to

--- a/internal/memory/api/handler.go
+++ b/internal/memory/api/handler.go
@@ -39,6 +39,11 @@ const (
 
 	// DefaultMaxBodySize is the maximum allowed request body size (16 MB).
 	DefaultMaxBodySize int64 = 16 << 20
+
+	// defaultBatchDeleteLimit is the default number of rows deleted per batch delete request.
+	defaultBatchDeleteLimit = 500
+	// maxBatchDeleteLimit is the maximum number of rows allowed per batch delete request.
+	maxBatchDeleteLimit = 10000
 )
 
 // MemoryListResponse is the JSON response for memory list/search endpoints.
@@ -55,6 +60,11 @@ type MemoryResponse struct {
 // ErrorResponse is the JSON response for errors.
 type ErrorResponse struct {
 	Error string `json:"error"`
+}
+
+// BatchDeleteResponse is the JSON response for DELETE /api/v1/memories/batch.
+type BatchDeleteResponse struct {
+	Deleted int `json:"deleted"`
 }
 
 // SaveMemoryRequest is the JSON body for POST /api/v1/memories.
@@ -96,6 +106,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/memories/export", h.handleExportMemories)
 	mux.HandleFunc("POST /api/v1/memories", h.handleSaveMemory)
 	mux.HandleFunc("DELETE /api/v1/memories/{id}", h.handleDeleteMemory)
+	mux.HandleFunc("DELETE /api/v1/memories/batch", h.handleBatchDeleteMemories)
 	mux.HandleFunc("DELETE /api/v1/memories", h.handleDeleteAllMemories)
 
 	h.registerDocsRoutes(mux)
@@ -265,6 +276,31 @@ func (h *Handler) handleDeleteAllMemories(w http.ResponseWriter, r *http.Request
 
 	h.log.V(1).Info("all memories deleted", "workspace", scope[memory.ScopeWorkspaceID])
 	w.WriteHeader(http.StatusOK)
+}
+
+// handleBatchDeleteMemories deletes up to limit memories for a scope (paginated DSAR).
+// Route: DELETE /api/v1/memories/batch?workspace=X&user_id=Y&limit=N
+func (h *Handler) handleBatchDeleteMemories(w http.ResponseWriter, r *http.Request) {
+	scope, err := parseWorkspaceScope(r)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	limit := parseIntParam(r, "limit", defaultBatchDeleteLimit)
+	if limit > maxBatchDeleteLimit {
+		limit = maxBatchDeleteLimit
+	}
+
+	n, err := h.service.BatchDeleteMemories(r.Context(), scope, limit)
+	if err != nil {
+		h.log.Error(err, "BatchDeleteMemories failed", "workspace", scope[memory.ScopeWorkspaceID])
+		writeError(w, err)
+		return
+	}
+
+	h.log.V(1).Info("batch memories deleted", "workspace", scope[memory.ScopeWorkspaceID], "count", n)
+	writeJSON(w, BatchDeleteResponse{Deleted: n})
 }
 
 // --- helpers -----------------------------------------------------------------

--- a/internal/memory/api/handler_test.go
+++ b/internal/memory/api/handler_test.go
@@ -38,14 +38,16 @@ import (
 // --- Mock store ---
 
 type mockStore struct {
-	memories     []*memory.Memory
-	saveErr      error
-	retErr       error
-	listErr      error
-	delErr       error
-	delAllErr    error
-	exportAllErr error
-	savedMem     *memory.Memory
+	memories       []*memory.Memory
+	saveErr        error
+	retErr         error
+	listErr        error
+	delErr         error
+	delAllErr      error
+	batchDeleteErr error
+	batchDeleteN   int
+	exportAllErr   error
+	savedMem       *memory.Memory
 }
 
 func (m *mockStore) Save(_ context.Context, mem *memory.Memory) error {
@@ -84,6 +86,13 @@ func (m *mockStore) ExportAll(_ context.Context, _ map[string]string) ([]*memory
 		return nil, m.exportAllErr
 	}
 	return m.memories, nil
+}
+
+func (m *mockStore) BatchDelete(_ context.Context, _ map[string]string, _ int) (int, error) {
+	if m.batchDeleteErr != nil {
+		return 0, m.batchDeleteErr
+	}
+	return m.batchDeleteN, nil
 }
 
 func newTestHandler(store memory.Store) *Handler {
@@ -511,6 +520,78 @@ func TestHandler_ExportMemories_StoreError(t *testing.T) {
 	mux.ServeHTTP(rr, req)
 
 	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+// --- BatchDeleteMemories tests ---
+
+func TestHandleBatchDeleteMemories_Success(t *testing.T) {
+	store := &mockStore{batchDeleteN: 3}
+	h := newTestHandler(store)
+	mux := setupMux(h)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/memories/batch?workspace=ws1&limit=3", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp BatchDeleteResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 3, resp.Deleted)
+}
+
+func TestHandleBatchDeleteMemories_ZeroRows(t *testing.T) {
+	store := &mockStore{batchDeleteN: 0}
+	h := newTestHandler(store)
+	mux := setupMux(h)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/memories/batch?workspace=ws1", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	var resp BatchDeleteResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Equal(t, 0, resp.Deleted)
+}
+
+func TestHandleBatchDeleteMemories_MissingWorkspace(t *testing.T) {
+	h := newTestHandler(&mockStore{})
+	mux := setupMux(h)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/memories/batch", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+	var resp ErrorResponse
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&resp))
+	assert.Contains(t, resp.Error, "workspace")
+}
+
+func TestHandleBatchDeleteMemories_StoreError(t *testing.T) {
+	store := &mockStore{batchDeleteErr: fmt.Errorf("db error")}
+	h := newTestHandler(store)
+	mux := setupMux(h)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/memories/batch?workspace=ws1", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+func TestHandleBatchDeleteMemories_LimitClamped(t *testing.T) {
+	// limit exceeding maxBatchDeleteLimit is clamped
+	store := &mockStore{batchDeleteN: 5}
+	h := newTestHandler(store)
+	mux := setupMux(h)
+
+	req := httptest.NewRequest(http.MethodDelete,
+		fmt.Sprintf("/api/v1/memories/batch?workspace=ws1&limit=%d", maxBatchDeleteLimit+999), nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
 // fakeQuery implements the interface used by buildScope.

--- a/internal/memory/api/privacy_middleware.go
+++ b/internal/memory/api/privacy_middleware.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	"github.com/altairalabs/omnia/pkg/logging"
+)
+
+// OptOutChecker returns false when the user has opted out of memory storage,
+// indicating the write should be silently dropped.
+type OptOutChecker func(ctx context.Context, userID, workspace string) bool
+
+// ContentRedactor redacts PII from memory content text.
+// Returns the redacted string; if redaction is not configured it returns the
+// original text unchanged.
+type ContentRedactor func(ctx context.Context, workspace, content string) (string, error)
+
+// MemoryPrivacyMiddleware intercepts POST requests to the memory API and:
+//  1. Returns 204 No Content when the user has opted out of memory storage.
+//  2. Redacts PII from the request body's "content" field before forwarding.
+//
+// Only POST requests are intercepted. GET, DELETE, and other methods pass
+// through without modification. This type is only constructed in enterprise
+// mode; non-enterprise builds receive a nil pointer and the wrapper function
+// is a no-op.
+type MemoryPrivacyMiddleware struct {
+	checkOptOut OptOutChecker
+	redact      ContentRedactor
+	log         logr.Logger
+}
+
+// NewMemoryPrivacyMiddleware creates a MemoryPrivacyMiddleware.
+// checkOptOut and redact must not be nil.
+func NewMemoryPrivacyMiddleware(
+	checkOptOut OptOutChecker,
+	redact ContentRedactor,
+	log logr.Logger,
+) *MemoryPrivacyMiddleware {
+	return &MemoryPrivacyMiddleware{
+		checkOptOut: checkOptOut,
+		redact:      redact,
+		log:         log.WithName("memory-privacy"),
+	}
+}
+
+// Wrap returns an http.Handler that enforces privacy policy before delegating
+// to next. Only POST requests are intercepted.
+func (m *MemoryPrivacyMiddleware) Wrap(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		workspace := r.URL.Query().Get("workspace")
+		userID := r.URL.Query().Get("user_id")
+
+		// Check opt-out: if the user has opted out, silently drop the write.
+		if userID != "" && !m.checkOptOut(r.Context(), userID, workspace) {
+			m.log.V(1).Info("memory write suppressed", "reason", "user opt-out", "userHash", logging.HashID(userID), "workspace", workspace)
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		// Apply PII redaction to the request body's content field.
+		if err := m.applyRedaction(r, workspace); err != nil {
+			m.log.Error(err, "content redaction failed, blocking request", "workspace", workspace)
+			http.Error(w, "redaction failed", http.StatusInternalServerError)
+			return
+		}
+
+		next.ServeHTTP(w, r)
+	})
+}
+
+// applyRedaction reads the request body, redacts the content field, and
+// replaces r.Body with the redacted payload.
+func (m *MemoryPrivacyMiddleware) applyRedaction(r *http.Request, workspace string) error {
+	if r.Body == nil {
+		return nil
+	}
+
+	data, err := io.ReadAll(r.Body)
+	_ = r.Body.Close()
+	if err != nil {
+		return fmt.Errorf("reading request body: %w", err)
+	}
+
+	if len(data) == 0 {
+		r.Body = io.NopCloser(bytes.NewReader(data))
+		return nil
+	}
+
+	var req SaveMemoryRequest
+	if err := json.Unmarshal(data, &req); err != nil {
+		// Not valid JSON — restore the body and let the handler return the
+		// appropriate 400 error.
+		r.Body = io.NopCloser(bytes.NewReader(data))
+		return nil
+	}
+
+	redacted, err := m.redact(r.Context(), workspace, req.Content)
+	if err != nil {
+		return fmt.Errorf("redacting content: %w", err)
+	}
+
+	if redacted == req.Content {
+		// Nothing changed — avoid re-encoding unnecessarily.
+		r.Body = io.NopCloser(bytes.NewReader(data))
+		return nil
+	}
+
+	req.Content = redacted
+	encoded, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("re-encoding request body: %w", err)
+	}
+
+	r.Body = io.NopCloser(bytes.NewReader(encoded))
+	r.ContentLength = int64(len(encoded))
+	return nil
+}

--- a/internal/memory/api/privacy_middleware_test.go
+++ b/internal/memory/api/privacy_middleware_test.go
@@ -1,0 +1,313 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// passthroughOptOut always returns true (no opt-out).
+var passthroughOptOut OptOutChecker = func(_ context.Context, _, _ string) bool { return true }
+
+// noOpRedact returns content unchanged.
+var noOpRedact ContentRedactor = func(_ context.Context, _, content string) (string, error) {
+	return content, nil
+}
+
+// optedOutChecker always returns false (user opted out).
+var optedOutChecker OptOutChecker = func(_ context.Context, _, _ string) bool { return false }
+
+// panicOptOut panics if called — use to assert opt-out is never checked.
+var panicOptOut OptOutChecker = func(_ context.Context, _, _ string) bool {
+	panic("OptOutChecker must not be called for this request")
+}
+
+// panicRedact panics if called — use to assert redaction is never invoked.
+var panicRedact ContentRedactor = func(_ context.Context, _, _ string) (string, error) {
+	panic("ContentRedactor must not be called for this request")
+}
+
+func newTestMiddleware(checkOptOut OptOutChecker, redact ContentRedactor) *MemoryPrivacyMiddleware {
+	return NewMemoryPrivacyMiddleware(checkOptOut, redact, logr.Discard())
+}
+
+func postBody(t *testing.T, content string) *bytes.Buffer {
+	t.Helper()
+	req := SaveMemoryRequest{
+		Type:    "fact",
+		Content: content,
+		Scope:   map[string]string{"workspace": "ws-1"},
+	}
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+	return bytes.NewBuffer(b)
+}
+
+func makePostRequest(t *testing.T, content, workspace, userID string) *http.Request {
+	t.Helper()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/memories", postBody(t, content))
+	q := r.URL.Query()
+	q.Set("workspace", workspace)
+	if userID != "" {
+		q.Set("user_id", userID)
+	}
+	r.URL.RawQuery = q.Encode()
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+// --- Tests ---
+
+func TestMemoryPrivacyMiddleware_OptedOutUser_Returns204(t *testing.T) {
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(optedOutChecker, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "user-abc")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code, "opted-out user should get 204")
+	assert.False(t, handlerCalled, "next handler must not be called when opted out")
+}
+
+func TestMemoryPrivacyMiddleware_NoUserID_PassesThrough(t *testing.T) {
+	// No user_id — opt-out check must be skipped entirely.
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	// Use panicOptOut: if the opt-out checker is called, the test panics.
+	mw := newTestMiddleware(panicOptOut, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_UserNotOptedOut_PassesThrough(t *testing.T) {
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(passthroughOptOut, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "my content", "ws-1", "user-xyz")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_PIIRedaction_ContentRedacted(t *testing.T) {
+	const originalContent = "my email is test@example.com"
+	const redactedContent = "my email is [EMAIL]"
+
+	// Capture what the handler sees in the body.
+	var receivedContent string
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var req SaveMemoryRequest
+		err := json.NewDecoder(r.Body).Decode(&req)
+		require.NoError(t, err)
+		receivedContent = req.Content
+	})
+
+	redactor := ContentRedactor(func(_ context.Context, _, content string) (string, error) {
+		if content == originalContent {
+			return redactedContent, nil
+		}
+		return content, nil
+	})
+
+	mw := newTestMiddleware(passthroughOptOut, redactor)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, originalContent, "ws-pii-test", "user-xyz")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, redactedContent, receivedContent, "handler should receive redacted content")
+}
+
+func TestMemoryPrivacyMiddleware_RedactionError_Returns500(t *testing.T) {
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	errRedact := ContentRedactor(func(_ context.Context, _, _ string) (string, error) {
+		return "", errors.New("regex engine failure")
+	})
+
+	mw := newTestMiddleware(passthroughOptOut, errRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "user-xyz")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestMemoryPrivacyMiddleware_GETRequest_PassesThroughWithoutChecks(t *testing.T) {
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Both panicking functions — neither should be called for a GET.
+	mw := newTestMiddleware(panicOptOut, panicRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/memories?workspace=ws-1&user_id=user-abc", nil)
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_DELETERequest_PassesThroughWithoutChecks(t *testing.T) {
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	mw := newTestMiddleware(panicOptOut, panicRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodDelete, "/api/v1/memories/mem-1?workspace=ws-1", nil)
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.True(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_NoRedactionWhenContentUnchanged(t *testing.T) {
+	const originalContent = "clean content"
+
+	// Track that redactor was called but content unchanged.
+	redactorCallCount := 0
+	redactor := ContentRedactor(func(_ context.Context, _, content string) (string, error) {
+		redactorCallCount++
+		return content, nil // no change
+	})
+
+	var receivedBody []byte
+	next := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		require.NoError(t, err)
+	})
+
+	mw := newTestMiddleware(passthroughOptOut, redactor)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, originalContent, "ws-1", "user-xyz")
+
+	// Capture original body bytes for comparison.
+	originalBody, _ := io.ReadAll(r.Body)
+	r.Body = io.NopCloser(bytes.NewReader(originalBody))
+
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, 1, redactorCallCount, "redactor should be called once")
+	assert.Equal(t, originalBody, receivedBody, "body bytes should be unchanged when content not modified")
+}
+
+func TestMemoryPrivacyMiddleware_EmptyBody_PassesThrough(t *testing.T) {
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusBadRequest) // handler would return 400 for empty body
+	})
+
+	mw := newTestMiddleware(passthroughOptOut, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/memories?workspace=ws-1", nil)
+	handler.ServeHTTP(w, r)
+
+	// Handler should be called even with empty body — middleware doesn't block it.
+	assert.True(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_InvalidJSON_PassesThrough(t *testing.T) {
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	// noOpRedact — invalid JSON should not trigger redaction error, just pass through.
+	mw := newTestMiddleware(passthroughOptOut, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/memories?workspace=ws-1",
+		bytes.NewBufferString(`{not valid json`))
+	handler.ServeHTTP(w, r)
+
+	// Handler should be called; it returns 400 for invalid JSON.
+	assert.True(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_OptedOutUserWithNoRedaction_Returns204(t *testing.T) {
+	// Verify opt-out check happens before redaction (redactor must NOT be called).
+	mw := newTestMiddleware(optedOutChecker, panicRedact)
+	handler := mw.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "user-abc")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+}

--- a/internal/memory/api/service.go
+++ b/internal/memory/api/service.go
@@ -153,6 +153,29 @@ func (s *MemoryService) DeleteAllMemories(ctx context.Context, scope map[string]
 	return s.store.DeleteAll(ctx, scope)
 }
 
+// BatchDeleteMemories hard-deletes up to limit memories for the given scope (paginated DSAR).
+// Returns the count of deleted rows so the caller can loop until 0.
+func (s *MemoryService) BatchDeleteMemories(ctx context.Context, scope map[string]string, limit int) (int, error) {
+	n, err := s.store.BatchDelete(ctx, scope, limit)
+	if err != nil {
+		return 0, err
+	}
+	if n > 0 && s.eventPublisher != nil {
+		event := MemoryEvent{
+			EventType:   eventTypeMemoryDeleted,
+			WorkspaceID: scope[memory.ScopeWorkspaceID],
+			UserID:      scope[memory.ScopeUserID],
+			Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		}
+		go func() {
+			if err := s.eventPublisher.PublishMemoryEvent(context.Background(), event); err != nil {
+				s.log.Error(err, "memory batch delete event publish failed", "eventType", event.EventType, "count", n)
+			}
+		}()
+	}
+	return n, nil
+}
+
 // ExportMemories returns all memories for a scope without pagination (DSAR export).
 func (s *MemoryService) ExportMemories(ctx context.Context, scope map[string]string) ([]*memory.Memory, error) {
 	memories, err := s.store.ExportAll(ctx, scope)

--- a/internal/memory/api/service.go
+++ b/internal/memory/api/service.go
@@ -29,8 +29,15 @@ import (
 	"github.com/altairalabs/omnia/internal/memory"
 )
 
-// eventTypeMemoryCreated is the event type published when a memory is saved.
-const eventTypeMemoryCreated = "memory_created"
+// Audit event type constants for memory operations.
+const (
+	// eventTypeMemoryCreated is the event type published when a memory is saved.
+	eventTypeMemoryCreated = "memory_created"
+	// auditEventMemoryAccessed is the event type emitted when memories are read.
+	auditEventMemoryAccessed = "memory_accessed"
+	// auditEventMemoryExported is the event type emitted on DSAR export.
+	auditEventMemoryExported = "memory_exported"
+)
 
 // eventTypeMemoryDeleted is the event type published when a memory is deleted.
 const eventTypeMemoryDeleted = "memory_deleted"
@@ -53,11 +60,32 @@ type MemoryServiceConfig struct {
 	Purpose string
 }
 
+// MemoryAuditLogger is the audit logging interface for memory operations.
+// Implemented in ee/pkg/audit for enterprise deployments.
+type MemoryAuditLogger interface {
+	// LogEvent records an audit entry. Implementations must be non-blocking —
+	// entries may be dropped if the internal buffer is full.
+	LogEvent(ctx context.Context, entry *MemoryAuditEntry)
+}
+
+// MemoryAuditEntry represents a single audit log entry for a memory operation.
+type MemoryAuditEntry struct {
+	EventType   string
+	MemoryID    string
+	WorkspaceID string
+	UserID      string
+	Kind        string
+	IPAddress   string
+	UserAgent   string
+	Metadata    map[string]string
+}
+
 // MemoryService wraps the memory store with business logic for the HTTP layer.
 type MemoryService struct {
 	store          memory.Store
 	embeddingSvc   *memory.EmbeddingService // nil if embeddings not configured
 	eventPublisher MemoryEventPublisher     // nil if event publishing not configured
+	auditLogger    MemoryAuditLogger        // nil if audit logging not configured
 	config         MemoryServiceConfig
 	log            logr.Logger
 }
@@ -77,6 +105,27 @@ func NewMemoryService(store memory.Store, embeddingSvc *memory.EmbeddingService,
 // It may be called at most once before the service begins handling requests.
 func (s *MemoryService) SetEventPublisher(p MemoryEventPublisher) {
 	s.eventPublisher = p
+}
+
+// SetAuditLogger configures the audit logger for the service.
+// It may be called at most once before the service begins handling requests.
+func (s *MemoryService) SetAuditLogger(l MemoryAuditLogger) {
+	s.auditLogger = l
+}
+
+// emitAuditEvent fires an audit log entry asynchronously. If no audit logger is
+// configured the call is a no-op. Request metadata (IP, User-Agent) is extracted
+// from the context when present.
+func (s *MemoryService) emitAuditEvent(ctx context.Context, entry *MemoryAuditEntry) {
+	if s.auditLogger == nil {
+		return
+	}
+	if meta, ok := requestMetaFromCtx(ctx); ok {
+		entry.IPAddress = meta.IPAddress
+		entry.UserAgent = meta.UserAgent
+	}
+	logger := s.auditLogger
+	go logger.LogEvent(context.Background(), entry)
 }
 
 // SaveMemory persists a memory entry and, if an embedding service is configured,
@@ -113,17 +162,44 @@ func (s *MemoryService) SaveMemory(ctx context.Context, mem *memory.Memory) erro
 			}
 		}()
 	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   eventTypeMemoryCreated,
+		MemoryID:    mem.ID,
+		WorkspaceID: mem.Scope[memory.ScopeWorkspaceID],
+		UserID:      mem.Scope[memory.ScopeUserID],
+		Kind:        mem.Type,
+	})
 	return nil
 }
 
 // SearchMemories retrieves memories matching a query and scope.
 func (s *MemoryService) SearchMemories(ctx context.Context, scope map[string]string, query string, opts memory.RetrieveOptions) ([]*memory.Memory, error) {
-	return s.store.Retrieve(ctx, scope, query, opts)
+	results, err := s.store.Retrieve(ctx, scope, query, opts)
+	if err != nil {
+		return nil, err
+	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   auditEventMemoryAccessed,
+		WorkspaceID: scope[memory.ScopeWorkspaceID],
+		UserID:      scope[memory.ScopeUserID],
+		Metadata:    map[string]string{"operation": "search"},
+	})
+	return results, nil
 }
 
 // ListMemories returns memories for a given scope with pagination.
 func (s *MemoryService) ListMemories(ctx context.Context, scope map[string]string, opts memory.ListOptions) ([]*memory.Memory, error) {
-	return s.store.List(ctx, scope, opts)
+	results, err := s.store.List(ctx, scope, opts)
+	if err != nil {
+		return nil, err
+	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   auditEventMemoryAccessed,
+		WorkspaceID: scope[memory.ScopeWorkspaceID],
+		UserID:      scope[memory.ScopeUserID],
+		Metadata:    map[string]string{"operation": "list"},
+	})
+	return results, nil
 }
 
 // DeleteMemory performs a soft delete (forget) of a single memory.
@@ -145,12 +221,27 @@ func (s *MemoryService) DeleteMemory(ctx context.Context, scope map[string]strin
 			}
 		}()
 	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   eventTypeMemoryDeleted,
+		MemoryID:    memoryID,
+		WorkspaceID: scope[memory.ScopeWorkspaceID],
+		UserID:      scope[memory.ScopeUserID],
+	})
 	return nil
 }
 
 // DeleteAllMemories hard-deletes all memories for the given scope (DSAR).
 func (s *MemoryService) DeleteAllMemories(ctx context.Context, scope map[string]string) error {
-	return s.store.DeleteAll(ctx, scope)
+	if err := s.store.DeleteAll(ctx, scope); err != nil {
+		return err
+	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   eventTypeMemoryDeleted,
+		WorkspaceID: scope[memory.ScopeWorkspaceID],
+		UserID:      scope[memory.ScopeUserID],
+		Metadata:    map[string]string{"operation": "delete_all"},
+	})
+	return nil
 }
 
 // BatchDeleteMemories hard-deletes up to limit memories for the given scope (paginated DSAR).
@@ -173,6 +264,14 @@ func (s *MemoryService) BatchDeleteMemories(ctx context.Context, scope map[strin
 			}
 		}()
 	}
+	if n > 0 {
+		s.emitAuditEvent(ctx, &MemoryAuditEntry{
+			EventType:   eventTypeMemoryDeleted,
+			WorkspaceID: scope[memory.ScopeWorkspaceID],
+			UserID:      scope[memory.ScopeUserID],
+			Metadata:    map[string]string{"operation": "batch_delete"},
+		})
+	}
 	return n, nil
 }
 
@@ -183,5 +282,10 @@ func (s *MemoryService) ExportMemories(ctx context.Context, scope map[string]str
 		return nil, err
 	}
 	s.log.V(1).Info("memories exported", "workspace", scope[memory.ScopeWorkspaceID], "count", len(memories))
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   auditEventMemoryExported,
+		WorkspaceID: scope[memory.ScopeWorkspaceID],
+		UserID:      scope[memory.ScopeUserID],
+	})
 	return memories, nil
 }

--- a/internal/memory/api/service_test.go
+++ b/internal/memory/api/service_test.go
@@ -438,3 +438,49 @@ func TestMemoryService_SaveWithExplicitExpiry(t *testing.T) {
 	assert.True(t, mem.ExpiresAt.Equal(explicit),
 		"explicit ExpiresAt should not be overridden by DefaultTTL")
 }
+
+func TestServiceBatchDeleteMemories(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+
+	// Save 5 memories.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, svc.SaveMemory(ctx, &memory.Memory{
+			Type:       "fact",
+			Content:    fmt.Sprintf("batch memory %d", i),
+			Confidence: 0.8,
+			Scope:      scope,
+		}))
+	}
+
+	// BatchDelete with limit 3 should delete 3.
+	n, err := svc.BatchDeleteMemories(ctx, scope, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	// 2 remain.
+	remaining, err := svc.ListMemories(ctx, scope, memory.ListOptions{Limit: 10})
+	require.NoError(t, err)
+	assert.Len(t, remaining, 2)
+}
+
+func TestServiceBatchDeleteMemories_Empty(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+
+	// BatchDelete on empty store returns 0.
+	n, err := svc.BatchDeleteMemories(ctx, scope, 500)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestServiceBatchDeleteMemories_MissingWorkspace(t *testing.T) {
+	svc := newTestService(t)
+	ctx := context.Background()
+
+	_, err := svc.BatchDeleteMemories(ctx, map[string]string{}, 500)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace_id")
+}

--- a/internal/memory/api/service_test.go
+++ b/internal/memory/api/service_test.go
@@ -484,3 +484,217 @@ func TestServiceBatchDeleteMemories_MissingWorkspace(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "workspace_id")
 }
+
+// --- Audit logger tests ---
+
+// mockAuditLogger records MemoryAuditEntry values for assertion.
+type mockAuditLogger struct {
+	entries chan *MemoryAuditEntry
+}
+
+func newMockAuditLogger() *mockAuditLogger {
+	return &mockAuditLogger{entries: make(chan *MemoryAuditEntry, 16)}
+}
+
+func (m *mockAuditLogger) LogEvent(_ context.Context, entry *MemoryAuditEntry) {
+	m.entries <- entry
+}
+
+// receiveEntry waits up to 5 seconds for an audit entry from the logger.
+func (m *mockAuditLogger) receiveEntry(t *testing.T) *MemoryAuditEntry {
+	t.Helper()
+	select {
+	case e := <-m.entries:
+		return e
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for audit entry")
+		return nil
+	}
+}
+
+func TestAuditLogger_SaveMemory_EmitsCreated(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	ctx := context.Background()
+	mem := &memory.Memory{
+		Type:       "fact",
+		Content:    "audit test",
+		Confidence: 0.9,
+		Scope:      map[string]string{memory.ScopeWorkspaceID: testWorkspaceID},
+	}
+	require.NoError(t, svc.SaveMemory(ctx, mem))
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, eventTypeMemoryCreated, entry.EventType)
+	assert.Equal(t, testWorkspaceID, entry.WorkspaceID)
+	assert.NotEmpty(t, entry.MemoryID)
+}
+
+func TestAuditLogger_SearchMemories_EmitsAccessed(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+	require.NoError(t, svc.SaveMemory(ctx, &memory.Memory{
+		Type: "fact", Content: "searchable", Confidence: 0.8, Scope: scope,
+	}))
+	// Drain the created event.
+	al.receiveEntry(t)
+
+	_, err := svc.SearchMemories(ctx, scope, "search", memory.RetrieveOptions{Limit: 5})
+	require.NoError(t, err)
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, auditEventMemoryAccessed, entry.EventType)
+	assert.Equal(t, "search", entry.Metadata["operation"])
+}
+
+func TestAuditLogger_ListMemories_EmitsAccessed(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+
+	_, err := svc.ListMemories(ctx, scope, memory.ListOptions{Limit: 5})
+	require.NoError(t, err)
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, auditEventMemoryAccessed, entry.EventType)
+	assert.Equal(t, "list", entry.Metadata["operation"])
+}
+
+func TestAuditLogger_DeleteMemory_EmitsDeleted(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+
+	mem := &memory.Memory{
+		Type: "fact", Content: "to delete", Confidence: 0.8, Scope: scope,
+	}
+	require.NoError(t, svc.SaveMemory(ctx, mem))
+	al.receiveEntry(t) // drain created event
+
+	require.NoError(t, svc.DeleteMemory(ctx, scope, mem.ID))
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, eventTypeMemoryDeleted, entry.EventType)
+	assert.Equal(t, mem.ID, entry.MemoryID)
+}
+
+func TestAuditLogger_DeleteAllMemories_EmitsDeleted(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+
+	require.NoError(t, svc.DeleteAllMemories(ctx, scope))
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, eventTypeMemoryDeleted, entry.EventType)
+	assert.Equal(t, "delete_all", entry.Metadata["operation"])
+}
+
+func TestAuditLogger_BatchDeleteMemories_EmitsDeleted(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+
+	// Save one memory so there is something to delete.
+	require.NoError(t, svc.SaveMemory(ctx, &memory.Memory{
+		Type: "fact", Content: "batch", Confidence: 0.8, Scope: scope,
+	}))
+	al.receiveEntry(t) // drain created event
+
+	n, err := svc.BatchDeleteMemories(ctx, scope, 10)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, eventTypeMemoryDeleted, entry.EventType)
+	assert.Equal(t, "batch_delete", entry.Metadata["operation"])
+}
+
+func TestAuditLogger_BatchDeleteMemories_NoEmitWhenEmpty(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+
+	n, err := svc.BatchDeleteMemories(ctx, scope, 10)
+	require.NoError(t, err)
+	require.Equal(t, 0, n)
+
+	// No audit event should be emitted for empty batch delete.
+	select {
+	case entry := <-al.entries:
+		t.Fatalf("unexpected audit entry for zero-row batch delete: %+v", entry)
+	case <-time.After(100 * time.Millisecond):
+		// Expected — no entry emitted.
+	}
+}
+
+func TestAuditLogger_ExportMemories_EmitsExported(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+
+	_, err := svc.ExportMemories(ctx, scope)
+	require.NoError(t, err)
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, auditEventMemoryExported, entry.EventType)
+}
+
+func TestAuditLogger_NilLogger_NoEvents(t *testing.T) {
+	// No audit logger set — operations must succeed without panicking.
+	svc := newTestService(t)
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := context.Background()
+
+	mem := &memory.Memory{Type: "fact", Content: "nil logger", Confidence: 0.7, Scope: scope}
+	require.NoError(t, svc.SaveMemory(ctx, mem))
+
+	_, err := svc.ListMemories(ctx, scope, memory.ListOptions{Limit: 5})
+	require.NoError(t, err)
+
+	_, err = svc.ExportMemories(ctx, scope)
+	require.NoError(t, err)
+}
+
+func TestAuditLogger_RequestMetaInContext_PropagatesIPAndUA(t *testing.T) {
+	svc := newTestService(t)
+	al := newMockAuditLogger()
+	svc.SetAuditLogger(al)
+
+	scope := map[string]string{memory.ScopeWorkspaceID: testWorkspaceID}
+	ctx := withRequestMeta(context.Background(), RequestMeta{
+		IPAddress: "10.1.2.3",
+		UserAgent: "omnia-test/1.0",
+	})
+
+	_, err := svc.ListMemories(ctx, scope, memory.ListOptions{Limit: 5})
+	require.NoError(t, err)
+
+	entry := al.receiveEntry(t)
+	assert.Equal(t, "10.1.2.3", entry.IPAddress)
+	assert.Equal(t, "omnia-test/1.0", entry.UserAgent)
+}

--- a/internal/memory/cache.go
+++ b/internal/memory/cache.go
@@ -138,6 +138,18 @@ func (c *CachedStore) ExportAll(ctx context.Context, scope map[string]string) ([
 	return c.inner.ExportAll(ctx, scope)
 }
 
+// BatchDelete delegates to the inner store then invalidates the cache for the scope.
+func (c *CachedStore) BatchDelete(ctx context.Context, scope map[string]string, limit int) (int, error) {
+	n, err := c.inner.BatchDelete(ctx, scope, limit)
+	if err != nil {
+		return 0, err
+	}
+	if n > 0 {
+		c.bumpVersion(ctx, scope)
+	}
+	return n, nil
+}
+
 // --- cache helpers -------------------------------------------------------------
 
 // versionKey returns the Redis key that tracks the invalidation version for a scope.

--- a/internal/memory/cache_test.go
+++ b/internal/memory/cache_test.go
@@ -102,6 +102,20 @@ func (m *cacheTestStore) ExportAll(_ context.Context, _ map[string]string) ([]*M
 	return []*Memory{}, nil
 }
 
+func (m *cacheTestStore) BatchDelete(_ context.Context, _ map[string]string, limit int) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.deleteAllErr != nil {
+		return 0, m.deleteAllErr
+	}
+	n := len(m.memories)
+	if limit > 0 && limit < n {
+		n = limit
+	}
+	m.memories = m.memories[n:]
+	return n, nil
+}
+
 // cacheTestScope returns a minimal scope map for CachedStore tests.
 func cacheTestScope() map[string]string {
 	return map[string]string{ScopeWorkspaceID: "ws-1", ScopeUserID: "user-1"}
@@ -440,6 +454,79 @@ func TestCachedStore_EmptyCache_DoesNotMaskInnerData(t *testing.T) {
 	}
 	if len(mems) != 1 {
 		t.Fatalf("expected 1 memory after version bump, got %d (empty cache was incorrectly trusted)", len(mems))
+	}
+}
+
+// --- BatchDelete tests --------------------------------------------------------
+
+func TestCachedStore_BatchDelete_InvalidatesCache(t *testing.T) {
+	inner := &cacheTestStore{memories: []*Memory{
+		{ID: "m1", Content: "one"},
+		{ID: "m2", Content: "two"},
+		{ID: "m3", Content: "three"},
+	}}
+	cs, _ := newTestCache(t, inner)
+	ctx := context.Background()
+	scope := cacheTestScope()
+
+	if _, err := cs.List(ctx, scope, ListOptions{}); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	listBefore := inner.listCalls
+
+	n, err := cs.BatchDelete(ctx, scope, 2)
+	if err != nil {
+		t.Fatalf("batch delete: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 deleted, got %d", n)
+	}
+
+	if _, err := cs.List(ctx, scope, ListOptions{}); err != nil {
+		t.Fatalf("list after batch delete: %v", err)
+	}
+	if inner.listCalls != listBefore+1 {
+		t.Fatalf("expected inner called again after BatchDelete; calls=%d", inner.listCalls)
+	}
+}
+
+func TestCachedStore_BatchDelete_ZeroRows_NoBump(t *testing.T) {
+	inner := &cacheTestStore{memories: []*Memory{}}
+	cs, _ := newTestCache(t, inner)
+	ctx := context.Background()
+	scope := cacheTestScope()
+
+	// Prime cache.
+	if _, err := cs.List(ctx, scope, ListOptions{}); err != nil {
+		t.Fatalf("prime: %v", err)
+	}
+	listBefore := inner.listCalls
+
+	// BatchDelete with nothing to delete returns 0 — no version bump needed.
+	n, err := cs.BatchDelete(ctx, scope, 500)
+	if err != nil {
+		t.Fatalf("batch delete: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("expected 0 deleted, got %d", n)
+	}
+
+	// Cache should NOT be invalidated (version not bumped).
+	if _, err := cs.List(ctx, scope, ListOptions{}); err != nil {
+		t.Fatalf("list after no-op batch delete: %v", err)
+	}
+	if inner.listCalls != listBefore {
+		t.Fatalf("expected inner NOT called again (no invalidation); calls=%d", inner.listCalls)
+	}
+}
+
+func TestCachedStore_BatchDelete_InnerError(t *testing.T) {
+	inner := &cacheTestStore{deleteAllErr: errTest}
+	cs, _ := newTestCache(t, inner)
+
+	_, err := cs.BatchDelete(context.Background(), cacheTestScope(), 500)
+	if err == nil {
+		t.Fatal("expected error from inner batch delete, got nil")
 	}
 }
 

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -69,6 +69,10 @@ func (m *mockStore) ExportAll(_ context.Context, _ map[string]string) ([]*Memory
 	return []*Memory{}, nil
 }
 
+func (m *mockStore) BatchDelete(_ context.Context, _ map[string]string, _ int) (int, error) {
+	return 0, nil
+}
+
 // mockPopulator is a MemoryPopulator mock.
 type mockPopulator struct {
 	result *PopulationResult

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -286,6 +286,39 @@ func buildDeleteAllQuery(scope map[string]string) (string, *pgutil.QueryBuilder)
 	return sql, &qb
 }
 
+// BatchDelete hard-deletes up to limit entities (and cascading observations/relations) for the scope.
+// It returns the count of deleted rows. Use limit=500 in a loop until count=0 for DSAR cascades.
+func (s *PostgresMemoryStore) BatchDelete(ctx context.Context, scope map[string]string, limit int) (int, error) {
+	if scope[ScopeWorkspaceID] == "" {
+		return 0, errors.New(errWorkspaceRequired)
+	}
+
+	sql, qb := buildBatchDeleteQuery(scope, limit)
+
+	tag, err := s.pool.Exec(ctx, sql, qb.Args()...)
+	if err != nil {
+		return 0, fmt.Errorf("memory: batch delete: %w", err)
+	}
+	return int(tag.RowsAffected()), nil
+}
+
+// buildBatchDeleteQuery constructs the SQL and arguments for a BatchDelete call.
+func buildBatchDeleteQuery(scope map[string]string, limit int) (string, *pgutil.QueryBuilder) {
+	var qb pgutil.QueryBuilder
+	qb.Add(colWorkspaceID, scope[ScopeWorkspaceID])
+
+	if uid := scope[ScopeUserID]; uid != "" {
+		qb.Add(colVirtualUserID, uid)
+	}
+
+	subquery := "SELECT id FROM memory_entities WHERE 1=1" + qb.Where()
+	subquery = qb.AppendPagination(subquery, limit, 0)
+
+	sql := "DELETE FROM memory_entities WHERE id IN (" + subquery + ")"
+
+	return sql, &qb
+}
+
 // exportAllLimit is the maximum number of memories returned by ExportAll (DSAR cap).
 const exportAllLimit = 10000
 

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -695,3 +695,60 @@ func TestPostgresMemoryStore_ExportAll_ExcludesForgotten(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, results, 2, "ExportAll should exclude soft-deleted memories")
 }
+
+func TestPostgresMemoryStore_BatchDelete(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	scope := testScope(testWorkspace1)
+
+	// Save 5 memories.
+	for i := range 5 {
+		mem := &Memory{
+			Type:       "fact",
+			Content:    fmt.Sprintf("batch fact %d", i),
+			Confidence: 0.9,
+			Scope:      scope,
+		}
+		require.NoError(t, store.Save(ctx, mem))
+	}
+
+	// BatchDelete with limit=3 should delete 3 rows.
+	n, err := store.BatchDelete(ctx, scope, 3)
+	require.NoError(t, err)
+	assert.Equal(t, 3, n)
+
+	// 2 should remain.
+	results, err := store.List(ctx, scope, ListOptions{})
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// Delete the rest.
+	n, err = store.BatchDelete(ctx, scope, 10)
+	require.NoError(t, err)
+	assert.Equal(t, 2, n)
+
+	// All gone.
+	results, err = store.List(ctx, scope, ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestPostgresMemoryStore_BatchDelete_NoRows(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	scope := testScope(testWorkspace1)
+
+	// BatchDelete on empty store returns 0 with no error.
+	n, err := store.BatchDelete(ctx, scope, 500)
+	require.NoError(t, err)
+	assert.Equal(t, 0, n)
+}
+
+func TestPostgresMemoryStore_BatchDelete_MissingWorkspace(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	_, err := store.BatchDelete(ctx, map[string]string{}, 500)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace_id")
+}

--- a/internal/memory/store_unit_test.go
+++ b/internal/memory/store_unit_test.go
@@ -241,3 +241,34 @@ func TestBuildDeleteAllQuery_WithUserID(t *testing.T) {
 	assert.Contains(t, sql, "virtual_user_id=$2")
 	assert.Len(t, qb.Args(), 2)
 }
+
+func TestBuildBatchDeleteQuery_Basic(t *testing.T) {
+	scope := map[string]string{ScopeWorkspaceID: "ws-uuid"}
+	sql, qb := buildBatchDeleteQuery(scope, 500)
+
+	assert.Contains(t, sql, "DELETE FROM memory_entities WHERE id IN")
+	assert.Contains(t, sql, "SELECT id FROM memory_entities WHERE 1=1")
+	assert.Contains(t, sql, "workspace_id=$1")
+	assert.Contains(t, sql, "LIMIT")
+	// workspace_id + limit = 2 args
+	assert.Len(t, qb.Args(), 2)
+	assert.Equal(t, 500, qb.Args()[1])
+}
+
+func TestBuildBatchDeleteQuery_WithUserID(t *testing.T) {
+	scope := map[string]string{ScopeWorkspaceID: "ws-uuid", ScopeUserID: "u1"}
+	sql, qb := buildBatchDeleteQuery(scope, 100)
+
+	assert.Contains(t, sql, "virtual_user_id=$2")
+	assert.Contains(t, sql, "LIMIT")
+	// workspace_id, virtual_user_id, limit = 3 args
+	assert.Len(t, qb.Args(), 3)
+	assert.Equal(t, 100, qb.Args()[2])
+}
+
+func TestBatchDelete_MissingWorkspace(t *testing.T) {
+	store := &PostgresMemoryStore{} // nil pool — validation fails before use
+	_, err := store.BatchDelete(context.Background(), map[string]string{}, 500)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "workspace_id")
+}

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -37,7 +37,9 @@ type (
 // Store extends the PromptKit memory.Store interface with Omnia-specific methods.
 // ExportAll is needed for DSAR (data subject access request) data export and is
 // not part of the PromptKit SDK contract.
+// BatchDelete is needed for paginated DSAR deletion (Task 4 cascade).
 type Store interface {
 	pkmemory.Store
 	ExportAll(ctx context.Context, scope map[string]string) ([]*Memory, error)
+	BatchDelete(ctx context.Context, scope map[string]string, limit int) (int, error)
 }


### PR DESCRIPTION
## Summary

- **PII Redactor**: `PatternRedactor` wraps existing redaction with fixed `PIIConfig` for the memory extraction pipeline, implementing `memory.Redactor` interface
- **Privacy Middleware**: Memory-api middleware enforces `ShouldRemember()` opt-out (204 on opted-out writes) and PII redaction on POST content, enterprise-only
- **Batch Delete**: `DELETE /api/v1/memories/batch` endpoint with paginated deletion (limit param) for DSAR cascade support
- **DSAR Cascade**: `MemoryHTTPDeleter` calls batch delete in a loop until all user memories are purged, wired into session-api `DeletionService`
- **Audit Logging**: Memory-api emits `memory_created/accessed/deleted/exported` audit events via `ee/pkg/audit.Logger` when enterprise enabled, with IP/User-Agent capture middleware
- **Doctor Checks**: Four privacy verification checks (PII redaction, opt-out, deletion cascade, audit log) registered under "Privacy" category

Spec: `docs/local-backlog/privacy-wiring-spec.md`

## Test Plan

- [x] All new code has >= 80% test coverage (enforced by pre-commit hook)
- [x] `go build ./...` passes (GOWORK=off)
- [x] All 6 changed packages pass tests
- [ ] CI passes (golangci-lint, go test, SonarCloud)
- [ ] Deploy to staging and run `omnia-doctor --run-once` to verify Privacy checks