### PR TITLE
feat: auto-classify memory content into consent categories

### DIFF
--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -427,7 +427,7 @@ func wrapPrivacyMiddleware(next http.Handler, pool *pgxpool.Pool, log logr.Logge
 		return redacted, err
 	})
 
-	mw := memoryapi.NewMemoryPrivacyMiddleware(checkOptOut, contentRedactor, log)
+	mw := memoryapi.NewMemoryPrivacyMiddleware(checkOptOut, contentRedactor, nil, log)
 	log.Info("memory privacy middleware enabled")
 	return mw.Wrap(next)
 }

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -427,7 +427,8 @@ func wrapPrivacyMiddleware(next http.Handler, pool *pgxpool.Pool, log logr.Logge
 		return redacted, err
 	})
 
-	mw := memoryapi.NewMemoryPrivacyMiddleware(checkOptOut, contentRedactor, nil, log)
+	classifier := memoryapi.ContentClassifier(privacy.NewContentClassifier())
+	mw := memoryapi.NewMemoryPrivacyMiddleware(checkOptOut, contentRedactor, classifier, log)
 	log.Info("memory privacy middleware enabled")
 	return mw.Wrap(next)
 }

--- a/ee/pkg/privacy/classifier.go
+++ b/ee/pkg/privacy/classifier.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"regexp"
+)
+
+// healthKeywords are checked with case-insensitive word boundary matching.
+var healthKeywords = []string{
+	"allergy", "allergic", "diagnosis", "diagnosed",
+	"medication", "prescription", "disability",
+	"blood type", "medical", "symptom",
+}
+
+// classifierPatterns holds compiled regexes for content classification.
+type classifierPatterns struct {
+	identity []*regexp.Regexp // SSN, CC, email, phone
+	location []*regexp.Regexp // IP address, location phrases
+	health   []*regexp.Regexp // health keyword word-boundary patterns
+}
+
+func compileClassifierPatterns() *classifierPatterns {
+	identity := []*regexp.Regexp{
+		regexp.MustCompile(`\b\d{3}-\d{2}-\d{4}\b`),                                    // SSN
+		regexp.MustCompile(`\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`),                  // credit card
+		regexp.MustCompile(`(?i)\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`), // email
+		regexp.MustCompile(`\b\d{3}[-.)\\s]?\d{3}[-.)\\s]?\d{4}\b`),                    // phone
+	}
+
+	location := []*regexp.Regexp{
+		regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`), // IP address
+		regexp.MustCompile(`(?i)\b(?:lives?\s+in|located\s+in|based\s+in|address\s+is)\b`),
+	}
+
+	health := make([]*regexp.Regexp, len(healthKeywords))
+	for i, kw := range healthKeywords {
+		health[i] = regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(kw) + `\b`)
+	}
+
+	return &classifierPatterns{identity: identity, location: location, health: health}
+}
+
+// NewContentClassifier returns a function that classifies memory content
+// into consent categories based on PII pattern detection.
+// Returns empty string when no sensitive content is detected.
+func NewContentClassifier() func(content string) string {
+	patterns := compileClassifierPatterns()
+
+	return func(content string) string {
+		if content == "" {
+			return ""
+		}
+
+		// Health first (GDPR special category, highest sensitivity)
+		for _, re := range patterns.health {
+			if re.MatchString(content) {
+				return string(ConsentMemoryHealth)
+			}
+		}
+
+		// Location patterns
+		for _, re := range patterns.location {
+			if re.MatchString(content) {
+				return string(ConsentMemoryLocation)
+			}
+		}
+
+		// Identity PII patterns
+		for _, re := range patterns.identity {
+			if re.MatchString(content) {
+				return string(ConsentMemoryIdentity)
+			}
+		}
+
+		return ""
+	}
+}

--- a/ee/pkg/privacy/classifier_test.go
+++ b/ee/pkg/privacy/classifier_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"testing"
+)
+
+func TestNewContentClassifier(t *testing.T) {
+	classify := NewContentClassifier()
+
+	tests := []struct {
+		name     string
+		content  string
+		expected string
+	}{
+		// Health keywords
+		{name: "allergy keyword", content: "user has an allergy to peanuts", expected: string(ConsentMemoryHealth)},
+		{name: "diagnosed keyword", content: "was diagnosed with diabetes", expected: string(ConsentMemoryHealth)},
+		{name: "medication keyword", content: "takes medication daily", expected: string(ConsentMemoryHealth)},
+		{name: "blood type keyword", content: "blood type is O positive", expected: string(ConsentMemoryHealth)},
+		{name: "allergic keyword", content: "allergic to penicillin", expected: string(ConsentMemoryHealth)},
+		{name: "diagnosis keyword", content: "awaiting diagnosis from doctor", expected: string(ConsentMemoryHealth)},
+		{name: "prescription keyword", content: "has a prescription for metformin", expected: string(ConsentMemoryHealth)},
+		{name: "disability keyword", content: "has a disability accommodation", expected: string(ConsentMemoryHealth)},
+		{name: "medical keyword", content: "medical history reviewed", expected: string(ConsentMemoryHealth)},
+		{name: "symptom keyword", content: "reporting symptom of fatigue", expected: string(ConsentMemoryHealth)},
+
+		// Health case-insensitive
+		{name: "allergy uppercase", content: "ALLERGY to shellfish", expected: string(ConsentMemoryHealth)},
+		{name: "medication mixed case", content: "Medication: ibuprofen", expected: string(ConsentMemoryHealth)},
+
+		// Health word boundary — should NOT match partial words
+		{name: "premedical not matched", content: "premedical studies completed", expected: ""},
+		// "allergically" contains "allergic" but \ballergic\b requires a word boundary after "c";
+		// since "a" follows "c" in "allergically", the boundary does not match.
+		{name: "allergically not matched", content: "allergically induced response", expected: ""},
+		// "preallergy" — "allergy" appears as a suffix: \ballergy\b won't match inside "preallergy"
+		{name: "preallergy not matched", content: "user preallergy profile loaded", expected: ""},
+
+		// Location phrases
+		{name: "lives in location", content: "lives in Edinburgh", expected: string(ConsentMemoryLocation)},
+		{name: "located in", content: "located in London", expected: string(ConsentMemoryLocation)},
+		{name: "based in", content: "based in Berlin", expected: string(ConsentMemoryLocation)},
+		{name: "address is", content: "address is 42 Main Street", expected: string(ConsentMemoryLocation)},
+
+		// IP address
+		{name: "IP address", content: "server at 192.168.1.1", expected: string(ConsentMemoryLocation)},
+		{name: "loopback IP", content: "connects to 127.0.0.1", expected: string(ConsentMemoryLocation)},
+
+		// Identity PII — SSN
+		{name: "SSN", content: "SSN is 123-45-6789", expected: string(ConsentMemoryIdentity)},
+
+		// Identity PII — credit card
+		{name: "credit card with dashes", content: "card 4111-1111-1111-1111", expected: string(ConsentMemoryIdentity)},
+		{name: "credit card with spaces", content: "card 4111 1111 1111 1111", expected: string(ConsentMemoryIdentity)},
+		{name: "credit card no separator", content: "card 4111111111111111", expected: string(ConsentMemoryIdentity)},
+
+		// Identity PII — email
+		{name: "email address", content: "email is test@example.com", expected: string(ConsentMemoryIdentity)},
+		{name: "email uppercase domain", content: "contact at USER@DOMAIN.ORG", expected: string(ConsentMemoryIdentity)},
+
+		// Identity PII — phone
+		{name: "phone with dashes", content: "call 555-123-4567", expected: string(ConsentMemoryIdentity)},
+
+		// No PII
+		{name: "no PII dark mode", content: "user prefers dark mode", expected: ""},
+		{name: "no PII generic", content: "user likes coffee in the morning", expected: ""},
+		{name: "no PII preferences", content: "language preference is English", expected: ""},
+
+		// Empty content
+		{name: "empty string", content: "", expected: ""},
+
+		// Priority: health > location > identity
+		{
+			name:     "health beats identity",
+			content:  "allergic to penicillin, email test@example.com",
+			expected: string(ConsentMemoryHealth),
+		},
+		{
+			name:     "health beats location",
+			content:  "lives in Paris, diagnosed with asthma",
+			expected: string(ConsentMemoryHealth),
+		},
+		{
+			name:     "location beats identity",
+			content:  "lives in NYC, SSN is 123-45-6789",
+			expected: string(ConsentMemoryLocation),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := classify(tt.content)
+			if got != tt.expected {
+				t.Errorf("classify(%q) = %q, want %q", tt.content, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNewContentClassifier_ReturnsNewFunctionEachCall(t *testing.T) {
+	c1 := NewContentClassifier()
+	c2 := NewContentClassifier()
+
+	// Both should produce consistent results independently
+	result1 := c1("SSN is 123-45-6789")
+	result2 := c2("SSN is 123-45-6789")
+
+	if result1 != string(ConsentMemoryIdentity) {
+		t.Errorf("c1 result = %q, want %q", result1, ConsentMemoryIdentity)
+	}
+	if result2 != string(ConsentMemoryIdentity) {
+		t.Errorf("c2 result = %q, want %q", result2, ConsentMemoryIdentity)
+	}
+}

--- a/internal/memory/api/privacy_middleware.go
+++ b/internal/memory/api/privacy_middleware.go
@@ -41,6 +41,10 @@ type OptOutChecker func(ctx context.Context, userID, workspace, category string)
 // original text unchanged.
 type ContentRedactor func(ctx context.Context, workspace, content string) (string, error)
 
+// ContentClassifier infers a consent category from memory content.
+// Returns a category string (e.g. "memory:identity") or empty string for default.
+type ContentClassifier func(content string) string
+
 // MemoryPrivacyMiddleware intercepts POST requests to the memory API and:
 //  1. Returns 204 No Content when the user has opted out of memory storage.
 //  2. Redacts PII from the request body's "content" field before forwarding.
@@ -52,21 +56,41 @@ type ContentRedactor func(ctx context.Context, workspace, content string) (strin
 type MemoryPrivacyMiddleware struct {
 	checkOptOut OptOutChecker
 	redact      ContentRedactor
+	classifier  ContentClassifier // optional, nil when not configured
 	log         logr.Logger
 }
 
 // NewMemoryPrivacyMiddleware creates a MemoryPrivacyMiddleware.
-// checkOptOut and redact must not be nil.
+// checkOptOut and redact must not be nil. classifier may be nil.
 func NewMemoryPrivacyMiddleware(
 	checkOptOut OptOutChecker,
 	redact ContentRedactor,
+	classifier ContentClassifier,
 	log logr.Logger,
 ) *MemoryPrivacyMiddleware {
 	return &MemoryPrivacyMiddleware{
 		checkOptOut: checkOptOut,
 		redact:      redact,
+		classifier:  classifier,
 		log:         log.WithName("memory-privacy"),
 	}
+}
+
+// readAndDecode reads the request body and attempts to decode it as a SaveMemoryRequest.
+// Returns the raw bytes, the decoded request, and whether decoding succeeded.
+func readAndDecode(r *http.Request) ([]byte, SaveMemoryRequest, bool, error) {
+	var data []byte
+	if r.Body != nil {
+		var err error
+		data, err = io.ReadAll(r.Body)
+		_ = r.Body.Close()
+		if err != nil {
+			return nil, SaveMemoryRequest{}, false, err
+		}
+	}
+	var req SaveMemoryRequest
+	decoded := len(data) > 0 && json.Unmarshal(data, &req) == nil
+	return data, req, decoded, nil
 }
 
 // Wrap returns an http.Handler that enforces privacy policy before delegating
@@ -81,21 +105,16 @@ func (m *MemoryPrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 		workspace := r.URL.Query().Get("workspace")
 		userID := r.URL.Query().Get("user_id")
 
-		// Read body once so we can inspect category for opt-out and content for redaction.
-		var data []byte
-		if r.Body != nil {
-			var err error
-			data, err = io.ReadAll(r.Body)
-			_ = r.Body.Close()
-			if err != nil {
-				http.Error(w, "failed to read body", http.StatusInternalServerError)
-				return
-			}
+		data, req, decoded, err := readAndDecode(r)
+		if err != nil {
+			http.Error(w, "failed to read body", http.StatusInternalServerError)
+			return
 		}
 
-		// Try to decode to get category and content for downstream use.
-		var req SaveMemoryRequest
-		decoded := len(data) > 0 && json.Unmarshal(data, &req) == nil
+		// Classify content when no explicit category provided.
+		if decoded && req.Category == "" && m.classifier != nil {
+			req.Category = m.classifier(req.Content)
+		}
 
 		// Check opt-out with category (empty string if not decoded).
 		if userID != "" && !m.checkOptOut(r.Context(), userID, workspace, req.Category) {
@@ -106,9 +125,9 @@ func (m *MemoryPrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 
 		// Apply PII redaction when body was successfully decoded.
 		if decoded {
-			redacted, err := m.redact(r.Context(), workspace, req.Content)
-			if err != nil {
-				m.log.Error(err, "content redaction failed, blocking request", "workspace", workspace)
+			redacted, redactErr := m.redact(r.Context(), workspace, req.Content)
+			if redactErr != nil {
+				m.log.Error(redactErr, "content redaction failed, blocking request", "workspace", workspace)
 				http.Error(w, "redaction failed", http.StatusInternalServerError)
 				return
 			}

--- a/internal/memory/api/privacy_middleware_test.go
+++ b/internal/memory/api/privacy_middleware_test.go
@@ -55,7 +55,7 @@ var panicRedact ContentRedactor = func(_ context.Context, _, _ string) (string, 
 }
 
 func newTestMiddleware(checkOptOut OptOutChecker, redact ContentRedactor) *MemoryPrivacyMiddleware {
-	return NewMemoryPrivacyMiddleware(checkOptOut, redact, logr.Discard())
+	return NewMemoryPrivacyMiddleware(checkOptOut, redact, nil, logr.Discard())
 }
 
 func postBody(t *testing.T, content string) *bytes.Buffer {
@@ -396,6 +396,111 @@ func TestMemoryPrivacyMiddleware_CategoryOptedOut_Returns204(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	r := makePostRequestWithCategory(t, "my name is Alice", "ws-1", "user-abc", "memory:identity")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusNoContent, w.Code)
+	assert.False(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_ClassifiesWhenCategoryEmpty(t *testing.T) {
+	// POST with no category + classifier returns "memory:identity" → opt-out checker receives "memory:identity".
+	var receivedCategory string
+	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+		receivedCategory = category
+		return true // allow
+	})
+
+	classifier := ContentClassifier(func(_ string) string {
+		return "memory:identity"
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := NewMemoryPrivacyMiddleware(checker, noOpRedact, classifier, logr.Discard())
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "my name is Alice", "ws-1", "user-abc")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "memory:identity", receivedCategory, "classifier result should reach opt-out checker")
+}
+
+func TestMemoryPrivacyMiddleware_SkipsClassifierWhenCategoryProvided(t *testing.T) {
+	// POST with explicit category → classifier must NOT be called.
+	panicClassifier := ContentClassifier(func(_ string) string {
+		panic("ContentClassifier must not be called when category already set")
+	})
+
+	var receivedCategory string
+	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+		receivedCategory = category
+		return true
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := NewMemoryPrivacyMiddleware(checker, noOpRedact, panicClassifier, logr.Discard())
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequestWithCategory(t, "my preferences", "ws-1", "user-abc", "memory:preferences")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "memory:preferences", receivedCategory, "explicit category should pass through unchanged")
+}
+
+func TestMemoryPrivacyMiddleware_NilClassifier_CategoryStaysEmpty(t *testing.T) {
+	// POST with no category + nil classifier → opt-out checker receives empty string.
+	var receivedCategory string
+	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+		receivedCategory = category
+		return true
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	// nil classifier explicitly
+	mw := NewMemoryPrivacyMiddleware(checker, noOpRedact, nil, logr.Discard())
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "user-abc")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, "", receivedCategory, "category should remain empty when classifier is nil")
+}
+
+func TestMemoryPrivacyMiddleware_ClassifierBeforeOptOut(t *testing.T) {
+	// POST + classifier returns "memory:health" + opt-out rejects "memory:health" → 204.
+	classifier := ContentClassifier(func(_ string) string {
+		return "memory:health"
+	})
+
+	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+		return category != "memory:health" // reject memory:health
+	})
+
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := NewMemoryPrivacyMiddleware(checker, panicRedact, classifier, logr.Discard())
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "I have diabetes", "ws-1", "user-abc")
 	handler.ServeHTTP(w, r)
 
 	assert.Equal(t, http.StatusNoContent, w.Code)


### PR DESCRIPTION
## Summary

- **ContentClassifier**: Deterministic content scanner that detects health keywords, location patterns, and identity PII (SSN, CC, email, phone) in memory content and returns the appropriate consent category
- **Middleware integration**: Classifier runs in the privacy middleware when no explicit `category` is provided — covers both extraction pipeline and memory tool save paths automatically
- **Extensible**: Classifier is a `func(content string) string` injected at construction — swap in LLM-based or predicate-based classifiers later without changing the middleware

Classification priority: health (GDPR special category) > location > identity PII > default (`memory:context`)

Spec: `docs/local-backlog/content-classification-spec.md`

## Test Plan

- [x] 37 classifier tests covering all PII patterns, health keywords, word boundaries, priority ordering
- [x] 4 middleware integration tests (classify when empty, skip when provided, nil passthrough, classify-before-optout)
- [x] All pre-commit checks pass
- [ ] CI passes