### PR TITLE
fix(dashboard): remove hand-written re-exports from generated index

### DIFF
--- a/dashboard/src/types/generated/index.ts
+++ b/dashboard/src/types/generated/index.ts
@@ -6,5 +6,3 @@ export * from "./promptpack";
 export * from "./toolregistry";
 export * from "./provider";
 export * from "./sessionretentionpolicy";
-export * from "../agentpolicy";
-export * from "../toolpolicy";


### PR DESCRIPTION
## Summary

- Remove `export * from "../agentpolicy"` and `export * from "../toolpolicy"` from `dashboard/src/types/generated/index.ts`
- This file is overwritten by `make generate-dashboard-types` — hand-written re-exports don't survive codegen
- Route files already import directly from the hand-written type files (`@/types/agentpolicy`, `@/types/toolpolicy`)

Fixes the `Verify Codegen` CI failure on main introduced by #765.

## Test plan

- [ ] `make generate-dashboard-types` produces identical index.ts (no diff)
- [ ] 3812 tests passing
- [ ] TypeScript check passes