### PR TITLE
fix(runtime): wire MCP tool filter and remove stale lint exclusion

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,11 +86,6 @@ linters:
       - third_party$
       - builtin$
       - examples$
-      # Exclude runtime packages - require local PromptKit dependency (not published yet)
-      - ^internal/runtime/
-      - ^cmd/runtime/
-      # Exclude tooltest - imports internal/runtime/tools (PromptKit dependency)
-      - ^internal/tooltest/
 formatters:
   enable:
     - gofmt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,7 +235,7 @@ Exceptions configured in `sonar-project.properties` — cognitive complexity is 
 - **Duplicated strings**: Extract string literals used 3+ times into constants (SonarCloud `go:S1192`).
 - **Naming**: Follow Go conventions. Test doubles should use `Mock` prefix (e.g., `MockStore`).
 - **Formatting**: `gofmt` and `goimports` are enforced. Run before committing.
-- Runtime and runtime test packages (`internal/runtime/`, `cmd/runtime/`) are excluded from golangci-lint because they depend on the unpublished PromptKit SDK.
+- **Never exclude packages from golangci-lint** to work around build problems. If a package doesn't compile with `GOWORK=off`, fix the dependency — don't suppress the lint. All Go code in the repo must lint cleanly.
 
 ### PromptKit SDK Version Strategy
 

--- a/internal/runtime/tools/config.go
+++ b/internal/runtime/tools/config.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"fmt"
 	"os"
+	"slices"
 
 	"gopkg.in/yaml.v3"
 )
@@ -115,6 +116,15 @@ type MCPCfg struct {
 type MCPToolFilterCfg struct {
 	Allowlist []string `json:"allowlist,omitempty" yaml:"allowlist,omitempty"`
 	Blocklist []string `json:"blocklist,omitempty" yaml:"blocklist,omitempty"`
+}
+
+// Includes returns true if the given tool name passes the filter.
+// An empty filter (no allowlist and no blocklist) allows all tools.
+func (f *MCPToolFilterCfg) Includes(name string) bool {
+	if len(f.Allowlist) > 0 {
+		return slices.Contains(f.Allowlist, name)
+	}
+	return !slices.Contains(f.Blocklist, name)
 }
 
 // OpenAPICfg represents OpenAPI configuration for a tool.

--- a/internal/runtime/tools/config_test.go
+++ b/internal/runtime/tools/config_test.go
@@ -126,6 +126,30 @@ func TestLoadConfig(t *testing.T) {
 	}
 }
 
+func TestMCPToolFilterCfg_Includes(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter MCPToolFilterCfg
+		tool   string
+		want   bool
+	}{
+		{"empty filter allows all", MCPToolFilterCfg{}, "anything", true},
+		{"allowlist includes match", MCPToolFilterCfg{Allowlist: []string{"read", "write"}}, "read", true},
+		{"allowlist excludes non-match", MCPToolFilterCfg{Allowlist: []string{"read", "write"}}, "delete", false},
+		{"blocklist excludes match", MCPToolFilterCfg{Blocklist: []string{"delete", "drop"}}, "delete", false},
+		{"blocklist allows non-match", MCPToolFilterCfg{Blocklist: []string{"delete", "drop"}}, "read", true},
+		{"allowlist takes precedence over blocklist", MCPToolFilterCfg{Allowlist: []string{"read"}, Blocklist: []string{"read"}}, "read", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.filter.Includes(tt.tool)
+			if got != tt.want {
+				t.Errorf("Includes(%q) = %v, want %v", tt.tool, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestLoadConfig_FileNotFound(t *testing.T) {
 	_, err := LoadConfig("/nonexistent/path/config.yaml")
 	if err == nil {

--- a/internal/runtime/tools/omnia_executor.go
+++ b/internal/runtime/tools/omnia_executor.go
@@ -659,6 +659,10 @@ func (e *OmniaExecutor) initMCPHandler(ctx context.Context, name string, h *Hand
 			e.log.Error(err, "failed to list MCP tool", "handler", name)
 			continue
 		}
+		if h.MCPConfig.ToolFilter != nil && !h.MCPConfig.ToolFilter.Includes(tool.Name) {
+			e.log.V(1).Info("filtered out MCP tool", "tool", tool.Name, "handler", name)
+			continue
+		}
 		e.mcpTools[name][tool.Name] = tool
 		e.toolHandlers[tool.Name] = name
 		e.log.V(1).Info("registered MCP tool", "tool", tool.Name, "handler", name)


### PR DESCRIPTION
## Summary

Two changes:

1. **Wire MCP tool filter** — The ToolRegistry CRD's `MCPConfig.toolFilter` (allowlist/blocklist) was defined and tested but never applied during tool registration. MCP servers expose all their tools regardless of the filter. Add `MCPToolFilterCfg.Includes()` method and check it in `initMCPHandler` before registering each tool.

2. **Remove stale lint exclusion** — `internal/runtime/` and `cmd/runtime/` were excluded from golangci-lint because they "depend on the unpublished PromptKit SDK". They compile fine with `GOWORK=off` now and lint cleanly. Remove the exclusion so all Go code is linted consistently.

Also updates CLAUDE.md to clarify: never exclude packages from lint to work around build problems.

## Test plan

- [ ] `TestMCPToolFilterCfg_Includes` — 6 cases (empty filter, allowlist match/miss, blocklist match/miss, allowlist precedence)
- [ ] `golangci-lint run ./internal/runtime/... ./cmd/runtime/...` — 0 issues
- [ ] `go build ./...` passes