### PR TITLE
feat(ee): wire analytics and streaming Helm flags with provider factory

### DIFF
--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -77,6 +77,12 @@ spec:
             {{- if .Values.enterprise.enabled }}
             - --enterprise
             - --policy-proxy-image={{ .Values.enterprise.policyProxy.image.repository }}:{{ .Values.enterprise.policyProxy.image.tag | default .Chart.AppVersion }}
+            {{- if .Values.enterprise.analytics.enabled }}
+            - --enable-analytics
+            {{- end }}
+            {{- if .Values.enterprise.streaming.enabled }}
+            - --enable-streaming
+            {{- end }}
             {{- end }}
           ports:
             {{- if .Values.operator.apiBindAddress }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -194,6 +194,16 @@ enterprise:
       # -- Policy proxy image pull policy
       pullPolicy: IfNotPresent
 
+  # Analytics sync controller (SessionAnalyticsSync CRD)
+  analytics:
+    # -- Enable the SessionAnalyticsSync controller
+    enabled: false
+
+  # Session streaming controller (SessionStreamingConfig CRD)
+  streaming:
+    # -- Enable the SessionStreamingConfig controller
+    enabled: false
+
   # PromptKit LSP server for YAML validation
   promptkitLsp:
     # -- Enable PromptKit LSP server

--- a/ee/pkg/analyticsfactory/factory.go
+++ b/ee/pkg/analyticsfactory/factory.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+// Package analyticsfactory provides the AnalyticsProviderFactory implementation
+// used by the SessionAnalyticsSync controller for connectivity checks.
+package analyticsfactory
+
+import (
+	"context"
+	"fmt"
+
+	corev1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/analytics/snowflake"
+)
+
+// Factory implements the AnalyticsProviderFactory interface used by the
+// SessionAnalyticsSync controller to perform connectivity checks.
+type Factory struct{}
+
+// Ping verifies connectivity to the analytics provider described by spec.
+// It creates a temporary provider, initialises it (which pings the backend),
+// then closes it. The provider is never used for sync — only for the Ping.
+func (f *Factory) Ping(ctx context.Context, spec corev1alpha1.SessionAnalyticsSyncSpec) error {
+	switch spec.Provider {
+	case corev1alpha1.AnalyticsProviderSnowflake:
+		return pingSnowflake(ctx, spec)
+	default:
+		return fmt.Errorf("unsupported analytics provider: %q", spec.Provider)
+	}
+}
+
+// pingSnowflake creates a temporary Snowflake provider, calls Init (which
+// opens the connection and pings the database), then closes it.
+func pingSnowflake(ctx context.Context, spec corev1alpha1.SessionAnalyticsSyncSpec) error {
+	if spec.Snowflake == nil {
+		return fmt.Errorf("snowflake configuration is required")
+	}
+
+	cfg := &snowflake.Config{
+		Account:   spec.Snowflake.Account,
+		Database:  spec.Snowflake.Database,
+		Schema:    spec.Snowflake.Schema,
+		Warehouse: spec.Snowflake.Warehouse,
+		Role:      spec.Snowflake.Role,
+	}
+
+	p := snowflake.NewProvider(cfg, nil)
+	if err := p.Init(ctx); err != nil {
+		return fmt.Errorf("snowflake ping: %w", err)
+	}
+	return p.Close()
+}

--- a/ee/pkg/analyticsfactory/factory_test.go
+++ b/ee/pkg/analyticsfactory/factory_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package analyticsfactory_test
+
+import (
+	"context"
+	"testing"
+
+	corev1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+	"github.com/altairalabs/omnia/ee/pkg/analyticsfactory"
+)
+
+func TestFactory_Ping_UnsupportedProvider_BigQuery(t *testing.T) {
+	f := &analyticsfactory.Factory{}
+	spec := corev1alpha1.SessionAnalyticsSyncSpec{
+		Provider: corev1alpha1.AnalyticsProviderBigQuery,
+	}
+	err := f.Ping(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected error for unsupported provider, got nil")
+	}
+	want := `unsupported analytics provider: "bigquery"`
+	if err.Error() != want {
+		t.Errorf("unexpected error message:\n  got:  %q\n  want: %q", err.Error(), want)
+	}
+}
+
+func TestFactory_Ping_UnsupportedProvider_ClickHouse(t *testing.T) {
+	f := &analyticsfactory.Factory{}
+	spec := corev1alpha1.SessionAnalyticsSyncSpec{
+		Provider: corev1alpha1.AnalyticsProviderClickHouse,
+	}
+	err := f.Ping(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected error for unsupported provider, got nil")
+	}
+	want := `unsupported analytics provider: "clickhouse"`
+	if err.Error() != want {
+		t.Errorf("unexpected error message:\n  got:  %q\n  want: %q", err.Error(), want)
+	}
+}
+
+func TestFactory_Ping_Snowflake_MissingConfig(t *testing.T) {
+	f := &analyticsfactory.Factory{}
+	spec := corev1alpha1.SessionAnalyticsSyncSpec{
+		Provider: corev1alpha1.AnalyticsProviderSnowflake,
+		// Snowflake is nil — no config provided
+	}
+	err := f.Ping(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected error when snowflake config is nil, got nil")
+	}
+	if err.Error() != "snowflake configuration is required" {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestFactory_Ping_Snowflake_InvalidConfig(t *testing.T) {
+	f := &analyticsfactory.Factory{}
+	spec := corev1alpha1.SessionAnalyticsSyncSpec{
+		Provider: corev1alpha1.AnalyticsProviderSnowflake,
+		Snowflake: &corev1alpha1.SnowflakeConfig{
+			Account:   "invalid-account",
+			Database:  "test_db",
+			Schema:    "public",
+			Warehouse: "test_wh",
+		},
+	}
+	// Init will fail because the account doesn't exist — exercises the
+	// pingSnowflake path through Config construction and Init error.
+	err := f.Ping(context.Background(), spec)
+	if err == nil {
+		t.Fatal("expected error for invalid snowflake account, got nil")
+	}
+	// The error should be wrapped with "snowflake ping:" prefix
+	if len(err.Error()) < 16 || err.Error()[:16] != "snowflake ping: " {
+		t.Errorf("expected error prefixed with 'snowflake ping: ', got: %v", err)
+	}
+}

--- a/ee/pkg/setup/setup.go
+++ b/ee/pkg/setup/setup.go
@@ -16,6 +16,7 @@ import (
 
 	eecontroller "github.com/altairalabs/omnia/ee/internal/controller"
 	"github.com/altairalabs/omnia/ee/internal/webhook"
+	"github.com/altairalabs/omnia/ee/pkg/analyticsfactory"
 	"github.com/altairalabs/omnia/ee/pkg/license"
 	"github.com/altairalabs/omnia/ee/pkg/metrics"
 	"github.com/altairalabs/omnia/ee/pkg/policy"
@@ -143,9 +144,10 @@ func registerConditionalControllers(mgr ctrl.Manager, opts EnterpriseOptions) er
 // registerSessionAnalyticsSync sets up the SessionAnalyticsSync controller.
 func registerSessionAnalyticsSync(mgr ctrl.Manager) error {
 	return (&eecontroller.SessionAnalyticsSyncReconciler{
-		Client:   mgr.GetClient(),
-		Scheme:   mgr.GetScheme(),
-		Recorder: eventRecorder(mgr, "sessionanalyticssync-controller"),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		Recorder:        eventRecorder(mgr, "sessionanalyticssync-controller"),
+		ProviderFactory: &analyticsfactory.Factory{},
 	}).SetupWithManager(mgr)
 }
 


### PR DESCRIPTION
## Summary

Wire the enterprise SessionAnalyticsSync and SessionStreamingConfig features that were built but couldn't be enabled from Helm.

- **Helm values**: Add `enterprise.analytics.enabled` and `enterprise.streaming.enabled` (default false)
- **Deployment template**: Pass `--enable-analytics` and `--enable-streaming` flags to operator when enabled
- **ProviderFactory**: Create `ee/pkg/analyticsfactory` with Snowflake ping support, inject into the SessionAnalyticsSync controller in setup.go

The controller was registered but had a nil ProviderFactory — Ping checks always returned nil error. Now the controller can actually verify Snowflake connectivity.

## Test plan

- [ ] `TestFactory_Ping_UnsupportedProvider_BigQuery` — returns unsupported error
- [ ] `TestFactory_Ping_UnsupportedProvider_ClickHouse` — returns unsupported error
- [ ] `TestFactory_Ping_Snowflake_MissingConfig` — returns missing config error
- [ ] `TestFactory_Ping_Snowflake_InvalidConfig` — returns init error with snowflake prefix
- [ ] `helm template` with `enterprise.analytics.enabled=true` shows `--enable-analytics`
- [ ] `helm template` with `enterprise.streaming.enabled=true` shows `--enable-streaming`
- [ ] Factory coverage: 90%