### PR TITLE
feat: transport-agnostic consent grant propagation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,7 +326,7 @@ generate-dashboard-types: sync-chart-crds ## Generate TypeScript types from CRD 
 
 .PHONY: generate-websocket-types
 generate-websocket-types: ## Generate TypeScript types from Go WebSocket protocol structs
-	tygo generate
+	env GOWORK=off tygo generate
 
 .PHONY: generate-dashboard-api
 generate-dashboard-api: ## Generate TypeScript API client from OpenAPI spec

--- a/api/proto/runtime/v1/runtime.proto
+++ b/api/proto/runtime/v1/runtime.proto
@@ -39,6 +39,10 @@ message ClientMessage {
   // client_tool_result carries the result of a client-side tool execution.
   // Set when responding to a ToolCall with execution=CLIENT.
   ClientToolResult client_tool_result = 5;
+
+  // consent_grants carries per-message consent category grants from the client.
+  // When present, these override stored consent for this request.
+  repeated string consent_grants = 6;
 }
 
 // ClientToolResult carries the client's response to a client-side tool call.

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -410,12 +410,18 @@ func wrapPrivacyMiddleware(next http.Handler, pool *pgxpool.Pool, log logr.Logge
 	prefStore := privacy.NewPreferencesStore(pool)
 	redactor := redaction.NewRedactor()
 
-	checkOptOut := memoryapi.OptOutChecker(func(ctx context.Context, userID, workspace, category string) bool {
+	checkOptOut := memoryapi.OptOutChecker(func(ctx context.Context, userID, workspace, category string, consentOverride []string) bool {
 		cat := privacy.ConsentCategory(category)
 		if cat == "" {
 			cat = privacy.ConsentMemoryContext
 		}
-		return privacy.ShouldRememberCategory(ctx, prefStore, prefStore, userID, workspace, "", cat)
+		var source privacy.ConsentSource
+		if len(consentOverride) > 0 {
+			source = privacy.NewStaticConsentSource(consentOverride)
+		} else {
+			source = prefStore
+		}
+		return privacy.ShouldRememberCategory(ctx, prefStore, source, userID, workspace, "", cat)
 	})
 
 	contentRedactor := memoryapi.ContentRedactor(func(ctx context.Context, workspace, content string) (string, error) {

--- a/dashboard/src/types/generated/websocket.ts
+++ b/dashboard/src/types/generated/websocket.ts
@@ -215,6 +215,11 @@ export interface ClientMessage {
    * ToolCallNack rejects a client-side tool call.
    */
   tool_call_nack?: ToolCallNackInfo;
+  /**
+   * ConsentGrants carries per-message consent category grants from the client.
+   * When present, these override stored consent for this request.
+   */
+  consent_grants?: string[];
 }
 /**
  * ServerMessage represents a message sent from server to client.

--- a/ee/pkg/privacy/static_consent_source.go
+++ b/ee/pkg/privacy/static_consent_source.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import "context"
+
+// StaticConsentSource implements ConsentSource with a fixed list of grants.
+// Used when consent grants are provided per-request (e.g. via HTTP header)
+// instead of read from the database.
+type StaticConsentSource struct {
+	grants []ConsentCategory
+}
+
+// NewStaticConsentSource creates a StaticConsentSource from a list of category strings.
+// Invalid categories are silently filtered out.
+func NewStaticConsentSource(grants []string) *StaticConsentSource {
+	cats := make([]ConsentCategory, 0, len(grants))
+	for _, g := range grants {
+		if _, valid := CategoryInfo(ConsentCategory(g)); valid {
+			cats = append(cats, ConsentCategory(g))
+		}
+	}
+	return &StaticConsentSource{grants: cats}
+}
+
+var _ ConsentSource = (*StaticConsentSource)(nil)
+
+func (s *StaticConsentSource) GetConsentGrants(_ context.Context, _ string) ([]ConsentCategory, error) {
+	return s.grants, nil
+}

--- a/ee/pkg/privacy/static_consent_source_test.go
+++ b/ee/pkg/privacy/static_consent_source_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package privacy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewStaticConsentSource_ValidGrants(t *testing.T) {
+	src := NewStaticConsentSource([]string{
+		"memory:preferences",
+		"memory:context",
+	})
+	grants, err := src.GetConsentGrants(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, []ConsentCategory{
+		ConsentMemoryPreferences,
+		ConsentMemoryContext,
+	}, grants)
+}
+
+func TestNewStaticConsentSource_InvalidCategoriesFiltered(t *testing.T) {
+	src := NewStaticConsentSource([]string{
+		"memory:bogus",
+		"memory:preferences",
+		"analytics:fake",
+	})
+	grants, err := src.GetConsentGrants(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, []ConsentCategory{ConsentMemoryPreferences}, grants)
+}
+
+func TestNewStaticConsentSource_EmptyInput(t *testing.T) {
+	src := NewStaticConsentSource([]string{})
+	grants, err := src.GetConsentGrants(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+}
+
+func TestNewStaticConsentSource_MixedValidAndInvalid(t *testing.T) {
+	src := NewStaticConsentSource([]string{
+		"memory:identity",
+		"memory:bogus",
+		"analytics:aggregate",
+		"not:valid",
+	})
+	grants, err := src.GetConsentGrants(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Equal(t, []ConsentCategory{
+		ConsentMemoryIdentity,
+		ConsentAnalyticsAggregate,
+	}, grants)
+}
+
+func TestNewStaticConsentSource_AllInvalid(t *testing.T) {
+	src := NewStaticConsentSource([]string{"bogus", "memory:bogus", "analytics:fake"})
+	grants, err := src.GetConsentGrants(context.Background(), "user-1")
+	require.NoError(t, err)
+	assert.Empty(t, grants)
+}
+
+func TestStaticConsentSource_UserIDIgnored(t *testing.T) {
+	src := NewStaticConsentSource([]string{"memory:history"})
+	grants1, err := src.GetConsentGrants(context.Background(), "user-A")
+	require.NoError(t, err)
+	grants2, err := src.GetConsentGrants(context.Background(), "user-B")
+	require.NoError(t, err)
+	assert.Equal(t, grants1, grants2)
+}

--- a/internal/facade/protocol.go
+++ b/internal/facade/protocol.go
@@ -163,6 +163,9 @@ type ClientMessage struct {
 	ToolCallAck *ToolCallAckInfo `json:"tool_call_ack,omitempty"`
 	// ToolCallNack rejects a client-side tool call.
 	ToolCallNack *ToolCallNackInfo `json:"tool_call_nack,omitempty"`
+	// ConsentGrants carries per-message consent category grants from the client.
+	// When present, these override stored consent for this request.
+	ConsentGrants []string `json:"consent_grants,omitempty"`
 }
 
 // ServerMessage represents a message sent from server to client.

--- a/internal/facade/session.go
+++ b/internal/facade/session.go
@@ -35,6 +35,7 @@ import (
 	"github.com/altairalabs/omnia/internal/session/otlp"
 	"github.com/altairalabs/omnia/internal/tracing"
 	"github.com/altairalabs/omnia/pkg/logctx"
+	"github.com/altairalabs/omnia/pkg/policy"
 )
 
 // processMessage handles processing of an incoming client message.
@@ -60,6 +61,9 @@ func (s *Server) processMessage(ctx context.Context, c *Connection, msg *ClientM
 	ctx = logctx.WithTraceID(ctx, msgSpan.SpanContext().TraceID().String())
 	if c.userID != "" {
 		ctx = httpclient.WithUserID(ctx, c.userID)
+	}
+	if len(msg.ConsentGrants) > 0 {
+		ctx = policy.WithConsentGrants(ctx, msg.ConsentGrants)
 	}
 	log = logctx.LoggerWithContext(s.log, ctx)
 

--- a/internal/memory/api/privacy_middleware.go
+++ b/internal/memory/api/privacy_middleware.go
@@ -24,17 +24,22 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/go-logr/logr"
 
 	"github.com/altairalabs/omnia/pkg/logging"
 )
 
+const consentGrantsHeader = "X-Consent-Grants"
+
 // OptOutChecker returns false when the user has opted out of memory storage,
 // indicating the write should be silently dropped.
 // category is the consent category from the request body (may be empty string
 // when no category was supplied; callers should apply a default in that case).
-type OptOutChecker func(ctx context.Context, userID, workspace, category string) bool
+// consentOverride, when non-nil, provides per-request grant overrides from the
+// X-Consent-Grants header, bypassing the database-backed consent source.
+type OptOutChecker func(ctx context.Context, userID, workspace, category string, consentOverride []string) bool
 
 // ContentRedactor redacts PII from memory content text.
 // Returns the redacted string; if redaction is not configured it returns the
@@ -116,8 +121,14 @@ func (m *MemoryPrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 			req.Category = m.classifier(req.Content)
 		}
 
+		// Read per-request consent override from header.
+		var consentOverride []string
+		if h := r.Header.Get(consentGrantsHeader); h != "" {
+			consentOverride = strings.Split(h, ",")
+		}
+
 		// Check opt-out with category (empty string if not decoded).
-		if userID != "" && !m.checkOptOut(r.Context(), userID, workspace, req.Category) {
+		if userID != "" && !m.checkOptOut(r.Context(), userID, workspace, req.Category, consentOverride) {
 			m.log.V(1).Info("memory write suppressed", "reason", "user opt-out", "userHash", logging.HashID(userID), "workspace", workspace, "category", req.Category)
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/internal/memory/api/privacy_middleware_test.go
+++ b/internal/memory/api/privacy_middleware_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 // passthroughOptOut always returns true (no opt-out).
-var passthroughOptOut OptOutChecker = func(_ context.Context, _, _, _ string) bool { return true }
+var passthroughOptOut OptOutChecker = func(_ context.Context, _, _, _ string, _ []string) bool { return true }
 
 // noOpRedact returns content unchanged.
 var noOpRedact ContentRedactor = func(_ context.Context, _, content string) (string, error) {
@@ -42,10 +42,10 @@ var noOpRedact ContentRedactor = func(_ context.Context, _, content string) (str
 }
 
 // optedOutChecker always returns false (user opted out).
-var optedOutChecker OptOutChecker = func(_ context.Context, _, _, _ string) bool { return false }
+var optedOutChecker OptOutChecker = func(_ context.Context, _, _, _ string, _ []string) bool { return false }
 
 // panicOptOut panics if called — use to assert opt-out is never checked.
-var panicOptOut OptOutChecker = func(_ context.Context, _, _, _ string) bool {
+var panicOptOut OptOutChecker = func(_ context.Context, _, _, _ string, _ []string) bool {
 	panic("OptOutChecker must not be called for this request")
 }
 
@@ -336,7 +336,7 @@ func makePostRequestWithCategory(t *testing.T, content, workspace, userID, categ
 func TestMemoryPrivacyMiddleware_NoCategoryInBody_OptOutCheckerReceivesEmpty(t *testing.T) {
 	// POST without a category field — opt-out checker must receive an empty string.
 	var receivedCategory string
-	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+	checker := OptOutChecker(func(_ context.Context, _, _, category string, _ []string) bool {
 		receivedCategory = category
 		return true // allow
 	})
@@ -359,7 +359,7 @@ func TestMemoryPrivacyMiddleware_NoCategoryInBody_OptOutCheckerReceivesEmpty(t *
 func TestMemoryPrivacyMiddleware_WithCategory_OptOutCheckerReceivesCategory(t *testing.T) {
 	// POST with category: "memory:identity" — opt-out checker must receive it.
 	var receivedCategory string
-	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+	checker := OptOutChecker(func(_ context.Context, _, _, category string, _ []string) bool {
 		receivedCategory = category
 		return true // allow
 	})
@@ -381,7 +381,7 @@ func TestMemoryPrivacyMiddleware_WithCategory_OptOutCheckerReceivesCategory(t *t
 
 func TestMemoryPrivacyMiddleware_CategoryOptedOut_Returns204(t *testing.T) {
 	// Opt-out checker that only rejects "memory:identity".
-	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+	checker := OptOutChecker(func(_ context.Context, _, _, category string, _ []string) bool {
 		return category != "memory:identity"
 	})
 
@@ -405,7 +405,7 @@ func TestMemoryPrivacyMiddleware_CategoryOptedOut_Returns204(t *testing.T) {
 func TestMemoryPrivacyMiddleware_ClassifiesWhenCategoryEmpty(t *testing.T) {
 	// POST with no category + classifier returns "memory:identity" → opt-out checker receives "memory:identity".
 	var receivedCategory string
-	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+	checker := OptOutChecker(func(_ context.Context, _, _, category string, _ []string) bool {
 		receivedCategory = category
 		return true // allow
 	})
@@ -436,7 +436,7 @@ func TestMemoryPrivacyMiddleware_SkipsClassifierWhenCategoryProvided(t *testing.
 	})
 
 	var receivedCategory string
-	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+	checker := OptOutChecker(func(_ context.Context, _, _, category string, _ []string) bool {
 		receivedCategory = category
 		return true
 	})
@@ -459,7 +459,7 @@ func TestMemoryPrivacyMiddleware_SkipsClassifierWhenCategoryProvided(t *testing.
 func TestMemoryPrivacyMiddleware_NilClassifier_CategoryStaysEmpty(t *testing.T) {
 	// POST with no category + nil classifier → opt-out checker receives empty string.
 	var receivedCategory string
-	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+	checker := OptOutChecker(func(_ context.Context, _, _, category string, _ []string) bool {
 		receivedCategory = category
 		return true
 	})
@@ -486,7 +486,7 @@ func TestMemoryPrivacyMiddleware_ClassifierBeforeOptOut(t *testing.T) {
 		return "memory:health"
 	})
 
-	checker := OptOutChecker(func(_ context.Context, _, _, category string) bool {
+	checker := OptOutChecker(func(_ context.Context, _, _, category string, _ []string) bool {
 		return category != "memory:health" // reject memory:health
 	})
 
@@ -505,4 +505,80 @@ func TestMemoryPrivacyMiddleware_ClassifierBeforeOptOut(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, w.Code)
 	assert.False(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_ConsentOverrideHeader_PassedToChecker(t *testing.T) {
+	// POST with X-Consent-Grants header → checker receives the parsed grants slice.
+	var receivedOverride []string
+	checker := OptOutChecker(func(_ context.Context, _, _, _ string, consentOverride []string) bool {
+		receivedOverride = consentOverride
+		return true
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(checker, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "user-abc")
+	r.Header.Set(consentGrantsHeader, "memory:identity,memory:preferences")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Equal(t, []string{"memory:identity", "memory:preferences"}, receivedOverride)
+}
+
+func TestMemoryPrivacyMiddleware_NoConsentHeader_NilOverride(t *testing.T) {
+	// POST without X-Consent-Grants header → checker receives nil override.
+	var receivedOverride []string
+	checker := OptOutChecker(func(_ context.Context, _, _, _ string, consentOverride []string) bool {
+		receivedOverride = consentOverride
+		return true
+	})
+
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(checker, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "some content", "ws-1", "user-abc")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	assert.Nil(t, receivedOverride, "no header should yield nil override")
+}
+
+func TestMemoryPrivacyMiddleware_ConsentOverride_OverridesDB(t *testing.T) {
+	// Checker that allows when override contains "memory:identity", else denies.
+	checker := OptOutChecker(func(_ context.Context, _, _, _ string, consentOverride []string) bool {
+		for _, g := range consentOverride {
+			if g == "memory:identity" {
+				return true
+			}
+		}
+		return false
+	})
+
+	var handlerCalled bool
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusCreated)
+	})
+
+	mw := newTestMiddleware(checker, noOpRedact)
+	handler := mw.Wrap(next)
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "my name is Alice", "ws-1", "user-abc")
+	r.Header.Set(consentGrantsHeader, "memory:identity")
+	handler.ServeHTTP(w, r)
+
+	assert.Equal(t, http.StatusCreated, w.Code, "header override should allow the write")
+	assert.True(t, handlerCalled)
 }

--- a/internal/memory/httpclient/store.go
+++ b/internal/memory/httpclient/store.go
@@ -29,11 +29,13 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
 
 	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/altairalabs/omnia/pkg/policy"
 )
 
 // Default timeout for HTTP requests to the memory-api.
@@ -223,6 +225,11 @@ func (s *Store) doRequest(ctx context.Context, method, path string, body []byte)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+
+	// Forward consent grants if present in context.
+	if grants := policy.ConsentGrantsFromContext(ctx); len(grants) > 0 {
+		req.Header.Set("X-Consent-Grants", strings.Join(grants, ","))
+	}
 
 	s.log.V(2).Info("memory-api request", "method", method, "path", path)
 

--- a/internal/memory/httpclient/store_test.go
+++ b/internal/memory/httpclient/store_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/altairalabs/omnia/pkg/policy"
 )
 
 // mockMemoryAPI creates a test server that mimics the memory-api endpoints.
@@ -251,4 +252,37 @@ func TestScopeParams_MinimalScope(t *testing.T) {
 	assert.Equal(t, "ws-1", params.Get("workspace"))
 	assert.Empty(t, params.Get("user_id"))
 	assert.Empty(t, params.Get("agent"))
+}
+
+func TestStore_Save_ForwardsConsentGrants(t *testing.T) {
+	var capturedHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header.Get("X-Consent-Grants")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"memory":{"id":"m1"}}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	ctx := policy.WithConsentGrants(context.Background(), []string{"memory:identity", "memory:preferences"})
+	mem := &pkmemory.Memory{Content: "test", Scope: map[string]string{"workspace_id": "ws1"}}
+	err := store.Save(ctx, mem)
+	require.NoError(t, err)
+	assert.Equal(t, "memory:identity,memory:preferences", capturedHeader)
+}
+
+func TestStore_Save_NoConsentGrants_NoHeader(t *testing.T) {
+	var hasHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hasHeader = r.Header.Get("X-Consent-Grants") != ""
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"memory":{"id":"m1"}}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	mem := &pkmemory.Memory{Content: "test", Scope: map[string]string{"workspace_id": "ws1"}}
+	err := store.Save(context.Background(), mem)
+	require.NoError(t, err)
+	assert.False(t, hasHeader)
 }

--- a/internal/runtime/interceptor.go
+++ b/internal/runtime/interceptor.go
@@ -18,6 +18,7 @@ package runtime
 
 import (
 	"context"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -85,6 +86,9 @@ func extractPolicyFromMetadata(ctx context.Context) context.Context {
 		Provider:      firstValue(md, policy.HeaderProvider),
 		Model:         firstValue(md, policy.HeaderModel),
 		Claims:        extractClaims(md),
+	}
+	if grants := firstValue(md, policy.HeaderConsentGrants); grants != "" {
+		fields.ConsentGrants = strings.Split(grants, ",")
 	}
 	return policy.WithPropagationFields(ctx, fields)
 }

--- a/pkg/policy/context.go
+++ b/pkg/policy/context.go
@@ -53,6 +53,8 @@ const (
 	ContextKeyModel contextKey = "omnia-model"
 	// ContextKeyClaims holds extracted JWT claims as a map.
 	ContextKeyClaims contextKey = "omnia-claims"
+	// ContextKeyConsentGrants holds per-request consent grants.
+	ContextKeyConsentGrants contextKey = "omnia-consent-grants"
 )
 
 // HTTP/gRPC header constants for context propagation.
@@ -86,6 +88,8 @@ const (
 	HeaderClaimPrefix = "x-omnia-claim-"
 	// HeaderParamPrefix is the prefix for promoted tool parameters.
 	HeaderParamPrefix = "x-omnia-param-"
+	// HeaderConsentGrants carries comma-separated consent category grants.
+	HeaderConsentGrants = "x-omnia-consent-grants"
 )
 
 // Istio-injected header names that the facade reads from the WebSocket upgrade request.
@@ -111,6 +115,8 @@ type PropagationFields struct {
 	Provider      string
 	Model         string
 	Claims        map[string]string
+	// ConsentGrants holds per-request consent category grants.
+	ConsentGrants []string
 }
 
 // WithAgentName returns a context with the agent name set.
@@ -168,6 +174,21 @@ func WithClaims(ctx context.Context, claims map[string]string) context.Context {
 	return context.WithValue(ctx, ContextKeyClaims, claims)
 }
 
+// WithConsentGrants returns a context with consent grants set.
+func WithConsentGrants(ctx context.Context, grants []string) context.Context {
+	return context.WithValue(ctx, ContextKeyConsentGrants, grants)
+}
+
+// ConsentGrantsFromContext extracts consent grants from context.
+func ConsentGrantsFromContext(ctx context.Context) []string {
+	if v := ctx.Value(ContextKeyConsentGrants); v != nil {
+		if grants, ok := v.([]string); ok {
+			return grants
+		}
+	}
+	return nil
+}
+
 // WithPropagationFields returns a context with all propagation fields set.
 // Only non-empty values are stored.
 func WithPropagationFields(ctx context.Context, fields *PropagationFields) context.Context {
@@ -186,6 +207,9 @@ func WithPropagationFields(ctx context.Context, fields *PropagationFields) conte
 	ctx = setIfNonEmpty(ctx, ContextKeyModel, fields.Model)
 	if len(fields.Claims) > 0 {
 		ctx = WithClaims(ctx, fields.Claims)
+	}
+	if len(fields.ConsentGrants) > 0 {
+		ctx = WithConsentGrants(ctx, fields.ConsentGrants)
 	}
 	return ctx
 }
@@ -212,6 +236,7 @@ func ExtractPropagationFields(ctx context.Context) PropagationFields {
 		Provider:      getString(ctx, ContextKeyProvider),
 		Model:         getString(ctx, ContextKeyModel),
 		Claims:        getClaims(ctx),
+		ConsentGrants: ConsentGrantsFromContext(ctx),
 	}
 }
 
@@ -294,6 +319,10 @@ func ToOutboundHeaders(ctx context.Context) map[string]string {
 	// Append claim headers
 	for name, value := range getClaims(ctx) {
 		headers[HeaderClaimPrefix+name] = value
+	}
+	// Append consent grants header.
+	if grants := ConsentGrantsFromContext(ctx); len(grants) > 0 {
+		headers[HeaderConsentGrants] = strings.Join(grants, ",")
 	}
 	return headers
 }

--- a/pkg/policy/context_test.go
+++ b/pkg/policy/context_test.go
@@ -239,3 +239,43 @@ func TestExtractPropagationFields_WrongType(t *testing.T) {
 	ctx := context.WithValue(context.Background(), ContextKeyAgentName, 12345)
 	assert.Equal(t, "", AgentName(ctx))
 }
+
+func TestConsentGrantsRoundTrip(t *testing.T) {
+	grants := []string{"memory", "analytics"}
+	ctx := WithConsentGrants(context.Background(), grants)
+	got := ConsentGrantsFromContext(ctx)
+	require.Equal(t, grants, got)
+}
+
+func TestConsentGrantsFromContextEmpty(t *testing.T) {
+	got := ConsentGrantsFromContext(context.Background())
+	assert.Nil(t, got)
+}
+
+func TestToGRPCMetadataIncludesConsentGrants(t *testing.T) {
+	ctx := WithConsentGrants(context.Background(), []string{"memory", "analytics"})
+	headers := ToGRPCMetadata(ctx)
+	assert.Equal(t, "memory,analytics", headers[HeaderConsentGrants])
+}
+
+func TestToGRPCMetadataOmitsConsentGrantsWhenEmpty(t *testing.T) {
+	headers := ToGRPCMetadata(context.Background())
+	_, ok := headers[HeaderConsentGrants]
+	assert.False(t, ok, "consent grants header should be absent when no grants set")
+}
+
+func TestWithPropagationFieldsConsentGrants(t *testing.T) {
+	fields := &PropagationFields{
+		ConsentGrants: []string{"memory"},
+	}
+	ctx := WithPropagationFields(context.Background(), fields)
+	got := ConsentGrantsFromContext(ctx)
+	require.Equal(t, []string{"memory"}, got)
+}
+
+func TestExtractPropagationFieldsConsentGrants(t *testing.T) {
+	grants := []string{"memory", "analytics"}
+	ctx := WithConsentGrants(context.Background(), grants)
+	fields := ExtractPropagationFields(ctx)
+	assert.Equal(t, grants, fields.ConsentGrants)
+}

--- a/pkg/runtime/v1/runtime.pb.go
+++ b/pkg/runtime/v1/runtime.pb.go
@@ -10,11 +10,12 @@
 package runtimev1
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -89,8 +90,11 @@ type ClientMessage struct {
 	// client_tool_result carries the result of a client-side tool execution.
 	// Set when responding to a ToolCall with execution=CLIENT.
 	ClientToolResult *ClientToolResult `protobuf:"bytes,5,opt,name=client_tool_result,json=clientToolResult,proto3" json:"client_tool_result,omitempty"`
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// consent_grants carries per-message consent category grants from the client.
+	// When present, these override stored consent for this request.
+	ConsentGrants []string `protobuf:"bytes,6,rep,name=consent_grants,json=consentGrants,proto3" json:"consent_grants,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ClientMessage) Reset() {
@@ -154,6 +158,13 @@ func (x *ClientMessage) GetParts() []*ContentPart {
 func (x *ClientMessage) GetClientToolResult() *ClientToolResult {
 	if x != nil {
 		return x.ClientToolResult
+	}
+	return nil
+}
+
+func (x *ClientMessage) GetConsentGrants() []string {
+	if x != nil {
+		return x.ConsentGrants
 	}
 	return nil
 }
@@ -1070,14 +1081,15 @@ var File_api_proto_runtime_v1_runtime_proto protoreflect.FileDescriptor
 
 const file_api_proto_runtime_v1_runtime_proto_rawDesc = "" +
 	"\n" +
-	"\"api/proto/runtime/v1/runtime.proto\x12\x10omnia.runtime.v1\"\xd7\x02\n" +
+	"\"api/proto/runtime/v1/runtime.proto\x12\x10omnia.runtime.v1\"\xfe\x02\n" +
 	"\rClientMessage\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12\x18\n" +
 	"\acontent\x18\x02 \x01(\tR\acontent\x12I\n" +
 	"\bmetadata\x18\x03 \x03(\v2-.omnia.runtime.v1.ClientMessage.MetadataEntryR\bmetadata\x123\n" +
 	"\x05parts\x18\x04 \x03(\v2\x1d.omnia.runtime.v1.ContentPartR\x05parts\x12P\n" +
-	"\x12client_tool_result\x18\x05 \x01(\v2\".omnia.runtime.v1.ClientToolResultR\x10clientToolResult\x1a;\n" +
+	"\x12client_tool_result\x18\x05 \x01(\v2\".omnia.runtime.v1.ClientToolResultR\x10clientToolResult\x12%\n" +
+	"\x0econsent_grants\x18\x06 \x03(\tR\rconsentGrants\x1a;\n" +
 	"\rMetadataEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\x98\x01\n" +

--- a/pkg/runtime/v1/runtime_grpc.pb.go
+++ b/pkg/runtime/v1/runtime_grpc.pb.go
@@ -11,6 +11,7 @@ package runtimev1
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"


### PR DESCRIPTION
## Summary

- **Policy context**: `ConsentGrants` added to `PropagationFields` with `WithConsentGrants`/`ConsentGrantsFromContext` helpers and `x-omnia-consent-grants` gRPC header serialization
- **StaticConsentSource**: `ConsentSource` implementation wrapping a per-request grant list (filters invalid categories)
- **Proto/protocol**: `consent_grants` field added to gRPC `ClientMessage` and WebSocket `ClientMessage`
- **Facade→runtime propagation**: Facade injects grants into context, gRPC interceptors serialize/deserialize automatically
- **HTTP client forwarding**: Memory httpclient sends `X-Consent-Grants` header on all requests when grants are in context
- **Middleware override**: Memory-api middleware reads `X-Consent-Grants` header and uses `StaticConsentSource` instead of database when present

Transport-agnostic design — any facade (WebSocket, A2A, HTTP) injects grants into context the same way. Override hierarchy: request-level grants → stored database grants → category defaults.

Spec: `docs/local-backlog/client-consent-spec.md`

## Test Plan

- [x] Policy context tests (round-trip, header serialization)
- [x] StaticConsentSource tests (valid/invalid filtering)
- [x] HTTP client tests (header forwarding)
- [x] Middleware tests (consent override via header, fallback to DB)
- [x] All pre-commit checks pass
- [ ] CI passes