### PR TITLE
feat: rollout support Phase 5 — cohort tracking propagation

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -8,6 +8,14 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ---
 
+## 2026-04-07
+- **Session API**: Added `cohortId` and `variant` fields to `CreateSessionRequest` and `Session` schemas
+  - Supports rollout cohort tracking: Istio routes set `x-omnia-cohort-id` and `x-omnia-variant` headers,
+    which the facade extracts and persists to the session for per-variant analysis.
+  - New Postgres columns `cohort_id` and `variant` with partial indexes (migration 000025).
+  - New OTel span attributes `omnia.cohort.id` and `omnia.variant` on `omnia.facade.message` spans.
+  - Non-breaking: both fields are optional with `omitempty`.
+
 ## 2026-03-28
 - **ArenaJob CRD** (Enterprise): Added `spec.sessionRecording` boolean (default: false)
   - **Breaking**: Session recording was previously always enabled when `SESSION_API_URL` was configured on the controller. Now requires explicit `sessionRecording: true` on the ArenaJob spec. Existing ArenaJobs without this field will stop recording sessions after upgrade.

--- a/api/session-api/openapi.yaml
+++ b/api/session-api/openapi.yaml
@@ -707,6 +707,12 @@ components:
           type: string
         promptPackVersion:
           type: string
+        cohortId:
+          type: string
+          description: Rollout cohort identifier
+        variant:
+          type: string
+          description: Rollout variant (e.g., stable, canary)
 
     Message:
       type: object
@@ -934,6 +940,12 @@ components:
           additionalProperties:
             type: string
           description: Optional initial key-value state for the session
+        cohortId:
+          type: string
+          description: Rollout cohort identifier
+        variant:
+          type: string
+          description: Rollout variant (e.g., stable, canary)
 
     RefreshTTLRequest:
       type: object

--- a/internal/facade/connection.go
+++ b/internal/facade/connection.go
@@ -48,6 +48,10 @@ type Connection struct {
 	userEmail     string
 	authorization string // Original JWT token for passthrough
 
+	// Rollout cohort tracking fields extracted from HTTP headers on WebSocket upgrade.
+	cohortID string
+	variant  string
+
 	// rateLimiter enforces per-connection message rate limiting. Nil when disabled.
 	rateLimiter *rate.Limiter
 }

--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -369,6 +369,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	userRoles := r.Header.Get(policy.IstioHeaderUserRoles)
 	userEmail := r.Header.Get(policy.IstioHeaderUserEmail)
 	authorization := r.Header.Get("Authorization")
+	cohortID := r.Header.Get(policy.HeaderCohortID)
+	variant := r.Header.Get(policy.HeaderVariant)
 
 	conn, err := s.upgrader.Upgrade(w, r, nil)
 	if err != nil {
@@ -387,6 +389,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		userRoles:     userRoles,
 		userEmail:     userEmail,
 		authorization: authorization,
+		cohortID:      cohortID,
+		variant:       variant,
 	}
 	if s.config.MessageRateLimit > 0 {
 		c.rateLimiter = rate.NewLimiter(rate.Limit(s.config.MessageRateLimit), s.config.MessageRateBurst)

--- a/internal/facade/session.go
+++ b/internal/facade/session.go
@@ -143,16 +143,24 @@ func (s *Server) startMessageSpan(ctx context.Context, c *Connection, sessionID 
 	})
 	ctx = trace.ContextWithRemoteSpanContext(ctx, remoteCtx)
 
+	spanAttrs := []attribute.KeyValue{
+		attribute.String("session.id", sessionID),
+		attribute.String(otlp.AttrOmniaAgentName, c.agentName),
+		attribute.String(otlp.AttrOmniaAgentNamespace, c.namespace),
+		attribute.String(otlp.AttrOmniaPromptPackName, s.config.PromptPackName),
+		attribute.String(otlp.AttrOmniaPromptPackVersion, s.config.PromptPackVersion),
+		attribute.String(otlp.AttrOmniaPromptPackNamespace, c.namespace),
+	}
+	if c.cohortID != "" {
+		spanAttrs = append(spanAttrs, attribute.String(otlp.AttrOmniaCohortID, c.cohortID))
+	}
+	if c.variant != "" {
+		spanAttrs = append(spanAttrs, attribute.String(otlp.AttrOmniaVariant, c.variant))
+	}
+
 	opts = append(opts,
 		trace.WithSpanKind(trace.SpanKindServer),
-		trace.WithAttributes(
-			attribute.String("session.id", sessionID),
-			attribute.String(otlp.AttrOmniaAgentName, c.agentName),
-			attribute.String(otlp.AttrOmniaAgentNamespace, c.namespace),
-			attribute.String(otlp.AttrOmniaPromptPackName, s.config.PromptPackName),
-			attribute.String(otlp.AttrOmniaPromptPackVersion, s.config.PromptPackVersion),
-			attribute.String(otlp.AttrOmniaPromptPackNamespace, c.namespace),
-		),
+		trace.WithAttributes(spanAttrs...),
 	)
 
 	return s.tracingProvider.Tracer().Start(ctx, "omnia.facade.message", opts...)
@@ -234,6 +242,8 @@ func (s *Server) ensureSession(ctx context.Context, c *Connection, sessionID str
 		PromptPackVersion: s.config.PromptPackVersion,
 		Tags:              buildSessionTags(c),
 		InitialState:      buildSessionState(c, s.config),
+		CohortID:          c.cohortID,
+		Variant:           c.variant,
 	})
 	if err != nil {
 		return "", err

--- a/internal/facade/session_test.go
+++ b/internal/facade/session_test.go
@@ -469,3 +469,236 @@ func TestProcessMessage_PropagatesUserIDToPolicyContext(t *testing.T) {
 		t.Errorf("policy.UserID(ctx) = %q, want %q", got, want)
 	}
 }
+
+func TestCohortHeaders_ExtractedAndStoredOnSession(t *testing.T) {
+	handler := &mockHandler{
+		handleFunc: func(_ context.Context, _ string, _ *ClientMessage, writer ResponseWriter) error {
+			return writer.WriteDone("ok")
+		},
+	}
+
+	store := session.NewMemoryStore()
+	cfg := DefaultServerConfig()
+	cfg.PingInterval = 100 * time.Millisecond
+	cfg.PongTimeout = 200 * time.Millisecond
+
+	log := logr.Discard()
+	server := NewServer(cfg, store, handler, log)
+
+	ts := httptest.NewServer(server)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = store.Close()
+	})
+
+	headers := http.Header{}
+	headers.Set(policy.HeaderCohortID, "cohort-abc")
+	headers.Set(policy.HeaderVariant, "canary")
+	ws, _, err := websocket.DefaultDialer.Dial(
+		strings.Replace(ts.URL, "http://", "ws://", 1)+"?agent=test-agent", headers)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	var connMsg ServerMessage
+	if err := ws.ReadJSON(&connMsg); err != nil {
+		t.Fatalf("Failed to read connected: %v", err)
+	}
+
+	// Send a message to trigger session persistence
+	if err := ws.WriteJSON(ClientMessage{
+		Type: MessageTypeMessage, SessionID: connMsg.SessionID, Content: "hi",
+	}); err != nil {
+		t.Fatalf("Failed to send: %v", err)
+	}
+
+	var doneMsg ServerMessage
+	if err := ws.ReadJSON(&doneMsg); err != nil {
+		t.Fatalf("Failed to read done: %v", err)
+	}
+
+	// Verify session was created with cohort fields
+	sess, err := store.GetSession(context.Background(), connMsg.SessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.CohortID != "cohort-abc" {
+		t.Errorf("CohortID = %q, want %q", sess.CohortID, "cohort-abc")
+	}
+	if sess.Variant != "canary" {
+		t.Errorf("Variant = %q, want %q", sess.Variant, "canary")
+	}
+}
+
+func TestCohortHeaders_EmptyWhenNotSet(t *testing.T) {
+	handler := &mockHandler{
+		handleFunc: func(_ context.Context, _ string, _ *ClientMessage, writer ResponseWriter) error {
+			return writer.WriteDone("ok")
+		},
+	}
+
+	store := session.NewMemoryStore()
+	cfg := DefaultServerConfig()
+	cfg.PingInterval = 100 * time.Millisecond
+	cfg.PongTimeout = 200 * time.Millisecond
+
+	log := logr.Discard()
+	server := NewServer(cfg, store, handler, log)
+
+	ts := httptest.NewServer(server)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = store.Close()
+	})
+
+	// Connect without cohort headers
+	ws, _, err := websocket.DefaultDialer.Dial(
+		strings.Replace(ts.URL, "http://", "ws://", 1)+"?agent=test-agent", nil)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	var connMsg ServerMessage
+	if err := ws.ReadJSON(&connMsg); err != nil {
+		t.Fatalf("Failed to read connected: %v", err)
+	}
+
+	if err := ws.WriteJSON(ClientMessage{
+		Type: MessageTypeMessage, SessionID: connMsg.SessionID, Content: "hi",
+	}); err != nil {
+		t.Fatalf("Failed to send: %v", err)
+	}
+
+	var doneMsg ServerMessage
+	if err := ws.ReadJSON(&doneMsg); err != nil {
+		t.Fatalf("Failed to read done: %v", err)
+	}
+
+	sess, err := store.GetSession(context.Background(), connMsg.SessionID)
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if sess.CohortID != "" {
+		t.Errorf("CohortID = %q, want empty", sess.CohortID)
+	}
+	if sess.Variant != "" {
+		t.Errorf("Variant = %q, want empty", sess.Variant)
+	}
+}
+
+func TestCohortHeaders_SpanAttributes(t *testing.T) {
+	provider, exporter := newTracingTestProvider(t)
+
+	handler := &mockHandler{
+		handleFunc: func(_ context.Context, _ string, _ *ClientMessage, writer ResponseWriter) error {
+			return writer.WriteDone("ok")
+		},
+	}
+
+	ts := newTestServerWithTracing(t, handler, provider)
+
+	headers := http.Header{}
+	headers.Set(policy.HeaderCohortID, "cohort-xyz")
+	headers.Set(policy.HeaderVariant, "stable")
+	ws, _, err := websocket.DefaultDialer.Dial(
+		strings.Replace(ts.URL, "http://", "ws://", 1)+"?agent=test-agent", headers)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	var connMsg ServerMessage
+	if err := ws.ReadJSON(&connMsg); err != nil {
+		t.Fatalf("Failed to read connected: %v", err)
+	}
+
+	if err := ws.WriteJSON(ClientMessage{
+		Type: MessageTypeMessage, SessionID: connMsg.SessionID, Content: "hi",
+	}); err != nil {
+		t.Fatalf("Failed to send: %v", err)
+	}
+
+	var doneMsg ServerMessage
+	if err := ws.ReadJSON(&doneMsg); err != nil {
+		t.Fatalf("Failed to read done: %v", err)
+	}
+
+	_ = ws.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	spans := exporter.GetSpans()
+	msgSpan := findSpanByName(spans, "omnia.facade.message")
+	if msgSpan == nil {
+		t.Fatal("expected 'omnia.facade.message' span")
+	}
+
+	cohortVal, ok := findSpanAttr(*msgSpan, "omnia.cohort.id")
+	if !ok {
+		t.Fatal("missing omnia.cohort.id attribute")
+	}
+	if cohortVal.AsString() != "cohort-xyz" {
+		t.Errorf("omnia.cohort.id = %q, want %q", cohortVal.AsString(), "cohort-xyz")
+	}
+
+	variantVal, ok := findSpanAttr(*msgSpan, "omnia.variant")
+	if !ok {
+		t.Fatal("missing omnia.variant attribute")
+	}
+	if variantVal.AsString() != "stable" {
+		t.Errorf("omnia.variant = %q, want %q", variantVal.AsString(), "stable")
+	}
+}
+
+func TestCohortHeaders_SpanOmitsEmptyAttributes(t *testing.T) {
+	provider, exporter := newTracingTestProvider(t)
+
+	handler := &mockHandler{
+		handleFunc: func(_ context.Context, _ string, _ *ClientMessage, writer ResponseWriter) error {
+			return writer.WriteDone("ok")
+		},
+	}
+
+	ts := newTestServerWithTracing(t, handler, provider)
+
+	// No cohort headers
+	ws, _, err := websocket.DefaultDialer.Dial(
+		strings.Replace(ts.URL, "http://", "ws://", 1)+"?agent=test-agent", nil)
+	if err != nil {
+		t.Fatalf("Failed to connect: %v", err)
+	}
+	defer func() { _ = ws.Close() }()
+
+	var connMsg ServerMessage
+	if err := ws.ReadJSON(&connMsg); err != nil {
+		t.Fatalf("Failed to read connected: %v", err)
+	}
+
+	if err := ws.WriteJSON(ClientMessage{
+		Type: MessageTypeMessage, SessionID: connMsg.SessionID, Content: "hi",
+	}); err != nil {
+		t.Fatalf("Failed to send: %v", err)
+	}
+
+	var doneMsg ServerMessage
+	if err := ws.ReadJSON(&doneMsg); err != nil {
+		t.Fatalf("Failed to read done: %v", err)
+	}
+
+	_ = ws.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	spans := exporter.GetSpans()
+	msgSpan := findSpanByName(spans, "omnia.facade.message")
+	if msgSpan == nil {
+		t.Fatal("expected 'omnia.facade.message' span")
+	}
+
+	if _, ok := findSpanAttr(*msgSpan, "omnia.cohort.id"); ok {
+		t.Error("omnia.cohort.id should not be set when header is empty")
+	}
+	if _, ok := findSpanAttr(*msgSpan, "omnia.variant"); ok {
+		t.Error("omnia.variant should not be set when header is empty")
+	}
+}

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -136,6 +136,8 @@ type CreateSessionRequest struct {
 	PromptPackVersion string            `json:"promptPackVersion,omitempty"`
 	Tags              []string          `json:"tags,omitempty"`
 	InitialState      map[string]string `json:"initialState,omitempty"`
+	CohortID          string            `json:"cohortId,omitempty"`
+	Variant           string            `json:"variant,omitempty"`
 }
 
 // AppendMessageRequest is the JSON body for POST /api/v1/sessions/{sessionID}/messages.
@@ -438,6 +440,8 @@ func (h *Handler) handleCreateSession(w http.ResponseWriter, r *http.Request) {
 		Status:            session.SessionStatusActive,
 		CreatedAt:         now,
 		UpdatedAt:         now,
+		CohortID:          req.CohortID,
+		Variant:           req.Variant,
 	}
 	if req.TTLSeconds > 0 {
 		sess.ExpiresAt = now.Add(time.Duration(req.TTLSeconds) * time.Second)

--- a/internal/session/api/handler_test.go
+++ b/internal/session/api/handler_test.go
@@ -3205,3 +3205,51 @@ func TestHandleRecordToolCall_InvalidBody(t *testing.T) {
 		t.Errorf("status = %d, want %d", rr.Code, http.StatusBadRequest)
 	}
 }
+
+func TestHandleCreateSession_WithCohortFields(t *testing.T) {
+	h, _, _ := setupHandler(t)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"id":"` + testSessionIDOther + `","agentName":"test-agent","namespace":"default","cohortId":"cohort-123","variant":"canary"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeJSON[SessionResponse](t, rec)
+	if resp.Session.CohortID != "cohort-123" {
+		t.Errorf("CohortID = %q, want %q", resp.Session.CohortID, "cohort-123")
+	}
+	if resp.Session.Variant != "canary" {
+		t.Errorf("Variant = %q, want %q", resp.Session.Variant, "canary")
+	}
+}
+
+func TestHandleCreateSession_NoCohortFields(t *testing.T) {
+	h, _, _ := setupHandler(t)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"id":"` + testSessionIDOther + `","agentName":"test-agent","namespace":"default"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/sessions", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", rec.Code, rec.Body.String())
+	}
+	resp := decodeJSON[SessionResponse](t, rec)
+	if resp.Session.CohortID != "" {
+		t.Errorf("CohortID = %q, want empty", resp.Session.CohortID)
+	}
+	if resp.Session.Variant != "" {
+		t.Errorf("Variant = %q, want empty", resp.Session.Variant)
+	}
+}

--- a/internal/session/api/openapi.yaml
+++ b/internal/session/api/openapi.yaml
@@ -707,6 +707,12 @@ components:
           type: string
         promptPackVersion:
           type: string
+        cohortId:
+          type: string
+          description: Rollout cohort identifier
+        variant:
+          type: string
+          description: Rollout variant (e.g., stable, canary)
 
     Message:
       type: object
@@ -932,6 +938,12 @@ components:
           additionalProperties:
             type: string
           description: Optional initial key-value state for the session
+        cohortId:
+          type: string
+          description: Rollout cohort identifier
+        variant:
+          type: string
+          description: Rollout variant (e.g., stable, canary)
 
     RefreshTTLRequest:
       type: object

--- a/internal/session/httpclient/store_test.go
+++ b/internal/session/httpclient/store_test.go
@@ -86,6 +86,8 @@ func mockSessionAPI(t *testing.T) *httptest.Server {
 			Status:    &status,
 			CreatedAt: &now,
 			UpdatedAt: &now,
+			CohortId:  req.CohortId,
+			Variant:   req.Variant,
 		}
 		if req.TtlSeconds != nil && *req.TtlSeconds > 0 {
 			exp := now.Add(time.Duration(*req.TtlSeconds) * time.Second)
@@ -1462,5 +1464,29 @@ func TestGetRuntimeEvents_NotFound(t *testing.T) {
 	_, err := store.GetRuntimeEvents(context.Background(), "bad-id", 0, 0)
 	if err != session.ErrSessionNotFound {
 		t.Fatalf("expected ErrSessionNotFound, got %v", err)
+	}
+}
+
+func TestCreateSession_WithCohortFields(t *testing.T) {
+	srv := mockSessionAPI(t)
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	t.Cleanup(func() { _ = store.Close() })
+
+	sess, err := store.CreateSession(context.Background(), session.CreateSessionOptions{
+		AgentName: "test-agent",
+		Namespace: "default",
+		CohortID:  "cohort-99",
+		Variant:   "canary",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sess.CohortID != "cohort-99" {
+		t.Errorf("CohortID = %q, want %q", sess.CohortID, "cohort-99")
+	}
+	if sess.Variant != "canary" {
+		t.Errorf("Variant = %q, want %q", sess.Variant, "canary")
 	}
 }

--- a/internal/session/memory.go
+++ b/internal/session/memory.go
@@ -78,6 +78,8 @@ func (m *MemoryStore) CreateSession(ctx context.Context, opts CreateSessionOptio
 		UpdatedAt: now,
 		Messages:  []Message{},
 		State:     make(map[string]string),
+		CohortID:  opts.CohortID,
+		Variant:   opts.Variant,
 	}
 
 	if opts.TTL > 0 {
@@ -507,6 +509,8 @@ func (m *MemoryStore) copySession(s *Session) *Session {
 		WorkspaceName:      s.WorkspaceName,
 		PromptPackName:     s.PromptPackName,
 		PromptPackVersion:  s.PromptPackVersion,
+		CohortID:           s.CohortID,
+		Variant:            s.Variant,
 		Status:             s.Status,
 		EndedAt:            s.EndedAt,
 		MessageCount:       s.MessageCount,

--- a/internal/session/otlp/attributes.go
+++ b/internal/session/otlp/attributes.go
@@ -73,6 +73,8 @@ const (
 	AttrOmniaPromptPackName      = "omnia.promptpack.name"
 	AttrOmniaPromptPackVersion   = "omnia.promptpack.version"
 	AttrOmniaPromptPackNamespace = "omnia.promptpack.namespace"
+	AttrOmniaCohortID            = "omnia.cohort.id"
+	AttrOmniaVariant             = "omnia.variant"
 )
 
 // PromptKit tool span attribute keys.

--- a/internal/session/postgres/migrations/000025_add_cohort_fields.down.sql
+++ b/internal/session/postgres/migrations/000025_add_cohort_fields.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_sessions_variant;
+DROP INDEX IF EXISTS idx_sessions_cohort_id;
+ALTER TABLE sessions DROP COLUMN IF EXISTS variant;
+ALTER TABLE sessions DROP COLUMN IF EXISTS cohort_id;

--- a/internal/session/postgres/migrations/000025_add_cohort_fields.up.sql
+++ b/internal/session/postgres/migrations/000025_add_cohort_fields.up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS cohort_id TEXT;
+ALTER TABLE sessions ADD COLUMN IF NOT EXISTS variant TEXT;
+CREATE INDEX IF NOT EXISTS idx_sessions_cohort_id ON sessions (cohort_id) WHERE cohort_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_sessions_variant ON sessions (variant) WHERE variant IS NOT NULL;

--- a/internal/session/providers/postgres/provider.go
+++ b/internal/session/providers/postgres/provider.go
@@ -96,7 +96,8 @@ const sessionColumns = `id, agent_name, namespace, workspace_name, status,
 	created_at, updated_at, expires_at, ended_at,
 	message_count, tool_call_count, total_input_tokens, total_output_tokens,
 	estimated_cost_usd, tags, state, last_message_preview,
-	prompt_pack_name, prompt_pack_version`
+	prompt_pack_name, prompt_pack_version,
+	cohort_id, variant`
 
 // nullableSessionFields groups nullable columns scanned from a session row.
 type nullableSessionFields struct {
@@ -104,6 +105,8 @@ type nullableSessionFields struct {
 	lastMsgPreview    *string
 	promptPackName    *string
 	promptPackVersion *string
+	cohortID          *string
+	variant           *string
 	expiresAt         *time.Time
 	endedAt           *time.Time
 	stateJSON         []byte
@@ -118,6 +121,8 @@ func populateSession(s *session.Session, n nullableSessionFields) {
 	s.LastMessagePreview = pgutil.DerefString(n.lastMsgPreview)
 	s.PromptPackName = pgutil.DerefString(n.promptPackName)
 	s.PromptPackVersion = pgutil.DerefString(n.promptPackVersion)
+	s.CohortID = pgutil.DerefString(n.cohortID)
+	s.Variant = pgutil.DerefString(n.variant)
 	if s.Tags == nil {
 		s.Tags = []string{}
 	}
@@ -133,6 +138,7 @@ func scanSession(row pgx.Row) (*session.Session, error) {
 		&s.MessageCount, &s.ToolCallCount, &s.TotalInputTokens, &s.TotalOutputTokens,
 		&s.EstimatedCostUSD, &s.Tags, &n.stateJSON, &n.lastMsgPreview,
 		&n.promptPackName, &n.promptPackVersion,
+		&n.cohortID, &n.variant,
 	)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -274,8 +280,9 @@ func (p *Provider) CreateSession(ctx context.Context, s *session.Session) error 
 		created_at, updated_at, expires_at, ended_at,
 		message_count, tool_call_count, total_input_tokens, total_output_tokens,
 		estimated_cost_usd, tags, state, last_message_preview,
-		prompt_pack_name, prompt_pack_version
-	) SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19
+		prompt_pack_name, prompt_pack_version,
+		cohort_id, variant
+	) SELECT $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21
 	WHERE NOT EXISTS (SELECT 1 FROM sessions WHERE id=$1)`
 
 	tags := s.Tags
@@ -289,6 +296,7 @@ func (p *Provider) CreateSession(ctx context.Context, s *session.Session) error 
 		s.MessageCount, s.ToolCallCount, s.TotalInputTokens, s.TotalOutputTokens,
 		s.EstimatedCostUSD, tags, pgutil.MarshalJSONB(s.State), pgutil.NullString(s.LastMessagePreview),
 		pgutil.NullString(s.PromptPackName), pgutil.NullString(s.PromptPackVersion),
+		pgutil.NullString(s.CohortID), pgutil.NullString(s.Variant),
 	)
 	if err != nil {
 		return fmt.Errorf("postgres: create session: %w", err)
@@ -309,7 +317,8 @@ func (p *Provider) UpdateSession(ctx context.Context, s *session.Session) error 
 		updated_at=$6, expires_at=$7, ended_at=$8,
 		message_count=$9, tool_call_count=$10, total_input_tokens=$11, total_output_tokens=$12,
 		estimated_cost_usd=$13, tags=$14, state=$15, last_message_preview=$16,
-		prompt_pack_name=$17, prompt_pack_version=$18
+		prompt_pack_name=$17, prompt_pack_version=$18,
+		cohort_id=$19, variant=$20
 	WHERE id=$1`
 
 	tags := s.Tags
@@ -323,6 +332,7 @@ func (p *Provider) UpdateSession(ctx context.Context, s *session.Session) error 
 		s.MessageCount, s.ToolCallCount, s.TotalInputTokens, s.TotalOutputTokens,
 		s.EstimatedCostUSD, tags, pgutil.MarshalJSONB(s.State), pgutil.NullString(s.LastMessagePreview),
 		pgutil.NullString(s.PromptPackName), pgutil.NullString(s.PromptPackVersion),
+		pgutil.NullString(s.CohortID), pgutil.NullString(s.Variant),
 	)
 	if err != nil {
 		return fmt.Errorf("postgres: update session: %w", err)

--- a/internal/session/store.go
+++ b/internal/session/store.go
@@ -180,6 +180,10 @@ type Session struct {
 	PromptPackName string `json:"promptPackName,omitempty"`
 	// PromptPackVersion is the version of the PromptPack at session creation.
 	PromptPackVersion string `json:"promptPackVersion,omitempty"`
+	// CohortID identifies the rollout cohort this session belongs to.
+	CohortID string `json:"cohortId,omitempty"`
+	// Variant identifies the rollout variant (e.g., "stable", "canary").
+	Variant string `json:"variant,omitempty"`
 }
 
 // IsExpired returns true if the session has expired.
@@ -213,6 +217,10 @@ type CreateSessionOptions struct {
 	PromptPackVersion string
 	// Tags are optional labels for categorizing sessions (e.g., "source:arena").
 	Tags []string
+	// CohortID identifies the rollout cohort this session belongs to.
+	CohortID string
+	// Variant identifies the rollout variant (e.g., "stable", "canary").
+	Variant string
 }
 
 // SessionStatusUpdate contains lifecycle state changes for a session.

--- a/pkg/policy/context.go
+++ b/pkg/policy/context.go
@@ -102,6 +102,14 @@ const (
 	IstioHeaderUserEmail = "x-user-email"
 )
 
+// Rollout cohort tracking headers set by Istio during canary deployments.
+const (
+	// HeaderCohortID identifies the cohort a request was routed to.
+	HeaderCohortID = "x-omnia-cohort-id"
+	// HeaderVariant identifies the rollout variant (e.g., "stable", "canary").
+	HeaderVariant = "x-omnia-variant"
+)
+
 // PropagationFields holds all values for context propagation across service boundaries.
 type PropagationFields struct {
 	AgentName     string

--- a/pkg/sessionapi/client.gen.go
+++ b/pkg/sessionapi/client.gen.go
@@ -51,6 +51,9 @@ const (
 type CreateSessionRequest struct {
 	AgentName *string `json:"agentName,omitempty"`
 
+	// CohortId Rollout cohort identifier
+	CohortId *string `json:"cohortId,omitempty"`
+
 	// Id Optional pre-generated session UUID
 	Id *openapi_types.UUID `json:"id,omitempty"`
 
@@ -64,7 +67,10 @@ type CreateSessionRequest struct {
 	Tags *[]string `json:"tags,omitempty"`
 
 	// TtlSeconds Session TTL in seconds (0 = no expiry)
-	TtlSeconds    *int    `json:"ttlSeconds,omitempty"`
+	TtlSeconds *int `json:"ttlSeconds,omitempty"`
+
+	// Variant Rollout variant (e.g., stable, canary)
+	Variant       *string `json:"variant,omitempty"`
 	WorkspaceName *string `json:"workspaceName,omitempty"`
 }
 
@@ -179,7 +185,10 @@ type RuntimeEvent struct {
 
 // Session defines model for Session.
 type Session struct {
-	AgentName          *string             `json:"agentName,omitempty"`
+	AgentName *string `json:"agentName,omitempty"`
+
+	// CohortId Rollout cohort identifier
+	CohortId           *string             `json:"cohortId,omitempty"`
 	CreatedAt          *time.Time          `json:"createdAt,omitempty"`
 	EndedAt            *time.Time          `json:"endedAt,omitempty"`
 	EstimatedCostUSD   *float64            `json:"estimatedCostUSD,omitempty"`
@@ -198,7 +207,10 @@ type Session struct {
 	TotalInputTokens   *int64              `json:"totalInputTokens,omitempty"`
 	TotalOutputTokens  *int64              `json:"totalOutputTokens,omitempty"`
 	UpdatedAt          *time.Time          `json:"updatedAt,omitempty"`
-	WorkspaceName      *string             `json:"workspaceName,omitempty"`
+
+	// Variant Rollout variant (e.g., stable, canary)
+	Variant       *string `json:"variant,omitempty"`
+	WorkspaceName *string `json:"workspaceName,omitempty"`
 }
 
 // SessionListResponse defines model for SessionListResponse.

--- a/pkg/sessionapi/convert.go
+++ b/pkg/sessionapi/convert.go
@@ -83,6 +83,12 @@ func SessionToAPI(id string, opts session.CreateSessionOptions) CreateSessionReq
 	if len(opts.InitialState) > 0 {
 		req.InitialState = &opts.InitialState
 	}
+	if opts.CohortID != "" {
+		req.CohortId = ptr(opts.CohortID)
+	}
+	if opts.Variant != "" {
+		req.Variant = ptr(opts.Variant)
+	}
 	return req
 }
 
@@ -269,6 +275,8 @@ func SessionFromAPI(s *Session) *session.Session {
 		LastMessagePreview: deref(s.LastMessagePreview),
 		PromptPackName:     deref(s.PromptPackName),
 		PromptPackVersion:  deref(s.PromptPackVersion),
+		CohortID:           deref(s.CohortId),
+		Variant:            deref(s.Variant),
 		Tags:               derefSlice(s.Tags),
 		State:              derefMap(s.State),
 		Messages:           MessagesFromAPI(s.Messages),

--- a/pkg/sessionapi/convert_test.go
+++ b/pkg/sessionapi/convert_test.go
@@ -146,6 +146,58 @@ func TestSessionToAPI_EmptyInitialState(t *testing.T) {
 	assert.Nil(t, result.InitialState)
 }
 
+func TestSessionToAPI_WithCohortFields(t *testing.T) {
+	id := uuid.New().String()
+	result := SessionToAPI(id, session.CreateSessionOptions{
+		AgentName: "a",
+		Namespace: "ns",
+		CohortID:  "cohort-42",
+		Variant:   "canary",
+	})
+
+	require.NotNil(t, result.CohortId)
+	assert.Equal(t, "cohort-42", *result.CohortId)
+	require.NotNil(t, result.Variant)
+	assert.Equal(t, "canary", *result.Variant)
+}
+
+func TestSessionToAPI_EmptyCohortFields(t *testing.T) {
+	id := uuid.New().String()
+	result := SessionToAPI(id, session.CreateSessionOptions{
+		AgentName: "a",
+		Namespace: "ns",
+	})
+
+	assert.Nil(t, result.CohortId)
+	assert.Nil(t, result.Variant)
+}
+
+func TestSessionFromAPI_WithCohortFields(t *testing.T) {
+	sid := uuid.New()
+	s := &Session{
+		Id:        &sid,
+		AgentName: ptr("a"),
+		Namespace: ptr("ns"),
+		CohortId:  ptr("cohort-42"),
+		Variant:   ptr("canary"),
+	}
+	result := SessionFromAPI(s)
+	assert.Equal(t, "cohort-42", result.CohortID)
+	assert.Equal(t, "canary", result.Variant)
+}
+
+func TestSessionFromAPI_NilCohortFields(t *testing.T) {
+	sid := uuid.New()
+	s := &Session{
+		Id:        &sid,
+		AgentName: ptr("a"),
+		Namespace: ptr("ns"),
+	}
+	result := SessionFromAPI(s)
+	assert.Empty(t, result.CohortID)
+	assert.Empty(t, result.Variant)
+}
+
 func TestMessageToAPI(t *testing.T) {
 	now := time.Now().Truncate(time.Second)
 	msg := session.Message{


### PR DESCRIPTION
## Summary

Phase 5 of rollout support. Adds cohort tracking that flows from Istio headers through the facade into session-api, Postgres, and OTel traces. Enables per-variant session filtering for A/B experiment analysis.

**Design spec:** `docs/superpowers/specs/2026-04-07-rollouts-and-experiments-design.md`

### Data flow

```
HTTP headers (x-omnia-cohort-id, x-omnia-variant)
  → Facade Connection (extracted from WebSocket upgrade)
    → CreateSessionOptions
      → Session API (new request fields)
        → Postgres (new columns + partial indexes)
        → OTel trace attributes (omnia.cohort.id, omnia.variant)
```

### What's implemented

- **Header constants** — `x-omnia-cohort-id`, `x-omnia-variant` in `pkg/policy/context.go`
- **Session model** — `CohortID`, `Variant` fields on Session and CreateSessionOptions
- **Postgres migration** — `000025_add_cohort_fields` adds columns with partial indexes
- **Session API** — new fields on CreateSessionRequest, included in responses
- **Facade** — extracts headers from WebSocket upgrade, passes to session creation
- **OTel** — `omnia.cohort.id` and `omnia.variant` span attributes
- **OpenAPI spec** — updated for both session-api and public API
- **API CHANGELOG** — documented the schema change

### Changes across 20 files (+488/-15)

| Layer | Files |
|-------|-------|
| API spec | `api/session-api/openapi.yaml`, `api/CHANGELOG.md` |
| Session model | `internal/session/store.go`, `internal/session/memory.go` |
| Postgres | migration + `providers/postgres/provider.go` |
| Session API | `internal/session/api/handler.go`, `openapi.yaml` |
| HTTP client | `internal/session/httpclient/store_test.go` |
| Facade | `connection.go`, `server.go`, `session.go` |
| OTel | `internal/session/otlp/attributes.go` |
| Policy | `pkg/policy/context.go` |
| Generated | `pkg/sessionapi/client.gen.go`, `convert.go` |

## Test plan

- [x] 4 facade tests (header extraction, session storage, span attributes)
- [x] 2 session-api handler tests (create with/without cohort)
- [x] 1 HTTP client round-trip test
- [x] 4 sessionapi convert tests (to/from API with/without cohort)
- [x] All builds pass (operator, facade, session-api)
- [x] Pre-commit hooks pass
- [ ] CI (all workflows)