### PR TITLE
perf(ci): cache Go modules and build cache for E2E jobs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -61,7 +61,23 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-          cache: true
+          cache: false  # We manage the module/build cache explicitly below.
+
+      # setup-go's built-in cache only reliably restores the Go toolchain,
+      # not the module download cache (~/go/pkg/mod) or the compiler build
+      # cache (~/.cache/go-build). Without this step, every E2E run re-downloads
+      # every module and recompiles every shared package from scratch — costing
+      # ~4-6 minutes. Keying on go.sum means the cache is invalidated only when
+      # dependencies change. See #732 follow-up.
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-e2e-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-e2e-${{ runner.os }}-
 
       - name: Install kind
         run: |
@@ -162,6 +178,18 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
+          cache: false  # We manage the module/build cache explicitly below.
+
+      # See Core E2E for rationale.
+      - name: Cache Go modules and build cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: go-e2e-${{ runner.os }}-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            go-e2e-${{ runner.os }}-
 
       - name: Install kind
         run: |


### PR DESCRIPTION
## Summary

`setup-go@v6`'s built-in cache only reliably restores the Go toolchain (~28 MB), **not** the module download cache (`~/go/pkg/mod`) or the compiler build cache (`~/.cache/go-build`). I confirmed this by inspecting the latest main run's cache logs — both Core E2E and Arena E2E re-download every module from scratch even with `cache: true` set.

Add an explicit `actions/cache@v4` step after `setup-go` in both jobs, keyed on the hash of `go.sum`. Fall back to the most-recent cache via `restore-keys` when the exact hash misses.

## Expected savings

From the last Arena E2E run on PR #737 (native build already landed):
- Native Go build: 8m 9s — **dominated by `go: downloading` lines for the first 5-6 minutes**
- Thin image packaging: 7s (nothing to speed up here)
- Kind image load: 9s
- Helm: 44s

Expected with module cache:
- Native Go build: **~2-3 min** (modules pre-populated, only shared-package compile needed)
- End-to-end Arena E2E: **~7-9 min** (from 13m 47s)
- Core E2E: similar ~3-5 min savings

## Follow-up to

- #732 (native build) — that PR removed 8 independent multi-stage docker builds. This PR removes the remaining cold-start cost of module downloads.

## Test plan

- [ ] Cache miss on first run (expected — no cache yet)
- [ ] Cache hit on second run — verify "Cache restored from key: go-e2e-..." in the log
- [ ] Arena E2E build step drops from ~8 min to ~2-3 min
- [ ] Core E2E total drops noticeably