### PR TITLE
docs: add progressive rollout documentation

### DIFF
--- a/docs/src/content/docs/explanation/rollout-strategies.md
+++ b/docs/src/content/docs/explanation/rollout-strategies.md
@@ -1,0 +1,199 @@
+---
+title: "Rollout Strategies"
+description: "How Omnia handles progressive delivery for AI agents"
+sidebar:
+  order: 6
+---
+
+
+Progressive rollouts let you deploy changes to AI agents incrementally, catching quality regressions before they reach all users. This document explains the design behind Omnia's rollout system and the trade-offs involved.
+
+## Why Progressive Rollouts for AI Agents?
+
+Traditional application rollouts focus on binary correctness — the new version either works or it crashes. AI agents have a subtler failure mode: **quality degradation**. A prompt change might deploy successfully but produce worse responses, hallucinate more, or misuse tools. These failures don't trigger health checks.
+
+Progressive rollouts address this by:
+
+- Exposing the new version to a small percentage of traffic first
+- Running automated quality analysis before increasing exposure
+- Providing automatic rollback when analysis detects degradation
+- Enabling A/B experiments with consistent user routing
+
+## The Dual Deployment Model
+
+When a rollout is active, the controller creates two Deployments behind the same Service:
+
+```mermaid
+graph TB
+    SVC[Service: my-agent] --> STABLE[Stable Deployment<br/>Current spec]
+    SVC --> CANDIDATE[Candidate Deployment<br/>Spec + overrides]
+
+    DR[DestinationRule] -->|subset: stable| STABLE
+    DR -->|subset: candidate| CANDIDATE
+    VS[VirtualService] -->|weight split| DR
+```
+
+Both Deployments run the same agent image. The only differences come from the `rollout.candidate` overrides — typically a different PromptPack version, provider, or tool configuration. Istio's VirtualService controls what percentage of traffic reaches each subset.
+
+This model means:
+
+- **No downtime** — the stable Deployment continues serving throughout the rollout
+- **Identical infrastructure** — both versions share the same Service, DNS, and TLS
+- **Clean teardown** — after promotion or rollback, the candidate Deployment is deleted
+
+## Candidate Overrides
+
+The candidate is a **sparse override**, not a full copy of the spec. Only the fields you want to change need to be specified:
+
+```yaml
+rollout:
+  candidate:
+    promptPackVersion: "2.0.0"        # Different prompts
+    providerRefs:                      # Different model
+      - name: default
+        providerRef:
+          name: claude-opus
+    toolRegistryRef:                   # Different tools
+      name: experimental-tools
+```
+
+Any field not listed in the candidate inherits from the main spec. This keeps rollout configurations small and avoids drift between the two versions.
+
+## Step-Based Progression
+
+Rollouts are defined as an ordered sequence of steps. Each step is one of three types:
+
+| Step | Purpose |
+|------|---------|
+| `setWeight` | Adjust the candidate's traffic percentage (0-100) |
+| `pause` | Wait for a duration, or indefinitely until manually resumed |
+| `analysis` | Run a RolloutAnalysis template and evaluate the result |
+
+The controller processes steps sequentially. It only advances to the next step when the current one completes successfully. A failed analysis step triggers the configured rollback behavior.
+
+### Canary Pattern
+
+Gradually increase traffic, pausing between steps for observation:
+
+```yaml
+steps:
+  - setWeight: 10
+  - pause: { duration: "5m" }
+  - setWeight: 50
+  - pause: { duration: "10m" }
+  - setWeight: 100
+```
+
+### Blue/Green Pattern
+
+Run analysis on the candidate with zero traffic, then flip all at once:
+
+```yaml
+steps:
+  - analysis: { templateName: smoke-test }
+  - setWeight: 100
+```
+
+### Experiment Pattern
+
+Split traffic evenly with sticky sessions for A/B testing:
+
+```yaml
+steps:
+  - setWeight: 50
+  - pause: {}  # Indefinite — manual promotion
+```
+
+All three patterns use the same step primitives. The strategy emerges from how you compose the steps.
+
+## Traffic Routing with Istio
+
+The rollout controller patches two Istio resources to manage traffic:
+
+- **VirtualService** — contains the weight split between stable and candidate subsets
+- **DestinationRule** — defines the subsets using pod labels (`omnia.altairalabs.ai/variant: stable|candidate`)
+
+The controller only modifies the routes listed in `trafficRouting.istio.virtualService.routes`. Other routes on the same VirtualService are untouched.
+
+:::tip
+Create the VirtualService and DestinationRule before configuring the rollout. The controller patches existing resources — it does not create them.
+:::
+
+## Cohort Tracking
+
+During an active rollout, the facade injects headers to identify which variant served each request:
+
+| Header | Value |
+|--------|-------|
+| `x-omnia-variant` | `stable` or `candidate` |
+| `x-omnia-cohort-id` | Unique cohort identifier for the rollout |
+
+These headers enable downstream analysis, logging, and experiment tracking. They are available in tool call headers and session metadata.
+
+## Sticky Sessions
+
+For experiments that require consistent user routing, configure `stickySession`:
+
+```yaml
+rollout:
+  stickySession:
+    hashOn: "x-user-id"
+```
+
+This adds a consistent hash to the Istio DestinationRule, ensuring the same user always reaches the same variant. Without sticky sessions, each request is independently routed by weight — a user might see both variants across consecutive messages.
+
+## Promotion and Rollback
+
+The rollout lifecycle has three terminal states:
+
+**Idle** — when `rollout.candidate` matches the current spec (or is absent), no rollout is active. The controller maintains a single Deployment.
+
+**Promotion** — when the rollout completes all steps, the candidate overrides are merged into the main spec. The candidate Deployment is deleted. The stable Deployment now runs the new configuration.
+
+**Rollback** — the candidate is reverted to match the current spec, and the candidate Deployment is deleted. Traffic returns to 100% stable.
+
+Rollback behavior is controlled by `rollout.rollback.mode`:
+
+| Mode | Behavior |
+|------|----------|
+| `automatic` | Rolls back immediately when an analysis step fails |
+| `manual` (default) | Pauses the rollout on failure; operator must manually remove the candidate |
+| `disabled` | Continues the rollout regardless of analysis results |
+
+The `rollback.cooldown` field (default: "5m") prevents rapid rollback/re-deploy cycles by debouncing rollback triggers.
+
+## Analysis Integration
+
+:::note[Enterprise]
+RolloutAnalysis is an enterprise feature.
+:::
+
+Analysis steps run a `RolloutAnalysis` CRD — a reusable template containing a Prometheus query and success conditions:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: RolloutAnalysis
+metadata:
+  name: quality-check
+spec:
+  metrics:
+    - name: error-rate
+      provider:
+        prometheus:
+          address: http://prometheus:9090
+          query: |
+            sum(rate(omnia_agent_errors_total{variant="candidate"}[5m]))
+            /
+            sum(rate(omnia_agent_requests_total{variant="candidate"}[5m]))
+      successCondition: "result < 0.05"
+      failureLimit: 3
+      interval: "1m"
+```
+
+The controller evaluates the query at the specified interval. If the success condition fails more times than `failureLimit`, the analysis step fails and triggers the configured rollback behavior.
+
+## Related Resources
+
+- [Progressive Rollouts Tutorial](/tutorials/progressive-rollouts/) — step-by-step walkthrough
+- [AgentRuntime CRD Reference](/reference/agentruntime/#rollout) — field-by-field specification
+- [RolloutAnalysis CRD Reference](/reference/rolloutanalysis/) — analysis template specification

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -24,10 +24,10 @@ Omnia is a Kubernetes operator that simplifies the deployment and management of 
 
 <CardGrid stagger>
   <Card title="AgentRuntime CRD" icon="rocket">
-    Deploy AI agents as Kubernetes-native workloads with automatic scaling and health management.
+    Deploy AI agents with progressive rollouts, autoscaling, and observability.
   </Card>
   <Card title="PromptPack CRD" icon="document">
-    Version and manage prompt configurations with canary rollouts for safe updates.
+    Version and manage prompt configurations for your agents.
   </Card>
   <Card title="ToolRegistry CRD" icon="setting">
     Discover and orchestrate tools via HTTP, gRPC, MCP, or OpenAPI handlers.

--- a/docs/src/content/docs/reference/agentruntime.md
+++ b/docs/src/content/docs/reference/agentruntime.md
@@ -25,13 +25,12 @@ Reference to the PromptPack containing agent prompts.
 |-------|------|----------|
 | `promptPackRef.name` | string | Yes |
 | `promptPackRef.version` | string | No |
-| `promptPackRef.track` | string | No (default: "stable") |
 
 ```yaml
 spec:
   promptPackRef:
     name: my-prompts
-    version: "1.0.0"  # Or use track: "canary"
+    version: "1.0.0"
 ```
 
 ### `providers`
@@ -461,6 +460,71 @@ spec:
       inactivityTimeout: 10m
 ```
 
+### `rollout`
+
+Progressive rollout configuration. When `rollout.candidate` is set and differs from the current spec, the controller creates a candidate Deployment and progresses through the defined steps.
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `rollout.candidate` | object | No | Overrides for the candidate version |
+| `rollout.candidate.promptPackVersion` | string | No | PromptPack version for the candidate |
+| `rollout.candidate.providerRefs` | array | No | Provider overrides for the candidate |
+| `rollout.candidate.toolRegistryRef` | object | No | ToolRegistry override for the candidate |
+| `rollout.steps` | array | Yes | Ordered sequence of rollout actions |
+| `rollout.steps[].setWeight` | integer | — | Set candidate traffic weight (0-100) |
+| `rollout.steps[].pause` | object | — | Pause the rollout |
+| `rollout.steps[].pause.duration` | string | No | Pause duration (e.g., "5m"). Omit for indefinite |
+| `rollout.steps[].analysis` | object | — | Run a RolloutAnalysis template |
+| `rollout.steps[].analysis.templateName` | string | Yes | Name of the RolloutAnalysis CRD |
+| `rollout.steps[].analysis.args` | array | No | Argument overrides for the template |
+| `rollout.stickySession` | object | No | Consistent routing for experiments |
+| `rollout.stickySession.hashOn` | string | Yes | Header for consistent hashing (e.g., "x-user-id") |
+| `rollout.rollback` | object | No | Rollback configuration |
+| `rollout.rollback.mode` | string | No | `automatic`, `manual` (default), or `disabled` |
+| `rollout.rollback.cooldown` | string | No | Debounce duration (default: "5m") |
+| `rollout.trafficRouting` | object | No | Traffic management provider |
+| `rollout.trafficRouting.istio.virtualService.name` | string | Yes | VirtualService to patch |
+| `rollout.trafficRouting.istio.virtualService.routes` | array | Yes | Route names to manage |
+| `rollout.trafficRouting.istio.destinationRule.name` | string | Yes | DestinationRule to patch |
+
+:::note[Enterprise]
+The `analysis` step type requires the `RolloutAnalysis` CRD, which is an enterprise feature.
+:::
+
+#### Rollout Example
+
+```yaml
+# Canary rollout with analysis
+spec:
+  promptPackRef:
+    name: customer-support-pack
+    version: "1.0.0"
+  rollout:
+    candidate:
+      promptPackVersion: "2.0.0"
+    steps:
+      - setWeight: 10
+      - pause:
+          duration: "5m"
+      - analysis:
+          templateName: quality-check
+      - setWeight: 50
+      - pause:
+          duration: "10m"
+      - setWeight: 100
+    rollback:
+      mode: automatic
+    trafficRouting:
+      istio:
+        virtualService:
+          name: customer-support-vs
+          routes: [primary]
+        destinationRule:
+          name: customer-support-dr
+```
+
+When candidate matches the current spec, the rollout is idle. Promotion copies candidate overrides into the main spec. Rollback reverts the candidate to match the current spec.
+
 ## Status Fields
 
 ### `phase`
@@ -478,6 +542,16 @@ spec:
 | `status.replicas.desired` | Desired replicas |
 | `status.replicas.ready` | Ready replicas |
 | `status.replicas.available` | Available replicas |
+
+### `rollout` (status)
+
+| Field | Description |
+|-------|-------------|
+| `status.rollout.active` | Whether a rollout is in progress |
+| `status.rollout.currentStep` | Current step index |
+| `status.rollout.currentWeight` | Current candidate traffic weight |
+| `status.rollout.stableVersion` | Version serving stable traffic |
+| `status.rollout.candidateVersion` | Version serving candidate traffic |
 
 ### `conditions`
 

--- a/docs/src/content/docs/reference/promptpack.md
+++ b/docs/src/content/docs/reference/promptpack.md
@@ -38,27 +38,6 @@ spec:
       name: my-prompts  # ConfigMap must have pack.json key
 ```
 
-### `rollout`
-
-Rollout strategy for prompt updates.
-
-| Field | Type | Default | Required |
-|-------|------|---------|----------|
-| `rollout.strategy` | string | immediate | No |
-| `rollout.canary.weight` | integer | - | No |
-
-```yaml
-spec:
-  rollout:
-    strategy: canary
-    canary:
-      weight: 20  # 20% of traffic uses new prompts
-```
-
-Strategies:
-- `immediate` - Updates apply immediately to all agents
-- `canary` - Gradual rollout with traffic splitting
-
 ## Status Fields
 
 ### `phase`
@@ -69,16 +48,12 @@ Current phase of the PromptPack.
 |-------|-------------|
 | `Pending` | Validating source |
 | `Active` | Prompts are valid and in use |
-| `Canary` | Canary rollout in progress |
+| `Superseded` | A newer version has replaced this pack |
 | `Failed` | Source validation failed |
 
 ### `activeVersion`
 
 The currently active prompt version (content hash).
-
-### `canaryVersion`
-
-The canary version during rollout (if applicable).
 
 ### `conditions`
 
@@ -168,45 +143,9 @@ data:
 
 For the complete specification, see [promptpack.org](https://promptpack.org/docs/spec/schema-reference).
 
-## Canary Rollout
-
-### Start Canary
-
-```yaml
-spec:
-  rollout:
-    strategy: canary
-    canary:
-      weight: 10  # Start with 10%
-```
-
-### Increase Traffic
-
-Update the weight to increase canary traffic:
-
-```yaml
-spec:
-  rollout:
-    canary:
-      weight: 50  # Increase to 50%
-```
-
-### Promote to Active
-
-Set weight to 100 to promote canary:
-
-```yaml
-spec:
-  rollout:
-    canary:
-      weight: 100  # Promotes canary to active
-```
-
-The status will transition from `Canary` to `Active`.
-
 ## Example
 
-Complete PromptPack example with canary rollout:
+Complete PromptPack example:
 
 ```yaml
 apiVersion: omnia.altairalabs.ai/v1alpha1
@@ -220,20 +159,14 @@ spec:
     type: configmap
     configMapRef:
       name: cs-prompts-v2
-  rollout:
-    type: canary
-    canary:
-      weight: 25
 ```
 
 Status after deployment:
 
 ```yaml
 status:
-  phase: Canary
-  activeVersion: "1.0.0"
-  canaryVersion: "2.0.0"
-  canaryWeight: 25
+  phase: Active
+  activeVersion: "2.0.0"
   conditions:
     - type: SourceValid
       status: "True"

--- a/docs/src/content/docs/tutorials/getting-started.md
+++ b/docs/src/content/docs/tutorials/getting-started.md
@@ -107,8 +107,6 @@ metadata:
   namespace: default
 spec:
   version: "1.0.0"
-  rollout:
-    type: immediate
   source:
     type: configmap
     configMapRef:

--- a/docs/src/content/docs/tutorials/progressive-rollouts.md
+++ b/docs/src/content/docs/tutorials/progressive-rollouts.md
@@ -1,0 +1,275 @@
+---
+title: "Progressive Rollouts"
+description: "Safely roll out prompt, model, and tool changes with canary deployments"
+sidebar:
+  order: 6
+---
+
+
+This tutorial walks through deploying a prompt change using progressive rollouts. You'll configure Istio traffic routing, create a canary rollout, watch it progress, and then promote the change.
+
+## Scenario
+
+You have a customer support agent (`support-agent`) running PromptPack version `1.0.0`. You've written a new version `2.0.0` with improved system prompts, and want to roll it out gradually — starting at 10% of traffic, validating quality, then increasing to 100%.
+
+## Prerequisites
+
+- A running Omnia cluster with **Istio** installed
+- An existing AgentRuntime (`support-agent`) in the `production` namespace
+- The new PromptPack version (`2.0.0`) deployed as a ConfigMap and PromptPack resource
+- `kubectl` and `istioctl` available
+
+## Step 1: Create Istio Traffic Resources
+
+The rollout controller manages traffic by patching Istio VirtualService and DestinationRule resources. Create these for your agent:
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: support-agent-dr
+  namespace: production
+spec:
+  host: support-agent
+  subsets:
+    - name: stable
+      labels:
+        omnia.altairalabs.ai/variant: stable
+    - name: candidate
+      labels:
+        omnia.altairalabs.ai/variant: candidate
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: support-agent-vs
+  namespace: production
+spec:
+  hosts:
+    - support-agent
+  http:
+    - name: primary
+      route:
+        - destination:
+            host: support-agent
+            subset: stable
+          weight: 100
+        - destination:
+            host: support-agent
+            subset: candidate
+          weight: 0
+```
+
+Apply:
+
+```bash
+kubectl apply -f istio-traffic.yaml
+```
+
+## Step 2: Configure the Rollout
+
+Update your AgentRuntime to add a rollout configuration with the candidate version:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: support-agent
+  namespace: production
+spec:
+  promptPackRef:
+    name: support-pack
+    version: "1.0.0"
+
+  providers:
+    - name: default
+      providerRef:
+        name: claude-sonnet
+
+  facade:
+    type: websocket
+    port: 8080
+    handler: runtime
+
+  rollout:
+    candidate:
+      promptPackVersion: "2.0.0"
+    steps:
+      - setWeight: 10
+      - pause:
+          duration: "5m"
+      - analysis:
+          templateName: quality-check
+      - setWeight: 50
+      - pause:
+          duration: "10m"
+      - setWeight: 100
+    rollback:
+      mode: automatic
+    trafficRouting:
+      istio:
+        virtualService:
+          name: support-agent-vs
+          routes: [primary]
+        destinationRule:
+          name: support-agent-dr
+```
+
+Apply:
+
+```bash
+kubectl apply -f support-agent.yaml
+```
+
+The controller detects that `candidate.promptPackVersion` ("2.0.0") differs from `spec.promptPackRef.version` ("1.0.0") and begins the rollout.
+
+## Step 3: Watch the Rollout Progress
+
+Monitor the rollout status:
+
+```bash
+kubectl get agentruntime support-agent -n production -o jsonpath='{.status.rollout}' | jq
+```
+
+```json
+{
+  "active": true,
+  "currentStep": 0,
+  "currentWeight": 10,
+  "stableVersion": "1.0.0",
+  "candidateVersion": "2.0.0"
+}
+```
+
+The controller creates a second Deployment for the candidate and sets the initial traffic weight to 10%.
+
+## Step 4: Verify Traffic Splitting
+
+Confirm Istio is routing traffic correctly:
+
+```bash
+kubectl get virtualservice support-agent-vs -n production -o jsonpath='{.spec.http[0].route}' | jq
+```
+
+You should see the stable subset at weight 90 and the candidate subset at weight 10.
+
+:::tip
+Use the `x-omnia-variant` response header to confirm which version served a request. Stable traffic returns `stable`, candidate traffic returns `candidate`.
+:::
+
+## Step 5: Observe Analysis and Progression
+
+After the 5-minute pause, the controller runs the `quality-check` analysis. If the analysis passes, it advances to the next step (setWeight: 50), pauses for 10 minutes, then completes at 100%.
+
+Watch the step progression:
+
+```bash
+kubectl get agentruntime support-agent -n production -w
+```
+
+:::note[Enterprise]
+The `analysis` step type requires the `RolloutAnalysis` CRD, which is an enterprise feature. Without it, use `pause` steps with manual verification.
+:::
+
+## Step 6: Promotion
+
+When the rollout reaches `setWeight: 100`, the controller promotes the candidate. It copies the candidate overrides into the main spec, removes the candidate Deployment, and returns to a single-Deployment state.
+
+After promotion:
+
+```bash
+kubectl get agentruntime support-agent -n production -o jsonpath='{.status.rollout}'
+```
+
+```json
+{
+  "active": false,
+  "stableVersion": "2.0.0"
+}
+```
+
+The `spec.promptPackRef.version` is now `"2.0.0"` and the rollout is idle.
+
+## Rolling Back
+
+If a problem is detected during the rollout, rollback depends on the configured mode:
+
+- **automatic** — the controller reverts the candidate to match the current spec if an analysis step fails
+- **manual** — remove the `rollout.candidate` block and reapply; the controller tears down the candidate Deployment
+- **disabled** — the rollout continues regardless of analysis failures
+
+```bash
+# Manual rollback: remove the candidate
+kubectl patch agentruntime support-agent -n production --type merge \
+  -p '{"spec":{"rollout":{"candidate":null}}}'
+```
+
+## Alternative Patterns
+
+### Blue/Green (Instant Flip)
+
+Skip the gradual weight increase and flip all traffic at once, with a pre-flip analysis:
+
+```yaml
+rollout:
+  candidate:
+    promptPackVersion: "2.0.0"
+  steps:
+    - analysis:
+        templateName: pre-deploy-check
+    - setWeight: 100
+  rollback:
+    mode: automatic
+```
+
+### A/B Experiment with Sticky Sessions
+
+Split traffic 50/50 with consistent user routing for experiments:
+
+```yaml
+rollout:
+  candidate:
+    promptPackVersion: "2.0.0"
+  steps:
+    - setWeight: 50
+    - pause: {}  # Indefinite — promote manually when experiment concludes
+  stickySession:
+    hashOn: "x-user-id"
+```
+
+With `stickySession`, the same user always hits the same variant, enabling clean A/B comparisons.
+
+## What You've Built
+
+```mermaid
+graph TB
+    VS[VirtualService] -->|weight: 90| STABLE[Stable Deployment<br/>v1.0.0]
+    VS -->|weight: 10| CANDIDATE[Candidate Deployment<br/>v2.0.0]
+    STABLE --> SVC[Service: support-agent]
+    CANDIDATE --> SVC
+
+    subgraph "Rollout Controller"
+        RC[AgentRuntime Controller] -->|patches weights| VS
+        RC -->|creates/deletes| CANDIDATE
+        RC -->|runs analysis| RA[RolloutAnalysis]
+    end
+```
+
+The rollout controller manages the full lifecycle:
+1. Creates a candidate Deployment with the override configuration
+2. Patches Istio VirtualService weights at each `setWeight` step
+3. Pauses for observation or runs analysis templates
+4. Promotes by merging candidate into spec, or rolls back on failure
+
+## Next Steps
+
+- Review the [AgentRuntime rollout reference](/reference/agentruntime/#rollout) for all available fields
+- Read [Rollout Strategies](/explanation/rollout-strategies/) to understand the design decisions
+- Configure [RolloutAnalysis](/reference/rolloutanalysis/) templates for automated quality gates
+- Set up [observability](/how-to/setup-observability/) to monitor rollout metrics
+
+## Related Resources
+
+- [Rollout Strategies](/explanation/rollout-strategies/) — design and architecture
+- [AgentRuntime CRD Reference](/reference/agentruntime/) — field-by-field specification
+- [RolloutAnalysis CRD Reference](/reference/rolloutanalysis/) — analysis template specification


### PR DESCRIPTION
## Summary

- Remove deleted PromptPack canary rollout fields (`rollout`, `canaryVersion`, `canaryWeight`, `Canary` phase) from reference docs and tutorials
- Add `rollout` section to AgentRuntime CRD reference with full field table, example, and status fields
- Add progressive rollouts tutorial (canary, blue/green, and experiment patterns)
- Add rollout strategies explanation page (dual Deployment model, Istio routing, analysis, promotion/rollback)
- Update index page cards and getting-started tutorial to reflect the change

## Test plan

- [x] `npm run build` in `docs/` passes (57 pages built)
- [ ] Verify internal links resolve correctly in the built site
- [ ] Visual review of new pages in the Starlight dev server
