### PR TITLE
fix(controller): watch owned Deployments for service readiness changes

### DIFF
--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -1095,6 +1096,9 @@ func (r *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		For(&omniav1alpha1.Workspace{}).
+		// Watch Deployments owned by this controller so service readiness
+		// changes (pods becoming ready/unready) trigger a workspace reconcile.
+		Owns(&appsv1.Deployment{}).
 		// Watch PVCs with the workspace label to trigger reconciliation when PVC phase changes
 		Watches(
 			&corev1.PersistentVolumeClaim{},


### PR DESCRIPTION
## Summary

- Add `Owns(&appsv1.Deployment{})` to workspace controller's `SetupWithManager`
- When session-api or memory-api pods recover from crashes, the Deployment status change now triggers a workspace reconcile, updating `services[].ready` automatically
- Previously, readiness stayed stale until a manual annotation or CRD change forced reconciliation

## Test plan

- [ ] Workspace services show Ready after pod restart without manual intervention
- [ ] Controller tests pass (envtest)
- [ ] E2E: workspace services[0].ready becomes true after operator deploys services