### PR TITLE
feat: per-category consent infrastructure for memory system

### DIFF
--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -410,8 +410,12 @@ func wrapPrivacyMiddleware(next http.Handler, pool *pgxpool.Pool, log logr.Logge
 	prefStore := privacy.NewPreferencesStore(pool)
 	redactor := redaction.NewRedactor()
 
-	checkOptOut := memoryapi.OptOutChecker(func(ctx context.Context, userID, workspace string) bool {
-		return privacy.ShouldRemember(ctx, prefStore, userID, workspace, "")
+	checkOptOut := memoryapi.OptOutChecker(func(ctx context.Context, userID, workspace, category string) bool {
+		cat := privacy.ConsentCategory(category)
+		if cat == "" {
+			cat = privacy.ConsentMemoryContext
+		}
+		return privacy.ShouldRememberCategory(ctx, prefStore, prefStore, userID, workspace, "", cat)
 	})
 
 	contentRedactor := memoryapi.ContentRedactor(func(ctx context.Context, workspace, content string) (string, error) {

--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -482,6 +482,9 @@ func registerEnterpriseRoutes(mux *http.ServeMux, pool *pgxpool.Pool, registry *
 		privacyStore := privacy.NewPreferencesStore(pool)
 		optOutHandler := privacy.NewOptOutHandler(privacyStore, log)
 		optOutHandler.RegisterRoutes(mux)
+
+		consentHandler := privacy.NewConsentHandler(privacyStore, auditLogger, log)
+		consentHandler.RegisterRoutes(mux)
 	}
 }
 

--- a/ee/pkg/privacy/consent.go
+++ b/ee/pkg/privacy/consent.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"sort"
+)
+
+// ConsentCategory represents a granular memory consent scope.
+type ConsentCategory string
+
+const (
+	ConsentMemoryPreferences  ConsentCategory = "memory:preferences"
+	ConsentMemoryContext      ConsentCategory = "memory:context"
+	ConsentMemoryHistory      ConsentCategory = "memory:history"
+	ConsentMemoryIdentity     ConsentCategory = "memory:identity"
+	ConsentMemoryLocation     ConsentCategory = "memory:location"
+	ConsentMemoryHealth       ConsentCategory = "memory:health"
+	ConsentAnalyticsAggregate ConsentCategory = "analytics:aggregate"
+)
+
+type categoryMeta struct {
+	RequiresExplicitGrant bool
+}
+
+var categoryRegistry = map[ConsentCategory]categoryMeta{
+	ConsentMemoryPreferences:  {RequiresExplicitGrant: false},
+	ConsentMemoryContext:      {RequiresExplicitGrant: false},
+	ConsentMemoryHistory:      {RequiresExplicitGrant: false},
+	ConsentMemoryIdentity:     {RequiresExplicitGrant: true},
+	ConsentMemoryLocation:     {RequiresExplicitGrant: true},
+	ConsentMemoryHealth:       {RequiresExplicitGrant: true},
+	ConsentAnalyticsAggregate: {RequiresExplicitGrant: true},
+}
+
+// CategoryInfo returns whether a category requires an explicit user grant
+// and whether it is a valid platform-defined category.
+func CategoryInfo(c ConsentCategory) (requiresGrant bool, valid bool) {
+	meta, ok := categoryRegistry[c]
+	return meta.RequiresExplicitGrant, ok
+}
+
+// ValidCategories returns all defined consent categories in deterministic order.
+func ValidCategories() []ConsentCategory {
+	cats := make([]ConsentCategory, 0, len(categoryRegistry))
+	for c := range categoryRegistry {
+		cats = append(cats, c)
+	}
+	sort.Slice(cats, func(i, j int) bool { return cats[i] < cats[j] })
+	return cats
+}
+
+// ConsentSource abstracts where consent grants come from.
+// Implemented by PreferencesPostgresStore (reads from DB) and potentially
+// by a future TokenConsentSource (reads from JWT claims in context).
+type ConsentSource interface {
+	GetConsentGrants(ctx context.Context, userID string) ([]ConsentCategory, error)
+}

--- a/ee/pkg/privacy/consent_check.go
+++ b/ee/pkg/privacy/consent_check.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"slices"
+)
+
+// ShouldRememberCategory checks whether memory storage should proceed for a
+// given user and consent category. It first checks the binary opt-out (global,
+// workspace, agent). If not opted out, it checks category consent:
+//   - Categories that don't require explicit grant → allowed
+//   - Categories that require explicit grant → check user's consent grants
+//   - Unknown categories → rejected (fail closed)
+//   - ConsentSource errors → rejected for PII categories (fail closed)
+func ShouldRememberCategory(
+	ctx context.Context,
+	store PreferencesStore,
+	source ConsentSource,
+	userID, workspace, agent string,
+	category ConsentCategory,
+) bool {
+	// 1. Binary opt-out check (reuse existing shouldProceed)
+	if !shouldProceed(ctx, store, userID, workspace, agent) {
+		return false
+	}
+
+	// 2. Category validation
+	requiresGrant, valid := CategoryInfo(category)
+	if !valid {
+		return false
+	}
+
+	// 3. Non-PII categories don't need explicit grant
+	if !requiresGrant {
+		return true
+	}
+
+	// 4. PII categories need explicit grant
+	grants, err := source.GetConsentGrants(ctx, userID)
+	if err != nil {
+		// Fail closed for PII categories
+		return false
+	}
+	return slices.Contains(grants, category)
+}

--- a/ee/pkg/privacy/consent_check_test.go
+++ b/ee/pkg/privacy/consent_check_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type mockConsentSource struct {
+	grants []ConsentCategory
+	err    error
+}
+
+func (m *mockConsentSource) GetConsentGrants(_ context.Context, _ string) ([]ConsentCategory, error) {
+	return m.grants, m.err
+}
+
+func TestShouldRememberCategory_OptOutAll(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        true,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	source := &mockConsentSource{grants: []ConsentCategory{ConsentMemoryIdentity}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryIdentity)
+	assert.False(t, result)
+}
+
+func TestShouldRememberCategory_OptOutWorkspace(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{"ws1"},
+		OptOutAgents:     []string{},
+	}}
+	source := &mockConsentSource{grants: []ConsentCategory{ConsentMemoryIdentity}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryIdentity)
+	assert.False(t, result)
+}
+
+func TestShouldRememberCategory_NonPII_NoGrants(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	source := &mockConsentSource{grants: []ConsentCategory{}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryContext)
+	assert.True(t, result)
+}
+
+func TestShouldRememberCategory_NonPII_NewUser(t *testing.T) {
+	store := &mockPreferencesStore{err: ErrPreferencesNotFound}
+	source := &mockConsentSource{grants: []ConsentCategory{}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryContext)
+	assert.True(t, result)
+}
+
+func TestShouldRememberCategory_PII_NoGrants(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	source := &mockConsentSource{grants: []ConsentCategory{}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryIdentity)
+	assert.False(t, result)
+}
+
+func TestShouldRememberCategory_PII_MatchingGrant(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	source := &mockConsentSource{grants: []ConsentCategory{ConsentMemoryIdentity}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryIdentity)
+	assert.True(t, result)
+}
+
+func TestShouldRememberCategory_PII_DifferentGrant(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	// User granted ConsentMemoryLocation but we're checking ConsentMemoryIdentity
+	source := &mockConsentSource{grants: []ConsentCategory{ConsentMemoryLocation}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryIdentity)
+	assert.False(t, result)
+}
+
+func TestShouldRememberCategory_UnknownCategory(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	source := &mockConsentSource{grants: []ConsentCategory{}}
+	unknown := ConsentCategory("memory:unknown")
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", unknown)
+	assert.False(t, result)
+}
+
+func TestShouldRememberCategory_ConsentSourceError(t *testing.T) {
+	store := &mockPreferencesStore{prefs: &Preferences{
+		OptOutAll:        false,
+		OptOutWorkspaces: []string{},
+		OptOutAgents:     []string{},
+	}}
+	source := &mockConsentSource{err: errors.New("db error")}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryIdentity)
+	assert.False(t, result, "should fail closed on ConsentSource error for PII categories")
+}
+
+func TestShouldRememberCategory_NoPreferences_NonPII(t *testing.T) {
+	store := &mockPreferencesStore{err: ErrPreferencesNotFound}
+	source := &mockConsentSource{grants: []ConsentCategory{}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryContext)
+	assert.True(t, result)
+}
+
+func TestShouldRememberCategory_NoPreferences_PII(t *testing.T) {
+	store := &mockPreferencesStore{err: ErrPreferencesNotFound}
+	// No preferences means no grants exist
+	source := &mockConsentSource{grants: []ConsentCategory{}}
+	result := ShouldRememberCategory(context.Background(), store, source, "user1", "ws1", "agent1", ConsentMemoryIdentity)
+	assert.False(t, result)
+}

--- a/ee/pkg/privacy/consent_handler.go
+++ b/ee/pkg/privacy/consent_handler.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	"github.com/altairalabs/omnia/internal/session/api"
+	"github.com/altairalabs/omnia/pkg/logging"
+)
+
+// ConsentHandler provides HTTP endpoints for managing consent grants.
+type ConsentHandler struct {
+	store *PreferencesPostgresStore
+	audit api.AuditLogger
+	log   logr.Logger
+}
+
+// NewConsentHandler creates a new ConsentHandler.
+func NewConsentHandler(store *PreferencesPostgresStore, audit api.AuditLogger, log logr.Logger) *ConsentHandler {
+	return &ConsentHandler{
+		store: store,
+		audit: audit,
+		log:   log.WithName("consent-handler"),
+	}
+}
+
+// RegisterRoutes registers consent API routes on the given mux.
+func (h *ConsentHandler) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("PUT /api/v1/privacy/preferences/{userID}/consent", h.handleSetConsent)
+	mux.HandleFunc("GET /api/v1/privacy/preferences/{userID}/consent", h.handleGetConsent)
+}
+
+// ConsentRequest is the JSON body for consent mutation operations.
+type ConsentRequest struct {
+	Grants      []ConsentCategory `json:"grants"`
+	Revocations []ConsentCategory `json:"revocations"`
+}
+
+// ConsentResponse is the JSON response body for consent state.
+type ConsentResponse struct {
+	Grants   []ConsentCategory `json:"grants"`
+	Defaults []ConsentCategory `json:"defaults"`
+	Denied   []ConsentCategory `json:"denied"`
+}
+
+// handleSetConsent applies consent grants and/or revocations for a user.
+func (h *ConsentHandler) handleSetConsent(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("userID")
+	if userID == "" {
+		writeErr(w, http.StatusBadRequest, "user ID is required")
+		return
+	}
+
+	var req ConsentRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if err := validateCategories(req.Grants, req.Revocations); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	if err := h.applyGrants(r, userID, req.Grants); err != nil {
+		h.log.Error(err, "apply grants failed", "userHash", logging.HashID(userID))
+		writeErr(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	if err := h.applyRevocations(r, userID, req.Revocations); err != nil {
+		h.log.Error(err, "apply revocations failed", "userHash", logging.HashID(userID))
+		writeErr(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	resp, err := h.buildConsentResponse(r, userID)
+	if err != nil {
+		h.log.Error(err, "build consent response failed", "userHash", logging.HashID(userID))
+		writeErr(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// handleGetConsent returns the current consent state for a user.
+func (h *ConsentHandler) handleGetConsent(w http.ResponseWriter, r *http.Request) {
+	userID := r.PathValue("userID")
+	if userID == "" {
+		writeErr(w, http.StatusBadRequest, "user ID is required")
+		return
+	}
+
+	resp, err := h.buildConsentResponse(r, userID)
+	if err != nil {
+		h.log.Error(err, "get consent failed", "userHash", logging.HashID(userID))
+		writeErr(w, http.StatusInternalServerError, "internal server error")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}
+
+// validateCategories checks that all provided categories are known platform categories.
+func validateCategories(grants, revocations []ConsentCategory) error {
+	for _, cat := range grants {
+		if _, valid := CategoryInfo(cat); !valid {
+			return errors.New("unknown consent category: " + string(cat))
+		}
+	}
+	for _, cat := range revocations {
+		if _, valid := CategoryInfo(cat); !valid {
+			return errors.New("unknown consent category: " + string(cat))
+		}
+	}
+	return nil
+}
+
+// applyGrants calls SetConsentGrant for each category and emits audit events.
+func (h *ConsentHandler) applyGrants(r *http.Request, userID string, grants []ConsentCategory) error {
+	for _, cat := range grants {
+		if err := h.store.SetConsentGrant(r.Context(), userID, cat); err != nil {
+			return err
+		}
+		h.emitAudit(r, "consent_granted", userID, cat)
+	}
+	return nil
+}
+
+// applyRevocations calls RemoveConsentGrant for each category, ignoring ErrPreferencesNotFound.
+func (h *ConsentHandler) applyRevocations(r *http.Request, userID string, revocations []ConsentCategory) error {
+	for _, cat := range revocations {
+		err := h.store.RemoveConsentGrant(r.Context(), userID, cat)
+		if err != nil && !errors.Is(err, ErrPreferencesNotFound) {
+			return err
+		}
+		h.emitAudit(r, "consent_revoked", userID, cat)
+	}
+	return nil
+}
+
+// buildConsentResponse fetches current grants and computes defaults/denied.
+func (h *ConsentHandler) buildConsentResponse(r *http.Request, userID string) (*ConsentResponse, error) {
+	grants, err := h.store.GetConsentGrants(r.Context(), userID)
+	if err != nil {
+		return nil, err
+	}
+
+	grantSet := make(map[ConsentCategory]bool, len(grants))
+	for _, g := range grants {
+		grantSet[g] = true
+	}
+
+	var defaults, denied []ConsentCategory
+	for _, cat := range ValidCategories() {
+		requiresGrant, _ := CategoryInfo(cat)
+		if !requiresGrant {
+			defaults = append(defaults, cat)
+		} else if !grantSet[cat] {
+			denied = append(denied, cat)
+		}
+	}
+
+	if grants == nil {
+		grants = []ConsentCategory{}
+	}
+	if defaults == nil {
+		defaults = []ConsentCategory{}
+	}
+	if denied == nil {
+		denied = []ConsentCategory{}
+	}
+
+	return &ConsentResponse{
+		Grants:   grants,
+		Defaults: defaults,
+		Denied:   denied,
+	}, nil
+}
+
+// emitAudit emits an audit event if an audit logger is configured.
+func (h *ConsentHandler) emitAudit(r *http.Request, eventType, userID string, cat ConsentCategory) {
+	if h.audit == nil {
+		return
+	}
+	h.audit.LogEvent(r.Context(), &api.AuditEntry{
+		EventType: eventType,
+		Metadata: map[string]string{
+			"user_id":  userID,
+			"category": string(cat),
+		},
+	})
+}

--- a/ee/pkg/privacy/consent_handler_test.go
+++ b/ee/pkg/privacy/consent_handler_test.go
@@ -1,0 +1,452 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	"github.com/altairalabs/omnia/internal/session/api"
+)
+
+// mockConsentAuditLogger captures emitted audit events for assertions.
+type mockConsentAuditLogger struct {
+	events []*api.AuditEntry
+}
+
+func (m *mockConsentAuditLogger) LogEvent(_ context.Context, entry *api.AuditEntry) {
+	m.events = append(m.events, entry)
+}
+
+func (m *mockConsentAuditLogger) Close() error {
+	return nil
+}
+
+// newTestConsentHandler builds a ConsentHandler backed by a prefsMockPool.
+func newTestConsentHandler(pool dbPool, audit api.AuditLogger) *ConsentHandler {
+	log := zap.New(zap.UseDevMode(true))
+	store := NewPreferencesStore(pool)
+	return NewConsentHandler(store, audit, log)
+}
+
+// consentHandlerViaRouter registers routes on a ServeMux and serves a request,
+// returning the recorder. This exercises PathValue routing.
+func serveConsentRequest(h *ConsentHandler, method, target string, body []byte) *httptest.ResponseRecorder {
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest(method, target, bytes.NewReader(body))
+	} else {
+		req = httptest.NewRequest(method, target, nil)
+	}
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	return rec
+}
+
+// successExecPool returns a pool whose Exec always succeeds and QueryRow scans the provided grants.
+func successExecPool(responseGrants []string) *prefsMockPool {
+	return &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*[]string) = responseGrants
+				return nil
+			}}
+		},
+	}
+}
+
+// ---- PUT /consent tests ----
+
+func TestConsentHandlerPUT_ValidGrants(t *testing.T) {
+	pool := successExecPool([]string{string(ConsentMemoryIdentity)})
+	h := newTestConsentHandler(pool, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Grants: []ConsentCategory{ConsentMemoryIdentity},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ConsentResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Contains(t, resp.Grants, ConsentMemoryIdentity)
+	assert.NotEmpty(t, resp.Defaults)
+}
+
+func TestConsentHandlerPUT_ValidRevocations(t *testing.T) {
+	// Exec returns UPDATE 1 for revocation; QueryRow returns no grants.
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*[]string) = []string{}
+				return nil
+			}}
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Revocations: []ConsentCategory{ConsentMemoryIdentity},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	var resp ConsentResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Empty(t, resp.Grants)
+}
+
+func TestConsentHandlerPUT_RevocationIgnoresNotFound(t *testing.T) {
+	// removeArrayElement returns UPDATE 0 → ErrPreferencesNotFound, handler must swallow it.
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 0"), nil
+		},
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*[]string) = []string{}
+				return nil
+			}}
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Revocations: []ConsentCategory{ConsentMemoryLocation},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestConsentHandlerPUT_UnknownCategory(t *testing.T) {
+	h := newTestConsentHandler(&prefsMockPool{}, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Grants: []ConsentCategory{"unknown:category"},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestConsentHandlerPUT_UnknownCategoryInRevocations(t *testing.T) {
+	h := newTestConsentHandler(&prefsMockPool{}, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Revocations: []ConsentCategory{"bad:cat"},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestConsentHandlerPUT_EmptyUserID(t *testing.T) {
+	// Route won't match with empty segment — use handleSetConsent directly.
+	h := newTestConsentHandler(&prefsMockPool{}, nil)
+	log := zap.New(zap.UseDevMode(true))
+	h.log = log
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/privacy/preferences//consent", nil)
+	rec := httptest.NewRecorder()
+	h.handleSetConsent(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestConsentHandlerPUT_InvalidJSON(t *testing.T) {
+	h := newTestConsentHandler(&prefsMockPool{}, nil)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	req := httptest.NewRequest(http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent",
+		bytes.NewReader([]byte("not-json")))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestConsentHandlerPUT_StoreErrorOnGrant(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.CommandTag{}, assert.AnError
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Grants: []ConsentCategory{ConsentMemoryIdentity},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestConsentHandlerPUT_StoreErrorOnQueryAfterGrant(t *testing.T) {
+	// Grant succeeds, but GetConsentGrants (QueryRow) fails.
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(_ ...any) error {
+				return assert.AnError
+			}}
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Grants: []ConsentCategory{ConsentMemoryIdentity},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestConsentHandlerPUT_AuditEventsEmitted(t *testing.T) {
+	pool := successExecPool([]string{
+		string(ConsentMemoryIdentity),
+		string(ConsentMemoryPreferences),
+	})
+	audit := &mockConsentAuditLogger{}
+	h := newTestConsentHandler(pool, audit)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Grants:      []ConsentCategory{ConsentMemoryIdentity, ConsentMemoryPreferences},
+		Revocations: []ConsentCategory{ConsentMemoryLocation},
+	})
+
+	// Exec: 2 grants succeed (INSERT), then 1 revocation returns UPDATE 0 (ErrPreferencesNotFound, swallowed).
+	callCount := 0
+	pool.execFn = func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+		callCount++
+		if callCount <= 2 {
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		}
+		// revocation: UPDATE 0 → ErrPreferencesNotFound, swallowed
+		return pgconn.NewCommandTag("UPDATE 0"), nil
+	}
+
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, audit.events, 3)
+
+	assert.Equal(t, "consent_granted", audit.events[0].EventType)
+	assert.Equal(t, "user1", audit.events[0].Metadata["user_id"])
+	assert.Equal(t, string(ConsentMemoryIdentity), audit.events[0].Metadata["category"])
+
+	assert.Equal(t, "consent_granted", audit.events[1].EventType)
+	assert.Equal(t, string(ConsentMemoryPreferences), audit.events[1].Metadata["category"])
+
+	assert.Equal(t, "consent_revoked", audit.events[2].EventType)
+	assert.Equal(t, string(ConsentMemoryLocation), audit.events[2].Metadata["category"])
+}
+
+func TestConsentHandlerPUT_NoAuditWhenLoggerNil(t *testing.T) {
+	pool := successExecPool([]string{string(ConsentMemoryIdentity)})
+	h := newTestConsentHandler(pool, nil) // nil audit logger
+
+	body, _ := json.Marshal(ConsentRequest{
+		Grants: []ConsentCategory{ConsentMemoryIdentity},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	// No panic and request succeeds.
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+// ---- GET /consent tests ----
+
+func TestConsentHandlerGET_WithGrants(t *testing.T) {
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*[]string) = []string{
+					string(ConsentMemoryIdentity),
+				}
+				return nil
+			}}
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	rec := serveConsentRequest(h, http.MethodGet,
+		"/api/v1/privacy/preferences/user1/consent", nil)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ConsentResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	// ConsentMemoryIdentity is explicit-grant, so it should appear in grants, not denied.
+	assert.Contains(t, resp.Grants, ConsentMemoryIdentity)
+	assert.NotContains(t, resp.Denied, ConsentMemoryIdentity)
+	assert.NotContains(t, resp.Defaults, ConsentMemoryIdentity)
+
+	// Default categories (requiresGrant=false) should appear in defaults.
+	assert.Contains(t, resp.Defaults, ConsentMemoryPreferences)
+	assert.Contains(t, resp.Defaults, ConsentMemoryContext)
+	assert.Contains(t, resp.Defaults, ConsentMemoryHistory)
+
+	// Explicit-grant categories that weren't granted go to denied.
+	assert.Contains(t, resp.Denied, ConsentMemoryLocation)
+	assert.Contains(t, resp.Denied, ConsentMemoryHealth)
+}
+
+func TestConsentHandlerGET_NoPreferences(t *testing.T) {
+	// GetConsentGrants returns empty when user has no preferences row.
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(_ ...any) error {
+				return pgx.ErrNoRows
+			}}
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	rec := serveConsentRequest(h, http.MethodGet,
+		"/api/v1/privacy/preferences/newuser/consent", nil)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp ConsentResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+
+	assert.Empty(t, resp.Grants)
+	assert.NotEmpty(t, resp.Defaults)
+	// All explicit-grant categories should be denied.
+	assert.Contains(t, resp.Denied, ConsentMemoryIdentity)
+	assert.Contains(t, resp.Denied, ConsentMemoryLocation)
+	assert.Contains(t, resp.Denied, ConsentMemoryHealth)
+	assert.Contains(t, resp.Denied, ConsentAnalyticsAggregate)
+}
+
+func TestConsentHandlerGET_StoreError(t *testing.T) {
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(_ ...any) error {
+				return assert.AnError
+			}}
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	rec := serveConsentRequest(h, http.MethodGet,
+		"/api/v1/privacy/preferences/user1/consent", nil)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestConsentHandlerGET_EmptyUserID(t *testing.T) {
+	h := newTestConsentHandler(&prefsMockPool{}, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/privacy/preferences//consent", nil)
+	rec := httptest.NewRecorder()
+	h.handleGetConsent(rec, req)
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestConsentHandlerRegisterRoutes(t *testing.T) {
+	pool := successExecPool([]string{})
+	h := newTestConsentHandler(pool, nil)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	// PUT
+	body, _ := json.Marshal(ConsentRequest{})
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodPut,
+		"/api/v1/privacy/preferences/u1/consent", bytes.NewReader(body)))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	// GET
+	rec = httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet,
+		"/api/v1/privacy/preferences/u1/consent", nil))
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestValidateCategories_Valid(t *testing.T) {
+	err := validateCategories(
+		[]ConsentCategory{ConsentMemoryIdentity, ConsentMemoryLocation},
+		[]ConsentCategory{ConsentMemoryHealth},
+	)
+	assert.NoError(t, err)
+}
+
+func TestValidateCategories_InvalidInGrants(t *testing.T) {
+	err := validateCategories([]ConsentCategory{"bad:cat"}, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bad:cat")
+}
+
+func TestValidateCategories_InvalidInRevocations(t *testing.T) {
+	err := validateCategories(nil, []ConsentCategory{"also:bad"})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "also:bad")
+}
+
+func TestConsentHandlerPUT_MixedGrantsAndRevocations(t *testing.T) {
+	execCalls := 0
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			execCalls++
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*[]string) = []string{string(ConsentMemoryIdentity)}
+				return nil
+			}}
+		},
+	}
+	h := newTestConsentHandler(pool, nil)
+
+	body, _ := json.Marshal(ConsentRequest{
+		Grants:      []ConsentCategory{ConsentMemoryIdentity},
+		Revocations: []ConsentCategory{ConsentMemoryLocation},
+	})
+	rec := serveConsentRequest(h, http.MethodPut,
+		"/api/v1/privacy/preferences/user1/consent", body)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, 2, execCalls, "expected one exec per grant and one per revocation")
+}

--- a/ee/pkg/privacy/consent_test.go
+++ b/ee/pkg/privacy/consent_test.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"sort"
+	"testing"
+)
+
+func TestCategoryInfo_NonPII(t *testing.T) {
+	nonPII := []ConsentCategory{
+		ConsentMemoryPreferences,
+		ConsentMemoryContext,
+		ConsentMemoryHistory,
+	}
+	for _, cat := range nonPII {
+		requiresGrant, valid := CategoryInfo(cat)
+		if !valid {
+			t.Errorf("CategoryInfo(%q): expected valid=true, got false", cat)
+		}
+		if requiresGrant {
+			t.Errorf("CategoryInfo(%q): expected requiresGrant=false, got true", cat)
+		}
+	}
+}
+
+func TestCategoryInfo_PII(t *testing.T) {
+	pii := []ConsentCategory{
+		ConsentMemoryIdentity,
+		ConsentMemoryLocation,
+		ConsentMemoryHealth,
+		ConsentAnalyticsAggregate,
+	}
+	for _, cat := range pii {
+		requiresGrant, valid := CategoryInfo(cat)
+		if !valid {
+			t.Errorf("CategoryInfo(%q): expected valid=true, got false", cat)
+		}
+		if !requiresGrant {
+			t.Errorf("CategoryInfo(%q): expected requiresGrant=true, got false", cat)
+		}
+	}
+}
+
+func TestCategoryInfo_Unknown(t *testing.T) {
+	requiresGrant, valid := CategoryInfo("memory:unknown")
+	if valid {
+		t.Error("CategoryInfo(\"memory:unknown\"): expected valid=false, got true")
+	}
+	if requiresGrant {
+		t.Error("CategoryInfo(\"memory:unknown\"): expected requiresGrant=false, got true")
+	}
+}
+
+func TestValidCategories_Count(t *testing.T) {
+	cats := ValidCategories()
+	if len(cats) != 7 {
+		t.Errorf("ValidCategories(): expected 7 categories, got %d", len(cats))
+	}
+}
+
+func TestValidCategories_Sorted(t *testing.T) {
+	cats := ValidCategories()
+	if !sort.SliceIsSorted(cats, func(i, j int) bool { return cats[i] < cats[j] }) {
+		t.Errorf("ValidCategories(): result is not sorted: %v", cats)
+	}
+}
+
+func TestValidCategories_Deterministic(t *testing.T) {
+	first := ValidCategories()
+	second := ValidCategories()
+	if len(first) != len(second) {
+		t.Fatalf("ValidCategories(): inconsistent length: %d vs %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("ValidCategories(): non-deterministic at index %d: %q vs %q", i, first[i], second[i])
+		}
+	}
+}
+
+func TestValidCategories_ContainsAll(t *testing.T) {
+	expected := []ConsentCategory{
+		ConsentAnalyticsAggregate,
+		ConsentMemoryContext,
+		ConsentMemoryHealth,
+		ConsentMemoryHistory,
+		ConsentMemoryIdentity,
+		ConsentMemoryLocation,
+		ConsentMemoryPreferences,
+	}
+	cats := ValidCategories()
+	if len(cats) != len(expected) {
+		t.Fatalf("ValidCategories(): expected %d categories, got %d", len(expected), len(cats))
+	}
+	for i, cat := range cats {
+		if cat != expected[i] {
+			t.Errorf("ValidCategories()[%d]: expected %q, got %q", i, expected[i], cat)
+		}
+	}
+}

--- a/ee/pkg/privacy/store.go
+++ b/ee/pkg/privacy/store.go
@@ -11,6 +11,7 @@ package privacy
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -36,12 +37,13 @@ var ErrPreferencesNotFound = errors.New("privacy: user preferences not found")
 
 // Preferences represents a user's privacy opt-out preferences.
 type Preferences struct {
-	UserID           string    `json:"userId"`
-	OptOutAll        bool      `json:"optOutAll"`
-	OptOutWorkspaces []string  `json:"optOutWorkspaces"`
-	OptOutAgents     []string  `json:"optOutAgents"`
-	CreatedAt        time.Time `json:"createdAt"`
-	UpdatedAt        time.Time `json:"updatedAt"`
+	UserID           string            `json:"userId"`
+	OptOutAll        bool              `json:"optOutAll"`
+	OptOutWorkspaces []string          `json:"optOutWorkspaces"`
+	OptOutAgents     []string          `json:"optOutAgents"`
+	ConsentGrants    []ConsentCategory `json:"consentGrants"`
+	CreatedAt        time.Time         `json:"createdAt"`
+	UpdatedAt        time.Time         `json:"updatedAt"`
 }
 
 // PreferencesStore defines the interface for privacy preference persistence.
@@ -61,21 +63,27 @@ func NewPreferencesStore(pool dbPool) *PreferencesPostgresStore {
 	return &PreferencesPostgresStore{pool: pool}
 }
 
-// Compile-time interface check.
+// Compile-time interface checks.
 var _ PreferencesStore = (*PreferencesPostgresStore)(nil)
+var _ ConsentSource = (*PreferencesPostgresStore)(nil)
 
 // GetPreferences retrieves privacy preferences for a user.
 func (s *PreferencesPostgresStore) GetPreferences(ctx context.Context, userID string) (*Preferences, error) {
 	p := &Preferences{UserID: userID}
+	var grants []string
 	err := s.pool.QueryRow(ctx,
-		`SELECT opt_out_all, opt_out_workspaces, opt_out_agents, created_at, updated_at
+		`SELECT opt_out_all, opt_out_workspaces, opt_out_agents, consent_grants, created_at, updated_at
 		 FROM user_privacy_preferences WHERE user_id = $1`, userID,
-	).Scan(&p.OptOutAll, &p.OptOutWorkspaces, &p.OptOutAgents, &p.CreatedAt, &p.UpdatedAt)
+	).Scan(&p.OptOutAll, &p.OptOutWorkspaces, &p.OptOutAgents, &grants, &p.CreatedAt, &p.UpdatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, ErrPreferencesNotFound
 	}
 	if err != nil {
 		return nil, err
+	}
+	p.ConsentGrants = make([]ConsentCategory, len(grants))
+	for i, g := range grants {
+		p.ConsentGrants[i] = ConsentCategory(g)
 	}
 	normalizeSlices(p)
 	return p, nil
@@ -109,6 +117,44 @@ func (s *PreferencesPostgresStore) RemoveOptOut(ctx context.Context, userID, sco
 	}
 }
 
+// GetConsentGrants returns the consent grants for a user.
+// Returns an empty slice (not an error) when the user has no preferences row.
+func (s *PreferencesPostgresStore) GetConsentGrants(ctx context.Context, userID string) ([]ConsentCategory, error) {
+	var grants []string
+	err := s.pool.QueryRow(ctx,
+		`SELECT consent_grants FROM user_privacy_preferences WHERE user_id = $1`, userID,
+	).Scan(&grants)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return []ConsentCategory{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	result := make([]ConsentCategory, len(grants))
+	for i, g := range grants {
+		result[i] = ConsentCategory(g)
+	}
+	return result, nil
+}
+
+// SetConsentGrant adds a consent grant for a user.
+func (s *PreferencesPostgresStore) SetConsentGrant(ctx context.Context, userID string, category ConsentCategory) error {
+	if _, valid := CategoryInfo(category); !valid {
+		return fmt.Errorf("privacy: unknown consent category: %q", category)
+	}
+	return s.upsertArrayElement(ctx, userID, "consent_grants", string(category))
+}
+
+// RemoveConsentGrant removes a consent grant for a user.
+func (s *PreferencesPostgresStore) RemoveConsentGrant(
+	ctx context.Context, userID string, category ConsentCategory,
+) error {
+	if _, valid := CategoryInfo(category); !valid {
+		return fmt.Errorf("privacy: unknown consent category: %q", category)
+	}
+	return s.removeArrayElement(ctx, userID, "consent_grants", string(category))
+}
+
 // normalizeSlices ensures nil slices become empty slices for JSON serialization.
 func normalizeSlices(p *Preferences) {
 	if p.OptOutWorkspaces == nil {
@@ -116,6 +162,9 @@ func normalizeSlices(p *Preferences) {
 	}
 	if p.OptOutAgents == nil {
 		p.OptOutAgents = []string{}
+	}
+	if p.ConsentGrants == nil {
+		p.ConsentGrants = []ConsentCategory{}
 	}
 }
 

--- a/ee/pkg/privacy/store_test.go
+++ b/ee/pkg/privacy/store_test.go
@@ -55,8 +55,9 @@ func TestGetPreferences_Found(t *testing.T) {
 				*dest[0].(*bool) = true
 				*dest[1].(*[]string) = []string{"ws1"}
 				*dest[2].(*[]string) = []string{"agent1"}
-				*dest[3].(*time.Time) = now
+				*dest[3].(*[]string) = []string{string(ConsentMemoryPreferences)}
 				*dest[4].(*time.Time) = now
+				*dest[5].(*time.Time) = now
 				return nil
 			}}
 		},
@@ -69,6 +70,7 @@ func TestGetPreferences_Found(t *testing.T) {
 	assert.True(t, prefs.OptOutAll)
 	assert.Equal(t, []string{"ws1"}, prefs.OptOutWorkspaces)
 	assert.Equal(t, []string{"agent1"}, prefs.OptOutAgents)
+	assert.Equal(t, []ConsentCategory{ConsentMemoryPreferences}, prefs.ConsentGrants)
 }
 
 func TestGetPreferences_NotFound(t *testing.T) {
@@ -93,8 +95,9 @@ func TestGetPreferences_NilSlices(t *testing.T) {
 				*dest[0].(*bool) = false
 				*dest[1].(*[]string) = nil
 				*dest[2].(*[]string) = nil
-				*dest[3].(*time.Time) = now
+				*dest[3].(*[]string) = nil
 				*dest[4].(*time.Time) = now
+				*dest[5].(*time.Time) = now
 				return nil
 			}}
 		},
@@ -107,6 +110,8 @@ func TestGetPreferences_NilSlices(t *testing.T) {
 	assert.NotNil(t, prefs.OptOutAgents)
 	assert.Empty(t, prefs.OptOutWorkspaces)
 	assert.Empty(t, prefs.OptOutAgents)
+	assert.NotNil(t, prefs.ConsentGrants)
+	assert.Empty(t, prefs.ConsentGrants)
 }
 
 func TestGetPreferences_DBError(t *testing.T) {
@@ -244,4 +249,91 @@ func TestSetOptOut_ExecError(t *testing.T) {
 	store := NewPreferencesStore(pool)
 	err := store.SetOptOut(context.Background(), "user1", ScopeAll, "")
 	assert.Error(t, err)
+}
+
+func TestGetConsentGrants_NoPreferences(t *testing.T) {
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(_ ...any) error {
+				return pgx.ErrNoRows
+			}}
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	grants, err := store.GetConsentGrants(context.Background(), "user1")
+	require.NoError(t, err)
+	assert.NotNil(t, grants)
+	assert.Empty(t, grants)
+}
+
+func TestGetConsentGrants_ReturnsGrants(t *testing.T) {
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(dest ...any) error {
+				*dest[0].(*[]string) = []string{
+					string(ConsentMemoryPreferences),
+					string(ConsentMemoryContext),
+				}
+				return nil
+			}}
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	grants, err := store.GetConsentGrants(context.Background(), "user1")
+	require.NoError(t, err)
+	assert.Equal(t, []ConsentCategory{ConsentMemoryPreferences, ConsentMemoryContext}, grants)
+}
+
+func TestGetConsentGrants_DBError(t *testing.T) {
+	pool := &prefsMockPool{
+		queryRowFn: func(_ context.Context, _ string, _ ...any) pgx.Row {
+			return &prefsMockRow{scanFn: func(_ ...any) error {
+				return errors.New("connection refused")
+			}}
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	_, err := store.GetConsentGrants(context.Background(), "user1")
+	assert.Error(t, err)
+}
+
+func TestSetConsentGrant_ValidCategory(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("INSERT 0 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.SetConsentGrant(context.Background(), "user1", ConsentMemoryIdentity)
+	assert.NoError(t, err)
+}
+
+func TestSetConsentGrant_UnknownCategory(t *testing.T) {
+	store := NewPreferencesStore(&prefsMockPool{})
+	err := store.SetConsentGrant(context.Background(), "user1", ConsentCategory("invalid:category"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown consent category")
+}
+
+func TestRemoveConsentGrant_ValidCategory(t *testing.T) {
+	pool := &prefsMockPool{
+		execFn: func(_ context.Context, _ string, _ ...any) (pgconn.CommandTag, error) {
+			return pgconn.NewCommandTag("UPDATE 1"), nil
+		},
+	}
+
+	store := NewPreferencesStore(pool)
+	err := store.RemoveConsentGrant(context.Background(), "user1", ConsentMemoryHealth)
+	assert.NoError(t, err)
+}
+
+func TestRemoveConsentGrant_UnknownCategory(t *testing.T) {
+	store := NewPreferencesStore(&prefsMockPool{})
+	err := store.RemoveConsentGrant(context.Background(), "user1", ConsentCategory("invalid:category"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown consent category")
 }

--- a/internal/memory/api/handler.go
+++ b/internal/memory/api/handler.go
@@ -76,6 +76,7 @@ type SaveMemoryRequest struct {
 	Scope      map[string]string `json:"scope"`
 	SessionID  string            `json:"session_id,omitempty"`
 	TurnRange  [2]int            `json:"turn_range,omitempty"`
+	Category   string            `json:"category,omitempty"`
 }
 
 // Handler provides HTTP endpoints for the memory API.

--- a/internal/memory/api/privacy_middleware.go
+++ b/internal/memory/api/privacy_middleware.go
@@ -22,7 +22,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 
@@ -33,7 +32,9 @@ import (
 
 // OptOutChecker returns false when the user has opted out of memory storage,
 // indicating the write should be silently dropped.
-type OptOutChecker func(ctx context.Context, userID, workspace string) bool
+// category is the consent category from the request body (may be empty string
+// when no category was supplied; callers should apply a default in that case).
+type OptOutChecker func(ctx context.Context, userID, workspace, category string) bool
 
 // ContentRedactor redacts PII from memory content text.
 // Returns the redacted string; if redaction is not configured it returns the
@@ -80,68 +81,46 @@ func (m *MemoryPrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 		workspace := r.URL.Query().Get("workspace")
 		userID := r.URL.Query().Get("user_id")
 
-		// Check opt-out: if the user has opted out, silently drop the write.
-		if userID != "" && !m.checkOptOut(r.Context(), userID, workspace) {
-			m.log.V(1).Info("memory write suppressed", "reason", "user opt-out", "userHash", logging.HashID(userID), "workspace", workspace)
+		// Read body once so we can inspect category for opt-out and content for redaction.
+		var data []byte
+		if r.Body != nil {
+			var err error
+			data, err = io.ReadAll(r.Body)
+			_ = r.Body.Close()
+			if err != nil {
+				http.Error(w, "failed to read body", http.StatusInternalServerError)
+				return
+			}
+		}
+
+		// Try to decode to get category and content for downstream use.
+		var req SaveMemoryRequest
+		decoded := len(data) > 0 && json.Unmarshal(data, &req) == nil
+
+		// Check opt-out with category (empty string if not decoded).
+		if userID != "" && !m.checkOptOut(r.Context(), userID, workspace, req.Category) {
+			m.log.V(1).Info("memory write suppressed", "reason", "user opt-out", "userHash", logging.HashID(userID), "workspace", workspace, "category", req.Category)
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 
-		// Apply PII redaction to the request body's content field.
-		if err := m.applyRedaction(r, workspace); err != nil {
-			m.log.Error(err, "content redaction failed, blocking request", "workspace", workspace)
-			http.Error(w, "redaction failed", http.StatusInternalServerError)
-			return
+		// Apply PII redaction when body was successfully decoded.
+		if decoded {
+			redacted, err := m.redact(r.Context(), workspace, req.Content)
+			if err != nil {
+				m.log.Error(err, "content redaction failed, blocking request", "workspace", workspace)
+				http.Error(w, "redaction failed", http.StatusInternalServerError)
+				return
+			}
+			if redacted != req.Content {
+				req.Content = redacted
+				encoded, _ := json.Marshal(req)
+				data = encoded
+			}
 		}
 
+		r.Body = io.NopCloser(bytes.NewReader(data))
+		r.ContentLength = int64(len(data))
 		next.ServeHTTP(w, r)
 	})
-}
-
-// applyRedaction reads the request body, redacts the content field, and
-// replaces r.Body with the redacted payload.
-func (m *MemoryPrivacyMiddleware) applyRedaction(r *http.Request, workspace string) error {
-	if r.Body == nil {
-		return nil
-	}
-
-	data, err := io.ReadAll(r.Body)
-	_ = r.Body.Close()
-	if err != nil {
-		return fmt.Errorf("reading request body: %w", err)
-	}
-
-	if len(data) == 0 {
-		r.Body = io.NopCloser(bytes.NewReader(data))
-		return nil
-	}
-
-	var req SaveMemoryRequest
-	if err := json.Unmarshal(data, &req); err != nil {
-		// Not valid JSON — restore the body and let the handler return the
-		// appropriate 400 error.
-		r.Body = io.NopCloser(bytes.NewReader(data))
-		return nil
-	}
-
-	redacted, err := m.redact(r.Context(), workspace, req.Content)
-	if err != nil {
-		return fmt.Errorf("redacting content: %w", err)
-	}
-
-	if redacted == req.Content {
-		// Nothing changed — avoid re-encoding unnecessarily.
-		r.Body = io.NopCloser(bytes.NewReader(data))
-		return nil
-	}
-
-	req.Content = redacted
-	encoded, err := json.Marshal(req)
-	if err != nil {
-		return fmt.Errorf("re-encoding request body: %w", err)
-	}
-
-	r.Body = io.NopCloser(bytes.NewReader(encoded))
-	r.ContentLength = int64(len(encoded))
-	return nil
 }

--- a/internal/memory/api/privacy_middleware_test.go
+++ b/internal/memory/api/privacy_middleware_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // passthroughOptOut always returns true (no opt-out).
-var passthroughOptOut OptOutChecker = func(_ context.Context, _, _ string) bool { return true }
+var passthroughOptOut OptOutChecker = func(_ context.Context, _, _, _ string) bool { return true }
 
 // noOpRedact returns content unchanged.
 var noOpRedact ContentRedactor = func(_ context.Context, _, content string) (string, error) {
@@ -42,10 +42,10 @@ var noOpRedact ContentRedactor = func(_ context.Context, _, content string) (str
 }
 
 // optedOutChecker always returns false (user opted out).
-var optedOutChecker OptOutChecker = func(_ context.Context, _, _ string) bool { return false }
+var optedOutChecker OptOutChecker = func(_ context.Context, _, _, _ string) bool { return false }
 
 // panicOptOut panics if called — use to assert opt-out is never checked.
-var panicOptOut OptOutChecker = func(_ context.Context, _, _ string) bool {
+var panicOptOut OptOutChecker = func(_ context.Context, _, _, _ string) bool {
 	panic("OptOutChecker must not be called for this request")
 }
 
@@ -310,4 +310,94 @@ func TestMemoryPrivacyMiddleware_OptedOutUserWithNoRedaction_Returns204(t *testi
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusNoContent, w.Code)
+}
+
+func makePostRequestWithCategory(t *testing.T, content, workspace, userID, category string) *http.Request {
+	t.Helper()
+	req := SaveMemoryRequest{
+		Type:     "fact",
+		Content:  content,
+		Scope:    map[string]string{"workspace": workspace},
+		Category: category,
+	}
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/memories", bytes.NewBuffer(b))
+	q := r.URL.Query()
+	q.Set("workspace", workspace)
+	if userID != "" {
+		q.Set("user_id", userID)
+	}
+	r.URL.RawQuery = q.Encode()
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
+func TestMemoryPrivacyMiddleware_NoCategoryInBody_OptOutCheckerReceivesEmpty(t *testing.T) {
+	// POST without a category field — opt-out checker must receive an empty string.
+	var receivedCategory string
+	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+		receivedCategory = category
+		return true // allow
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(checker, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "user-abc")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "", receivedCategory, "category should be empty string when not in body")
+}
+
+func TestMemoryPrivacyMiddleware_WithCategory_OptOutCheckerReceivesCategory(t *testing.T) {
+	// POST with category: "memory:identity" — opt-out checker must receive it.
+	var receivedCategory string
+	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+		receivedCategory = category
+		return true // allow
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(checker, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequestWithCategory(t, "my name is Alice", "ws-1", "user-abc", "memory:identity")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "memory:identity", receivedCategory, "checker should receive the category from the body")
+}
+
+func TestMemoryPrivacyMiddleware_CategoryOptedOut_Returns204(t *testing.T) {
+	// Opt-out checker that only rejects "memory:identity".
+	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+		return category != "memory:identity"
+	})
+
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(checker, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequestWithCategory(t, "my name is Alice", "ws-1", "user-abc", "memory:identity")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.False(t, handlerCalled)
 }

--- a/internal/session/postgres/migrations/000026_consent_grants.down.sql
+++ b/internal/session/postgres/migrations/000026_consent_grants.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_privacy_preferences DROP COLUMN IF EXISTS consent_grants;

--- a/internal/session/postgres/migrations/000026_consent_grants.up.sql
+++ b/internal/session/postgres/migrations/000026_consent_grants.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_privacy_preferences ADD COLUMN IF NOT EXISTS consent_grants TEXT[] DEFAULT '{}';


### PR DESCRIPTION
## Summary

- **Consent categories**: 7 platform-defined categories (`memory:identity`, `memory:preferences`, `memory:context`, `memory:location`, `memory:health`, `memory:history`, `analytics:aggregate`) with hardcoded explicit-grant flags — PII categories require user consent, non-PII are implicitly granted
- **ConsentSource interface**: Abstracts where grants come from (Postgres now, JWT claims later)
- **Storage**: Migration 000026 adds `consent_grants TEXT[]` column to `user_privacy_preferences`; `PreferencesPostgresStore` implements `ConsentSource`
- **ShouldRememberCategory**: New function combining binary opt-out + category consent — fails closed for PII categories without explicit grants
- **Consent API**: `PUT/GET /api/v1/privacy/preferences/{userID}/consent` on session-api for managing grants/revocations with audit events
- **Memory-API wiring**: `SaveMemoryRequest` accepts optional `category` field; privacy middleware passes it to `ShouldRememberCategory` (defaults to `memory:context`)

Spec: `docs/local-backlog/consent-infrastructure-spec.md`

## Test Plan

- [x] All new code has >= 80% test coverage (enforced by pre-commit hook)
- [x] `go build ./...` passes (GOWORK=off)
- [x] All affected packages pass tests
- [x] Backward compatible — no category = `memory:context` (implicitly granted)
- [ ] CI passes (golangci-lint, go test, SonarCloud)
- [ ] Deploy to staging and verify consent API responds correctly