### PR TITLE
fix(controller): wire AgentRuntime.spec.facade.clientToolTimeout (#728 Part 2)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -281,6 +281,14 @@ func createHandler(cfg *agent.Config, log logr.Logger, tp *tracing.Provider) (fa
 		}
 
 		handler := agent.NewRuntimeHandler(client)
+		// Apply CRD-driven client tool timeout. The config struct is populated
+		// from AgentRuntime.spec.facade.clientToolTimeout by agent.LoadFromCRD.
+		// Without this, the handler always used defaultClientToolTimeout (60s)
+		// and the CRD field was dead.
+		if cfg.ClientToolTimeout > 0 {
+			handler.SetClientToolTimeout(cfg.ClientToolTimeout)
+			log.V(1).Info("client tool timeout override applied", "timeout", cfg.ClientToolTimeout)
+		}
 		cleanup := func() {
 			if err := client.Close(); err != nil {
 				log.Error(err, "error closing runtime client")

--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -160,6 +160,11 @@ type Config struct {
 	// Session configuration.
 	SessionTTL time.Duration
 
+	// ClientToolTimeout overrides the default 60s timeout for client tool
+	// responses. Sourced from AgentRuntime.spec.facade.clientToolTimeout.
+	// Zero means "use RuntimeHandler default".
+	ClientToolTimeout time.Duration
+
 	// Media storage configuration.
 	MediaStorageType MediaStorageType
 	MediaStoragePath string

--- a/internal/agent/config_crd.go
+++ b/internal/agent/config_crd.go
@@ -57,6 +57,9 @@ func LoadFromCRD(ctx context.Context, c client.Client, name, namespace string) (
 	} else {
 		cfg.FacadePort = DefaultFacadePort
 	}
+	if ar.Spec.Facade.ClientToolTimeout != nil {
+		cfg.ClientToolTimeout = ar.Spec.Facade.ClientToolTimeout.Duration
+	}
 
 	// Handler mode from env (operator decides this, not CRD)
 	cfg.HandlerMode = HandlerMode(getEnvOrDefault(EnvHandlerMode, string(HandlerModeRuntime)))

--- a/internal/agent/config_crd_wiring_test.go
+++ b/internal/agent/config_crd_wiring_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package agent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// TestLoadFromCRD_ClientToolTimeoutPropagates is a controller wiring test for
+// #728 Part 2 item 6: CRD field propagation. The field
+// AgentRuntime.spec.facade.clientToolTimeout was defined on the API type but
+// LoadFromCRD never read it into Config.ClientToolTimeout, so the facade's
+// RuntimeHandler always used defaultClientToolTimeout (60s) and the CRD field
+// was dead.
+//
+// Unlike the service-binary wiring tests under cmd/<service>/ which start the
+// real server, this test targets the CRD-loading boundary directly. It uses a
+// controller-runtime fake client to serve an AgentRuntime with
+// ClientToolTimeout set, calls LoadFromCRD, and asserts that
+// cfg.ClientToolTimeout is populated. The facade then reads cfg.ClientToolTimeout
+// and calls handler.SetClientToolTimeout — that wiring is covered inline in
+// cmd/agent/main.go (see the RuntimeHandler construction path).
+//
+// This follows the codebase pattern: containers read the AgentRuntime CRD
+// directly at startup via the k8s client and their Downward-API-injected
+// identity; env vars are only for things the operator uniquely knows
+// (tracing, handler mode) or runtime plumbing.
+func TestLoadFromCRD_ClientToolTimeoutPropagates(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	ar := &v1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wiring-test",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.AgentRuntimeSpec{
+			PromptPackRef: v1alpha1.PromptPackRef{Name: "test-prompts"},
+			Facade: v1alpha1.FacadeConfig{
+				Type:              v1alpha1.FacadeTypeWebSocket,
+				ClientToolTimeout: &metav1.Duration{Duration: 45 * time.Second},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar).Build()
+
+	cfg, err := LoadFromCRD(context.Background(), c, "wiring-test", "default")
+	if err != nil {
+		t.Fatalf("LoadFromCRD: %v", err)
+	}
+
+	if cfg.ClientToolTimeout != 45*time.Second {
+		t.Errorf("cfg.ClientToolTimeout = %v, want 45s — "+
+			"spec.facade.clientToolTimeout is not being read from the CRD "+
+			"into the agent Config; the field is dead",
+			cfg.ClientToolTimeout)
+	}
+}
+
+// TestLoadFromCRD_ClientToolTimeoutZeroWhenNil verifies the inverse: when
+// spec.facade.clientToolTimeout is not set, cfg.ClientToolTimeout stays zero
+// and cmd/agent/main.go falls back to the RuntimeHandler default (60s).
+// Guards against a future change that always sets a non-zero value.
+func TestLoadFromCRD_ClientToolTimeoutZeroWhenNil(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add scheme: %v", err)
+	}
+
+	ar := &v1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "wiring-test", Namespace: "default"},
+		Spec: v1alpha1.AgentRuntimeSpec{
+			PromptPackRef: v1alpha1.PromptPackRef{Name: "test-prompts"},
+			Facade: v1alpha1.FacadeConfig{
+				Type: v1alpha1.FacadeTypeWebSocket,
+				// ClientToolTimeout deliberately not set
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar).Build()
+
+	cfg, err := LoadFromCRD(context.Background(), c, "wiring-test", "default")
+	if err != nil {
+		t.Fatalf("LoadFromCRD: %v", err)
+	}
+
+	if cfg.ClientToolTimeout != 0 {
+		t.Errorf("cfg.ClientToolTimeout = %v, want 0 (unset); future change "+
+			"may be populating a default before the nil check",
+			cfg.ClientToolTimeout)
+	}
+}


### PR DESCRIPTION
Part 2 of #728 — controller wiring tests. Closes the dead-field portion of #728.

## What landed (item 6)

`AgentRuntime.spec.facade.clientToolTimeout` has been defined on the CRD since `agentruntime_types.go:104` but was never propagated to the running facade:
- `internal/agent/config_crd.LoadFromCRD` did not read the field
- `cmd/agent/main.go` constructed `RuntimeHandler` with the hardcoded `defaultClientToolTimeout` (60s)
- `RuntimeHandler.SetClientToolTimeout` setter existed but had no caller

Setting the CRD field had zero effect in production. Classic "CRD field added, consumer never updated" regression — exactly the class of bug this Part 2 was meant to catch.

### Fix (follows the existing codebase pattern)

The facade reads the AgentRuntime CRD directly at startup via the k8s client, using the Downward-API-injected identity. Env vars are reserved for things the operator uniquely knows (tracing, handler mode). Per the comment in `buildFacadeEnvVars`: *"Identity from Downward API — facade reads CRD directly using these"*.

- `internal/agent/config.go` — added `Config.ClientToolTimeout time.Duration`
- `internal/agent/config_crd.go` — `LoadFromCRD` populates it from `ar.Spec.Facade.ClientToolTimeout` alongside the other CRD reads
- `cmd/agent/main.go` — after `NewRuntimeHandler`, calls `handler.SetClientToolTimeout(cfg.ClientToolTimeout)` when > 0

### Wiring test

`internal/agent/config_crd_wiring_test.go`:
- `TestLoadFromCRD_ClientToolTimeoutPropagates` — feeds a `controller-runtime` fake client with an `AgentRuntime` where `ClientToolTimeout=45s`, asserts `cfg.ClientToolTimeout == 45s`
- `TestLoadFromCRD_ClientToolTimeoutZeroWhenNil` — nil guard, prevents a future change from silently applying a default

Both run in <1s under `go test ./internal/agent/...` with no envtest, no kind, no Postgres.

## Items 7 and 8: investigated, not wiring gaps

The other two items from Part 2 were mischaracterized when I filed the ticket. Investigation found:

### Item 7 — Workspace `anonymousAccess` enforcement
`AnonymousAccess` is referenced **nowhere in Go code** outside its own type definition. No controller reads it, no dashboard backend reads it. It's a specced-but-never-implemented feature, not a wiring gap where the controller ignores a CRD field. A wiring test can't meaningfully assert on behavior that doesn't exist. Dashboard anonymous access is enforced via the `OMNIA_AUTH_MODE=anonymous` env var the dashboard reads, not by querying the Workspace CRD.

### Item 8 — AgentPolicy → AuthorizationPolicy subfield propagation
`buildDesiredAuthPolicies` uses `Spec.ToolAccess`, `Spec.Mode`, and `Spec.Selector` — all wired correctly to the produced Istio `AuthorizationPolicy`. The subfields I listed as "dropped" are:
- `Spec.ClaimMapping` — validated in `validateClaimMappings` but produces no Istio output (no `RequestAuthentication`, no `EnvoyFilter`)
- `Spec.OnFailure` — zero references in the controller

Both are dead fields: specced-but-never-implemented. Existing tests (`TestReconcile_WithToolAccessAllowlist`, `TestReconcile_WithToolAccessDenylist`, `TestReconcile_PermissiveMode`) already cover the wired path comprehensively. Adding a wiring test for `ClaimMapping`/`OnFailure` would assert "nothing happens", which is not a useful regression guard.

Both items 7 and 8 are better tracked as "implement feature X" tickets rather than "add wiring test". Not doing that work in this PR.

## Test plan
- [x] `env GOWORK=off go test ./internal/agent/... ./cmd/agent/... ./internal/controller/... -count=1` — all pass
- [x] `env GOWORK=off go build ./...` — clean
- [x] Per-commit pre-commit hook green (lint, vet, coverage, generated code, PII check)
- [ ] CI green on this PR