### PR TITLE
fix(eval-worker): resolve session-api URL via Workspace CRD (#742)

### DIFF
--- a/charts/omnia/templates/eval-worker/deployment.yaml
+++ b/charts/omnia/templates/eval-worker/deployment.yaml
@@ -42,6 +42,21 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             {{- end }}
+            # OMNIA_NAMESPACE tells the service-discovery resolver which
+            # Workspace CRD to read session-api/memory-api URLs from. In a
+            # multi-tenant deployment, set workspaceNamespace to the namespace
+            # of the workspace this eval-worker serves. Defaults to the
+            # eval-worker's own pod namespace, which only works if there is a
+            # Workspace CRD matching that namespace. See #742.
+            {{- if .Values.enterprise.evalWorker.workspaceNamespace }}
+            - name: OMNIA_NAMESPACE
+              value: {{ .Values.enterprise.evalWorker.workspaceNamespace | quote }}
+            {{- else }}
+            - name: OMNIA_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             - name: METRICS_ADDR
               value: ":9090"
             {{- if .Values.redis.enabled }}

--- a/charts/omnia/templates/eval-worker/rbac.yaml
+++ b/charts/omnia/templates/eval-worker/rbac.yaml
@@ -12,6 +12,13 @@ rules:
   - apiGroups: ["omnia.altairalabs.ai"]
     resources: ["agentruntimes", "providers"]
     verbs: ["get", "list"]
+  # Workspaces are cluster-scoped and the resolver lists them to find the
+  # one that matches the eval-worker's OMNIA_NAMESPACE, in order to read
+  # the per-workspace session-api URL from .status.services. Post-#717 the
+  # operator no longer injects SESSION_API_URL as an env var (#742).
+  - apiGroups: ["omnia.altairalabs.ai"]
+    resources: ["workspaces"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -167,6 +167,15 @@ enterprise:
     # If set, watches all listed namespaces (multi-namespace mode) and uses
     # ClusterRole RBAC instead of namespace-scoped Role.
     namespaces: []
+    # -- Namespace of the Workspace CRD whose session-api this eval-worker
+    # should target. Post-#717, the eval-worker discovers its session-api
+    # URL from Workspace.status.services rather than an injected env var,
+    # and it needs to know which Workspace to look up. Defaults to the
+    # eval-worker's own pod namespace, which only works when the eval-worker
+    # is deployed inside a workspace namespace. In multi-tenant clusters
+    # where the eval-worker lives in a control-plane namespace, set this
+    # to the target workspace's namespace. See #742.
+    workspaceNamespace: ""
     # -- Extra environment variables for eval worker (e.g., provider API keys for LLM judges)
     extraEnv: []
     # - name: OPENAI_API_KEY

--- a/ee/cmd/arena-eval-worker/main.go
+++ b/ee/cmd/arena-eval-worker/main.go
@@ -34,6 +34,7 @@ import (
 	redisprovider "github.com/altairalabs/omnia/internal/session/providers/redis"
 	"github.com/altairalabs/omnia/internal/tracing"
 	"github.com/altairalabs/omnia/pkg/k8s"
+	"github.com/altairalabs/omnia/pkg/servicediscovery"
 
 	// Register PromptKit provider factories for LLM judge eval execution.
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/claude"
@@ -48,10 +49,12 @@ const (
 	envNamespace    = "NAMESPACE"
 	envNamespaces   = "NAMESPACES"
 	envSessionAPI   = "SESSION_API_URL"
+	envServiceGroup = "OMNIA_SERVICE_GROUP"
 	envLogLevel     = "LOG_LEVEL"
 	envMetricsAddr  = "METRICS_ADDR"
 	defaultLogLevel = "info"
 	defaultMetrics  = ":9090"
+	defaultSvcGroup = "default"
 )
 
 func main() {
@@ -88,12 +91,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set up K8s client for PromptPack ConfigMap reads.
+	// Set up K8s client for PromptPack ConfigMap reads and Workspace CRD
+	// lookups (see resolveSessionAPIURL).
 	k8sClient, err := k8s.NewClient()
 	if err != nil {
 		logger.Error("failed to create k8s client", "error", err)
 		os.Exit(1)
 	}
+
+	// Resolve the session-api URL. Prefers SESSION_API_URL for back-compat,
+	// otherwise looks up Workspace.status.services via the resolver.
+	resolver := servicediscovery.NewResolver(k8sClient)
+	sessionAPIURL, err := resolveSessionAPIURL(context.Background(), resolver, cfg.SessionAPIURL)
+	if err != nil {
+		logger.Error("failed to resolve session-api URL", "error", err)
+		os.Exit(1)
+	}
+	cfg.SessionAPIURL = sessionAPIURL
 
 	packLoader := evals.NewPromptPackLoader(k8sClient)
 
@@ -190,7 +204,10 @@ type workerEnvConfig struct {
 	MetricsAddr   string
 }
 
-// loadConfig reads and validates environment variables.
+// loadConfig reads and validates environment variables. It does NOT resolve
+// SessionAPIURL — that happens in resolveSessionAPIURL after the Kubernetes
+// client is available, because post-#717 the URL comes from the Workspace CRD
+// rather than a static env var injected by the operator.
 func loadConfig() (*workerEnvConfig, error) {
 	cfg := &workerEnvConfig{
 		RedisAddr:     os.Getenv(envRedisAddr),
@@ -207,9 +224,6 @@ func loadConfig() (*workerEnvConfig, error) {
 	if len(cfg.Namespaces) == 0 {
 		return nil, fmt.Errorf("%s or %s is required", envNamespaces, envNamespace)
 	}
-	if cfg.SessionAPIURL == "" {
-		return nil, fmt.Errorf("%s is required", envSessionAPI)
-	}
 	if cfg.MetricsAddr == "" {
 		cfg.MetricsAddr = defaultMetrics
 	}
@@ -223,6 +237,36 @@ func loadConfig() (*workerEnvConfig, error) {
 	}
 
 	return cfg, nil
+}
+
+// resolveSessionAPIURL returns the session-api URL, preferring an explicit
+// SESSION_API_URL env var override and falling back to per-workspace service
+// discovery via the Workspace CRD. The resolver needs a Kubernetes client, so
+// this runs after the client is built in main — not inside loadConfig.
+//
+// Post-#717 the operator no longer injects SESSION_API_URL on per-workspace
+// services; the URL lives in Workspace.status.services[*].sessionURL. See
+// pkg/servicediscovery and issue #742.
+func resolveSessionAPIURL(
+	ctx context.Context,
+	resolver *servicediscovery.Resolver,
+	envOverride string,
+) (string, error) {
+	if envOverride != "" {
+		return envOverride, nil
+	}
+	if resolver == nil {
+		return "", fmt.Errorf("%s not set and no Kubernetes client for service discovery", envSessionAPI)
+	}
+	group := os.Getenv(envServiceGroup)
+	if group == "" {
+		group = defaultSvcGroup
+	}
+	urls, err := resolver.ResolveServiceURLs(ctx, group)
+	if err != nil {
+		return "", fmt.Errorf("resolve session-api URL via Workspace CRD (service group %q): %w", group, err)
+	}
+	return urls.SessionURL, nil
 }
 
 // parseNamespaces reads NAMESPACES (comma-separated) with fallback to NAMESPACE.

--- a/ee/cmd/arena-eval-worker/main_test.go
+++ b/ee/cmd/arena-eval-worker/main_test.go
@@ -9,14 +9,20 @@ Functional Source License. See ee/LICENSE for details.
 package main
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	"github.com/altairalabs/omnia/pkg/k8s"
+	"github.com/altairalabs/omnia/pkg/servicediscovery"
 )
 
 func TestNewK8sClient_Success(t *testing.T) {
@@ -45,9 +51,12 @@ func TestLoadConfig_RequiredFields(t *testing.T) {
 			wantErr: "NAMESPACE",
 		},
 		{
-			name:    "missing SESSION_API_URL",
-			env:     map[string]string{"REDIS_ADDR": "localhost:6379", "NAMESPACE": "ns"},
-			wantErr: "SESSION_API_URL",
+			// SESSION_API_URL is now resolved separately after the k8s
+			// client is built (see resolveSessionAPIURL), so loadConfig no
+			// longer enforces its presence. The empty-env case is covered
+			// by TestResolveSessionAPIURL_MissingEverything.
+			name: "no session api url — loadConfig still passes",
+			env:  map[string]string{"REDIS_ADDR": "localhost:6379", "NAMESPACE": "ns"},
 		},
 		{
 			name: "all required present",
@@ -206,4 +215,57 @@ func TestParseNamespaces_NeitherSet(t *testing.T) {
 
 	result := parseNamespaces()
 	assert.Nil(t, result)
+}
+
+// TestResolveSessionAPIURL_EnvOverride verifies that an explicit
+// SESSION_API_URL env var takes precedence over service discovery.
+func TestResolveSessionAPIURL_EnvOverride(t *testing.T) {
+	url, err := resolveSessionAPIURL(context.Background(), nil, "http://explicit:8080")
+	require.NoError(t, err)
+	assert.Equal(t, "http://explicit:8080", url)
+}
+
+// TestResolveSessionAPIURL_MissingEverything verifies we return a clear
+// error when neither the env var nor a resolver is available.
+func TestResolveSessionAPIURL_MissingEverything(t *testing.T) {
+	_, err := resolveSessionAPIURL(context.Background(), nil, "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), envSessionAPI)
+}
+
+// TestResolveSessionAPIURL_FromWorkspaceCRD verifies that the resolver
+// returns a session-api URL from the Workspace CRD's status when no env var
+// override is set. This is the post-#717 path: the operator no longer injects
+// SESSION_API_URL; services read it from Workspace.status.services[*].
+func TestResolveSessionAPIURL_FromWorkspaceCRD(t *testing.T) {
+	// Tell the resolver which namespace this "process" runs in (the
+	// eval-worker pod's workspace namespace in a real deployment).
+	t.Setenv("OMNIA_NAMESPACE", "ws-ns")
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, omniav1alpha1.AddToScheme(scheme))
+
+	ws := &omniav1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: "ws"},
+		Spec: omniav1alpha1.WorkspaceSpec{
+			DisplayName: "ws",
+			Namespace:   omniav1alpha1.NamespaceConfig{Name: "ws-ns"},
+		},
+		Status: omniav1alpha1.WorkspaceStatus{
+			Services: []omniav1alpha1.ServiceGroupStatus{
+				{
+					Name:       "default",
+					Ready:      true,
+					SessionURL: "http://session-ws.ws-ns.svc:8080",
+					MemoryURL:  "http://memory-ws.ws-ns.svc:8080",
+				},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ws).Build()
+	resolver := servicediscovery.NewResolver(c)
+
+	url, err := resolveSessionAPIURL(context.Background(), resolver, "")
+	require.NoError(t, err)
+	assert.Equal(t, "http://session-ws.ws-ns.svc:8080", url)
 }

--- a/scripts/setup-arena-e2e.sh
+++ b/scripts/setup-arena-e2e.sh
@@ -279,6 +279,7 @@ retry 2 15 helm upgrade --install omnia charts/omnia \
     --set enterprise.evalWorker.image.repository=omnia-eval-worker-dev \
     --set enterprise.evalWorker.image.tag=latest \
     --set enterprise.evalWorker.image.pullPolicy=Never \
+    --set enterprise.evalWorker.workspaceNamespace=dev-agents \
     --set enterprise.arena.queue.type=redis \
     --set enterprise.arena.queue.redis.host=omnia-redis-master \
     --set enterprise.arena.queue.redis.port=6379 \


### PR DESCRIPTION
## Summary

The eval-worker crashed on startup in Arena E2E with \`SESSION_API_URL is required\`. Post-#717 the operator no longer injects \`SESSION_API_URL\` as an env var — per-workspace services are expected to discover their session-api and memory-api URLs by reading \`Workspace.status.services\` via \`pkg/servicediscovery\`. The facade was migrated in #717 but the eval-worker was missed.

This blocker sat on main for 3 weeks while Arena E2E was red for other reasons; #738 unmasked it by fixing the earlier-failing ArenaJob progress assertion.

## Changes

1. **\`ee/cmd/arena-eval-worker/main.go\`** — \`loadConfig\` no longer validates \`SESSION_API_URL\`. A new \`resolveSessionAPIURL\` helper prefers the env var for back-compat, falling back to the shared \`pkg/servicediscovery\` resolver.

2. **Helm chart**:
   - \`rbac.yaml\`: add \`workspaces get/list/watch\` to the eval-worker ClusterRole.
   - \`deployment.yaml\` + \`values.yaml\`: new \`enterprise.evalWorker.workspaceNamespace\` value. When set, pins \`OMNIA_NAMESPACE\` so the resolver looks up the right Workspace regardless of where the eval-worker pod lives. Defaults to the pod's own namespace.

3. **\`scripts/setup-arena-e2e.sh\`**: sets \`workspaceNamespace=dev-agents\` to match the Workspace CRD the Arena E2E suite creates.

4. **Tests**: \`TestResolveSessionAPIURL_EnvOverride\`, \`_MissingEverything\`, \`_FromWorkspaceCRD\` cover all three resolution paths. Dropped the obsolete "missing SESSION_API_URL" loadConfig case.

## Test plan

- [x] \`GOWORK=off go test ./ee/cmd/arena-eval-worker/... -count=1\` passes
- [x] \`helm lint --strict charts/omnia\` passes
- [x] \`helm template\` renders \`OMNIA_NAMESPACE: "dev-agents"\` when \`workspaceNamespace\` is set
- [ ] Arena E2E reaches the Eval Worker Pipeline tests without the pod crashing

Fixes #742