### PR TITLE
fix: verify Arena E2E workspace service deployment (#750)

### DIFF
--- a/internal/controller/workspace_services.go
+++ b/internal/controller/workspace_services.go
@@ -68,7 +68,9 @@ func setServicesReadyCondition(conditions *[]metav1.Condition, generation int64,
 
 // reconcileServices ensures that each service group defined in the workspace
 // spec has the correct Deployments, Services, and status entries.
-func (r *WorkspaceReconciler) reconcileServices(ctx context.Context, workspace *omniav1alpha1.Workspace) error {
+func (r *WorkspaceReconciler) reconcileServices(
+	ctx context.Context, workspace *omniav1alpha1.Workspace,
+) error {
 	log := logf.FromContext(ctx)
 	namespace := workspace.Spec.Namespace.Name
 


### PR DESCRIPTION
Empty PR to trigger Arena E2E on top of #749's RBAC fix. If Arena E2E passes, #750 was caused by the missing enterprise RBAC and is already fixed. If it still fails, there's a deeper workspace controller issue to investigate.