### PR TITLE
ci: prototype ko-based smoke workflow

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -199,6 +199,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build doctor from source
+        env:
+          GOWORK: "off"
+        run: go build -o /tmp/doctor ./cmd/doctor
+
       - name: Download image artifacts
         uses: actions/download-artifact@v4
         with:
@@ -282,22 +293,12 @@ jobs:
       - name: Run doctor smoke test
         run: |
           set -euo pipefail
-          # TODO: the `doctor` binary is currently an untracked local build
-          # (a Go CLI that talks to a live cluster). Until it is either
-          # committed as source under cmd/doctor/ and built here, or
-          # published as a release artifact, run a placeholder so the
-          # workflow is fully wired and runnable end-to-end.
-          #
-          # When doctor ships: replace this with either
-          #   go run ./cmd/doctor -- --namespace omnia-system
-          # or download the release binary for linux/amd64 and invoke it.
-          if [ -x ./doctor ]; then
-            ./doctor --namespace omnia-system
-          else
-            echo "doctor binary not present in repo — running placeholder smoke checks"
-            kubectl -n omnia-system wait --for=condition=Available deploy --all --timeout=120s || true
-            kubectl -n omnia-system get pods
-          fi
+          # doctor is built from ./cmd/doctor earlier in this job. It reads
+          # KUBECONFIG from the environment (kind-action sets this) and talks
+          # to in-cluster services by DNS name, resolved from the --namespace
+          # flag. --run-once runs all checks, prints a JSON report, and
+          # --exit-code makes the process exit 1 if any check fails.
+          /tmp/doctor --run-once --exit-code --namespace omnia-system
 
       - name: Dump logs on failure
         if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ docs/local-backlog/
 **/out/
 /omnia-arena-controller
 /memory-api
+/doctor


### PR DESCRIPTION
## Summary
Prototype smoke workflow that replaces docker image builds with `ko` for the three Go services (operator, facade, runtime) to cut PR CI wall-clock. Dashboard still uses docker build.

**Draft — this is a measurement PR.** Goal is to see how long ko takes on real GHA runners vs the current docker-based pipeline. Building all four images every run (no path-filter gating yet) for a clean apples-to-apples comparison.

## What to look at
- `build-images` job timing — this is the number that matters.
- `smoke` job will probably fail on helm install (heavy chart defaults: cert-manager, Gateway API, replica counts). That's expected; next iteration.

## Not for merge
Once we have the timing, this either graduates into a real workflow (with path filters + trimmed helm values) or gets closed.