### PR TITLE
ci(release): publish Helm chart to charts.altairalabs.ai

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,59 @@ jobs:
           name: helm-chart
           path: dist/omnia-*.tgz
 
+  helm-repo-publish:
+    name: Publish chart to charts.altairalabs.ai
+    needs: [parse-version, helm-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download packaged chart
+        uses: actions/download-artifact@v7
+        with:
+          name: helm-chart
+          path: dist/
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Checkout charts repo
+        uses: actions/checkout@v6
+        with:
+          repository: AltairaLabs/charts
+          token: ${{ secrets.CHARTS_REPO_TOKEN }}
+          path: charts-repo
+          fetch-depth: 1
+
+      - name: Copy chart and regenerate index
+        run: |
+          VERSION="${{ needs.parse-version.outputs.version }}"
+          echo "Publishing omnia-${VERSION}.tgz to charts.altairalabs.ai"
+
+          cp dist/omnia-*.tgz charts-repo/
+          cd charts-repo
+          helm repo index . --url https://charts.altairalabs.ai --merge index.yaml
+
+          echo "Updated index.yaml:"
+          cat index.yaml
+
+      - name: Commit and push
+        run: |
+          VERSION="${{ needs.parse-version.outputs.version }}"
+          cd charts-repo
+          git config user.name 'omnia-release-bot'
+          git config user.email 'omnia-release@users.noreply.github.com'
+
+          git add -A
+
+          if git diff --staged --quiet; then
+            echo "No changes to commit (chart already published at this version?)"
+            exit 0
+          fi
+
+          git commit -m "chore: publish omnia v${VERSION} [skip ci]"
+          git push
+
   docs-build:
     name: Build Documentation
     needs: parse-version
@@ -322,7 +375,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: [parse-version, docker-release, helm-release, docs-deploy]
+    needs: [parse-version, docker-release, helm-release, helm-repo-publish, docs-deploy]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -98,17 +98,32 @@ For stable releases, additional tags are created:
 
 ### Helm Chart
 
-The Helm chart is pushed as an OCI artifact:
+The Helm chart is published to **two channels** on every release:
 
+**1. OCI registry** (GHCR):
 ```
 oci://ghcr.io/altairalabs/charts/omnia:<version>
 ```
 
-Users can install with:
-
+Install with:
 ```bash
 helm install omnia oci://ghcr.io/altairalabs/charts/omnia --version 0.2.0
 ```
+
+**2. Traditional HTTPS Helm repository** (charts.altairalabs.ai):
+
+The chart `.tgz` and an updated `index.yaml` are published to the `AltairaLabs/charts` repository, which is served via GitHub Pages at `https://charts.altairalabs.ai`.
+
+Install with:
+```bash
+helm repo add altaira https://charts.altairalabs.ai
+helm repo update
+helm install omnia altaira/omnia --version 0.2.0
+```
+
+Prereleases (`*-alpha.*`, `*-beta.*`, `*-rc.*`) are included in the HTTPS repo and in OCI. Per Helm's SemVer conventions, `helm install` without `--version` will select the latest stable release by default; users wanting prereleases should pass `--devel` or an explicit `--version`.
+
+**Required secret**: The release workflow needs a `CHARTS_REPO_TOKEN` secret configured on the Omnia repository. This should be a fine-grained Personal Access Token scoped to `AltairaLabs/charts` with `contents: write` permission, or a GitHub App installation token with equivalent scope.
 
 ### Documentation
 


### PR DESCRIPTION
## Summary

- Adds a new `helm-repo-publish` job to `.github/workflows/release.yml` that mirrors the packaged Helm chart into the `AltairaLabs/charts` GitHub Pages repository, making the chart installable via `helm repo add altaira https://charts.altairalabs.ai && helm install omnia altaira/omnia` alongside the existing OCI path.
- Gates `github-release` on `helm-repo-publish` so releases stay atomic — a failed HTTPS publish blocks the GitHub Release (no silent partial successes).
- Updates `RELEASING.md` to document both distribution channels.

## Why

`charts.altairalabs.ai` + the `AltairaLabs/charts` repo were set up ~2 weeks ago (CNAME, GitHub Pages enabled, empty `index.yaml`) but nothing in the release pipeline ever wrote to it. The chart is currently published **only** to OCI at `ghcr.io/altairalabs/charts/omnia`. This PR wires up the second channel so enterprise users, older Helm installs, and Artifact Hub discovery all work.

## How the new job works

1. Downloads the `helm-chart` artifact produced by the existing `helm-release` job
2. Installs Helm 3.14
3. Checks out `AltairaLabs/charts` using a new repo secret `CHARTS_REPO_TOKEN`
4. Copies the new `.tgz` into the charts repo checkout
5. Runs `helm repo index . --url https://charts.altairalabs.ai --merge index.yaml` to regenerate the index
6. Commits with `[skip ci]` (so the charts repo doesn't re-trigger its own Pages workflow unnecessarily) and pushes
7. Idempotent: if the same chart version is already present, commits nothing and exits 0

Prereleases are published to both channels. Per Helm SemVer conventions, bare `helm install` picks the latest stable, and `--devel` or explicit `--version` is required to reach prereleases.

## ⚠️ Action required before the next release tag

A new repository secret must be created **before the next `v*` tag is pushed**, or the `helm-repo-publish` job will fail and block the release:

- **Secret name**: \`CHARTS_REPO_TOKEN\`
- **Scope**: \`contents: write\` on \`AltairaLabs/charts\`
- **Type**: fine-grained Personal Access Token, or a GitHub App installation token with equivalent scope
- **Recommended**: GitHub App over PAT for longevity and scoped permissions

## No backfill

Existing alpha releases (\`v0.2.0-alpha.1\` through \`v0.2.0-alpha.12\`) are **not** backfilled into \`charts.altairalabs.ai\`. The HTTPS repo starts fresh from the first release after this PR merges. Alphas remain available via OCI for anyone who needs them.

## Test plan

- [x] YAML parses cleanly (\`yq eval '.jobs | keys'\` lists all 7 jobs including \`helm-repo-publish\`)
- [x] \`github-release.needs\` includes \`helm-repo-publish\` (verified via yq)
- [x] Pre-commit hooks pass (Go/dashboard checks skipped — no relevant files staged)
- [ ] Create \`CHARTS_REPO_TOKEN\` secret on this repo
- [ ] Tag a test prerelease (e.g., \`v0.2.0-alpha.13\`) and verify:
  - [ ] \`helm-repo-publish\` job runs successfully
  - [ ] A new commit appears on \`AltairaLabs/charts\` main
  - [ ] \`https://charts.altairalabs.ai/index.yaml\` contains the new entry
  - [ ] \`helm repo add altaira https://charts.altairalabs.ai && helm repo update && helm search repo altaira/omnia --devel\` returns the new version
  - [ ] \`helm install omnia altaira/omnia --version 0.2.0-alpha.13 --devel\` works end-to-end
- [ ] Verify \`github-release\` still runs and creates the GitHub Release after \`helm-repo-publish\` succeeds