### PR TITLE
fix(dashboard): avoid passing multi-param function directly to .map()

### DIFF
--- a/dashboard/src/components/memories/memory-graph.tsx
+++ b/dashboard/src/components/memories/memory-graph.tsx
@@ -96,7 +96,7 @@ export function MemoryGraph({ memories, onNodeClick }: MemoryGraphProps) {
     let cancelled = false;
     layoutingRef.current = true;
 
-    layoutNodes(memories.map(memoryToNode)).then((positioned) => {
+    layoutNodes(memories.map((m, i) => memoryToNode(m, i))).then((positioned) => {
       if (!cancelled) {
         setNodes(positioned);
         setIsLayouting(false);


### PR DESCRIPTION
## Summary

- Fixes SonarCloud bug S7727 on main — `memoryToNode` was passed directly to `.map()`, which passes `(element, index, array)` to it. While the third arg is harmless here (no third param), SonarCloud flags this as error-prone.
- Wraps in an explicit arrow function: `memories.map((m, i) => memoryToNode(m, i))`

## Test plan

- [x] `npm run typecheck` passes
- [x] Pre-commit ESLint, coverage (87.2% on changed file) all pass
- [ ] SonarCloud analysis (CI)