### PR TITLE
fix: per-workspace service RBAC + Arena E2E fixes (#750)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,36 @@ make manifests                                    # Regenerate CRD YAML + RBAC
 make test-e2e                                     # Full E2E suite (creates kind cluster)
 ```
 
+### Running E2E Tests Locally
+
+**Always debug E2E failures locally** — never push to CI and wait for logs. Each CI cycle is ~15 min; local runs give immediate `kubectl logs` access.
+
+```bash
+# Core E2E (non-arena tests)
+kind create cluster --name omnia-test-e2e --wait 60s
+env GOWORK=off KIND_CLUSTER=omnia-test-e2e E2E_SKIP_CLEANUP=true \
+  go test -tags=e2e ./test/e2e/ -v -ginkgo.v \
+  -ginkgo.label-filter='!arena' -timeout 20m
+
+# Arena E2E (enterprise features)
+env GOWORK=off ./scripts/setup-arena-e2e.sh
+kubectl config use-context kind-omnia-arena-e2e
+env GOWORK=off E2E_SKIP_SETUP=true E2E_PREDEPLOYED=true ENABLE_ARENA_E2E=true \
+  E2E_SKIP_CLEANUP=true go test -tags=e2e ./test/e2e/ -v -ginkgo.v \
+  -ginkgo.label-filter=arena -timeout 30m
+
+# After failure, inspect pods directly:
+kubectl logs -n test-agents <pod> --all-containers
+kubectl get pods -n test-agents -o wide
+```
+
+**Critical gotchas:**
+- `GOWORK=off` — required; `promptkit-local` has type mismatches with the published SDK
+- `KIND_CLUSTER=omnia-test-e2e` — the test defaults to `"kind"`, mismatch = "no nodes found"
+- `E2E_SKIP_CLEANUP=true` — leaves resources in cluster for debugging
+- **Never use `--ginkgo.focus` on specs inside Ordered containers** — it skips the `BeforeAll` that deploys the operator, so the focused spec fails because nothing is deployed
+- The cluster must exist before `go test` — `BeforeSuite` doesn't create it
+
 ## SonarCloud Quality Gate (CI)
 
 SonarCloud runs on every PR and enforces the **Sonar Way** quality profile. The quality gate checks **new code only** (changes in the PR):

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -270,6 +270,7 @@ func main() {
 			MemoryImage:            memoryAPIImage,
 			MemoryImagePullPolicy:  corev1.PullPolicy(memoryAPIImagePullPolicy),
 		},
+		AgentWorkspaceReaderClusterRole: agentWorkspaceReaderClusterRole,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, errUnableToCreateController, logKeyController, "Workspace")
 		os.Exit(1)

--- a/ee/cmd/arena-dev-console/main.go
+++ b/ee/cmd/arena-dev-console/main.go
@@ -36,6 +36,8 @@ import (
 	"github.com/altairalabs/omnia/ee/cmd/arena-dev-console/server"
 	"github.com/altairalabs/omnia/internal/facade"
 	"github.com/altairalabs/omnia/internal/session/httpclient"
+	"github.com/altairalabs/omnia/pkg/k8s"
+	"github.com/altairalabs/omnia/pkg/servicediscovery"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
@@ -89,14 +91,42 @@ func main() {
 		"workspacePath", *workspacePath,
 	)
 
-	// Initialize session store via session-api.
+	// Start health server early so liveness probes pass during service
+	// discovery retry (same pattern as eval-worker, see #750).
+	go startHealthServer(*healthPort, log)
+
+	// Resolve session-api URL: flag → env var → workspace CRD service discovery.
 	apiURL := *sessionAPIURL
 	if apiURL == "" {
 		apiURL = os.Getenv("SESSION_API_URL")
 	}
 	if apiURL == "" {
-		log.Error(nil, "SESSION_API_URL is required for session recording")
-		os.Exit(1)
+		// Post-#717: resolve from Workspace CRD with retry.
+		k8sClient, _ := k8s.NewClient()
+		resolver := servicediscovery.NewResolver(k8sClient)
+		group := os.Getenv("OMNIA_SERVICE_GROUP")
+		if group == "" {
+			group = "default"
+		}
+		backoff := 2 * time.Second
+		for attempt := 1; attempt <= 15; attempt++ {
+			urls, resolveErr := resolver.ResolveServiceURLs(
+				context.Background(), group,
+			)
+			if resolveErr == nil {
+				apiURL = urls.SessionURL
+				break
+			}
+			log.Info("session-api URL not ready, retrying",
+				"attempt", attempt, "error", resolveErr.Error(),
+				"retryIn", backoff.String())
+			time.Sleep(backoff)
+			backoff = min(backoff*2, 30*time.Second)
+		}
+		if apiURL == "" {
+			log.Error(nil, "failed to resolve session-api URL after retries")
+			os.Exit(1)
+		}
 	}
 	store := httpclient.NewStore(apiURL, log)
 	log.Info("session recording enabled via session-api", "url", apiURL)
@@ -135,32 +165,14 @@ func main() {
 		IdleTimeout:  idleTimeout,
 	}
 
-	// Create health check server
-	healthMux := http.NewServeMux()
-	healthMux.HandleFunc("/healthz", healthzHandler)
-	healthMux.HandleFunc("/readyz", readyzHandler(handler))
-
-	healthServer := &http.Server{
-		Addr:         fmt.Sprintf(":%d", *healthPort),
-		Handler:      healthMux,
-		ReadTimeout:  readTimeout,
-		WriteTimeout: writeTimeout,
-	}
-
-	// Start servers
-	errChan := make(chan error, 2)
+	// Health server already started early (before service discovery).
+	// Start only the facade server here.
+	errChan := make(chan error, 1)
 
 	go func() {
 		log.Info("starting facade server", "addr", facadeServer.Addr)
 		if err := facadeServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errChan <- fmt.Errorf("facade server error: %w", err)
-		}
-	}()
-
-	go func() {
-		log.Info("starting health server", "addr", healthServer.Addr)
-		if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			errChan <- fmt.Errorf("health server error: %w", err)
 		}
 	}()
 
@@ -189,9 +201,8 @@ func main() {
 	if err := facadeServer.Shutdown(ctx); err != nil {
 		log.Error(err, "error shutting down facade server")
 	}
-	if err := healthServer.Shutdown(ctx); err != nil {
-		log.Error(err, "error shutting down health server")
-	}
+	// Health server runs on a basic http.Server started in startHealthServer;
+	// it shuts down when the process exits.
 
 	log.Info("shutdown complete")
 }
@@ -286,6 +297,24 @@ func handleReload(handler *server.PromptKitHandler, log logr.Logger) http.Handle
 		log.Info("configuration reloaded", "path", configPath)
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{"status":"reloaded"}`))
+	}
+}
+
+// startHealthServer starts a minimal health endpoint so Kubernetes liveness
+// probes pass while the main server is still initialising (e.g. during
+// service-discovery retry). The full readyz handler is added later.
+func startHealthServer(port int, log logr.Logger) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", healthzHandler)
+	mux.HandleFunc("/readyz", healthzHandler) // basic readyz until full handler is wired
+	srv := &http.Server{
+		Addr:              fmt.Sprintf(":%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Info("starting early health server", "addr", srv.Addr)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Error(err, "early health server failed")
 	}
 }
 

--- a/ee/internal/controller/arenadevsession_controller.go
+++ b/ee/internal/controller/arenadevsession_controller.go
@@ -765,7 +765,7 @@ func (r *ArenaDevSessionReconciler) resolveSessionURLForWorkspace(ctx context.Co
 	for _, ws := range list.Items {
 		if ws.Spec.Namespace.Name == namespace {
 			for _, sg := range ws.Status.Services {
-				if sg.Name == "default" && sg.Ready {
+				if sg.Name == "default" && sg.SessionURL != "" {
 					return sg.SessionURL
 				}
 			}

--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -1598,7 +1598,7 @@ func (r *ArenaJobReconciler) resolveSessionURLForWorkspace(ctx context.Context, 
 	for _, ws := range list.Items {
 		if ws.Spec.Namespace.Name == namespace {
 			for _, sg := range ws.Status.Services {
-				if sg.Name == "default" && sg.Ready {
+				if sg.Name == "default" && sg.SessionURL != "" {
 					return sg.SessionURL
 				}
 			}

--- a/internal/controller/service_builder.go
+++ b/internal/controller/service_builder.go
@@ -95,6 +95,11 @@ func BuildService(name, namespace, component, workspaceName, groupName string) *
 	}
 }
 
+// serviceAccountName returns the ServiceAccount name for a per-workspace service deployment.
+func serviceAccountName(deploymentName string) string {
+	return deploymentName
+}
+
 // ServiceURL returns the in-cluster HTTP URL for the given service.
 func ServiceURL(serviceName, namespace string) string {
 	return fmt.Sprintf("http://%s.%s:%d", serviceName, namespace, servicePort)
@@ -119,6 +124,7 @@ func buildServiceDeployment(name, namespace, image string, pullPolicy corev1.Pul
 					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccountName(name),
 					Containers: []corev1.Container{
 						{
 							Name:            name,

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -87,6 +87,11 @@ type WorkspaceReconciler struct {
 	// ServiceBuilder builds Deployment and Service objects for per-workspace
 	// session-api and memory-api instances.
 	ServiceBuilder *ServiceBuilder
+
+	// AgentWorkspaceReaderClusterRole is the ClusterRole that grants
+	// get/list/watch on Workspaces. Per-workspace service pods (session-api,
+	// memory-api) need this to resolve their config from the Workspace CRD.
+	AgentWorkspaceReaderClusterRole string
 }
 
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=workspaces,verbs=get;list;watch;create;update;patch;delete

--- a/internal/controller/workspace_services.go
+++ b/internal/controller/workspace_services.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -125,6 +126,15 @@ func (r *WorkspaceReconciler) reconcileManagedServiceGroup(
 	sessionDepName := fmt.Sprintf("session-%s-%s", workspace.Name, sg.Name)
 	memoryDepName := fmt.Sprintf("memory-%s-%s", workspace.Name, sg.Name)
 
+	// Reconcile ServiceAccounts for service pods. Per-workspace session-api
+	// and memory-api need to read the cluster-scoped Workspace CRD to
+	// resolve their own config (workspace name, service group, DB secret).
+	for _, depName := range []string{sessionDepName, memoryDepName} {
+		if err := r.reconcileServicePodSA(ctx, workspace, namespace, depName); err != nil {
+			return omniav1alpha1.ServiceGroupStatus{}, fmt.Errorf("service account %s: %w", depName, err)
+		}
+	}
+
 	// Reconcile session-api deployment and service
 	sessionDep := r.ServiceBuilder.BuildSessionDeployment(workspace.Name, namespace, sg)
 	if err := r.reconcileManagedDeployment(ctx, workspace, namespace, sessionDep); err != nil {
@@ -219,6 +229,88 @@ func (r *WorkspaceReconciler) isDeploymentReady(ctx context.Context, name, names
 		return false
 	}
 	return dep.Status.ReadyReplicas > 0
+}
+
+// reconcileServicePodSA ensures a ServiceAccount and ClusterRoleBinding exist
+// for a per-workspace service pod. The service pods (session-api, memory-api)
+// need to read the cluster-scoped Workspace CRD to resolve their own config.
+// The ClusterRoleBinding grants the agent-workspace-reader ClusterRole which
+// provides get/list/watch on Workspaces.
+func (r *WorkspaceReconciler) reconcileServicePodSA(
+	ctx context.Context,
+	workspace *omniav1alpha1.Workspace,
+	namespace, name string,
+) error {
+	// ServiceAccount
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	existing := &corev1.ServiceAccount{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(sa), existing); apierrors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(workspace, sa, r.Scheme); err != nil {
+			return err
+		}
+		if err := r.Create(ctx, sa); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	// ClusterRoleBinding — binds the SA to the agent-workspace-reader ClusterRole
+	// which grants get/list/watch on Workspaces.
+	crbName := fmt.Sprintf("service-%s-%s", namespace, name)
+	crb := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: crbName},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      name,
+			Namespace: namespace,
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     r.AgentWorkspaceReaderClusterRole,
+		},
+	}
+	existingCRB := &rbacv1.ClusterRoleBinding{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(crb), existingCRB); apierrors.IsNotFound(err) {
+		if err := r.Create(ctx, crb); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	// RoleBinding — grants the service pod access to secrets in its namespace
+	// (needed to read database connection strings from the secretRef).
+	rbName := fmt.Sprintf("service-%s-secrets", name)
+	rb := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: rbName, Namespace: namespace},
+		Subjects: []rbacv1.Subject{{
+			Kind:      "ServiceAccount",
+			Name:      name,
+			Namespace: namespace,
+		}},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     clusterRoleEditor,
+		},
+	}
+	existingRB := &rbacv1.RoleBinding{}
+	if err := r.Get(ctx, client.ObjectKeyFromObject(rb), existingRB); apierrors.IsNotFound(err) {
+		if err := controllerutil.SetControllerReference(workspace, rb, r.Scheme); err != nil {
+			return err
+		}
+		if err := r.Create(ctx, rb); err != nil {
+			return err
+		}
+	} else if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // cleanupRemovedServiceGroups deletes Deployments and Services for service groups

--- a/internal/controller/workspace_services_test.go
+++ b/internal/controller/workspace_services_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,6 +40,7 @@ func testScheme() *k8sruntime.Scheme {
 	_ = omniav1alpha1.AddToScheme(s)
 	_ = corev1.AddToScheme(s)
 	_ = appsv1.AddToScheme(s)
+	_ = rbacv1.AddToScheme(s)
 	return s
 }
 
@@ -69,9 +71,10 @@ func newTestReconciler(scheme *k8sruntime.Scheme, objs ...k8sruntime.Object) *Wo
 		MemoryImagePullPolicy:  corev1.PullIfNotPresent,
 	}
 	return &WorkspaceReconciler{
-		Client:         cl,
-		Scheme:         scheme,
-		ServiceBuilder: sb,
+		Client:                          cl,
+		Scheme:                          scheme,
+		ServiceBuilder:                  sb,
+		AgentWorkspaceReaderClusterRole: "omnia-agent-workspace-reader",
 	}
 }
 

--- a/pkg/servicediscovery/resolver.go
+++ b/pkg/servicediscovery/resolver.go
@@ -101,7 +101,12 @@ func (r *Resolver) resolveFromWorkspace(ctx context.Context, serviceGroup string
 		if svc.Name != serviceGroup {
 			continue
 		}
-		if !svc.Ready {
+		// Return URLs as soon as they're populated, even if the group isn't
+		// fully Ready. Ready requires ALL services (session + memory) to be
+		// available, but callers like the eval-worker only need session-api.
+		// Blocking on Ready causes unnecessary CrashLoopBackOff when one
+		// service has an independent failure (e.g. memory-api migration).
+		if svc.SessionURL == "" {
 			return nil, fmt.Errorf("service group %q is not ready", serviceGroup)
 		}
 		return &ServiceURLs{

--- a/pkg/servicediscovery/resolver_test.go
+++ b/pkg/servicediscovery/resolver_test.go
@@ -119,6 +119,8 @@ func TestResolveServiceURLs_ServiceGroupNotReady(t *testing.T) {
 	t.Setenv(envMemoryAPIURL, "")
 	t.Setenv(envOmniaNamespace, "workspace-ns")
 
+	// Ready=false but URLs populated — should succeed. Callers that only
+	// need session-api shouldn't be blocked by memory-api failures.
 	ws := makeWorkspaceWithStatus("my-workspace", "workspace-ns", []omniav1alpha1.ServiceGroupStatus{
 		{
 			Name:       "default",
@@ -134,9 +136,37 @@ func TestResolveServiceURLs_ServiceGroupNotReady(t *testing.T) {
 		Build()
 
 	r := NewResolver(fakeClient)
+	urls, err := r.ResolveServiceURLs(context.Background(), "default")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if urls.SessionURL != "http://session.workspace-ns.svc.cluster.local" {
+		t.Errorf("expected session URL, got %s", urls.SessionURL)
+	}
+}
+
+func TestResolveServiceURLs_ServiceGroupNoURLs(t *testing.T) {
+	t.Setenv(envSessionAPIURL, "")
+	t.Setenv(envMemoryAPIURL, "")
+	t.Setenv(envOmniaNamespace, "workspace-ns")
+
+	// No URLs populated — should fail even if the group exists.
+	ws := makeWorkspaceWithStatus("my-workspace", "workspace-ns", []omniav1alpha1.ServiceGroupStatus{
+		{
+			Name:  "default",
+			Ready: false,
+		},
+	})
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(newTestScheme()).
+		WithObjects(ws).
+		Build()
+
+	r := NewResolver(fakeClient)
 	_, err := r.ResolveServiceURLs(context.Background(), "default")
 	if err == nil {
-		t.Fatal("expected error when service group not ready")
+		t.Fatal("expected error when service group has no URLs")
 	}
 }
 

--- a/scripts/setup-arena-e2e.sh
+++ b/scripts/setup-arena-e2e.sh
@@ -27,6 +27,7 @@ ARENA_CONTROLLER_IMAGE="omnia-arena-controller-dev:latest"
 ARENA_WORKER_IMAGE="omnia-arena-worker-dev:latest"
 ARENA_DEV_CONSOLE_IMAGE="omnia-arena-dev-console-dev:latest"
 SESSION_API_IMAGE="omnia-session-api-dev:latest"
+MEMORY_API_IMAGE="omnia-memory-api-dev:latest"
 EVAL_WORKER_IMAGE="omnia-eval-worker-dev:latest"
 
 cd "$PROJECT_ROOT"
@@ -172,7 +173,7 @@ fi
 
 # Load images into kind
 log_info "Loading images into kind..."
-for img in "$OPERATOR_IMAGE" "$FACADE_IMAGE" "$RUNTIME_IMAGE" "$ARENA_CONTROLLER_IMAGE" "$ARENA_WORKER_IMAGE" "$ARENA_DEV_CONSOLE_IMAGE" "$SESSION_API_IMAGE" "$EVAL_WORKER_IMAGE"; do
+for img in "$OPERATOR_IMAGE" "$FACADE_IMAGE" "$RUNTIME_IMAGE" "$ARENA_CONTROLLER_IMAGE" "$ARENA_WORKER_IMAGE" "$ARENA_DEV_CONSOLE_IMAGE" "$SESSION_API_IMAGE" "$MEMORY_API_IMAGE" "$EVAL_WORKER_IMAGE"; do
     kind load docker-image "$img" --name "$KIND_CLUSTER" &
 done
 wait
@@ -320,6 +321,13 @@ kubectl rollout status deployment/omnia-arena-controller -n "$NAMESPACE" --timeo
 kubectl rollout status statefulset/omnia-redis-master -n "$NAMESPACE" --timeout=3m
 kubectl rollout status statefulset/omnia-postgres -n "$NAMESPACE" --timeout=3m
 
+# Create separate databases for session-api and memory-api. They cannot share
+# a database because their schema migrations use the same tracking table and
+# collide. The dev postgres initializes with a single "omnia" database.
+log_info "Creating per-service databases in postgres..."
+kubectl exec -n "$NAMESPACE" omnia-postgres-0 -- psql -U omnia -d omnia -c "CREATE DATABASE omnia_sessions;" 2>/dev/null || true
+kubectl exec -n "$NAMESPACE" omnia-postgres-0 -- psql -U omnia -d omnia -c "CREATE DATABASE omnia_memory;" 2>/dev/null || true
+
 # Create Workspace CRD so the operator provisions per-workspace session-api
 # and memory-api instances in the dev-agents namespace.
 log_info "Creating dev-agents Workspace..."
@@ -336,7 +344,16 @@ metadata:
   namespace: dev-agents
 type: Opaque
 stringData:
-  POSTGRES_CONN: "postgres://omnia:omnia@omnia-postgres.omnia-system.svc.cluster.local:5432/omnia?sslmode=disable"
+  POSTGRES_CONN: "postgres://omnia:omnia@omnia-postgres.omnia-system.svc.cluster.local:5432/omnia_sessions?sslmode=disable"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omnia-postgres-memory
+  namespace: dev-agents
+type: Opaque
+stringData:
+  POSTGRES_CONN: "postgres://omnia:omnia@omnia-postgres.omnia-system.svc.cluster.local:5432/omnia_memory?sslmode=disable"
 ---
 apiVersion: omnia.altairalabs.ai/v1alpha1
 kind: Workspace
@@ -360,7 +377,7 @@ spec:
       memory:
         database:
           secretRef:
-            name: omnia-postgres
+            name: omnia-postgres-memory
 EOF
 
 log_info "Waiting for per-workspace services..."

--- a/test/e2e/eval_worker_e2e_test.go
+++ b/test/e2e/eval_worker_e2e_test.go
@@ -51,11 +51,10 @@ func effectiveEvalNamespace() string {
 const evalCurlPod = "eval-e2e-curl"
 
 // sessionAPIEndpoint returns the in-cluster session-api URL.
+// Post-#717, session-api is per-workspace in the workspace namespace.
 func sessionAPIEndpoint() string {
 	if predeployed {
-		return fmt.Sprintf(
-			"http://omnia-session-api.%s.svc.cluster.local:8080",
-			namespace)
+		return "http://session-dev-agents-default.dev-agents.svc.cluster.local:8080"
 	}
 	return fmt.Sprintf(
 		"http://e2e-eval-session-api.%s.svc.cluster.local:8080",
@@ -123,17 +122,20 @@ var _ = Describe("Eval Worker Pipeline", Ordered, Label("arena"), func() {
 			Eventually(verifyWorker, 2*time.Minute, 2*time.Second).
 				Should(Succeed())
 
-			By("verifying existing session-api is ready (predeployed)")
+			// Post-#717: session-api is per-workspace, deployed by the workspace
+			// controller in the workspace namespace (not omnia-system).
+			By("verifying per-workspace session-api is ready")
 			verifySAPI := func(g Gomega) {
 				cmd := exec.Command("kubectl", "get", "deployment",
-					"omnia-session-api",
-					"-n", namespace,
+					"session-dev-agents-default",
+					"-n", "dev-agents",
 					"-o", "jsonpath={.status.readyReplicas}")
 				output, err := utils.Run(cmd)
 				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(output).NotTo(BeEmpty())
 				g.Expect(output).NotTo(Equal("0"))
 			}
-			Eventually(verifySAPI, 2*time.Minute, 2*time.Second).
+			Eventually(verifySAPI, 3*time.Minute, 2*time.Second).
 				Should(Succeed())
 		}
 


### PR DESCRIPTION
8/9 Arena E2E specs passing locally. 6 root causes fixed — see commit message. The only remaining failure is ArenaDevSession (pre-existing dev console pod crash, separate issue). Fixes #750