### PR TITLE
fix(dashboard): stop polling completed sessions indefinitely (#723)

### DIFF
--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -327,11 +327,12 @@ export default function SessionDetailPage({
   const defaultTab = searchParams.get("tab") ?? "conversation";
   const [memorySidebarOpen, setMemorySidebarOpen] = useState(false);
   const { data: session, isLoading, error } = useSessionDetail(id);
-  const { data: evalResults } = useSessionEvalResults(id);
-  const { data: rawToolCalls } = useSessionToolCalls(id);
+  const sessionReady = !!session;
+  const { data: evalResults } = useSessionEvalResults(id, sessionReady);
+  const { data: rawToolCalls } = useSessionToolCalls(id, sessionReady);
   const toolCalls = rawToolCalls ? collapseToolCalls(rawToolCalls) : undefined;
-  const { data: providerCalls } = useSessionProviderCalls(id);
-  const { data: runtimeEvents } = useSessionRuntimeEvents(id);
+  const { data: providerCalls } = useSessionProviderCalls(id, sessionReady);
+  const { data: runtimeEvents } = useSessionRuntimeEvents(id, sessionReady);
   const grafana = useGrafana();
   const sessionDashboardUrl = grafana.enabled && session
     ? buildSessionDashboardUrl(grafana, id, session.agentName, session.agentNamespace)
@@ -950,7 +951,7 @@ function ConversationWithDebugPanel({
     hasMore,
     isFetchingMore,
     fetchMore,
-  } = useSessionAllMessages(session.id);
+  } = useSessionAllMessages(session.id, session.status);
 
   // Use paginated messages once loaded, otherwise fall back to session.messages
   const messages = paginatedMessages.length > 0 ? paginatedMessages : session.messages;

--- a/dashboard/src/hooks/sessions.ts
+++ b/dashboard/src/hooks/sessions.ts
@@ -1,4 +1,4 @@
-export { useSessions, useSessionDetail, useSessionSearch, useSessionMessages, useSessionAllMessages, useSessionToolCalls, useSessionProviderCalls, useSessionRuntimeEvents, useSessionEvalResults } from "./use-sessions";
+export { useSessions, useSessionDetail, useSessionSearch, useSessionAllMessages, useSessionToolCalls, useSessionProviderCalls, useSessionRuntimeEvents, useSessionEvalResults } from "./use-sessions";
 export { useEvalSummary } from "./use-eval-quality";
 export type { EvalScoreSummary } from "./use-eval-quality";
 export { useEvalScoreTrends, useEvalMetrics, EVAL_TREND_RANGES } from "./use-eval-trends";

--- a/dashboard/src/hooks/use-sessions.test.ts
+++ b/dashboard/src/hooks/use-sessions.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/data/session-api-service", () => ({
 }));
 
 // Import after mocks
-import { useSessions, useSessionDetail, useSessionSearch, useSessionMessages, useSessionAllMessages, useSessionToolCalls, useSessionProviderCalls, useSessionEvalResults } from "./use-sessions";
+import { useSessions, useSessionDetail, useSessionSearch, useSessionAllMessages, useSessionToolCalls, useSessionProviderCalls, useSessionEvalResults } from "./use-sessions";
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -140,34 +140,6 @@ describe("useSessionSearch", () => {
   });
 });
 
-describe("useSessionMessages", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockGetSessionMessages.mockResolvedValue({
-      messages: [{ id: "m1", role: "user", content: "hello", timestamp: new Date().toISOString() }],
-      hasMore: false,
-    });
-  });
-
-  it("fetches messages for a session", async () => {
-    const { result } = renderHook(() => useSessionMessages("s1"), { wrapper: createWrapper() });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(mockGetSessionMessages).toHaveBeenCalledWith("test-workspace", "s1", {});
-    expect(result.current.data?.messages).toHaveLength(1);
-  });
-
-  it("passes pagination options", async () => {
-    const opts = { limit: 10, after: 5 };
-    const { result } = renderHook(() => useSessionMessages("s1", opts), { wrapper: createWrapper() });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(mockGetSessionMessages).toHaveBeenCalledWith("test-workspace", "s1", opts);
-  });
-});
-
 describe("useSessionAllMessages", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -199,7 +171,7 @@ describe("useSessionAllMessages", () => {
   });
 
   it("is disabled when enabled=false", () => {
-    const { result } = renderHook(() => useSessionAllMessages("s1", false), { wrapper: createWrapper() });
+    const { result } = renderHook(() => useSessionAllMessages("s1", undefined, false), { wrapper: createWrapper() });
     expect(result.current.isLoading).toBe(false);
     expect(result.current.messages).toHaveLength(0);
   });

--- a/dashboard/src/hooks/use-sessions.ts
+++ b/dashboard/src/hooks/use-sessions.ts
@@ -99,28 +99,6 @@ export function useSessionSearch(options: SessionSearchOptions) {
   });
 }
 
-/**
- * Fetch paginated messages for a session.
- */
-export function useSessionMessages(sessionId: string, options: SessionMessageOptions = {}) {
-  const service = useDataService();
-  const { currentWorkspace } = useWorkspace();
-
-  const { limit, before, after } = options;
-
-  return useQuery({
-    queryKey: ["session-messages", currentWorkspace?.name, sessionId, limit, before, after, service.name],
-    queryFn: async () => {
-      if (!currentWorkspace) {
-        return { messages: [], hasMore: false };
-      }
-      return service.getSessionMessages(currentWorkspace.name, sessionId, options);
-    },
-    enabled: !!currentWorkspace && !!sessionId,
-    staleTime: 5000,
-  });
-}
-
 /** Page size for infinite message loading. */
 const MESSAGE_PAGE_SIZE = 100;
 
@@ -128,8 +106,15 @@ const MESSAGE_PAGE_SIZE = 100;
  * Fetch all session messages using cursor-based infinite loading.
  * Pages are fetched via the /messages endpoint using `after` sequence cursors.
  * Returns a flat deduplicated message array and load-more controls.
+ *
+ * Only polls for new messages when sessionStatus is "active". Completed
+ * sessions are fetched once and never re-polled. See #723.
  */
-export function useSessionAllMessages(sessionId: string, enabled = true) {
+export function useSessionAllMessages(
+  sessionId: string,
+  sessionStatus?: string,
+  enabled = true,
+) {
   const service = useDataService();
   const { currentWorkspace } = useWorkspace();
 
@@ -153,14 +138,9 @@ export function useSessionAllMessages(sessionId: string, enabled = true) {
     },
     enabled: !!currentWorkspace && !!sessionId && enabled,
     staleTime: 5000,
-    refetchInterval: (query) => {
-      // Only auto-refetch if we haven't loaded all pages yet
-      // (active sessions keep getting new messages)
-      const pages = query.state.data?.pages;
-      if (pages && pages.length > 0) {
-        const lastPage = pages[pages.length - 1];
-        if (lastPage.hasMore) return false; // don't refetch partial loads
-      }
+    refetchInterval: () => {
+      // Only poll active sessions. Completed sessions are fetched once.
+      if (sessionStatus !== "active") return false;
       return 5000;
     },
   });
@@ -198,7 +178,7 @@ export function useSessionAllMessages(sessionId: string, enabled = true) {
 /**
  * Fetch tool calls for a session from the first-class tool_calls table.
  */
-export function useSessionToolCalls(sessionId: string) {
+export function useSessionToolCalls(sessionId: string, enabled = true) {
   const { currentWorkspace } = useWorkspace();
 
   return useQuery({
@@ -208,7 +188,7 @@ export function useSessionToolCalls(sessionId: string) {
       const service = new SessionApiService();
       return service.getToolCalls(currentWorkspace.name, sessionId);
     },
-    enabled: !!currentWorkspace && !!sessionId,
+    enabled: !!currentWorkspace && !!sessionId && enabled,
     staleTime: 10000,
   });
 }
@@ -216,7 +196,7 @@ export function useSessionToolCalls(sessionId: string) {
 /**
  * Fetch provider calls for a session from the first-class provider_calls table.
  */
-export function useSessionProviderCalls(sessionId: string) {
+export function useSessionProviderCalls(sessionId: string, enabled = true) {
   const { currentWorkspace } = useWorkspace();
 
   return useQuery({
@@ -226,7 +206,7 @@ export function useSessionProviderCalls(sessionId: string) {
       const service = new SessionApiService();
       return service.getProviderCalls(currentWorkspace.name, sessionId);
     },
-    enabled: !!currentWorkspace && !!sessionId,
+    enabled: !!currentWorkspace && !!sessionId && enabled,
     staleTime: 10000,
   });
 }
@@ -234,7 +214,7 @@ export function useSessionProviderCalls(sessionId: string) {
 /**
  * Fetch runtime events for a session from the first-class runtime_events table.
  */
-export function useSessionRuntimeEvents(sessionId: string) {
+export function useSessionRuntimeEvents(sessionId: string, enabled = true) {
   const { currentWorkspace } = useWorkspace();
 
   return useQuery({
@@ -244,7 +224,7 @@ export function useSessionRuntimeEvents(sessionId: string) {
       const service = new SessionApiService();
       return service.getEvents(currentWorkspace.name, sessionId);
     },
-    enabled: !!currentWorkspace && !!sessionId,
+    enabled: !!currentWorkspace && !!sessionId && enabled,
     staleTime: 10000,
   });
 }
@@ -254,7 +234,7 @@ export function useSessionRuntimeEvents(sessionId: string) {
  * Uses SessionApiService directly since eval results are not part of the
  * DataService interface (they are session-api specific).
  */
-export function useSessionEvalResults(sessionId: string) {
+export function useSessionEvalResults(sessionId: string, enabled = true) {
   const { currentWorkspace } = useWorkspace();
 
   return useQuery({
@@ -266,7 +246,7 @@ export function useSessionEvalResults(sessionId: string) {
       const service = new SessionApiService();
       return service.getSessionEvalResults(currentWorkspace.name, sessionId);
     },
-    enabled: !!currentWorkspace && !!sessionId,
+    enabled: !!currentWorkspace && !!sessionId && enabled,
     staleTime: 10000,
   });
 }


### PR DESCRIPTION
## Summary

`useSessionAllMessages` polled every 5s forever regardless of session status. For every open session detail tab, the dashboard made HTTP requests to session-api indefinitely — even for sessions that completed hours ago.

## Root cause

The `refetchInterval` callback only gated on pagination state (`hasMore`) and never checked whether the session was active:

```typescript
// Before: polls forever once all pages are loaded
refetchInterval: (query) => {
  if (lastPage.hasMore) return false; // only stops during pagination
  return 5000; // polls forever after
}
```

Compare with `useSessionDetail` which was already correct:
```typescript
refetchInterval: (query) => {
  if (data?.status === "active") return 5000;
  return false; // stops when completed
}
```

## Fix

- `useSessionAllMessages` takes `sessionStatus` param; only polls when `"active"`
- Removed unused `useSessionMessages` hook (never imported outside tests)
- Added `enabled` param to detail hooks (`useSessionToolCalls`, `useSessionProviderCalls`, `useSessionRuntimeEvents`, `useSessionEvalResults`) — queries don't fire until session detail has loaded
- Updated barrel export and all test call sites

## Test plan

- [x] `npx vitest run src/hooks/use-sessions.test.ts` — 17 passed
- [x] `npx vitest run src/app/sessions` — 41 passed  
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (4 pre-existing warnings)
- [x] Per-file coverage ≥ 80%

Fixes #723