### PR TITLE
fix(arena): always serialize and populate ArenaJob progress on terminal phase (#736)

### DIFF
--- a/ee/api/v1alpha1/arenajob_types.go
+++ b/ee/api/v1alpha1/arenajob_types.go
@@ -397,22 +397,25 @@ const (
 )
 
 // JobProgress tracks the progress of a job execution.
+// Fields do NOT use omitempty so a zero count (e.g. a job that failed before
+// any work items ran) still serializes as "0" rather than being stripped from
+// the JSON, which previously caused jsonpath queries to return an empty string.
 type JobProgress struct {
 	// total is the total number of work items.
 	// +optional
-	Total int32 `json:"total,omitempty"`
+	Total int32 `json:"total"`
 
 	// completed is the number of successfully completed work items.
 	// +optional
-	Completed int32 `json:"completed,omitempty"`
+	Completed int32 `json:"completed"`
 
 	// failed is the number of failed work items.
 	// +optional
-	Failed int32 `json:"failed,omitempty"`
+	Failed int32 `json:"failed"`
 
 	// pending is the number of pending work items.
 	// +optional
-	Pending int32 `json:"pending,omitempty"`
+	Pending int32 `json:"pending"`
 }
 
 // JobResult contains summary results for a completed job.

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -1212,18 +1212,23 @@ func (r *ArenaJobReconciler) updateStatusFromJob(ctx context.Context, arenaJob *
 					log.V(1).Info("aggregator not available, skipping result aggregation")
 				}
 
-				// Set final progress counts from aggregation or queue stats
-				if arenaJob.Status.Progress != nil {
-					if hasAggregation {
-						arenaJob.Status.Progress.Completed = int32(passedItems)
-						arenaJob.Status.Progress.Failed = int32(failedItems)
+				// Set final progress counts from aggregation or queue stats.
+				// Lazy-init Progress so the struct is always populated on a
+				// terminal phase — callers (and jsonpath queries) can rely on
+				// .status.progress existing once the job reaches Succeeded or
+				// Failed, even if createWorkerJob never ran in this reconcile.
+				if arenaJob.Status.Progress == nil {
+					arenaJob.Status.Progress = &omniav1alpha1.JobProgress{}
+				}
+				if hasAggregation {
+					arenaJob.Status.Progress.Completed = int32(passedItems)
+					arenaJob.Status.Progress.Failed = int32(failedItems)
+					arenaJob.Status.Progress.Pending = 0
+				} else if r.Queue != nil {
+					if stats, err := r.Queue.GetStats(ctx, arenaJob.Name); err == nil && stats != nil {
+						arenaJob.Status.Progress.Completed = int32(stats.Passed)
+						arenaJob.Status.Progress.Failed = int32(stats.Failed)
 						arenaJob.Status.Progress.Pending = 0
-					} else if r.Queue != nil {
-						if stats, err := r.Queue.GetStats(ctx, arenaJob.Name); err == nil && stats != nil {
-							arenaJob.Status.Progress.Completed = int32(stats.Passed)
-							arenaJob.Status.Progress.Failed = int32(stats.Failed)
-							arenaJob.Status.Progress.Pending = 0
-						}
 					}
 				}
 
@@ -1278,6 +1283,22 @@ func (r *ArenaJobReconciler) updateStatusFromJob(ctx context.Context, arenaJob *
 				arenaJob.Status.Phase = omniav1alpha1.ArenaJobPhaseFailed
 				now := metav1.Now()
 				arenaJob.Status.CompletionTime = &now
+				// Lazy-init Progress so callers can rely on .status.progress
+				// existing once the job reaches a terminal phase, even when
+				// the failure happened before any work items were enqueued.
+				if arenaJob.Status.Progress == nil {
+					arenaJob.Status.Progress = &omniav1alpha1.JobProgress{}
+				}
+				// Pull final counts from the queue if we have one; otherwise
+				// leave the zero values (which now serialize thanks to the
+				// JobProgress field tag change).
+				if r.Queue != nil {
+					if stats, err := r.Queue.GetStats(ctx, arenaJob.Name); err == nil && stats != nil {
+						arenaJob.Status.Progress.Completed = int32(stats.Passed)
+						arenaJob.Status.Progress.Failed = int32(stats.Failed)
+						arenaJob.Status.Progress.Pending = 0
+					}
+				}
 				SetCondition(&arenaJob.Status.Conditions, arenaJob.Generation, ArenaJobConditionTypeProgressing, metav1.ConditionFalse,
 					"JobFailed", condition.Message)
 				SetCondition(&arenaJob.Status.Conditions, arenaJob.Generation, ArenaJobConditionTypeReady, metav1.ConditionFalse,

--- a/ee/internal/controller/arenajob_controller_test.go
+++ b/ee/internal/controller/arenajob_controller_test.go
@@ -1091,6 +1091,51 @@ var _ = Describe("ArenaJob Controller", func() {
 
 			Expect(arenaJob.Status.Phase).To(Equal(omniav1alpha1.ArenaJobPhaseFailed))
 			Expect(arenaJob.Status.CompletionTime).NotTo(BeNil())
+			// Regression for #736: Progress must be lazy-initialized on the
+			// JobFailed path so .status.progress always exists (and serializes
+			// as {completed:0,failed:0,pending:0,total:0}) once the job
+			// reaches a terminal phase — even when the failure happened
+			// before any work items were enqueued and Progress was nil.
+			Expect(arenaJob.Status.Progress).NotTo(BeNil())
+		})
+
+		It("should lazy-init Progress on JobComplete when Progress was nil (#736)", func() {
+			arenaJob := &omniav1alpha1.ArenaJob{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "complete-nil-progress-job",
+					Namespace: arenaJobNamespace,
+				},
+				Status: omniav1alpha1.ArenaJobStatus{
+					Phase: omniav1alpha1.ArenaJobPhaseRunning,
+					// Progress deliberately left nil — simulates the case
+					// where enqueueWorkItems never ran (e.g. reconcile sees
+					// an existing Job on a restart).
+				},
+			}
+
+			completions := int32(1)
+			k8sJob := &batchv1.Job{
+				Spec: batchv1.JobSpec{Completions: &completions},
+				Status: batchv1.JobStatus{
+					Active:    0,
+					Succeeded: 1,
+					Failed:    0,
+					Conditions: []batchv1.JobCondition{
+						{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+					},
+				},
+			}
+
+			reconciler := &ArenaJobReconciler{
+				Client:   k8sClient,
+				Scheme:   k8sClient.Scheme(),
+				Recorder: record.NewFakeRecorder(10),
+			}
+
+			reconciler.updateStatusFromJob(ctx, arenaJob, k8sJob)
+
+			Expect(arenaJob.Status.Progress).NotTo(BeNil(),
+				"Progress must be lazy-initialized on a terminal phase, even when previously nil")
 		})
 
 		It("should update active workers when job is still running", func() {


### PR DESCRIPTION
## Summary

Arena E2E's `should complete a basic Arena job with mock provider` has been failing because `kubectl get arenajob -o jsonpath={.status.progress.completed}` returned the empty string once the job reached a terminal phase. Two bugs conspired:

1. **`omitempty` strips legitimate zeros.** `JobProgress.Completed/Failed/Pending/Total` were tagged `json:"...,omitempty"`, so a zero value was stripped from the serialized JSON and jsonpath returned `""` instead of `"0"`. Any CRD consumer expecting the field to be present was affected.
2. **`Status.Progress` could be nil on a terminal phase.** The `JobFailed` branch of `updateStatusFromJob` never touched `Status.Progress`, and the `JobComplete` branch only updated it when `Progress` was already non-nil. If the failure happened before any work items were enqueued (or reconcile saw an existing Job on a restart), `Status.Progress` was left nil entirely and the field tree didn't exist.

## Fix

- Drop `omitempty` from all four `JobProgress` counters so they always serialize.
- Lazy-init `arenaJob.Status.Progress` on both terminal branches (`JobComplete` and `JobFailed`).
- Populate from queue stats on `JobFailed` when a queue is wired.
- Add regression assertion to the existing JobFailed test and a new test covering the `JobComplete` + nil-`Progress` path.

## Test plan

- [x] `go test ./ee/internal/controller/... -count=1` — all green
- [x] `golangci-lint run ./ee/internal/controller/... ./ee/api/...` — 0 issues
- [x] `GOWORK=off go build ./...` — clean
- [x] Coverage on changed files ≥ 80%
- [ ] Arena E2E passes in CI (unblocking the 3-week red streak)

Fixes #736