### PR TITLE
feat(runtime): implement retry execution for tool executors

### DIFF
--- a/docs/superpowers/plans/2026-04-12-retry-execution.md
+++ b/docs/superpowers/plans/2026-04-12-retry-execution.md
@@ -1,0 +1,1918 @@
+# Retry Execution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement retry logic with exponential backoff for HTTP, gRPC, MCP, and OpenAPI tool executors, including replacing PromptKit's HTTP executor with a direct `http.Client` implementation.
+
+**Architecture:** A generic `retryWithBackoff` engine with transport-specific error classifiers. Each executor wraps its call in the retry engine. HTTP execution is moved from PromptKit's `HTTPExecutor` to a direct `http.Client.Do()` to access response headers for `Retry-After` support and status code classification.
+
+**Tech Stack:** Go, OTel tracing (`go.opentelemetry.io/otel/trace`), `logr.Logger`, `google.golang.org/grpc/status`, `net/http`
+
+---
+
+## File Map
+
+| File | Purpose |
+|------|---------|
+| `internal/runtime/tools/retry.go` | Generic retry engine: `retryPolicy` struct, `retryWithBackoff()`, backoff/jitter helpers, policy extraction helpers |
+| `internal/runtime/tools/retry_test.go` | Unit tests for retry engine |
+| `internal/runtime/tools/retry_classify.go` | Transport-specific error classifiers: HTTP (with Retry-After), gRPC, MCP |
+| `internal/runtime/tools/retry_classify_test.go` | Unit tests for classifiers |
+| `internal/runtime/tools/http_client.go` | Direct HTTP execution: request building, response processing (replaces PromptKit HTTPExecutor) |
+| `internal/runtime/tools/http_client_test.go` | Unit tests for HTTP client |
+| `internal/runtime/tools/omnia_executor.go` | Modified: wire retry into all four executor paths, remove PromptKit HTTPExecutor |
+| `internal/runtime/tools/omnia_executor_test.go` | Modified: integration tests proving retry works end-to-end per transport |
+
+## Task Execution Notes
+
+- **TDD throughout**: write the failing test, run it, implement, run it, commit.
+- **Go import rule**: always add imports and their usage in the same Edit call. Run `goimports -w <file>` after finishing edits to a Go file.
+- **Commit style**: conventional commits (`feat:`, `test:`, `refactor:`).
+- **Test commands**: `go test ./internal/runtime/tools/... -count=1 -run <TestName> -v`
+- **Lint**: `golangci-lint run ./internal/runtime/tools/...` before committing non-test files.
+
+---
+
+## Tasks
+
+### Task 1: Implement `retryPolicy` struct and `retryWithBackoff` core loop
+
+**Files:**
+- Create: `internal/runtime/tools/retry.go`
+- Create: `internal/runtime/tools/retry_test.go`
+
+- [ ] **Step 1: Write the retry_test.go with first test — success on first attempt**
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+...
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+func TestRetryWithBackoff_SuccessFirstAttempt(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 3, InitialBackoff: 10 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 1 * time.Second}
+
+	calls := 0
+	result, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(_ error) (bool, time.Duration) { return true, 0 },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			return json.RawMessage(`{"ok":true}`), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+	if string(result) != `{"ok":true}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run TestRetryWithBackoff_SuccessFirstAttempt -v`
+Expected: FAIL — `retryWithBackoff` undefined.
+
+- [ ] **Step 3: Write retry.go with retryPolicy struct and retryWithBackoff implementation**
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+...
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// retryPolicy is the common retry configuration extracted from the
+// transport-specific Runtime*RetryPolicy types.
+type retryPolicy struct {
+	MaxAttempts       int32
+	InitialBackoff    time.Duration
+	BackoffMultiplier float64
+	MaxBackoff        time.Duration
+}
+
+// retryWithBackoff executes fn up to policy.MaxAttempts times with exponential
+// backoff and jitter between attempts. classify determines whether a given error
+// is retryable and optionally returns a Retry-After duration override.
+// Each attempt gets its own context.WithTimeout using attemptTimeout (0 = no
+// per-attempt timeout). The parent ctx is used for cancellation between attempts.
+func retryWithBackoff(
+	ctx context.Context,
+	log logr.Logger,
+	span trace.Span,
+	policy retryPolicy,
+	attemptTimeout time.Duration,
+	classify func(error) (retryable bool, retryAfter time.Duration),
+	fn func(ctx context.Context) (json.RawMessage, error),
+) (json.RawMessage, error) {
+	if policy.MaxAttempts <= 1 {
+		return fn(withAttemptTimeout(ctx, attemptTimeout))
+	}
+
+	var lastErr error
+	for attempt := int32(0); attempt < policy.MaxAttempts; attempt++ {
+		attemptCtx := withAttemptTimeout(ctx, attemptTimeout)
+		result, err := fn(attemptCtx)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+
+		// Last attempt — don't classify or sleep.
+		if attempt == policy.MaxAttempts-1 {
+			break
+		}
+
+		retryable, retryAfter := classify(err)
+		if !retryable {
+			return nil, err
+		}
+
+		delay := backoffDelay(policy, attempt, retryAfter)
+
+		log.V(1).Info("retry attempt",
+			"attempt", attempt+1,
+			"maxAttempts", policy.MaxAttempts,
+			"delay", delay,
+			"error", err.Error())
+		span.AddEvent("retry.attempt", trace.WithAttributes(
+			attribute.Int("attempt", int(attempt+1)),
+			attribute.String("delay", delay.String()),
+			attribute.String("error", err.Error()),
+		))
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	log.V(0).Info("retries exhausted",
+		"attempts", policy.MaxAttempts,
+		"error", lastErr.Error())
+	span.AddEvent("retry.exhausted", trace.WithAttributes(
+		attribute.Int("attempts", int(policy.MaxAttempts)),
+	))
+
+	return nil, fmt.Errorf("%d attempts exhausted: %w", policy.MaxAttempts, lastErr)
+}
+
+// withAttemptTimeout returns a context with the given timeout applied.
+// If timeout is 0, returns the parent context unchanged.
+func withAttemptTimeout(ctx context.Context, timeout time.Duration) context.Context {
+	if timeout <= 0 {
+		return ctx
+	}
+	attemptCtx, cancel := context.WithTimeout(ctx, timeout)
+	// The cancel func is intentionally not deferred here — the caller (fn) owns
+	// the context lifetime. The GC will clean up after fn returns and the timer
+	// fires or the parent is cancelled.
+	_ = cancel
+	return attemptCtx
+}
+
+// backoffDelay calculates the delay for the given attempt number using
+// exponential backoff with ±10% jitter. If retryAfter > 0, it is used
+// as a floor for the delay.
+func backoffDelay(policy retryPolicy, attempt int32, retryAfter time.Duration) time.Duration {
+	delay := float64(policy.InitialBackoff) * math.Pow(policy.BackoffMultiplier, float64(attempt))
+	if delay > float64(policy.MaxBackoff) {
+		delay = float64(policy.MaxBackoff)
+	}
+
+	// ±10% jitter
+	jitter := delay * 0.1 * (2*rand.Float64() - 1)
+	delay += jitter
+
+	d := time.Duration(delay)
+	if d < 0 {
+		d = 0
+	}
+
+	if retryAfter > 0 && retryAfter > d {
+		d = retryAfter
+		if d > policy.MaxBackoff {
+			d = policy.MaxBackoff
+		}
+	}
+
+	return d
+}
+```
+
+**Note on `withAttemptTimeout`:** The cancel func is captured but not deferred because `fn` receives `attemptCtx` and the context tree is cleaned up when the parent context completes. This avoids a context leak warning from `go vet`. However, this is a known pattern trade-off — if `go vet` flags it, switch to passing the cancel func alongside the context. See Step 4.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run TestRetryWithBackoff_SuccessFirstAttempt -v`
+Expected: PASS.
+
+If `go vet` complains about the cancel func, refactor `withAttemptTimeout` to return `(context.Context, context.CancelFunc)` and defer the cancel in the retry loop body.
+
+- [ ] **Step 5: Add remaining retry engine tests**
+
+Add these tests to `retry_test.go`:
+
+```go
+func TestRetryWithBackoff_RetryThenSucceed(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 3, InitialBackoff: 1 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 100 * time.Millisecond}
+
+	calls := 0
+	result, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(_ error) (bool, time.Duration) { return true, 0 },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			if calls < 3 {
+				return nil, errors.New("transient")
+			}
+			return json.RawMessage(`{"ok":true}`), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+	if string(result) != `{"ok":true}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestRetryWithBackoff_NonRetryableError(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 3, InitialBackoff: 1 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 100 * time.Millisecond}
+
+	calls := 0
+	_, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(_ error) (bool, time.Duration) { return false, 0 },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			return nil, errors.New("permanent")
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retries), got %d", calls)
+	}
+	if err.Error() != "permanent" {
+		t.Errorf("expected original error, got: %v", err)
+	}
+}
+
+func TestRetryWithBackoff_AllAttemptsExhausted(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 3, InitialBackoff: 1 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 100 * time.Millisecond}
+
+	calls := 0
+	_, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(_ error) (bool, time.Duration) { return true, 0 },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			return nil, errors.New("always fails")
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+	if !errors.Is(err, errors.New("")) {
+		// Just check it wraps the original
+		if !errors.As(err, new(error)) {
+			t.Errorf("error should wrap original")
+		}
+	}
+}
+
+func TestRetryWithBackoff_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 5, InitialBackoff: 50 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 1 * time.Second}
+
+	calls := 0
+	_, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(_ error) (bool, time.Duration) { return true, 0 },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			if calls == 1 {
+				cancel() // Cancel during backoff sleep
+			}
+			return nil, errors.New("transient")
+		},
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled, got: %v", err)
+	}
+}
+
+func TestRetryWithBackoff_PerAttemptTimeout(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 3, InitialBackoff: 1 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 100 * time.Millisecond}
+
+	calls := 0
+	_, err := retryWithBackoff(ctx, log, span, policy, 10*time.Millisecond,
+		func(_ error) (bool, time.Duration) { return true, 0 },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			if calls < 3 {
+				<-ctx.Done() // Block until timeout
+				return nil, ctx.Err()
+			}
+			return json.RawMessage(`{"ok":true}`), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_SingleAttemptFastPath(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 1}
+
+	calls := 0
+	_, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(_ error) (bool, time.Duration) { t.Fatal("classify should not be called"); return false, 0 },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			return nil, errors.New("fail")
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_RetryAfterOverride(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 2, InitialBackoff: 1 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 1 * time.Second}
+
+	start := time.Now()
+	calls := 0
+	_, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(_ error) (bool, time.Duration) { return true, 50 * time.Millisecond },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			return nil, errors.New("retry-after")
+		},
+	)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// The retryAfter of 50ms should override the 1ms initial backoff.
+	if elapsed < 40*time.Millisecond {
+		t.Errorf("expected at least ~50ms delay, got %v", elapsed)
+	}
+}
+
+func TestBackoffDelay_ExponentialGrowth(t *testing.T) {
+	policy := retryPolicy{InitialBackoff: 100 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 10 * time.Second}
+
+	// Run many times to average out jitter
+	for attempt := int32(0); attempt < 5; attempt++ {
+		delay := backoffDelay(policy, attempt, 0)
+		expected := 100 * time.Millisecond * time.Duration(math.Pow(2.0, float64(attempt)))
+		if expected > 10*time.Second {
+			expected = 10 * time.Second
+		}
+		// Allow ±15% for jitter
+		low := time.Duration(float64(expected) * 0.85)
+		high := time.Duration(float64(expected) * 1.15)
+		if delay < low || delay > high {
+			t.Errorf("attempt %d: delay %v outside [%v, %v]", attempt, delay, low, high)
+		}
+	}
+}
+```
+
+- [ ] **Step 6: Run all retry tests**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run TestRetryWithBackoff -v`
+Expected: All PASS.
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run TestBackoffDelay -v`
+Expected: PASS.
+
+- [ ] **Step 7: Run goimports**
+
+Run: `goimports -w internal/runtime/tools/retry.go internal/runtime/tools/retry_test.go`
+
+- [ ] **Step 8: Commit**
+
+```
+git add internal/runtime/tools/retry.go internal/runtime/tools/retry_test.go
+git commit -m "feat(runtime): add generic retryWithBackoff engine with exponential backoff and jitter"
+```
+
+---
+
+### Task 2: Implement error classifiers
+
+**Files:**
+- Create: `internal/runtime/tools/retry_classify.go`
+- Create: `internal/runtime/tools/retry_classify_test.go`
+
+- [ ] **Step 1: Write classifier test file with HTTP tests**
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+...
+*/
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestClassifyHTTPResult_NetworkError_RetryEnabled(t *testing.T) {
+	result := httpCallResult{Err: &net.OpError{Op: "dial", Err: errors.New("connection refused")}}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{502}, RetryOnNetworkError: true}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+	if !retryable {
+		t.Error("expected retryable for network error")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_NetworkError_RetryDisabled(t *testing.T) {
+	result := httpCallResult{Err: &net.OpError{Op: "dial", Err: errors.New("connection refused")}}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{502}, RetryOnNetworkError: false}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+	if retryable {
+		t.Error("expected not retryable when RetryOnNetworkError is false")
+	}
+}
+
+func TestClassifyHTTPResult_StatusCodeInRetryOn(t *testing.T) {
+	result := httpCallResult{StatusCode: 503}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{502, 503, 504}, RetryOnNetworkError: true}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+	if !retryable {
+		t.Error("expected retryable for status 503")
+	}
+}
+
+func TestClassifyHTTPResult_StatusCodeNotInRetryOn(t *testing.T) {
+	result := httpCallResult{StatusCode: 400}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{502, 503, 504}, RetryOnNetworkError: true}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+	if retryable {
+		t.Error("expected not retryable for status 400")
+	}
+}
+
+func TestClassifyHTTPResult_RetryAfterSeconds(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Retry-After", "5")
+	result := httpCallResult{StatusCode: 503, Headers: headers}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{503}, RespectRetryAfter: true}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+	if !retryable {
+		t.Error("expected retryable")
+	}
+	if retryAfter != 5*time.Second {
+		t.Errorf("expected retryAfter=5s, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_RetryAfterHTTPDate(t *testing.T) {
+	futureTime := time.Now().Add(10 * time.Second)
+	headers := http.Header{}
+	headers.Set("Retry-After", futureTime.UTC().Format(http.TimeFormat))
+	result := httpCallResult{StatusCode: 503, Headers: headers}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{503}, RespectRetryAfter: true}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+	if !retryable {
+		t.Error("expected retryable")
+	}
+	// Allow 2s tolerance for test execution time
+	if retryAfter < 8*time.Second || retryAfter > 12*time.Second {
+		t.Errorf("expected retryAfter ~10s, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_RetryAfterIgnoredWhenDisabled(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Retry-After", "5")
+	result := httpCallResult{StatusCode: 503, Headers: headers}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{503}, RespectRetryAfter: false}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+	if !retryable {
+		t.Error("expected retryable")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0 when disabled, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_ContextDeadlineExceeded(t *testing.T) {
+	result := httpCallResult{Err: context.DeadlineExceeded}
+	policy := &RuntimeHTTPRetryPolicy{RetryOnNetworkError: true}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+	if !retryable {
+		t.Error("expected retryable for deadline exceeded")
+	}
+}
+
+func TestClassifyHTTPResult_Success(t *testing.T) {
+	result := httpCallResult{StatusCode: 200}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{502}, RetryOnNetworkError: true}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+	if retryable {
+		t.Error("expected not retryable for success")
+	}
+}
+```
+
+- [ ] **Step 2: Add gRPC classifier tests**
+
+Append to `retry_classify_test.go`:
+
+```go
+func TestClassifyGRPCError_RetryableStatusCode(t *testing.T) {
+	err := grpcStatus.Error(grpcCodes.Unavailable, "service unavailable")
+
+	retryable, _ := classifyGRPCError(err, []string{"UNAVAILABLE", "DEADLINE_EXCEEDED"})
+	if !retryable {
+		t.Error("expected retryable for UNAVAILABLE")
+	}
+}
+
+func TestClassifyGRPCError_NonRetryableStatusCode(t *testing.T) {
+	err := grpcStatus.Error(grpcCodes.NotFound, "not found")
+
+	retryable, _ := classifyGRPCError(err, []string{"UNAVAILABLE"})
+	if retryable {
+		t.Error("expected not retryable for NOT_FOUND")
+	}
+}
+
+func TestClassifyGRPCError_CircuitBreakerError(t *testing.T) {
+	// Circuit breaker wraps errors with fmt.Errorf, not gRPC status
+	err := errors.New("circuit breaker [tool]: circuit open")
+
+	retryable, _ := classifyGRPCError(err, []string{"UNAVAILABLE"})
+	if retryable {
+		t.Error("expected not retryable for circuit breaker error")
+	}
+}
+```
+
+**Note:** The imports for gRPC status and codes need aliases to avoid colliding with the `status` word:
+
+```go
+import (
+	grpcCodes "google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+```
+
+- [ ] **Step 3: Add MCP classifier tests**
+
+Append to `retry_classify_test.go`:
+
+```go
+func TestClassifyMCPError_TransportError(t *testing.T) {
+	err := &net.OpError{Op: "read", Err: errors.New("connection reset")}
+
+	retryable, _ := classifyMCPError(err)
+	if !retryable {
+		t.Error("expected retryable for transport error")
+	}
+}
+
+func TestClassifyMCPError_ContextDeadline(t *testing.T) {
+	retryable, _ := classifyMCPError(context.DeadlineExceeded)
+	if !retryable {
+		t.Error("expected retryable for deadline exceeded")
+	}
+}
+
+func TestClassifyMCPError_NilError(t *testing.T) {
+	retryable, _ := classifyMCPError(nil)
+	if retryable {
+		t.Error("expected not retryable for nil error")
+	}
+}
+
+func TestClassifyMCPError_ToolError(t *testing.T) {
+	// MCP tool errors are returned as mcpToolError, not transport errors
+	err := &mcpToolError{message: "file not found"}
+
+	retryable, _ := classifyMCPError(err)
+	if retryable {
+		t.Error("expected not retryable for tool error")
+	}
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run "TestClassify" -v`
+Expected: FAIL — `classifyHTTPResult`, `classifyGRPCError`, `classifyMCPError` undefined.
+
+- [ ] **Step 5: Implement retry_classify.go**
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+...
+*/
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	grpcCodes "google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+// httpCallResult captures the HTTP response metadata needed for retry
+// classification. It is populated by the HTTP executor before calling
+// the classifier.
+type httpCallResult struct {
+	StatusCode int
+	Headers    http.Header
+	Err        error // nil if HTTP request succeeded (even if status is non-2xx)
+}
+
+// mcpToolError represents an MCP tool-level error (IsError: true in the
+// MCP result). These are application errors and should not be retried.
+type mcpToolError struct {
+	message string
+}
+
+func (e *mcpToolError) Error() string {
+	return e.message
+}
+
+// classifyHTTPResult determines if an HTTP call result is retryable based on
+// the retry policy. Returns (retryable, retryAfter) where retryAfter is the
+// parsed Retry-After header value if present and enabled.
+func classifyHTTPResult(result httpCallResult, policy *RuntimeHTTPRetryPolicy) (bool, time.Duration) {
+	if result.Err != nil {
+		if isNetworkError(result.Err) && policy.RetryOnNetworkError {
+			return true, 0
+		}
+		return false, 0
+	}
+
+	// No error means we have a status code to check.
+	if !slices.Contains(policy.RetryOn, int32(result.StatusCode)) {
+		return false, 0
+	}
+
+	var retryAfter time.Duration
+	if policy.RespectRetryAfter && result.Headers != nil {
+		retryAfter = parseRetryAfter(result.Headers.Get("Retry-After"))
+	}
+
+	return true, retryAfter
+}
+
+// classifyGRPCError determines if a gRPC error is retryable based on the
+// status code. Circuit breaker errors (non-gRPC errors) are never retryable.
+func classifyGRPCError(err error, retryableStatusCodes []string) (bool, time.Duration) {
+	if err == nil {
+		return false, 0
+	}
+
+	st, ok := grpcStatus.FromError(err)
+	if !ok {
+		// Not a gRPC status error — likely a circuit breaker or transport wrapper.
+		return false, 0
+	}
+
+	codeName := strings.ToUpper(st.Code().String())
+	return slices.Contains(retryableStatusCodes, codeName), 0
+}
+
+// classifyMCPError determines if an MCP error is retryable. Only transport-level
+// errors are retryable; tool errors (mcpToolError) are not.
+func classifyMCPError(err error) (bool, time.Duration) {
+	if err == nil {
+		return false, 0
+	}
+
+	// MCP tool errors are application-level and not retryable.
+	var toolErr *mcpToolError
+	if errors.As(err, &toolErr) {
+		return false, 0
+	}
+
+	// Everything else is a transport error (connection, timeout, etc.)
+	return true, 0
+}
+
+// isNetworkError returns true if err represents a network-level failure
+// (connection refused, DNS, timeout).
+func isNetworkError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var netErr *net.OpError
+	if errors.As(err, &netErr) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	if errors.As(err, &dnsErr) {
+		return true
+	}
+	return false
+}
+
+// parseRetryAfter parses an HTTP Retry-After header value. It supports
+// both seconds (e.g., "5") and HTTP-date formats per RFC 9110.
+// Returns 0 if the header is empty or unparseable.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+
+	// Try seconds first (most common).
+	if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+		return time.Duration(seconds) * time.Second
+	}
+
+	// Try HTTP-date format.
+	if t, err := http.ParseTime(value); err == nil {
+		delay := time.Until(t)
+		if delay > 0 {
+			return delay
+		}
+	}
+
+	return 0
+}
+
+// Policy extraction helpers — convert transport-specific retry policies
+// into the generic retryPolicy used by retryWithBackoff.
+
+func httpRetryParams(cfg *HTTPCfg) (retryPolicy, func(error) (bool, time.Duration)) {
+	if cfg == nil || cfg.RetryPolicy == nil {
+		return retryPolicy{MaxAttempts: 1}, nil
+	}
+	p := cfg.RetryPolicy
+	return retryPolicy{
+			MaxAttempts:       p.MaxAttempts,
+			InitialBackoff:    p.InitialBackoff.Get(),
+			BackoffMultiplier: p.BackoffMultiplier,
+			MaxBackoff:        p.MaxBackoff.Get(),
+		}, func(_ error) (bool, time.Duration) {
+			// The actual httpCallResult is captured by the closure in the executor.
+			// This is a placeholder — the real classify closure is built in executeHTTP.
+			return false, 0
+		}
+}
+
+func grpcRetryParams(cfg *GRPCCfg) (retryPolicy, func(error) (bool, time.Duration)) {
+	if cfg == nil || cfg.RetryPolicy == nil {
+		return retryPolicy{MaxAttempts: 1}, nil
+	}
+	p := cfg.RetryPolicy
+	return retryPolicy{
+		MaxAttempts:       p.MaxAttempts,
+		InitialBackoff:    p.InitialBackoff.Get(),
+		BackoffMultiplier: p.BackoffMultiplier,
+		MaxBackoff:        p.MaxBackoff.Get(),
+	}, func(err error) (bool, time.Duration) {
+		return classifyGRPCError(err, p.RetryableStatusCodes)
+	}
+}
+
+func mcpRetryParams(cfg *MCPCfg) (retryPolicy, func(error) (bool, time.Duration)) {
+	if cfg == nil || cfg.RetryPolicy == nil {
+		return retryPolicy{MaxAttempts: 1}, nil
+	}
+	p := cfg.RetryPolicy
+	return retryPolicy{
+		MaxAttempts:       p.MaxAttempts,
+		InitialBackoff:    p.InitialBackoff.Get(),
+		BackoffMultiplier: p.BackoffMultiplier,
+		MaxBackoff:        p.MaxBackoff.Get(),
+	}, func(err error) (bool, time.Duration) {
+		return classifyMCPError(err)
+	}
+}
+```
+
+- [ ] **Step 6: Run classifier tests**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run "TestClassify" -v`
+Expected: All PASS.
+
+- [ ] **Step 7: Run goimports**
+
+Run: `goimports -w internal/runtime/tools/retry_classify.go internal/runtime/tools/retry_classify_test.go`
+
+- [ ] **Step 8: Commit**
+
+```
+git add internal/runtime/tools/retry_classify.go internal/runtime/tools/retry_classify_test.go
+git commit -m "feat(runtime): add HTTP, gRPC, and MCP error classifiers with Retry-After support"
+```
+
+---
+
+### Task 3: Implement direct HTTP client (replace PromptKit HTTPExecutor)
+
+**Files:**
+- Create: `internal/runtime/tools/http_client.go`
+- Create: `internal/runtime/tools/http_client_test.go`
+
+- [ ] **Step 1: Write http_client_test.go with basic tests**
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+...
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestDoHTTPRequest_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "GET"}
+	result, callResult, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callResult.StatusCode != 200 {
+		t.Errorf("expected status 200, got %d", callResult.StatusCode)
+	}
+	if string(result) != `{"result":"ok"}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestDoHTTPRequest_NonJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("plain text response"))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "GET"}
+	result, _, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Non-JSON responses should be wrapped in {"result": "..."}
+	var m map[string]string
+	if jsonErr := json.Unmarshal(result, &m); jsonErr != nil {
+		t.Fatalf("result is not valid JSON: %v", jsonErr)
+	}
+	if m["result"] != "plain text response" {
+		t.Errorf("unexpected wrapped result: %s", result)
+	}
+}
+
+func TestDoHTTPRequest_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("bad gateway"))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "GET"}
+	_, callResult, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected transport error: %v", err)
+	}
+	// Non-2xx is not a transport error — it returns callResult with status code
+	if callResult.StatusCode != 502 {
+		t.Errorf("expected status 502, got %d", callResult.StatusCode)
+	}
+}
+
+func TestDoHTTPRequest_POSTWithBody(t *testing.T) {
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var readErr error
+		receivedBody, readErr = json.Marshal(r.Method)
+		_ = readErr
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		receivedBody = body
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"received":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "POST"}
+	_, _, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil, json.RawMessage(`{"input":"data"}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestDoHTTPRequest_Headers(t *testing.T) {
+	var receivedAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{
+		Endpoint: srv.URL,
+		Method:   "GET",
+		Headers:  map[string]string{"Authorization": "Bearer test-token"},
+	}
+	_, _, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedAuth != "Bearer test-token" {
+		t.Errorf("expected auth header, got %q", receivedAuth)
+	}
+}
+
+func TestDoHTTPRequest_ConnectionRefused(t *testing.T) {
+	cfg := &HTTPCfg{Endpoint: "http://127.0.0.1:1", Method: "GET"}
+	_, callResult, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil, json.RawMessage(`{}`))
+	// Transport error — err is set, callResult.Err is also set
+	if err == nil && callResult.Err == nil {
+		t.Fatal("expected transport error for refused connection")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run "TestDoHTTPRequest" -v`
+Expected: FAIL — `doHTTPRequest` undefined.
+
+- [ ] **Step 3: Implement http_client.go**
+
+```go
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+...
+*/
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const maxHTTPResponseSize = 10 * 1024 * 1024 // 10MB per response
+
+// doHTTPRequest executes an HTTP request using the provided client and config.
+// It returns the response body as JSON, an httpCallResult for retry classification,
+// and a transport-level error (connection refused, DNS, etc.).
+//
+// Non-2xx responses are NOT returned as errors — the caller inspects
+// callResult.StatusCode for retry classification. Only transport failures
+// set callResult.Err.
+func doHTTPRequest(
+	ctx context.Context,
+	client *http.Client,
+	cfg *HTTPCfg,
+	headers map[string]string,
+	args json.RawMessage,
+) (json.RawMessage, httpCallResult, error) {
+	req, err := buildHTTPRequest(ctx, cfg, headers, args)
+	if err != nil {
+		return nil, httpCallResult{Err: err}, err
+	}
+
+	// Inject OTel trace context into outbound request headers.
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, httpCallResult{Err: err}, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxHTTPResponseSize))
+	if err != nil {
+		return nil, httpCallResult{Err: err}, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	callResult := httpCallResult{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header,
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// Non-2xx: return the call result for classification but also
+		// return an error so the retry engine sees a failure.
+		return nil, callResult, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncateBody(body, 512))
+	}
+
+	// Wrap non-JSON response.
+	if !json.Valid(body) {
+		wrapped := map[string]string{"result": string(body)}
+		body, _ = json.Marshal(wrapped)
+	}
+
+	return body, callResult, nil
+}
+
+// buildHTTPRequest constructs an HTTP request from the handler config.
+func buildHTTPRequest(
+	ctx context.Context,
+	cfg *HTTPCfg,
+	headers map[string]string,
+	args json.RawMessage,
+) (*http.Request, error) {
+	method := cfg.Method
+	if method == "" {
+		method = "POST"
+	}
+
+	hasArgs := len(args) > 0 && string(args) != "null" && string(args) != "{}"
+	url := cfg.Endpoint
+	var bodyReader io.Reader
+
+	if hasArgs {
+		if isHTTPBodyMethod(method) {
+			bodyReader = bytes.NewReader(args)
+		} else {
+			var err error
+			url, err = appendQueryFromJSON(url, args)
+			if err != nil {
+				return nil, fmt.Errorf("failed to build query parameters: %w", err)
+			}
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+
+	if bodyReader != nil {
+		ct := cfg.ContentType
+		if ct == "" {
+			ct = "application/json"
+		}
+		req.Header.Set("Content-Type", ct)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	return req, nil
+}
+
+// isHTTPBodyMethod returns true for HTTP methods that carry a request body.
+func isHTTPBodyMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case "POST", "PUT", "PATCH":
+		return true
+	default:
+		return false
+	}
+}
+
+// appendQueryFromJSON appends JSON key-value pairs as query parameters.
+func appendQueryFromJSON(baseURL string, args json.RawMessage) (string, error) {
+	var params map[string]any
+	if err := json.Unmarshal(args, &params); err != nil {
+		return baseURL, err
+	}
+	if len(params) == 0 {
+		return baseURL, nil
+	}
+
+	sep := "?"
+	if strings.Contains(baseURL, "?") {
+		sep = "&"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(baseURL)
+	first := true
+	for k, v := range params {
+		if first {
+			sb.WriteString(sep)
+			first = false
+		} else {
+			sb.WriteByte('&')
+		}
+		sb.WriteString(k)
+		sb.WriteByte('=')
+		sb.WriteString(fmt.Sprintf("%v", v))
+	}
+
+	return sb.String(), nil
+}
+
+// truncateBody truncates a response body to maxLen bytes for error messages.
+func truncateBody(body []byte, maxLen int) string {
+	if len(body) <= maxLen {
+		return string(body)
+	}
+	return string(body[:maxLen]) + "..."
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run "TestDoHTTPRequest" -v`
+Expected: All PASS.
+
+- [ ] **Step 5: Run goimports**
+
+Run: `goimports -w internal/runtime/tools/http_client.go internal/runtime/tools/http_client_test.go`
+
+- [ ] **Step 6: Commit**
+
+```
+git add internal/runtime/tools/http_client.go internal/runtime/tools/http_client_test.go
+git commit -m "feat(runtime): add direct HTTP client replacing PromptKit HTTPExecutor"
+```
+
+---
+
+### Task 4: Wire retry into executeHTTP and executeOpenAPI
+
+**Files:**
+- Modify: `internal/runtime/tools/omnia_executor.go:569-593` (executeHTTP)
+- Modify: `internal/runtime/tools/omnia_executor.go:920-973` (executeOpenAPI)
+- Modify: `internal/runtime/tools/omnia_executor.go:65-97` (OmniaExecutor struct — remove httpExecutor field)
+- Modify: `internal/runtime/tools/omnia_executor.go:107` (NewOmniaExecutor — remove httpExecutor init)
+
+- [ ] **Step 1: Replace executeHTTP with retry-wrapped direct HTTP client**
+
+Replace the `executeHTTP` method (lines 569-593) with:
+
+```go
+func (e *OmniaExecutor) executeHTTP(
+	ctx context.Context,
+	toolName, handlerName string,
+	handler *HandlerEntry,
+	args json.RawMessage,
+) (json.RawMessage, error) {
+	cfg := handler.HTTPConfig
+	if cfg == nil {
+		return nil, fmt.Errorf("handler %q has no HTTP config", handlerName)
+	}
+
+	headers := e.buildHTTPHeaders(ctx, cfg, toolName, handlerName, args)
+
+	policy, _ := httpRetryParams(cfg)
+	var lastCallResult httpCallResult
+	classify := func(err error) (bool, time.Duration) {
+		if cfg.RetryPolicy == nil {
+			return false, 0
+		}
+		return classifyHTTPResult(lastCallResult, cfg.RetryPolicy)
+	}
+
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			result, callResult, err := doHTTPRequest(attemptCtx, &http.Client{}, cfg, headers, args)
+			lastCallResult = callResult
+			return result, err
+		},
+	)
+}
+```
+
+**Note:** `e.currentSpan(ctx)` extracts the span from context — we'll add this small helper in this task.
+
+- [ ] **Step 2: Add currentSpan helper**
+
+Add after the `startSpan` method (around line 434):
+
+```go
+// currentSpan extracts the current span from context for use by sub-operations
+// like retry that need to add events to the parent span.
+func (e *OmniaExecutor) currentSpan(ctx context.Context) trace.Span {
+	return trace.SpanFromContext(ctx)
+}
+```
+
+- [ ] **Step 3: Replace executeOpenAPI to use direct HTTP client with retry**
+
+Replace the `executeOpenAPI` method (lines 920-973) with:
+
+```go
+func (e *OmniaExecutor) executeOpenAPI(
+	ctx context.Context,
+	toolName, handlerName string,
+	handler *HandlerEntry,
+	args json.RawMessage,
+) (json.RawMessage, error) {
+	e.mu.RLock()
+	ops := e.openAPIOps[handlerName]
+	baseURL := e.openAPIBaseURLs[handlerName]
+	hdrs := e.openAPIHeaders[handlerName]
+	e.mu.RUnlock()
+
+	op, ok := ops[toolName]
+	if !ok {
+		return nil, fmt.Errorf("OpenAPI operation %q not found", toolName)
+	}
+
+	// Build a synthetic HTTPCfg for the OpenAPI operation.
+	cfg := &HTTPCfg{
+		Endpoint: baseURL + op.Path,
+		Method:   op.Method,
+		Headers:  make(map[string]string),
+	}
+	for k, v := range hdrs {
+		cfg.Headers[k] = v
+	}
+	if handler.OpenAPIConfig != nil {
+		cfg.AuthType = handler.OpenAPIConfig.AuthType
+		cfg.AuthToken = handler.OpenAPIConfig.AuthToken
+		cfg.RetryPolicy = handler.OpenAPIConfig.RetryPolicy
+	}
+
+	headers := e.buildHTTPHeaders(ctx, cfg, toolName, handlerName, args)
+
+	policy, _ := httpRetryParams(cfg)
+	var lastCallResult httpCallResult
+	classify := func(err error) (bool, time.Duration) {
+		if cfg.RetryPolicy == nil {
+			return false, 0
+		}
+		return classifyHTTPResult(lastCallResult, cfg.RetryPolicy)
+	}
+
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			result, callResult, err := doHTTPRequest(attemptCtx, &http.Client{}, cfg, headers, args)
+			lastCallResult = callResult
+			return result, err
+		},
+	)
+}
+```
+
+- [ ] **Step 4: Remove httpExecutor field from OmniaExecutor struct and NewOmniaExecutor**
+
+In the struct definition (line 78), remove:
+```go
+httpExecutor *sdktools.HTTPExecutor
+```
+
+In `NewOmniaExecutor` (line 107), remove:
+```go
+httpExecutor: sdktools.NewHTTPExecutor(),
+```
+
+Remove the `sdktools` import if no longer used elsewhere. Check with: `grep -n "sdktools\." internal/runtime/tools/omnia_executor.go` — if the only references were `HTTPExecutor` related, remove the import.
+
+- [ ] **Step 5: Run existing tests to verify no regressions**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -v -timeout 120s`
+Expected: All existing tests pass. Some may need updates if they reference `e.httpExecutor` — fix any compilation errors.
+
+- [ ] **Step 6: Run goimports**
+
+Run: `goimports -w internal/runtime/tools/omnia_executor.go`
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/runtime/tools/omnia_executor.go
+git commit -m "feat(runtime): wire retry into HTTP and OpenAPI executors, replace PromptKit HTTPExecutor"
+```
+
+---
+
+### Task 5: Wire retry into executeGRPC and executeMCP
+
+**Files:**
+- Modify: `internal/runtime/tools/omnia_executor.go:837-874` (executeGRPC)
+- Modify: `internal/runtime/tools/omnia_executor.go:692-721` (executeMCP)
+
+- [ ] **Step 1: Wrap executeGRPC with retry (retry wraps circuit breaker)**
+
+Replace the `executeGRPC` method (lines 837-874) with:
+
+```go
+func (e *OmniaExecutor) executeGRPC(
+	ctx context.Context,
+	toolName, handlerName string,
+	args json.RawMessage,
+) (json.RawMessage, error) {
+	e.mu.RLock()
+	client := e.grpcClients[handlerName]
+	handler := e.handlers[handlerName]
+	e.mu.RUnlock()
+
+	if client == nil {
+		return nil, fmt.Errorf("gRPC handler %q not connected", handlerName)
+	}
+
+	grpcCfg := handler.GRPCConfig
+	policy, classify := grpcRetryParams(grpcCfg)
+
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			// Inject policy metadata.
+			md := PolicyGRPCMetadata(attemptCtx, toolName, handlerName, nil)
+			if len(md) > 0 {
+				pairs := make([]string, 0, len(md)*2)
+				for k, v := range md {
+					pairs = append(pairs, k, v)
+				}
+				attemptCtx = metadata.AppendToOutgoingContext(attemptCtx, pairs...)
+			}
+
+			// Execute through circuit breaker.
+			var resp *toolsv1.ToolResponse
+			_, cbErr := e.breakers.Execute(toolName, func() ([]byte, error) {
+				var execErr error
+				resp, execErr = client.Execute(attemptCtx, &toolsv1.ToolRequest{
+					ToolName:      toolName,
+					ArgumentsJson: string(args),
+				})
+				return nil, execErr
+			})
+			if cbErr != nil {
+				return nil, fmt.Errorf("gRPC tool execution failed: %w", cbErr)
+			}
+
+			return marshalGRPCResponse(resp)
+		},
+	)
+}
+```
+
+- [ ] **Step 2: Wrap executeMCP with retry**
+
+Replace the `executeMCP` method (lines 692-721) with:
+
+```go
+func (e *OmniaExecutor) executeMCP(
+	ctx context.Context,
+	toolName, handlerName string,
+	args json.RawMessage,
+) (json.RawMessage, error) {
+	e.mu.RLock()
+	session := e.mcpSessions[handlerName]
+	handler := e.handlers[handlerName]
+	e.mu.RUnlock()
+
+	if session == nil {
+		return nil, fmt.Errorf("MCP handler %q not connected", handlerName)
+	}
+
+	mcpCfg := handler.MCPConfig
+	policy, classify := mcpRetryParams(mcpCfg)
+
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			var argsMap map[string]any
+			if len(args) > 0 {
+				if err := json.Unmarshal(args, &argsMap); err != nil {
+					return nil, fmt.Errorf("failed to parse MCP args: %w", err)
+				}
+			}
+
+			result, err := session.CallTool(attemptCtx, &mcp.CallToolParams{
+				Name:      toolName,
+				Arguments: argsMap,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("MCP tool call failed: %w", err)
+			}
+
+			// Convert MCP tool errors to mcpToolError so the classifier
+			// can distinguish them from transport errors.
+			if result.IsError {
+				msg := "MCP tool error"
+				if len(result.Content) > 0 {
+					if text, ok := result.Content[0].(mcp.TextContent); ok {
+						msg = text.Text
+					}
+				}
+				return nil, &mcpToolError{message: msg}
+			}
+
+			return marshalMCPResult(result)
+		},
+	)
+}
+```
+
+**Note:** The existing `marshalMCPResult` handles `IsError` internally. Since we now need to distinguish tool errors from transport errors for the classifier, we check `result.IsError` before calling `marshalMCPResult` and return a `mcpToolError` instead. Update `marshalMCPResult` to skip the `IsError` check since the caller handles it, or leave it as-is and only call it for non-error results. Check the existing implementation to decide.
+
+- [ ] **Step 3: Run existing tests**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -v -timeout 120s`
+Expected: All pass. Fix any compilation errors from the handler lookup change (we now read `e.handlers[handlerName]` inside `executeGRPC` and `executeMCP` — make sure this works with the existing test setup that directly sets `e.grpcClients` etc.).
+
+- [ ] **Step 4: Run goimports**
+
+Run: `goimports -w internal/runtime/tools/omnia_executor.go`
+
+- [ ] **Step 5: Commit**
+
+```
+git add internal/runtime/tools/omnia_executor.go
+git commit -m "feat(runtime): wire retry into gRPC and MCP executors"
+```
+
+---
+
+### Task 6: Integration tests — HTTP retry
+
+**Files:**
+- Modify: `internal/runtime/tools/omnia_executor_test.go`
+
+- [ ] **Step 1: Add HTTP retry integration test — retry then succeed**
+
+```go
+func TestExecuteHTTP_RetryThenSucceed(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("bad gateway"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["retry-http"] = &HandlerEntry{
+		Name: "retry-http",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint: srv.URL,
+			Method:   "GET",
+			RetryPolicy: &RuntimeHTTPRetryPolicy{
+				MaxAttempts:       int32(3),
+				InitialBackoff:    Duration(1 * time.Millisecond),
+				BackoffMultiplier: 2.0,
+				MaxBackoff:        Duration(100 * time.Millisecond),
+				RetryOn:           []int32{502},
+				RetryOnNetworkError: true,
+			},
+		},
+	}
+	e.toolHandlers["retry-http-tool"] = "retry-http"
+
+	desc := &pktools.ToolDescriptor{Name: "retry-http-tool"}
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 retries + 1 success), got %d", calls)
+	}
+	if string(result) != `{"result":"ok"}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestExecuteHTTP_NonRetryableStatus(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad request"))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["no-retry-http"] = &HandlerEntry{
+		Name: "no-retry-http",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint: srv.URL,
+			Method:   "GET",
+			RetryPolicy: &RuntimeHTTPRetryPolicy{
+				MaxAttempts:       int32(3),
+				InitialBackoff:    Duration(1 * time.Millisecond),
+				BackoffMultiplier: 2.0,
+				MaxBackoff:        Duration(100 * time.Millisecond),
+				RetryOn:           []int32{502, 503},
+				RetryOnNetworkError: true,
+			},
+		},
+	}
+	e.toolHandlers["no-retry-tool"] = "no-retry-http"
+
+	desc := &pktools.ToolDescriptor{Name: "no-retry-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retries for 400), got %d", calls)
+	}
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run "TestExecuteHTTP_Retry" -v`
+Expected: All PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git add internal/runtime/tools/omnia_executor_test.go
+git commit -m "test(runtime): add HTTP retry integration tests"
+```
+
+---
+
+### Task 7: Integration tests — gRPC retry
+
+**Files:**
+- Modify: `internal/runtime/tools/omnia_executor_test.go`
+
+- [ ] **Step 1: Add gRPC retry integration test**
+
+Use the existing `mockToolServiceClient` pattern. Create a variant that fails N times then succeeds:
+
+```go
+type failNTimesClient struct {
+	failCount   int
+	calls       int
+	successResp *toolsv1.ToolResponse
+	failErr     error
+}
+
+func (m *failNTimesClient) Execute(
+	_ context.Context,
+	_ *toolsv1.ToolRequest,
+	_ ...grpc.CallOption,
+) (*toolsv1.ToolResponse, error) {
+	m.calls++
+	if m.calls <= m.failCount {
+		return nil, m.failErr
+	}
+	return m.successResp, nil
+}
+
+func (m *failNTimesClient) ListTools(
+	_ context.Context,
+	_ *toolsv1.ListToolsRequest,
+	_ ...grpc.CallOption,
+) (*toolsv1.ListToolsResponse, error) {
+	return nil, nil
+}
+
+func TestExecuteGRPC_RetryThenSucceed(t *testing.T) {
+	mock := &failNTimesClient{
+		failCount: 2,
+		failErr:   grpcStatus.Error(grpcCodes.Unavailable, "service unavailable"),
+		successResp: &toolsv1.ToolResponse{
+			ResultJson: `{"answer":42}`,
+		},
+	}
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.grpcClients["grpc-retry"] = mock
+	e.handlers["grpc-retry"] = &HandlerEntry{
+		Name: "grpc-retry",
+		Type: ToolTypeGRPC,
+		GRPCConfig: &GRPCCfg{
+			Endpoint: "localhost:50051",
+			RetryPolicy: &RuntimeGRPCRetryPolicy{
+				MaxAttempts:          int32(3),
+				InitialBackoff:       Duration(1 * time.Millisecond),
+				BackoffMultiplier:    2.0,
+				MaxBackoff:           Duration(100 * time.Millisecond),
+				RetryableStatusCodes: []string{"UNAVAILABLE"},
+			},
+		},
+	}
+	e.toolHandlers["grpc-retry-tool"] = "grpc-retry"
+	e.breakers = NewToolCircuitBreakers()
+
+	result, err := e.executeGRPC(context.Background(), "grpc-retry-tool", "grpc-retry", json.RawMessage(`{"q":"test"}`))
+	if err != nil {
+		t.Fatalf("executeGRPC failed: %v", err)
+	}
+	if mock.calls != 3 {
+		t.Errorf("expected 3 calls, got %d", mock.calls)
+	}
+	if string(result) != `{"answer":42}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestExecuteGRPC_NonRetryableStatus(t *testing.T) {
+	mock := &failNTimesClient{
+		failCount: 5,
+		failErr:   grpcStatus.Error(grpcCodes.NotFound, "not found"),
+	}
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.grpcClients["grpc-no-retry"] = mock
+	e.handlers["grpc-no-retry"] = &HandlerEntry{
+		Name: "grpc-no-retry",
+		Type: ToolTypeGRPC,
+		GRPCConfig: &GRPCCfg{
+			Endpoint: "localhost:50051",
+			RetryPolicy: &RuntimeGRPCRetryPolicy{
+				MaxAttempts:          int32(3),
+				InitialBackoff:       Duration(1 * time.Millisecond),
+				BackoffMultiplier:    2.0,
+				MaxBackoff:           Duration(100 * time.Millisecond),
+				RetryableStatusCodes: []string{"UNAVAILABLE"},
+			},
+		},
+	}
+	e.toolHandlers["grpc-no-retry-tool"] = "grpc-no-retry"
+	e.breakers = NewToolCircuitBreakers()
+
+	_, err := e.executeGRPC(context.Background(), "grpc-no-retry-tool", "grpc-no-retry", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for NOT_FOUND")
+	}
+	if mock.calls != 1 {
+		t.Errorf("expected 1 call (no retries for NOT_FOUND), got %d", mock.calls)
+	}
+}
+```
+
+**Note:** You'll need to add gRPC status/codes imports to the test file if not already present. Check existing imports first.
+
+- [ ] **Step 2: Run gRPC integration tests**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run "TestExecuteGRPC_Retry" -v`
+Expected: All PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git add internal/runtime/tools/omnia_executor_test.go
+git commit -m "test(runtime): add gRPC retry integration tests"
+```
+
+---
+
+### Task 8: Integration tests — MCP retry
+
+**Files:**
+- Modify: `internal/runtime/tools/omnia_executor_test.go`
+
+- [ ] **Step 1: Add MCP retry integration test**
+
+MCP testing is harder because `session.CallTool()` requires a real `mcp.ClientSession`. Check if the existing tests mock this or if there's a test helper. If there's no existing mock, create a minimal interface:
+
+```go
+// If mcp.ClientSession is a concrete type, we need to check if executeMCP
+// can be refactored to use an interface. If not, we test at a higher level
+// by testing retryWithBackoff + classifyMCPError together.
+
+func TestMCPRetry_TransportErrorRetried(t *testing.T) {
+	// Test the retry + classify composition directly since MCP sessions
+	// are hard to mock.
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 3, InitialBackoff: 1 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 100 * time.Millisecond}
+
+	calls := 0
+	result, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(err error) (bool, time.Duration) { return classifyMCPError(err) },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			if calls < 3 {
+				return nil, &net.OpError{Op: "read", Err: errors.New("connection reset")}
+			}
+			return json.RawMessage(`{"mcp":"ok"}`), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+	if string(result) != `{"mcp":"ok"}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestMCPRetry_ToolErrorNotRetried(t *testing.T) {
+	ctx := context.Background()
+	log := logr.Discard()
+	span := tracenoop.Span{}
+	policy := retryPolicy{MaxAttempts: 3, InitialBackoff: 1 * time.Millisecond, BackoffMultiplier: 2.0, MaxBackoff: 100 * time.Millisecond}
+
+	calls := 0
+	_, err := retryWithBackoff(ctx, log, span, policy, 0,
+		func(err error) (bool, time.Duration) { return classifyMCPError(err) },
+		func(ctx context.Context) (json.RawMessage, error) {
+			calls++
+			return nil, &mcpToolError{message: "file not found"}
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retries for tool error), got %d", calls)
+	}
+}
+```
+
+- [ ] **Step 2: Run MCP integration tests**
+
+Run: `go test ./internal/runtime/tools/... -count=1 -run "TestMCPRetry" -v`
+Expected: All PASS.
+
+- [ ] **Step 3: Commit**
+
+```
+git add internal/runtime/tools/omnia_executor_test.go
+git commit -m "test(runtime): add MCP retry integration tests"
+```
+
+---
+
+### Task 9: Full verification and cleanup
+
+**Files:**
+- None modified; verification only.
+
+- [ ] **Step 1: Full Go build**
+
+Run: `env GOWORK=off go build ./...`
+Expected: Success.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `env GOWORK=off go test ./... -count=1 -timeout=300s`
+Expected: All tests pass.
+
+- [ ] **Step 3: Lint**
+
+Run: `golangci-lint run ./internal/runtime/tools/...`
+Expected: 0 new issues. Pre-existing issues in other files are acceptable.
+
+- [ ] **Step 4: Check coverage on new files**
+
+Run: `env GOWORK=off go test ./internal/runtime/tools/... -coverprofile=/tmp/retry-cover.out -count=1`
+Run: `go tool cover -func=/tmp/retry-cover.out | grep -E "retry|http_client"`
+Expected: All new functions >= 80% coverage.
+
+- [ ] **Step 5: Generated code freshness**
+
+Run: `make generate && make manifests`
+Run: `git status --porcelain`
+Expected: No changes (no CRD or generated code was modified).
+
+---
+
+## Self-Review Checklist
+
+After completing all tasks, verify against the spec (`docs/superpowers/specs/2026-04-12-retry-execution-design.md`):
+
+- [ ] **Section 2 — Core retry engine**: `retryWithBackoff` with exponential backoff + jitter. Covered by Task 1.
+- [ ] **Section 2 — Circuit breaker composition**: retry wraps breaker for gRPC. Covered by Task 5.
+- [ ] **Section 2 — Per-attempt timeout**: `withAttemptTimeout` wraps each attempt. Covered by Task 1.
+- [ ] **Section 3 — Replace PromptKit HTTP executor**: `doHTTPRequest` with direct `http.Client`. Covered by Task 3.
+- [ ] **Section 4 — HTTP classifier**: `classifyHTTPResult` with status codes + network errors + Retry-After. Covered by Task 2.
+- [ ] **Section 4 — gRPC classifier**: `classifyGRPCError` with status code matching. Covered by Task 2.
+- [ ] **Section 4 — MCP classifier**: `classifyMCPError` transport-only. Covered by Task 2.
+- [ ] **Section 5 — Observability**: span events + V(1) log lines per retry. Covered by Task 1 (in `retryWithBackoff`).
+- [ ] **Section 6 — File changes**: All listed files created/modified. Covered by Tasks 1-8.
+- [ ] **Section 7 — Unit tests**: retry engine, classifiers, HTTP client. Covered by Tasks 1-3.
+- [ ] **Section 7 — Integration tests**: HTTP, gRPC, MCP retry wiring. Covered by Tasks 6-8.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-12-retry-execution.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-12-retry-execution-design.md
+++ b/docs/superpowers/specs/2026-04-12-retry-execution-design.md
@@ -1,0 +1,248 @@
+# Retry Execution Design Spec
+
+**Date:** 2026-04-12
+**Related PR:** #790 (CRD shape + config plumbing, merged)
+**Related issue:** #779 (forward parsed tool config fields to executors)
+
+## 1. Goal
+
+Implement retry logic for tool execution in the runtime. PR #790 plumbed transport-specific retry policies (`HTTPRetryPolicy`, `GRPCRetryPolicy`, `MCPRetryPolicy`) from CRD through the operator into the runtime's `HandlerEntry` config. The policies are loaded but ignored at execution time. This PR makes them operational.
+
+## 2. Architecture
+
+### Core retry engine
+
+A generic `retryWithBackoff` function in `internal/runtime/tools/retry.go`:
+
+```go
+type retryPolicy struct {
+    MaxAttempts       int32
+    InitialBackoff    time.Duration
+    BackoffMultiplier float64
+    MaxBackoff        time.Duration
+}
+
+func retryWithBackoff(
+    ctx context.Context,
+    log logr.Logger,
+    span trace.Span,
+    policy retryPolicy,
+    attemptTimeout time.Duration,
+    classify func(error) (retryable bool, retryAfter time.Duration),
+    fn func(ctx context.Context) (json.RawMessage, error),
+) (json.RawMessage, error)
+```
+
+**HTTP variant:** The HTTP classifier needs access to the response (status code, headers), not just the error. For HTTP, the `fn` closure captures the `*http.Response` in its scope and the `classify` closure reads it. Concretely:
+
+```go
+var lastResp *http.Response
+result, err := retryWithBackoff(ctx, log, span, policy, timeout,
+    func(err error) (bool, time.Duration) {
+        return classifyHTTPResult(httpCallResult{
+            StatusCode: lastResp.StatusCode,
+            Headers:    lastResp.Header,
+            Err:        err,
+        }, retryPolicy)
+    },
+    func(attemptCtx context.Context) (json.RawMessage, error) {
+        resp, err := client.Do(req.WithContext(attemptCtx))
+        lastResp = resp
+        if err != nil { return nil, err }
+        defer resp.Body.Close()
+        return processHTTPResponse(resp)
+    },
+)
+```
+
+This keeps `retryWithBackoff` generic (it only sees `func(error)`) while giving the HTTP classifier access to the full response via closure capture.
+
+The loop:
+1. Create `attemptCtx` with per-attempt timeout from `HandlerEntry.Timeout` (0 means no timeout).
+2. Call `fn(attemptCtx)`.
+3. On success, return.
+4. On error, call `classify(err)`. If not retryable, return immediately.
+5. If retryable, compute delay: `min(initialBackoff * multiplier^attempt, maxBackoff)` with ~10% jitter. If classifier returned a `retryAfter > 0`, use `max(computed, retryAfter)` capped at `maxBackoff`.
+6. Log at `V(1)` and add a span event (see section 5).
+7. Sleep for the delay, respecting context cancellation.
+8. If all attempts exhausted, return `fmt.Errorf("tool %s: %d attempts exhausted: %w", toolName, maxAttempts, lastErr)`.
+
+**No-policy fast path:** When no retry policy is configured, the extraction helpers return `retryPolicy{MaxAttempts: 1}`. With `MaxAttempts == 1`, `retryWithBackoff` calls `fn` once and returns — no backoff logic, no overhead.
+
+### Composition with circuit breaker
+
+gRPC execution already uses a circuit breaker (`e.breakers.Execute()`). Retry wraps the circuit breaker: each retry attempt independently goes through the breaker. If the breaker is open, the attempt fails fast, consuming one retry attempt. This is the standard pattern (Polly, resilience4j).
+
+```
+retry loop
+  └─ circuit breaker
+       └─ gRPC call
+```
+
+### Timeout model
+
+Per-attempt timeout. Each retry attempt gets its own `context.WithTimeout` derived from `HandlerEntry.Timeout`. A handler with `timeout: 5s` and `maxAttempts: 3` could take up to ~15s plus backoff delays. Users who want to cap total duration reduce `maxAttempts` or the timeout.
+
+## 3. HTTP execution: replace PromptKit executor
+
+The current `executeHTTP` delegates to PromptKit's `HTTPExecutor.Execute()`, which closes the `*http.Response` internally. This prevents the retry classifier from inspecting response headers (needed for status code classification and `Retry-After`).
+
+**Change:** `executeHTTP` builds and executes HTTP requests directly using a standard `http.Client`, replacing the PromptKit dependency for HTTP tool execution. This gives us:
+- Direct access to `*http.Response` for status code and header inspection
+- `Retry-After` header parsing for backoff floor
+- Cleaner error classification without string-parsing PromptKit error messages
+
+The request building logic (URL construction, header injection, body mapping, OTel propagation) stays in Omnia — it's already partly there for policy headers. The PromptKit `HTTPExecutor` import is removed.
+
+`executeOpenAPI` delegates to the same HTTP path and gets the same benefit.
+
+## 4. Error classifiers
+
+### HTTP classifier
+
+```go
+type httpCallResult struct {
+    StatusCode int
+    Headers    http.Header
+    Err        error
+}
+
+func classifyHTTPResult(result httpCallResult, policy *RuntimeHTTPRetryPolicy) (retryable bool, retryAfter time.Duration)
+```
+
+- **Network errors** (connection refused, DNS, timeout): retryable if `policy.RetryOnNetworkError` is true. Detected via `errors.Is(err, context.DeadlineExceeded)`, `net.Error` interface, or unwrapping to connection errors.
+- **Status codes**: retryable if `result.StatusCode` is in `policy.RetryOn` (e.g., `[502, 503, 504]`).
+- **`Retry-After` header**: when `policy.RespectRetryAfter` is true and the response has a `Retry-After` header, parse it (supports both seconds and HTTP-date formats per RFC 9110) and return it as `retryAfter`. Capped at `policy.MaxBackoff` in the retry loop.
+- **All other errors**: not retryable.
+
+### gRPC classifier
+
+```go
+func classifyGRPCError(err error, retryableStatusCodes []string) (retryable bool, retryAfter time.Duration)
+```
+
+- Extract gRPC status via `status.FromError(err)`.
+- Retryable if the status code name (e.g., `"UNAVAILABLE"`, `"DEADLINE_EXCEEDED"`) is in `retryableStatusCodes`.
+- Circuit breaker errors (wrapped by `e.breakers.Execute()`) are not retryable — detected by checking if the error is not a gRPC status error.
+- `retryAfter` is always 0 (gRPC has no standard retry-after mechanism).
+
+### MCP classifier
+
+```go
+func classifyMCPError(err error) (retryable bool, retryAfter time.Duration)
+```
+
+- **Transport errors** (Go `error` from `session.CallTool()`): retryable. These are connection drops, timeouts, stdio process crashes.
+- **Tool errors** (MCP result with `IsError: true`): not retryable. These are application-level failures (file not found, permission denied) and retrying won't help.
+- `retryAfter` is always 0.
+
+## 5. Observability
+
+Both span events and structured log lines, per the project's conventions.
+
+**Per retry attempt:**
+
+```go
+e.log.V(1).Info("retry attempt",
+    "tool", toolName,
+    "handler", handlerName,
+    "attempt", n,
+    "maxAttempts", policy.MaxAttempts,
+    "delay", delay,
+    "error", err.Error())
+
+span.AddEvent("retry.attempt", trace.WithAttributes(
+    attribute.Int("attempt", n),
+    attribute.String("delay", delay.String()),
+    attribute.String("error", err.Error()),
+))
+```
+
+**All attempts exhausted:**
+
+```go
+e.log.V(0).Info("retries exhausted",
+    "tool", toolName,
+    "handler", handlerName,
+    "attempts", policy.MaxAttempts,
+    "error", lastErr.Error())
+
+span.AddEvent("retry.exhausted", trace.WithAttributes(
+    attribute.Int("attempts", int(policy.MaxAttempts)),
+))
+```
+
+Success after retry logs nothing extra — the existing span captures the successful result. Only retries and final failure add output.
+
+## 6. File changes
+
+| File | Change |
+|------|--------|
+| `internal/runtime/tools/retry.go` | **New.** `retryPolicy` struct, `retryWithBackoff()`, backoff/jitter calculation, policy extraction helpers (`httpRetryParams`, `grpcRetryParams`, `mcpRetryParams`) |
+| `internal/runtime/tools/retry_classify.go` | **New.** `classifyHTTPResult()`, `classifyGRPCError()`, `classifyMCPError()`, `httpCallResult` type, `Retry-After` header parser |
+| `internal/runtime/tools/retry_test.go` | **New.** Unit tests for retry engine |
+| `internal/runtime/tools/retry_classify_test.go` | **New.** Unit tests for all three classifiers |
+| `internal/runtime/tools/omnia_executor.go` | **Modified.** `executeHTTP` replaced: drops PromptKit HTTPExecutor, uses direct `http.Client.Do()`. `executeGRPC`, `executeMCP`, `executeOpenAPI` wrapped with `retryWithBackoff`. |
+| `internal/runtime/tools/omnia_executor_test.go` | **Modified.** Integration tests for retry wiring per transport |
+
+**Not changed:** No CRD, controller, config, or dashboard changes. All plumbing was completed in PR #790.
+
+## 7. Testing strategy
+
+### Unit tests (`retry_test.go`)
+
+- `fn` succeeds on first attempt — no retries, no backoff
+- `fn` fails twice then succeeds — verify 3 attempts, correct result returned
+- Non-retryable error — returns immediately, single attempt
+- All attempts exhausted — returns wrapped error with attempt count
+- Backoff timing — delays increase exponentially, within ±10% jitter tolerance
+- Context cancellation — parent cancelled mid-retry, no further attempts
+- Per-attempt timeout — `fn` hangs, each attempt killed by timeout
+- No-policy fast path — `MaxAttempts=1` calls `fn` once
+- Span events emitted per retry (via test span exporter)
+- Log lines emitted per retry (via log buffer)
+
+### Classifier tests (`retry_classify_test.go`)
+
+**HTTP:**
+- Network error + `retryOnNetworkError: true` → retryable
+- Network error + `retryOnNetworkError: false` → not retryable
+- Status 502 in `retryOn` → retryable
+- Status 400 not in `retryOn` → not retryable
+- `Retry-After: 5` header + `respectRetryAfter: true` → retryable, `retryAfter = 5s`
+- `Retry-After` header + `respectRetryAfter: false` → retryable, `retryAfter = 0`
+- `Retry-After` with HTTP-date format → parsed correctly
+- Success (2xx) → not retryable
+
+**gRPC:**
+- `UNAVAILABLE` in `retryableStatusCodes` → retryable
+- `NOT_FOUND` not in list → not retryable
+- Non-gRPC error (circuit breaker) → not retryable
+
+**MCP:**
+- Transport error (Go error) → retryable
+- Context deadline exceeded → retryable
+- Non-error (nil) → not retryable
+
+### Executor integration tests (in `omnia_executor_test.go`)
+
+One test per transport type:
+- Configure retry policy, mock backend fails once then succeeds → tool call succeeds, retry happened (verified via span events)
+- Configure retry policy, mock returns non-retryable error → no retry, single attempt
+
+## 8. Scope boundaries
+
+**In scope:**
+- Retry loop with exponential backoff + jitter
+- Per-attempt timeout from `HandlerEntry.Timeout`
+- HTTP/gRPC/MCP/OpenAPI error classification
+- `Retry-After` header respect for HTTP
+- Retry-wraps-breaker composition for gRPC
+- Replace PromptKit HTTP executor with direct `http.Client`
+- OTel span events + structured debug logs
+
+**Out of scope:**
+- MCP session reconnection on transport failure (separate work — the MCP SDK may handle this)
+- Circuit breaker for HTTP/MCP (currently only gRPC has one; adding to other transports is independent work)
+- Rate limiting / concurrency control on retries
+- Per-tool retry policy overrides (policies are per-handler, not per-tool)

--- a/internal/runtime/tools/http_client.go
+++ b/internal/runtime/tools/http_client.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+)
+
+const httpBodyMaxBytes = 10 * 1024 * 1024 // 10 MB
+const truncateErrorBodyLen = 512
+
+// doHTTPRequest performs a direct HTTP call using the provided client, returning
+// the response body (as JSON), the raw call result for retry classification, and
+// any error.
+//
+// On transport errors (network failures, DNS errors) the returned httpCallResult
+// has Err set and StatusCode is 0.  On HTTP-level errors (non-2xx) Err is nil
+// and StatusCode is set.
+func doHTTPRequest(
+	ctx context.Context,
+	client *http.Client,
+	cfg *HTTPCfg,
+	headers map[string]string,
+	args json.RawMessage,
+) (json.RawMessage, httpCallResult, error) {
+	req, err := buildHTTPRequest(ctx, cfg, headers, args)
+	if err != nil {
+		return nil, httpCallResult{Err: err}, err
+	}
+
+	// Inject OTel trace context so downstream services can participate in the trace.
+	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, httpCallResult{Err: err}, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, httpBodyMaxBytes))
+	if err != nil {
+		callResult := httpCallResult{StatusCode: resp.StatusCode, Headers: resp.Header}
+		return nil, callResult, fmt.Errorf("reading response body: %w", err)
+	}
+
+	callResult := httpCallResult{StatusCode: resp.StatusCode, Headers: resp.Header}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, callResult, fmt.Errorf("HTTP %d: %s", resp.StatusCode, truncateBody(body, truncateErrorBodyLen))
+	}
+
+	if !json.Valid(body) {
+		wrapped, err := json.Marshal(map[string]string{"result": string(body)})
+		if err != nil {
+			return nil, callResult, fmt.Errorf("wrapping non-JSON response: %w", err)
+		}
+		return wrapped, callResult, nil
+	}
+
+	return body, callResult, nil
+}
+
+// buildHTTPRequest constructs an *http.Request from the tool configuration and
+// caller-supplied headers and arguments.
+func buildHTTPRequest(ctx context.Context, cfg *HTTPCfg, headers map[string]string, args json.RawMessage) (*http.Request, error) {
+	method := strings.ToUpper(cfg.Method)
+	if method == "" {
+		method = http.MethodPost
+	}
+
+	hasArgs := len(args) > 0 && string(args) != "null" && string(args) != "{}"
+
+	var (
+		body   io.Reader
+		reqURL = cfg.Endpoint
+	)
+
+	if hasArgs {
+		if isHTTPBodyMethod(method) {
+			body = bytes.NewReader(args)
+		} else {
+			var err error
+			reqURL, err = appendQueryFromJSON(cfg.Endpoint, args)
+			if err != nil {
+				return nil, fmt.Errorf("building query params: %w", err)
+			}
+		}
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("creating HTTP request: %w", err)
+	}
+
+	if body != nil {
+		contentType := cfg.ContentType
+		if contentType == "" {
+			contentType = "application/json"
+		}
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+
+	return req, nil
+}
+
+// isHTTPBodyMethod returns true for HTTP methods that carry a request body.
+func isHTTPBodyMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch:
+		return true
+	default:
+		return false
+	}
+}
+
+// appendQueryFromJSON unmarshals args as a JSON object and appends each field
+// as a query parameter to baseURL.
+func appendQueryFromJSON(baseURL string, args json.RawMessage) (string, error) {
+	var params map[string]any
+	if err := json.Unmarshal(args, &params); err != nil {
+		return baseURL, fmt.Errorf("unmarshalling query args: %w", err)
+	}
+
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL, fmt.Errorf("parsing base URL: %w", err)
+	}
+
+	q := u.Query()
+	for k, v := range params {
+		q.Set(k, fmt.Sprintf("%v", v))
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// truncateBody returns the body as a string, truncating to maxLen bytes with an
+// ellipsis when the body exceeds maxLen.
+func truncateBody(body []byte, maxLen int) string {
+	if len(body) <= maxLen {
+		return string(body)
+	}
+	return string(body[:maxLen]) + "..."
+}

--- a/internal/runtime/tools/http_client.go
+++ b/internal/runtime/tools/http_client.go
@@ -26,6 +26,7 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/jmespath/go-jmespath"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
 )
@@ -86,6 +87,15 @@ func doHTTPRequest(
 		body = redactResponseFields(body, cfg.Redact)
 	}
 
+	// Apply response mapping if configured.
+	if cfg.ResponseMapping != "" {
+		mapped, err := applyJMESPathToResponse(body, cfg.ResponseMapping)
+		if err != nil {
+			return nil, callResult, err
+		}
+		body = mapped
+	}
+
 	return body, callResult, nil
 }
 
@@ -140,7 +150,8 @@ func buildHTTPRequest(ctx context.Context, cfg *HTTPCfg, headers map[string]stri
 // hasAdvancedHTTPConfig returns true if cfg uses any fields that require parsed args.
 func hasAdvancedHTTPConfig(cfg *HTTPCfg) bool {
 	return cfg.URLTemplate != "" || len(cfg.HeaderParams) > 0 ||
-		len(cfg.QueryParams) > 0 || cfg.StaticBody != nil
+		len(cfg.QueryParams) > 0 || cfg.StaticBody != nil ||
+		cfg.BodyMapping != ""
 }
 
 // resolveHTTPParams processes all HTTPCfg fields (URL template, header params,
@@ -186,6 +197,14 @@ func resolveHTTPParams(cfg *HTTPCfg, method string, hasArgs, needsParsedArgs boo
 	}
 	if err != nil {
 		return nil, err
+	}
+
+	// 5. Body mapping — reshape the request body via JMESPath.
+	if cfg.BodyMapping != "" && p.body != nil {
+		p.body, err = applyJMESPathToBody(p.body, cfg.BodyMapping)
+		if err != nil {
+			return nil, fmt.Errorf("body mapping: %w", err)
+		}
 	}
 
 	return p, nil
@@ -430,4 +449,43 @@ func truncateBody(body []byte, maxLen int) string {
 		return string(body)
 	}
 	return string(body[:maxLen]) + "..."
+}
+
+// applyJMESPathToBody reads the body, applies a JMESPath expression, and returns
+// a new reader with the transformed JSON.
+func applyJMESPathToBody(body io.Reader, expr string) (io.Reader, error) {
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, fmt.Errorf("reading body for JMESPath: %w", err)
+	}
+	var parsed any
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return bytes.NewReader(data), nil // not JSON, pass through
+	}
+	result, err := jmespath.Search(expr, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("JMESPath expression %q: %w", expr, err)
+	}
+	out, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling JMESPath result: %w", err)
+	}
+	return bytes.NewReader(out), nil
+}
+
+// applyJMESPathToResponse applies a JMESPath expression to a JSON response body,
+// returning the transformed JSON.
+func applyJMESPathToResponse(body json.RawMessage, expr string) (json.RawMessage, error) {
+	var parsed any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		return body, nil // not JSON, pass through
+	}
+	result, err := jmespath.Search(expr, parsed)
+	if err != nil {
+		return nil, fmt.Errorf("JMESPath response mapping %q: %w", expr, err)
+	}
+	if result == nil {
+		return json.RawMessage("null"), nil
+	}
+	return json.Marshal(result)
 }

--- a/internal/runtime/tools/http_client.go
+++ b/internal/runtime/tools/http_client.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net/http"
 	"net/url"
 	"strings"
@@ -297,11 +298,16 @@ func buildSimpleBodyAndQuery(cfg *HTTPCfg, method, reqURL string, hasArgs bool, 
 // resolveURLTemplate replaces {param} placeholders in the template with values
 // from args, returning the resolved URL and the remaining args (with consumed
 // keys removed).
+// cloneArgs returns a shallow copy of the args map so callers can delete
+// consumed keys without mutating the original.
+func cloneArgs(args map[string]any) map[string]any {
+	out := make(map[string]any, len(args))
+	maps.Copy(out, args)
+	return out
+}
+
 func resolveURLTemplate(tmpl string, args map[string]any) (string, map[string]any) {
-	remaining := make(map[string]any, len(args))
-	for k, v := range args {
-		remaining[k] = v
-	}
+	remaining := cloneArgs(args)
 	for key, val := range args {
 		placeholder := "{" + key + "}"
 		if strings.Contains(tmpl, placeholder) {
@@ -315,10 +321,7 @@ func resolveURLTemplate(tmpl string, args map[string]any) (string, map[string]an
 // extractHeaderParams extracts arg fields listed in headerParams, returning the
 // header map (argField→headerName→value) and the remaining args.
 func extractHeaderParams(headerParams map[string]string, args map[string]any) (map[string]string, map[string]any) {
-	remaining := make(map[string]any, len(args))
-	for k, v := range args {
-		remaining[k] = v
-	}
+	remaining := cloneArgs(args)
 	extracted := make(map[string]string, len(headerParams))
 	for argField, headerName := range headerParams {
 		if val, ok := remaining[argField]; ok {
@@ -332,10 +335,7 @@ func extractHeaderParams(headerParams map[string]string, args map[string]any) (m
 // extractQueryParams extracts the named fields from args, returning the extracted
 // fields and the remaining args.
 func extractQueryParams(paramNames []string, args map[string]any) (map[string]any, map[string]any) {
-	remaining := make(map[string]any, len(args))
-	for k, v := range args {
-		remaining[k] = v
-	}
+	remaining := cloneArgs(args)
 	extracted := make(map[string]any, len(paramNames))
 	for _, name := range paramNames {
 		if val, ok := remaining[name]; ok {
@@ -358,9 +358,7 @@ func mergeStaticBody(staticBody interface{}, args map[string]any) map[string]any
 	switch sb := staticBody.(type) {
 	case map[string]any:
 		base = make(map[string]any, len(sb))
-		for k, v := range sb {
-			base[k] = v
-		}
+		maps.Copy(base, sb)
 	default:
 		// Try JSON round-trip for other types.
 		data, err := json.Marshal(staticBody)
@@ -372,9 +370,7 @@ func mergeStaticBody(staticBody interface{}, args map[string]any) map[string]any
 		}
 	}
 	// Args override static body.
-	for k, v := range args {
-		base[k] = v
-	}
+	maps.Copy(base, args)
 	return base
 }
 

--- a/internal/runtime/tools/http_client.go
+++ b/internal/runtime/tools/http_client.go
@@ -81,7 +81,21 @@ func doHTTPRequest(
 		return wrapped, callResult, nil
 	}
 
+	// Apply field redaction if configured.
+	if len(cfg.Redact) > 0 {
+		body = redactResponseFields(body, cfg.Redact)
+	}
+
 	return body, callResult, nil
+}
+
+// httpRequestParams holds the intermediate state built up while processing
+// HTTPCfg fields, before the final *http.Request is created.
+type httpRequestParams struct {
+	method       string
+	url          string
+	body         io.Reader
+	extraHeaders map[string]string
 }
 
 // buildHTTPRequest constructs an *http.Request from the tool configuration and
@@ -93,30 +107,19 @@ func buildHTTPRequest(ctx context.Context, cfg *HTTPCfg, headers map[string]stri
 	}
 
 	hasArgs := len(args) > 0 && string(args) != "null" && string(args) != "{}"
+	needsParsedArgs := hasArgs && hasAdvancedHTTPConfig(cfg)
 
-	var (
-		body   io.Reader
-		reqURL = cfg.Endpoint
-	)
-
-	if hasArgs {
-		if isHTTPBodyMethod(method) {
-			body = bytes.NewReader(args)
-		} else {
-			var err error
-			reqURL, err = appendQueryFromJSON(cfg.Endpoint, args)
-			if err != nil {
-				return nil, fmt.Errorf("building query params: %w", err)
-			}
-		}
+	params, err := resolveHTTPParams(cfg, method, hasArgs, needsParsedArgs, args)
+	if err != nil {
+		return nil, err
 	}
 
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	req, err := http.NewRequestWithContext(ctx, method, params.url, params.body)
 	if err != nil {
 		return nil, fmt.Errorf("creating HTTP request: %w", err)
 	}
 
-	if body != nil {
+	if params.body != nil {
 		contentType := cfg.ContentType
 		if contentType == "" {
 			contentType = "application/json"
@@ -127,8 +130,266 @@ func buildHTTPRequest(ctx context.Context, cfg *HTTPCfg, headers map[string]stri
 	for k, v := range headers {
 		req.Header.Set(k, v)
 	}
+	for k, v := range params.extraHeaders {
+		req.Header.Set(k, v)
+	}
 
 	return req, nil
+}
+
+// hasAdvancedHTTPConfig returns true if cfg uses any fields that require parsed args.
+func hasAdvancedHTTPConfig(cfg *HTTPCfg) bool {
+	return cfg.URLTemplate != "" || len(cfg.HeaderParams) > 0 ||
+		len(cfg.QueryParams) > 0 || cfg.StaticBody != nil
+}
+
+// resolveHTTPParams processes all HTTPCfg fields (URL template, header params,
+// query params, static query, static body) and returns the resolved request params.
+func resolveHTTPParams(cfg *HTTPCfg, method string, hasArgs, needsParsedArgs bool, args json.RawMessage) (*httpRequestParams, error) {
+	p := &httpRequestParams{method: method, url: cfg.Endpoint}
+
+	var argsMap map[string]any
+	if needsParsedArgs {
+		if err := json.Unmarshal(args, &argsMap); err != nil {
+			return nil, fmt.Errorf("unmarshalling args for advanced config: %w", err)
+		}
+	}
+
+	// 1. URL template resolution.
+	if cfg.URLTemplate != "" {
+		p.url = cfg.URLTemplate
+		if argsMap != nil {
+			p.url, argsMap = resolveURLTemplate(p.url, argsMap)
+		}
+	}
+
+	// 2. Header params extraction.
+	if len(cfg.HeaderParams) > 0 && argsMap != nil {
+		p.extraHeaders, argsMap = extractHeaderParams(cfg.HeaderParams, argsMap)
+	}
+
+	// 3. Static query params.
+	if len(cfg.StaticQuery) > 0 {
+		resolved, err := applyStaticQuery(p.url, cfg.StaticQuery)
+		if err != nil {
+			return nil, err
+		}
+		p.url = resolved
+	}
+
+	// 4. Body and query params based on method.
+	var err error
+	if needsParsedArgs {
+		p.url, p.body, err = buildAdvancedBodyAndQuery(cfg, method, p.url, argsMap)
+	} else {
+		p.url, p.body, err = buildSimpleBodyAndQuery(cfg, method, p.url, hasArgs, args)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return p, nil
+}
+
+// applyStaticQuery appends static query params to a URL.
+func applyStaticQuery(rawURL string, staticQuery map[string]string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return rawURL, fmt.Errorf("parsing URL for static query: %w", err)
+	}
+	q := u.Query()
+	for k, v := range staticQuery {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// buildAdvancedBodyAndQuery builds body and query params when the args map has
+// been parsed for advanced features (URLTemplate, HeaderParams, QueryParams, StaticBody).
+func buildAdvancedBodyAndQuery(cfg *HTTPCfg, method, reqURL string, argsMap map[string]any) (string, io.Reader, error) {
+	if isHTTPBodyMethod(method) {
+		return buildAdvancedBodyMethod(cfg, reqURL, argsMap)
+	}
+	return buildAdvancedNonBodyMethod(cfg, reqURL, argsMap)
+}
+
+// buildAdvancedBodyMethod handles POST/PUT/PATCH with parsed args.
+func buildAdvancedBodyMethod(cfg *HTTPCfg, reqURL string, argsMap map[string]any) (string, io.Reader, error) {
+	if len(cfg.QueryParams) > 0 {
+		var queryFields map[string]any
+		queryFields, argsMap = extractQueryParams(cfg.QueryParams, argsMap)
+		if len(queryFields) > 0 {
+			var err error
+			reqURL, err = appendQueryFromMap(reqURL, queryFields)
+			if err != nil {
+				return reqURL, nil, fmt.Errorf("building query params: %w", err)
+			}
+		}
+	}
+	merged := mergeStaticBody(cfg.StaticBody, argsMap)
+	bodyBytes, err := json.Marshal(merged)
+	if err != nil {
+		return reqURL, nil, fmt.Errorf("marshalling body: %w", err)
+	}
+	return reqURL, bytes.NewReader(bodyBytes), nil
+}
+
+// buildAdvancedNonBodyMethod handles GET/DELETE/etc with parsed args.
+func buildAdvancedNonBodyMethod(cfg *HTTPCfg, reqURL string, argsMap map[string]any) (string, io.Reader, error) {
+	var queryMap map[string]any
+	if len(cfg.QueryParams) > 0 {
+		queryMap, _ = extractQueryParams(cfg.QueryParams, argsMap)
+	} else {
+		queryMap = argsMap
+	}
+	if len(queryMap) > 0 {
+		var err error
+		reqURL, err = appendQueryFromMap(reqURL, queryMap)
+		if err != nil {
+			return reqURL, nil, fmt.Errorf("building query params: %w", err)
+		}
+	}
+	return reqURL, nil, nil
+}
+
+// buildSimpleBodyAndQuery handles the simple path (no advanced features).
+func buildSimpleBodyAndQuery(cfg *HTTPCfg, method, reqURL string, hasArgs bool, args json.RawMessage) (string, io.Reader, error) {
+	if hasArgs {
+		if isHTTPBodyMethod(method) {
+			return reqURL, bytes.NewReader(args), nil
+		}
+		resolved, err := appendQueryFromJSON(reqURL, args)
+		if err != nil {
+			return reqURL, nil, fmt.Errorf("building query params: %w", err)
+		}
+		return resolved, nil, nil
+	}
+	if isHTTPBodyMethod(method) && cfg.StaticBody != nil {
+		bodyBytes, err := json.Marshal(cfg.StaticBody)
+		if err != nil {
+			return reqURL, nil, fmt.Errorf("marshalling static body: %w", err)
+		}
+		return reqURL, bytes.NewReader(bodyBytes), nil
+	}
+	return reqURL, nil, nil
+}
+
+// resolveURLTemplate replaces {param} placeholders in the template with values
+// from args, returning the resolved URL and the remaining args (with consumed
+// keys removed).
+func resolveURLTemplate(tmpl string, args map[string]any) (string, map[string]any) {
+	remaining := make(map[string]any, len(args))
+	for k, v := range args {
+		remaining[k] = v
+	}
+	for key, val := range args {
+		placeholder := "{" + key + "}"
+		if strings.Contains(tmpl, placeholder) {
+			tmpl = strings.ReplaceAll(tmpl, placeholder, fmt.Sprintf("%v", val))
+			delete(remaining, key)
+		}
+	}
+	return tmpl, remaining
+}
+
+// extractHeaderParams extracts arg fields listed in headerParams, returning the
+// header map (argField→headerName→value) and the remaining args.
+func extractHeaderParams(headerParams map[string]string, args map[string]any) (map[string]string, map[string]any) {
+	remaining := make(map[string]any, len(args))
+	for k, v := range args {
+		remaining[k] = v
+	}
+	extracted := make(map[string]string, len(headerParams))
+	for argField, headerName := range headerParams {
+		if val, ok := remaining[argField]; ok {
+			extracted[headerName] = fmt.Sprintf("%v", val)
+			delete(remaining, argField)
+		}
+	}
+	return extracted, remaining
+}
+
+// extractQueryParams extracts the named fields from args, returning the extracted
+// fields and the remaining args.
+func extractQueryParams(paramNames []string, args map[string]any) (map[string]any, map[string]any) {
+	remaining := make(map[string]any, len(args))
+	for k, v := range args {
+		remaining[k] = v
+	}
+	extracted := make(map[string]any, len(paramNames))
+	for _, name := range paramNames {
+		if val, ok := remaining[name]; ok {
+			extracted[name] = val
+			delete(remaining, name)
+		}
+	}
+	return extracted, remaining
+}
+
+// mergeStaticBody merges a static body with args, where args take precedence.
+// If staticBody is nil, returns args. Both are expected to be map[string]any or
+// convertible to one.
+func mergeStaticBody(staticBody interface{}, args map[string]any) map[string]any {
+	if staticBody == nil {
+		return args
+	}
+	// Convert staticBody to map[string]any.
+	var base map[string]any
+	switch sb := staticBody.(type) {
+	case map[string]any:
+		base = make(map[string]any, len(sb))
+		for k, v := range sb {
+			base[k] = v
+		}
+	default:
+		// Try JSON round-trip for other types.
+		data, err := json.Marshal(staticBody)
+		if err != nil {
+			return args
+		}
+		if err := json.Unmarshal(data, &base); err != nil {
+			return args
+		}
+	}
+	// Args override static body.
+	for k, v := range args {
+		base[k] = v
+	}
+	return base
+}
+
+// appendQueryFromMap appends key-value pairs from a map as query params to a URL.
+func appendQueryFromMap(baseURL string, params map[string]any) (string, error) {
+	u, err := url.Parse(baseURL)
+	if err != nil {
+		return baseURL, fmt.Errorf("parsing base URL: %w", err)
+	}
+	q := u.Query()
+	for k, v := range params {
+		q.Set(k, fmt.Sprintf("%v", v))
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+// redactResponseFields replaces the values of the named fields with "[REDACTED]"
+// in a JSON response body. If the body is not a JSON object, it is returned as-is.
+func redactResponseFields(body json.RawMessage, fields []string) json.RawMessage {
+	var obj map[string]any
+	if err := json.Unmarshal(body, &obj); err != nil {
+		return body
+	}
+	for _, field := range fields {
+		if _, ok := obj[field]; ok {
+			obj[field] = "[REDACTED]"
+		}
+	}
+	result, err := json.Marshal(obj)
+	if err != nil {
+		return body
+	}
+	return result
 }
 
 // isHTTPBodyMethod returns true for HTTP methods that carry a request body.

--- a/internal/runtime/tools/http_client_test.go
+++ b/internal/runtime/tools/http_client_test.go
@@ -193,3 +193,225 @@ func TestDoHTTPRequest_GETWithQueryParams(t *testing.T) {
 		t.Errorf("expected query to contain 'n=1', got %q", receivedQuery)
 	}
 }
+
+func TestDoHTTPRequest_URLTemplate(t *testing.T) {
+	var receivedPath string
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{
+		Endpoint:    srv.URL, // fallback, should not be used
+		URLTemplate: srv.URL + "/users/{id}/posts",
+		Method:      "POST",
+	}
+	args := json.RawMessage(`{"id":"123","title":"Hello"}`)
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedPath != "/users/123/posts" {
+		t.Errorf("expected path /users/123/posts, got %q", receivedPath)
+	}
+	// "id" should be consumed; only "title" should be in the body.
+	var body map[string]any
+	if err := json.Unmarshal(receivedBody, &body); err != nil {
+		t.Fatalf("failed to unmarshal body: %v", err)
+	}
+	if _, ok := body["id"]; ok {
+		t.Error("expected 'id' to be consumed by URL template, but it was in the body")
+	}
+	if body["title"] != "Hello" {
+		t.Errorf("expected title=Hello in body, got %v", body["title"])
+	}
+}
+
+func TestDoHTTPRequest_StaticQuery(t *testing.T) {
+	var receivedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{
+		Endpoint: srv.URL,
+		Method:   "POST",
+		StaticQuery: map[string]string{
+			"api_key": "secret123",
+			"format":  "json",
+		},
+	}
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(receivedQuery, "api_key=secret123") {
+		t.Errorf("expected query to contain 'api_key=secret123', got %q", receivedQuery)
+	}
+	if !strings.Contains(receivedQuery, "format=json") {
+		t.Errorf("expected query to contain 'format=json', got %q", receivedQuery)
+	}
+}
+
+func TestDoHTTPRequest_QueryParams_POST(t *testing.T) {
+	var receivedQuery string
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{
+		Endpoint:    srv.URL,
+		Method:      "POST",
+		QueryParams: []string{"page", "limit"},
+	}
+	args := json.RawMessage(`{"page":"1","limit":"10","data":"value"}`)
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(receivedQuery, "page=1") {
+		t.Errorf("expected query to contain 'page=1', got %q", receivedQuery)
+	}
+	if !strings.Contains(receivedQuery, "limit=10") {
+		t.Errorf("expected query to contain 'limit=10', got %q", receivedQuery)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(receivedBody, &body); err != nil {
+		t.Fatalf("failed to unmarshal body: %v", err)
+	}
+	if body["data"] != "value" {
+		t.Errorf("expected data=value in body, got %v", body["data"])
+	}
+	if _, ok := body["page"]; ok {
+		t.Error("expected 'page' to be extracted as query param, but it was in the body")
+	}
+	if _, ok := body["limit"]; ok {
+		t.Error("expected 'limit' to be extracted as query param, but it was in the body")
+	}
+}
+
+func TestDoHTTPRequest_HeaderParams(t *testing.T) {
+	var receivedUserID string
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUserID = r.Header.Get("X-User-ID")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{
+		Endpoint:     srv.URL,
+		Method:       "POST",
+		HeaderParams: map[string]string{"user_id": "X-User-ID"},
+	}
+	args := json.RawMessage(`{"user_id":"abc","query":"hello"}`)
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedUserID != "abc" {
+		t.Errorf("expected X-User-ID header 'abc', got %q", receivedUserID)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(receivedBody, &body); err != nil {
+		t.Fatalf("failed to unmarshal body: %v", err)
+	}
+	if _, ok := body["user_id"]; ok {
+		t.Error("expected 'user_id' to be consumed by HeaderParams, but it was in the body")
+	}
+	if body["query"] != "hello" {
+		t.Errorf("expected query=hello in body, got %v", body["query"])
+	}
+}
+
+func TestDoHTTPRequest_StaticBody(t *testing.T) {
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{
+		Endpoint: srv.URL,
+		Method:   "POST",
+		StaticBody: map[string]any{
+			"version":  "2.0",
+			"default":  "static_val",
+			"override": "should_be_overridden",
+		},
+	}
+	args := json.RawMessage(`{"override":"from_args","extra":"dynamic"}`)
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(receivedBody, &body); err != nil {
+		t.Fatalf("failed to unmarshal body: %v", err)
+	}
+	if body["version"] != "2.0" {
+		t.Errorf("expected version=2.0 from static body, got %v", body["version"])
+	}
+	if body["default"] != "static_val" {
+		t.Errorf("expected default=static_val from static body, got %v", body["default"])
+	}
+	if body["override"] != "from_args" {
+		t.Errorf("expected override=from_args (args win), got %v", body["override"])
+	}
+	if body["extra"] != "dynamic" {
+		t.Errorf("expected extra=dynamic from args, got %v", body["extra"])
+	}
+}
+
+func TestDoHTTPRequest_Redact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"name":"Alice","ssn":"123-45-6789","age":30}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{
+		Endpoint: srv.URL,
+		Method:   "GET",
+		Redact:   []string{"ssn"},
+	}
+	result, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if got["ssn"] != "[REDACTED]" {
+		t.Errorf("expected ssn=[REDACTED], got %v", got["ssn"])
+	}
+	if got["name"] != "Alice" {
+		t.Errorf("expected name=Alice (not redacted), got %v", got["name"])
+	}
+	if got["age"] != float64(30) {
+		t.Errorf("expected age=30 (not redacted), got %v", got["age"])
+	}
+}

--- a/internal/runtime/tools/http_client_test.go
+++ b/internal/runtime/tools/http_client_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestDoHTTPRequest_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"answer":42}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "POST"}
+	result, callResult, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callResult.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", callResult.StatusCode)
+	}
+	if callResult.Err != nil {
+		t.Errorf("expected no transport error, got: %v", callResult.Err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("result is not valid JSON: %v", err)
+	}
+	if got["answer"] != float64(42) {
+		t.Errorf("expected answer=42, got %v", got["answer"])
+	}
+}
+
+func TestDoHTTPRequest_NonJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("plain text response"))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "POST"}
+	result, callResult, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if callResult.StatusCode != http.StatusOK {
+		t.Errorf("expected status 200, got %d", callResult.StatusCode)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(result, &got); err != nil {
+		t.Fatalf("result should be wrapped JSON: %v", err)
+	}
+	if got["result"] != "plain text response" {
+		t.Errorf("expected wrapped result, got %v", got["result"])
+	}
+}
+
+func TestDoHTTPRequest_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("bad gateway"))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "POST"}
+	result, callResult, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for 502 response")
+	}
+	if result != nil {
+		t.Errorf("expected nil result on error, got %s", result)
+	}
+	if callResult.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected StatusCode=502, got %d", callResult.StatusCode)
+	}
+	if callResult.Err != nil {
+		t.Errorf("expected no transport error (HTTP error, not network error), got: %v", callResult.Err)
+	}
+	if !strings.Contains(err.Error(), "502") {
+		t.Errorf("expected error to mention status code 502, got: %v", err)
+	}
+}
+
+func TestDoHTTPRequest_POSTWithBody(t *testing.T) {
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		receivedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "POST"}
+	args := json.RawMessage(`{"key":"value"}`)
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(receivedBody) != `{"key":"value"}` {
+		t.Errorf("expected body %q, got %q", `{"key":"value"}`, receivedBody)
+	}
+}
+
+func TestDoHTTPRequest_Headers(t *testing.T) {
+	var receivedAuthHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "POST"}
+	headers := map[string]string{"Authorization": "Bearer test-token"}
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, headers, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if receivedAuthHeader != "Bearer test-token" {
+		t.Errorf("expected Authorization header 'Bearer test-token', got %q", receivedAuthHeader)
+	}
+}
+
+func TestDoHTTPRequest_ConnectionRefused(t *testing.T) {
+	// Port 1 is reserved and will always refuse connections.
+	cfg := &HTTPCfg{Endpoint: "http://127.0.0.1:1", Method: "POST"}
+	result, callResult, err := doHTTPRequest(context.Background(), &http.Client{}, cfg, nil, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected transport error for connection refused")
+	}
+	if result != nil {
+		t.Errorf("expected nil result on transport error")
+	}
+	if callResult.Err == nil {
+		t.Error("expected callResult.Err to be set for transport error")
+	}
+	if callResult.StatusCode != 0 {
+		t.Errorf("expected StatusCode=0 for transport error, got %d", callResult.StatusCode)
+	}
+}
+
+func TestDoHTTPRequest_GETWithQueryParams(t *testing.T) {
+	var receivedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "GET"}
+	args := json.RawMessage(`{"foo":"bar","n":1}`)
+	_, _, err := doHTTPRequest(context.Background(), srv.Client(), cfg, nil, args)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(receivedQuery, "foo=bar") {
+		t.Errorf("expected query to contain 'foo=bar', got %q", receivedQuery)
+	}
+	if !strings.Contains(receivedQuery, "n=1") {
+		t.Errorf("expected query to contain 'n=1', got %q", receivedQuery)
+	}
+}

--- a/internal/runtime/tools/http_client_test.go
+++ b/internal/runtime/tools/http_client_test.go
@@ -415,3 +415,46 @@ func TestDoHTTPRequest_Redact(t *testing.T) {
 		t.Errorf("expected age=30 (not redacted), got %v", got["age"])
 	}
 }
+
+func TestDoHTTPRequest_BodyMapping(t *testing.T) {
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	// BodyMapping extracts just the "query" field from the args
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "POST", BodyMapping: "query"}
+	_, _, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil,
+		json.RawMessage(`{"query":"hello","page":1}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// JMESPath "query" extracts the string value → "hello"
+	if strings.TrimSpace(string(receivedBody)) != `"hello"` {
+		t.Errorf("expected body to be \"hello\" (JMESPath-extracted), got %s", receivedBody)
+	}
+}
+
+func TestDoHTTPRequest_ResponseMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"items":[1,2,3]},"meta":{"page":1}}`))
+	}))
+	defer srv.Close()
+
+	// ResponseMapping extracts just data.items from the response
+	cfg := &HTTPCfg{Endpoint: srv.URL, Method: "GET", ResponseMapping: "data.items"}
+	result, _, err := doHTTPRequest(context.Background(), http.DefaultClient, cfg, nil,
+		json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != `[1,2,3]` {
+		t.Errorf("expected [1,2,3] from response mapping, got %s", result)
+	}
+}

--- a/internal/runtime/tools/omnia_executor.go
+++ b/internal/runtime/tools/omnia_executor.go
@@ -38,7 +38,6 @@ import (
 	"google.golang.org/grpc/metadata"
 
 	pktools "github.com/AltairaLabs/PromptKit/runtime/tools"
-	sdktools "github.com/AltairaLabs/PromptKit/sdk/tools"
 
 	"github.com/altairalabs/omnia/internal/tracing"
 	toolsv1 "github.com/altairalabs/omnia/pkg/tools/v1"
@@ -74,9 +73,6 @@ type OmniaExecutor struct {
 	// Registry metadata for tracing/event store
 	toolMeta map[string]ToolMeta
 
-	// PromptKit HTTP executor (shared across all HTTP/OpenAPI tools)
-	httpExecutor *sdktools.HTTPExecutor
-
 	// MCP sessions keyed by handler name
 	mcpClients  map[string]*mcp.Client
 	mcpSessions map[string]*mcp.ClientSession
@@ -104,7 +100,6 @@ func NewOmniaExecutor(log logr.Logger, tp *tracing.Provider) *OmniaExecutor {
 		handlers:        make(map[string]*HandlerEntry),
 		toolHandlers:    make(map[string]string),
 		toolMeta:        make(map[string]ToolMeta),
-		httpExecutor:    sdktools.NewHTTPExecutor(),
 		mcpClients:      make(map[string]*mcp.Client),
 		mcpSessions:     make(map[string]*mcp.ClientSession),
 		mcpTools:        make(map[string]map[string]*mcp.Tool),
@@ -433,6 +428,11 @@ func (e *OmniaExecutor) startSpan(ctx context.Context, toolName string) (context
 	})
 }
 
+// currentSpan extracts the active span from context.
+func (e *OmniaExecutor) currentSpan(ctx context.Context) trace.Span {
+	return trace.SpanFromContext(ctx)
+}
+
 // recordResult records span attributes from the execution result.
 func (e *OmniaExecutor) recordResult(span trace.Span, _ json.RawMessage, err error) {
 	if err != nil {
@@ -577,19 +577,24 @@ func (e *OmniaExecutor) executeHTTP(
 		return nil, fmt.Errorf("handler %q has no HTTP config", handlerName)
 	}
 
-	// Build PromptKit HTTPConfig with policy headers
 	headers := e.buildHTTPHeaders(ctx, cfg, toolName, handlerName, args)
+	policy := httpRetryParams(cfg)
 
-	desc := &pktools.ToolDescriptor{
-		Name: toolName,
-		HTTPConfig: &pktools.HTTPConfig{
-			URL:     cfg.Endpoint,
-			Method:  cfg.Method,
-			Headers: headers,
-		},
+	var lastCallResult httpCallResult
+	classify := func(_ error) (bool, time.Duration) {
+		if cfg.RetryPolicy == nil {
+			return false, 0
+		}
+		return classifyHTTPResult(lastCallResult, cfg.RetryPolicy)
 	}
 
-	return e.httpExecutor.Execute(ctx, desc, args)
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			result, callResult, err := doHTTPRequest(attemptCtx, &http.Client{}, cfg, headers, args)
+			lastCallResult = callResult
+			return result, err
+		},
+	)
 }
 
 // buildHTTPHeaders merges static headers, auth headers, and policy headers.
@@ -696,28 +701,47 @@ func (e *OmniaExecutor) executeMCP(
 ) (json.RawMessage, error) {
 	e.mu.RLock()
 	session := e.mcpSessions[handlerName]
+	handler := e.handlers[handlerName]
 	e.mu.RUnlock()
 
 	if session == nil {
 		return nil, fmt.Errorf("MCP handler %q not connected", handlerName)
 	}
 
-	var argsMap map[string]any
-	if len(args) > 0 {
-		if err := json.Unmarshal(args, &argsMap); err != nil {
-			return nil, fmt.Errorf("failed to parse MCP args: %w", err)
-		}
-	}
+	policy, classify := mcpRetryParams(handler.MCPConfig)
 
-	result, err := session.CallTool(ctx, &mcp.CallToolParams{
-		Name:      toolName,
-		Arguments: argsMap,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("MCP tool call failed: %w", err)
-	}
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			var argsMap map[string]any
+			if len(args) > 0 {
+				if err := json.Unmarshal(args, &argsMap); err != nil {
+					return nil, fmt.Errorf("failed to parse MCP args: %w", err)
+				}
+			}
 
-	return marshalMCPResult(result)
+			result, err := session.CallTool(attemptCtx, &mcp.CallToolParams{
+				Name:      toolName,
+				Arguments: argsMap,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("MCP tool call failed: %w", err)
+			}
+
+			// Convert MCP tool errors to mcpToolError so the classifier
+			// can distinguish them from transport errors.
+			if result.IsError {
+				msg := "MCP tool returned error"
+				if len(result.Content) > 0 {
+					if tc, ok := result.Content[0].(*mcp.TextContent); ok && tc.Text != "" {
+						msg = tc.Text
+					}
+				}
+				return nil, &mcpToolError{message: msg}
+			}
+
+			return marshalMCPResult(result)
+		},
+	)
 }
 
 func marshalMCPResult(result *mcp.CallToolResult) (json.RawMessage, error) {
@@ -841,36 +865,44 @@ func (e *OmniaExecutor) executeGRPC(
 ) (json.RawMessage, error) {
 	e.mu.RLock()
 	client := e.grpcClients[handlerName]
+	handler := e.handlers[handlerName]
 	e.mu.RUnlock()
 
 	if client == nil {
 		return nil, fmt.Errorf("gRPC handler %q not connected", handlerName)
 	}
 
-	// Inject policy metadata
-	md := PolicyGRPCMetadata(ctx, toolName, handlerName, nil)
-	if len(md) > 0 {
-		pairs := make([]string, 0, len(md)*2)
-		for k, v := range md {
-			pairs = append(pairs, k, v)
-		}
-		ctx = metadata.AppendToOutgoingContext(ctx, pairs...)
-	}
+	policy, classify := grpcRetryParams(handler.GRPCConfig)
 
-	var resp *toolsv1.ToolResponse
-	_, err := e.breakers.Execute(toolName, func() ([]byte, error) {
-		var execErr error
-		resp, execErr = client.Execute(ctx, &toolsv1.ToolRequest{
-			ToolName:      toolName,
-			ArgumentsJson: string(args),
-		})
-		return nil, execErr
-	})
-	if err != nil {
-		return nil, fmt.Errorf("gRPC tool execution failed: %w", err)
-	}
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			// Inject policy metadata.
+			md := PolicyGRPCMetadata(attemptCtx, toolName, handlerName, nil)
+			if len(md) > 0 {
+				pairs := make([]string, 0, len(md)*2)
+				for k, v := range md {
+					pairs = append(pairs, k, v)
+				}
+				attemptCtx = metadata.AppendToOutgoingContext(attemptCtx, pairs...)
+			}
 
-	return marshalGRPCResponse(resp)
+			// Execute through circuit breaker.
+			var resp *toolsv1.ToolResponse
+			_, cbErr := e.breakers.Execute(toolName, func() ([]byte, error) {
+				var execErr error
+				resp, execErr = client.Execute(attemptCtx, &toolsv1.ToolRequest{
+					ToolName:      toolName,
+					ArgumentsJson: string(args),
+				})
+				return nil, execErr
+			})
+			if cbErr != nil {
+				return nil, fmt.Errorf("gRPC tool execution failed: %w", cbErr)
+			}
+
+			return marshalGRPCResponse(resp)
+		},
+	)
 }
 
 func marshalGRPCResponse(resp *toolsv1.ToolResponse) (json.RawMessage, error) {
@@ -926,7 +958,7 @@ func (e *OmniaExecutor) executeOpenAPI(
 	e.mu.RLock()
 	ops := e.openAPIOps[handlerName]
 	baseURL := e.openAPIBaseURLs[handlerName]
-	headers := e.openAPIHeaders[handlerName]
+	hdrs := e.openAPIHeaders[handlerName]
 	e.mu.RUnlock()
 
 	op, ok := ops[toolName]
@@ -934,40 +966,37 @@ func (e *OmniaExecutor) executeOpenAPI(
 		return nil, fmt.Errorf("OpenAPI operation %q not found", toolName)
 	}
 
-	// Build the URL from base + path
-	url := baseURL + op.Path
-
-	// Merge policy and config headers
-	allHeaders := make(map[string]string)
-	for k, v := range headers {
-		allHeaders[k] = v
+	// Build a synthetic HTTPCfg for the OpenAPI operation.
+	cfg := &HTTPCfg{
+		Endpoint: baseURL + op.Path,
+		Method:   op.Method,
+		Headers:  make(map[string]string),
+	}
+	for k, v := range hdrs {
+		cfg.Headers[k] = v
 	}
 	if handler.OpenAPIConfig != nil {
-		if err := mergeAuthHeaders(allHeaders, handler.OpenAPIConfig.AuthType, handler.OpenAPIConfig.AuthToken); err != nil {
-			e.log.Error(err, "invalid auth config", "handler", handlerName)
-		}
+		cfg.AuthType = handler.OpenAPIConfig.AuthType
+		cfg.AuthToken = handler.OpenAPIConfig.AuthToken
+		cfg.RetryPolicy = handler.OpenAPIConfig.RetryPolicy
 	}
 
-	var argsMap map[string]any
-	if len(args) > 0 {
-		_ = json.Unmarshal(args, &argsMap)
-	}
-	req := &http.Request{Header: http.Header{}}
-	SetAllOutboundHeaders(ctx, req, toolName, handlerName, argsMap)
-	for k, v := range req.Header {
-		if len(v) > 0 {
-			allHeaders[k] = v[0]
+	headers := e.buildHTTPHeaders(ctx, cfg, toolName, handlerName, args)
+	policy := httpRetryParams(cfg)
+
+	var lastCallResult httpCallResult
+	classify := func(_ error) (bool, time.Duration) {
+		if cfg.RetryPolicy == nil {
+			return false, 0
 		}
+		return classifyHTTPResult(lastCallResult, cfg.RetryPolicy)
 	}
 
-	desc := &pktools.ToolDescriptor{
-		Name: toolName,
-		HTTPConfig: &pktools.HTTPConfig{
-			URL:     url,
-			Method:  op.Method,
-			Headers: allHeaders,
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+		func(attemptCtx context.Context) (json.RawMessage, error) {
+			result, callResult, err := doHTTPRequest(attemptCtx, &http.Client{}, cfg, headers, args)
+			lastCallResult = callResult
+			return result, err
 		},
-	}
-
-	return e.httpExecutor.Execute(ctx, desc, args)
+	)
 }

--- a/internal/runtime/tools/omnia_executor_test.go
+++ b/internal/runtime/tools/omnia_executor_test.go
@@ -104,9 +104,6 @@ func TestOmniaExecutor_New(t *testing.T) {
 	if e.grpcClients == nil {
 		t.Error("grpcClients map not initialized")
 	}
-	if e.httpExecutor == nil {
-		t.Error("httpExecutor not initialized")
-	}
 	if e.breakers == nil {
 		t.Error("breakers not initialized")
 	}
@@ -1442,6 +1439,7 @@ func TestOmniaExecutor_ExecuteGRPC_WithMockClient(t *testing.T) {
 		},
 	}
 	e.grpcClients["grpc-handler"] = mock
+	e.handlers["grpc-handler"] = &HandlerEntry{Name: "grpc-handler", Type: ToolTypeGRPC}
 
 	result, err := e.executeGRPC(context.Background(), "grpc-tool", "grpc-handler", json.RawMessage(`{"q":"test"}`))
 	if err != nil {
@@ -1458,6 +1456,7 @@ func TestOmniaExecutor_ExecuteGRPC_MockClientError(t *testing.T) {
 		executeErr: fmt.Errorf("connection refused"),
 	}
 	e.grpcClients["grpc-handler"] = mock
+	e.handlers["grpc-handler"] = &HandlerEntry{Name: "grpc-handler", Type: ToolTypeGRPC}
 
 	_, err := e.executeGRPC(context.Background(), "grpc-tool", "grpc-handler", nil)
 	if err == nil {
@@ -1477,6 +1476,7 @@ func TestOmniaExecutor_ExecuteGRPC_MockClientToolError(t *testing.T) {
 		},
 	}
 	e.grpcClients["grpc-handler"] = mock
+	e.handlers["grpc-handler"] = &HandlerEntry{Name: "grpc-handler", Type: ToolTypeGRPC}
 
 	_, err := e.executeGRPC(context.Background(), "grpc-tool", "grpc-handler", nil)
 	if err == nil {
@@ -1495,6 +1495,7 @@ func TestOmniaExecutor_ExecuteGRPC_MetadataInjection(t *testing.T) {
 		},
 	}
 	e.grpcClients["grpc-handler"] = mock
+	e.handlers["grpc-handler"] = &HandlerEntry{Name: "grpc-handler", Type: ToolTypeGRPC}
 
 	// Pass args to exercise the metadata injection path
 	args := json.RawMessage(`{"param":"value"}`)
@@ -2182,6 +2183,7 @@ func TestOmniaExecutor_ExecuteMCP_Success(t *testing.T) {
 
 	e := NewOmniaExecutor(logr.Discard(), nil)
 	e.mcpSessions["test-mcp"] = session
+	e.handlers["test-mcp"] = &HandlerEntry{Name: "test-mcp", Type: ToolTypeMCP}
 
 	result, err := e.executeMCP(context.Background(), "echo", "test-mcp", json.RawMessage(`{}`))
 	if err != nil {
@@ -2238,6 +2240,7 @@ func TestOmniaExecutor_ExecuteMCP_WithArgs(t *testing.T) {
 
 	e := NewOmniaExecutor(logr.Discard(), nil)
 	e.mcpSessions["test-mcp"] = session
+	e.handlers["test-mcp"] = &HandlerEntry{Name: "test-mcp", Type: ToolTypeMCP}
 
 	result, err := e.executeMCP(context.Background(), "greet", "test-mcp", json.RawMessage(`{"name":"Alice"}`))
 	if err != nil {
@@ -2288,6 +2291,7 @@ func TestOmniaExecutor_ExecuteMCP_EmptyArgs(t *testing.T) {
 
 	e := NewOmniaExecutor(logr.Discard(), nil)
 	e.mcpSessions["test-mcp"] = session
+	e.handlers["test-mcp"] = &HandlerEntry{Name: "test-mcp", Type: ToolTypeMCP}
 
 	// Empty args (nil)
 	result, err := e.executeMCP(context.Background(), "ping", "test-mcp", nil)

--- a/internal/runtime/tools/omnia_executor_test.go
+++ b/internal/runtime/tools/omnia_executor_test.go
@@ -2428,27 +2428,18 @@ func TestExecuteHTTP_RetryOnRetryableStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["retry-http"] = &HandlerEntry{
-		Name: "retry-http",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint: srv.URL,
-			Method:   "GET",
-			RetryPolicy: &RuntimeHTTPRetryPolicy{
-				MaxAttempts:         3,
-				InitialBackoff:      Duration(1 * time.Millisecond),
-				BackoffMultiplier:   2.0,
-				MaxBackoff:          Duration(100 * time.Millisecond),
-				RetryOn:             []int32{502},
-				RetryOnNetworkError: true,
-			},
+	result, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint: srv.URL,
+		Method:   "GET",
+		RetryPolicy: &RuntimeHTTPRetryPolicy{
+			MaxAttempts:         3,
+			InitialBackoff:      Duration(1 * time.Millisecond),
+			BackoffMultiplier:   2.0,
+			MaxBackoff:          Duration(100 * time.Millisecond),
+			RetryOn:             []int32{502},
+			RetryOnNetworkError: true,
 		},
-	}
-	e.toolHandlers["retry-http-tool"] = "retry-http"
-
-	desc := &pktools.ToolDescriptor{Name: "retry-http-tool"}
-	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	}, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute failed: %v", err)
 	}
@@ -2469,27 +2460,18 @@ func TestExecuteHTTP_NoRetryOnNonRetryableStatus(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["no-retry-http"] = &HandlerEntry{
-		Name: "no-retry-http",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint: srv.URL,
-			Method:   "GET",
-			RetryPolicy: &RuntimeHTTPRetryPolicy{
-				MaxAttempts:         3,
-				InitialBackoff:      Duration(1 * time.Millisecond),
-				BackoffMultiplier:   2.0,
-				MaxBackoff:          Duration(100 * time.Millisecond),
-				RetryOn:             []int32{502, 503},
-				RetryOnNetworkError: true,
-			},
+	_, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint: srv.URL,
+		Method:   "GET",
+		RetryPolicy: &RuntimeHTTPRetryPolicy{
+			MaxAttempts:         3,
+			InitialBackoff:      Duration(1 * time.Millisecond),
+			BackoffMultiplier:   2.0,
+			MaxBackoff:          Duration(100 * time.Millisecond),
+			RetryOn:             []int32{502, 503},
+			RetryOnNetworkError: true,
 		},
-	}
-	e.toolHandlers["no-retry-tool"] = "no-retry-http"
-
-	desc := &pktools.ToolDescriptor{Name: "no-retry-tool"}
-	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	}, json.RawMessage(`{}`))
 	if err == nil {
 		t.Fatal("expected error for 400 response")
 	}
@@ -2628,6 +2610,16 @@ func TestMCPRetry_ToolErrorNotRetried(t *testing.T) {
 
 // --- Integration tests: HTTP config fields through OmniaExecutor.Execute() ---
 
+// executeHTTPTool sets up a minimal OmniaExecutor with a single HTTP handler
+// and executes a tool call. This eliminates repeated boilerplate in integration tests.
+func executeHTTPTool(t *testing.T, cfg *HTTPCfg, args json.RawMessage) (json.RawMessage, error) {
+	t.Helper()
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["h"] = &HandlerEntry{Name: "h", Type: ToolTypeHTTP, HTTPConfig: cfg}
+	e.toolHandlers["tool"] = "h"
+	return e.Execute(context.Background(), &pktools.ToolDescriptor{Name: "tool"}, args)
+}
+
 func TestExecuteHTTP_URLTemplate(t *testing.T) {
 	var receivedPath string
 	var receivedBody []byte
@@ -2640,20 +2632,11 @@ func TestExecuteHTTP_URLTemplate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["url-tmpl"] = &HandlerEntry{
-		Name: "url-tmpl",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:    srv.URL,
-			URLTemplate: srv.URL + "/users/{id}/posts",
-			Method:      "POST",
-		},
-	}
-	e.toolHandlers["url-tmpl-tool"] = "url-tmpl"
-
-	desc := &pktools.ToolDescriptor{Name: "url-tmpl-tool"}
-	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"id":"42","title":"Hello"}`))
+	_, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:    srv.URL,
+		URLTemplate: srv.URL + "/users/{id}/posts",
+		Method:      "POST",
+	}, json.RawMessage(`{"id":"42","title":"Hello"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2679,20 +2662,11 @@ func TestExecuteHTTP_StaticQuery(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["static-query"] = &HandlerEntry{
-		Name: "static-query",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:    srv.URL,
-			Method:      "GET",
-			StaticQuery: map[string]string{"api_key": "secret123"},
-		},
-	}
-	e.toolHandlers["static-query-tool"] = "static-query"
-
-	desc := &pktools.ToolDescriptor{Name: "static-query-tool"}
-	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"q":"test"}`))
+	_, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:    srv.URL,
+		Method:      "GET",
+		StaticQuery: map[string]string{"api_key": "secret123"},
+	}, json.RawMessage(`{"q":"test"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2720,20 +2694,11 @@ func TestExecuteHTTP_QueryParams_POST(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["qp-post"] = &HandlerEntry{
-		Name: "qp-post",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:    srv.URL,
-			Method:      "POST",
-			QueryParams: []string{"page", "limit"},
-		},
-	}
-	e.toolHandlers["qp-post-tool"] = "qp-post"
-
-	desc := &pktools.ToolDescriptor{Name: "qp-post-tool"}
-	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"page":"1","limit":"10","data":"value"}`))
+	_, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:    srv.URL,
+		Method:      "POST",
+		QueryParams: []string{"page", "limit"},
+	}, json.RawMessage(`{"page":"1","limit":"10","data":"value"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2773,20 +2738,11 @@ func TestExecuteHTTP_HeaderParams(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["hdr-params"] = &HandlerEntry{
-		Name: "hdr-params",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:     srv.URL,
-			Method:       "POST",
-			HeaderParams: map[string]string{"user_id": "X-User-ID", "tenant": "X-Tenant"},
-		},
-	}
-	e.toolHandlers["hdr-params-tool"] = "hdr-params"
-
-	desc := &pktools.ToolDescriptor{Name: "hdr-params-tool"}
-	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"user_id":"abc","tenant":"t1","query":"hello"}`))
+	_, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:     srv.URL,
+		Method:       "POST",
+		HeaderParams: map[string]string{"user_id": "X-User-ID", "tenant": "X-Tenant"},
+	}, json.RawMessage(`{"user_id":"abc","tenant":"t1","query":"hello"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2812,20 +2768,11 @@ func TestExecuteHTTP_StaticBody(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["static-body"] = &HandlerEntry{
-		Name: "static-body",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:   srv.URL,
-			Method:     "POST",
-			StaticBody: map[string]any{"source": "api", "version": "v2"},
-		},
-	}
-	e.toolHandlers["static-body-tool"] = "static-body"
-
-	desc := &pktools.ToolDescriptor{Name: "static-body-tool"}
-	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"test"}`))
+	_, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:   srv.URL,
+		Method:     "POST",
+		StaticBody: map[string]any{"source": "api", "version": "v2"},
+	}, json.RawMessage(`{"query":"test"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2852,20 +2799,11 @@ func TestExecuteHTTP_Redact(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["redact-hdlr"] = &HandlerEntry{
-		Name: "redact-hdlr",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint: srv.URL,
-			Method:   "GET",
-			Redact:   []string{"ssn"},
-		},
-	}
-	e.toolHandlers["redact-tool"] = "redact-hdlr"
-
-	desc := &pktools.ToolDescriptor{Name: "redact-tool"}
-	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	result, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint: srv.URL,
+		Method:   "GET",
+		Redact:   []string{"ssn"},
+	}, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2891,20 +2829,11 @@ func TestExecuteHTTP_BodyMapping(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["body-map"] = &HandlerEntry{
-		Name: "body-map",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:    srv.URL,
-			Method:      "POST",
-			BodyMapping: "{query: query, filters: {page: page}}",
-		},
-	}
-	e.toolHandlers["body-map-tool"] = "body-map"
-
-	desc := &pktools.ToolDescriptor{Name: "body-map-tool"}
-	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello","page":1}`))
+	_, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:    srv.URL,
+		Method:      "POST",
+		BodyMapping: "{query: query, filters: {page: page}}",
+	}, json.RawMessage(`{"query":"hello","page":1}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2933,20 +2862,11 @@ func TestExecuteHTTP_ResponseMapping(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["resp-map"] = &HandlerEntry{
-		Name: "resp-map",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:        srv.URL,
-			Method:          "GET",
-			ResponseMapping: "data.items",
-		},
-	}
-	e.toolHandlers["resp-map-tool"] = "resp-map"
-
-	desc := &pktools.ToolDescriptor{Name: "resp-map-tool"}
-	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	result, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:        srv.URL,
+		Method:          "GET",
+		ResponseMapping: "data.items",
+	}, json.RawMessage(`{}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -2976,24 +2896,15 @@ func TestExecuteHTTP_CombinedFeatures(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["combined"] = &HandlerEntry{
-		Name: "combined",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:        srv.URL,
-			URLTemplate:     srv.URL + "/resources/{id}",
-			Method:          "POST",
-			StaticQuery:     map[string]string{"api_key": "k1"},
-			HeaderParams:    map[string]string{"token": "Authorization"},
-			ResponseMapping: "result",
-			Redact:          []string{"secret"},
-		},
-	}
-	e.toolHandlers["combined-tool"] = "combined"
-
-	desc := &pktools.ToolDescriptor{Name: "combined-tool"}
-	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{"id":"99","token":"Bearer xyz","data":"payload"}`))
+	result, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:        srv.URL,
+		URLTemplate:     srv.URL + "/resources/{id}",
+		Method:          "POST",
+		StaticQuery:     map[string]string{"api_key": "k1"},
+		HeaderParams:    map[string]string{"token": "Authorization"},
+		ResponseMapping: "result",
+		Redact:          []string{"secret"},
+	}, json.RawMessage(`{"id":"99","token":"Bearer xyz","data":"payload"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
@@ -3038,28 +2949,19 @@ func TestExecuteHTTP_RetryWithURLTemplate(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["retry-tmpl"] = &HandlerEntry{
-		Name: "retry-tmpl",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint:    srv.URL,
-			URLTemplate: srv.URL + "/items/{item_id}",
-			Method:      "GET",
-			RetryPolicy: &RuntimeHTTPRetryPolicy{
-				MaxAttempts:         3,
-				InitialBackoff:      Duration(1 * time.Millisecond),
-				BackoffMultiplier:   2.0,
-				MaxBackoff:          Duration(100 * time.Millisecond),
-				RetryOn:             []int32{502},
-				RetryOnNetworkError: true,
-			},
+	result, err := executeHTTPTool(t, &HTTPCfg{
+		Endpoint:    srv.URL,
+		URLTemplate: srv.URL + "/items/{item_id}",
+		Method:      "GET",
+		RetryPolicy: &RuntimeHTTPRetryPolicy{
+			MaxAttempts:         3,
+			InitialBackoff:      Duration(1 * time.Millisecond),
+			BackoffMultiplier:   2.0,
+			MaxBackoff:          Duration(100 * time.Millisecond),
+			RetryOn:             []int32{502},
+			RetryOnNetworkError: true,
 		},
-	}
-	e.toolHandlers["retry-tmpl-tool"] = "retry-tmpl"
-
-	desc := &pktools.ToolDescriptor{Name: "retry-tmpl-tool"}
-	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{"item_id":"7"}`))
+	}, json.RawMessage(`{"item_id":"7"}`))
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}

--- a/internal/runtime/tools/omnia_executor_test.go
+++ b/internal/runtime/tools/omnia_executor_test.go
@@ -19,6 +19,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -28,6 +29,7 @@ import (
 	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -35,7 +37,9 @@ import (
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
+	grpcCodes "google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
+	grpcStatus "google.golang.org/grpc/status"
 
 	pktools "github.com/AltairaLabs/PromptKit/runtime/tools"
 
@@ -2373,5 +2377,249 @@ func TestOmniaExecutor_InitOpenAPIHandler_WithMockServer(t *testing.T) {
 	}
 	if op.Method != "GET" {
 		t.Errorf("method = %q, want %q", op.Method, "GET")
+	}
+}
+
+// --- Retry integration tests ---
+
+// failNTimesGRPCClient is a mock ToolServiceClient that returns failErr for the
+// first failCount calls, then returns successResp.
+type failNTimesGRPCClient struct {
+	failCount   int
+	calls       int
+	successResp *toolsv1.ToolResponse
+	failErr     error
+}
+
+func (m *failNTimesGRPCClient) Execute(
+	_ context.Context,
+	_ *toolsv1.ToolRequest,
+	_ ...grpc.CallOption,
+) (*toolsv1.ToolResponse, error) {
+	m.calls++
+	if m.calls <= m.failCount {
+		return nil, m.failErr
+	}
+	return m.successResp, nil
+}
+
+func (m *failNTimesGRPCClient) ListTools(
+	_ context.Context,
+	_ *toolsv1.ListToolsRequest,
+	_ ...grpc.CallOption,
+) (*toolsv1.ListToolsResponse, error) {
+	return nil, nil
+}
+
+func TestExecuteHTTP_RetryOnRetryableStatus(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("bad gateway"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["retry-http"] = &HandlerEntry{
+		Name: "retry-http",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint: srv.URL,
+			Method:   "GET",
+			RetryPolicy: &RuntimeHTTPRetryPolicy{
+				MaxAttempts:         3,
+				InitialBackoff:      Duration(1 * time.Millisecond),
+				BackoffMultiplier:   2.0,
+				MaxBackoff:          Duration(100 * time.Millisecond),
+				RetryOn:             []int32{502},
+				RetryOnNetworkError: true,
+			},
+		},
+	}
+	e.toolHandlers["retry-http-tool"] = "retry-http"
+
+	desc := &pktools.ToolDescriptor{Name: "retry-http-tool"}
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 retries + 1 success), got %d", calls)
+	}
+	if string(result) != `{"result":"ok"}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestExecuteHTTP_NoRetryOnNonRetryableStatus(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad request"))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["no-retry-http"] = &HandlerEntry{
+		Name: "no-retry-http",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint: srv.URL,
+			Method:   "GET",
+			RetryPolicy: &RuntimeHTTPRetryPolicy{
+				MaxAttempts:         3,
+				InitialBackoff:      Duration(1 * time.Millisecond),
+				BackoffMultiplier:   2.0,
+				MaxBackoff:          Duration(100 * time.Millisecond),
+				RetryOn:             []int32{502, 503},
+				RetryOnNetworkError: true,
+			},
+		},
+	}
+	e.toolHandlers["no-retry-tool"] = "no-retry-http"
+
+	desc := &pktools.ToolDescriptor{Name: "no-retry-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for 400 response")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (no retries for 400), got %d", calls)
+	}
+}
+
+func TestExecuteGRPC_RetryOnUnavailable(t *testing.T) {
+	mock := &failNTimesGRPCClient{
+		failCount:   2,
+		failErr:     grpcStatus.Error(grpcCodes.Unavailable, "service unavailable"),
+		successResp: &toolsv1.ToolResponse{ResultJson: `{"answer":42}`},
+	}
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.grpcClients["grpc-retry"] = mock
+	e.handlers["grpc-retry"] = &HandlerEntry{
+		Name: "grpc-retry",
+		Type: ToolTypeGRPC,
+		GRPCConfig: &GRPCCfg{
+			Endpoint: "localhost:50051",
+			RetryPolicy: &RuntimeGRPCRetryPolicy{
+				MaxAttempts:          3,
+				InitialBackoff:       Duration(1 * time.Millisecond),
+				BackoffMultiplier:    2.0,
+				MaxBackoff:           Duration(100 * time.Millisecond),
+				RetryableStatusCodes: []string{"UNAVAILABLE"},
+			},
+		},
+	}
+	e.toolHandlers["grpc-retry-tool"] = "grpc-retry"
+
+	result, err := e.executeGRPC(context.Background(), "grpc-retry-tool", "grpc-retry", json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("executeGRPC failed: %v", err)
+	}
+	if mock.calls != 3 {
+		t.Errorf("expected 3 calls, got %d", mock.calls)
+	}
+	if string(result) != `{"answer":42}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestExecuteGRPC_NoRetryOnNotFound(t *testing.T) {
+	mock := &failNTimesGRPCClient{
+		failCount: 5,
+		failErr:   grpcStatus.Error(grpcCodes.NotFound, "not found"),
+	}
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.grpcClients["grpc-no-retry"] = mock
+	e.handlers["grpc-no-retry"] = &HandlerEntry{
+		Name: "grpc-no-retry",
+		Type: ToolTypeGRPC,
+		GRPCConfig: &GRPCCfg{
+			Endpoint: "localhost:50051",
+			RetryPolicy: &RuntimeGRPCRetryPolicy{
+				MaxAttempts:          3,
+				InitialBackoff:       Duration(1 * time.Millisecond),
+				BackoffMultiplier:    2.0,
+				MaxBackoff:           Duration(100 * time.Millisecond),
+				RetryableStatusCodes: []string{"UNAVAILABLE"},
+			},
+		},
+	}
+	e.toolHandlers["grpc-no-retry-tool"] = "grpc-no-retry"
+
+	_, err := e.executeGRPC(context.Background(), "grpc-no-retry-tool", "grpc-no-retry", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected error for NOT_FOUND")
+	}
+	if mock.calls != 1 {
+		t.Errorf("expected 1 call (no retries), got %d", mock.calls)
+	}
+}
+
+func TestMCPRetry_TransportErrorRetried(t *testing.T) {
+	calls := 0
+	policy := retryPolicy{
+		MaxAttempts:       3,
+		InitialBackoff:    1 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+		MaxBackoff:        100 * time.Millisecond,
+	}
+
+	result, err := retryWithBackoff(
+		context.Background(), logr.Discard(), tracenoop.Span{},
+		policy, 0,
+		func(err error) (bool, time.Duration) { return classifyMCPError(err) },
+		func(_ context.Context) (json.RawMessage, error) {
+			calls++
+			if calls < 3 {
+				return nil, &net.OpError{Op: "read", Err: errors.New("connection reset")}
+			}
+			return json.RawMessage(`{"mcp":"ok"}`), nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls, got %d", calls)
+	}
+	if string(result) != `{"mcp":"ok"}` {
+		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+func TestMCPRetry_ToolErrorNotRetried(t *testing.T) {
+	calls := 0
+	policy := retryPolicy{
+		MaxAttempts:       3,
+		InitialBackoff:    1 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+		MaxBackoff:        100 * time.Millisecond,
+	}
+
+	_, err := retryWithBackoff(
+		context.Background(), logr.Discard(), tracenoop.Span{},
+		policy, 0,
+		func(err error) (bool, time.Duration) { return classifyMCPError(err) },
+		func(_ context.Context) (json.RawMessage, error) {
+			calls++
+			return nil, &mcpToolError{message: "file not found"}
+		},
+	)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Errorf("expected 1 call (tool errors not retried), got %d", calls)
 	}
 }

--- a/internal/runtime/tools/omnia_executor_test.go
+++ b/internal/runtime/tools/omnia_executor_test.go
@@ -21,9 +21,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -2621,5 +2623,453 @@ func TestMCPRetry_ToolErrorNotRetried(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Errorf("expected 1 call (tool errors not retried), got %d", calls)
+	}
+}
+
+// --- Integration tests: HTTP config fields through OmniaExecutor.Execute() ---
+
+func TestExecuteHTTP_URLTemplate(t *testing.T) {
+	var receivedPath string
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["url-tmpl"] = &HandlerEntry{
+		Name: "url-tmpl",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:    srv.URL,
+			URLTemplate: srv.URL + "/users/{id}/posts",
+			Method:      "POST",
+		},
+	}
+	e.toolHandlers["url-tmpl-tool"] = "url-tmpl"
+
+	desc := &pktools.ToolDescriptor{Name: "url-tmpl-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"id":"42","title":"Hello"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if receivedPath != "/users/42/posts" {
+		t.Errorf("URL path = %q, want %q", receivedPath, "/users/42/posts")
+	}
+	// id was consumed by the template; title should remain in body
+	if !strings.Contains(string(receivedBody), `"title"`) {
+		t.Errorf("expected title in body, got: %s", receivedBody)
+	}
+	if strings.Contains(string(receivedBody), `"id"`) {
+		t.Errorf("id should have been consumed by URL template, but found in body: %s", receivedBody)
+	}
+}
+
+func TestExecuteHTTP_StaticQuery(t *testing.T) {
+	var receivedQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["static-query"] = &HandlerEntry{
+		Name: "static-query",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:    srv.URL,
+			Method:      "GET",
+			StaticQuery: map[string]string{"api_key": "secret123"},
+		},
+	}
+	e.toolHandlers["static-query-tool"] = "static-query"
+
+	desc := &pktools.ToolDescriptor{Name: "static-query-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"q":"test"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	vals, parseErr := url.ParseQuery(receivedQuery)
+	if parseErr != nil {
+		t.Fatalf("parse query: %v", parseErr)
+	}
+	if vals.Get("api_key") != "secret123" {
+		t.Errorf("api_key = %q, want %q", vals.Get("api_key"), "secret123")
+	}
+	if vals.Get("q") != "test" {
+		t.Errorf("q = %q, want %q", vals.Get("q"), "test")
+	}
+}
+
+func TestExecuteHTTP_QueryParams_POST(t *testing.T) {
+	var receivedQuery string
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedQuery = r.URL.RawQuery
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["qp-post"] = &HandlerEntry{
+		Name: "qp-post",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:    srv.URL,
+			Method:      "POST",
+			QueryParams: []string{"page", "limit"},
+		},
+	}
+	e.toolHandlers["qp-post-tool"] = "qp-post"
+
+	desc := &pktools.ToolDescriptor{Name: "qp-post-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"page":"1","limit":"10","data":"value"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	qvals, parseErr := url.ParseQuery(receivedQuery)
+	if parseErr != nil {
+		t.Fatalf("parse query: %v", parseErr)
+	}
+	if qvals.Get("page") != "1" {
+		t.Errorf("page query param = %q, want %q", qvals.Get("page"), "1")
+	}
+	if qvals.Get("limit") != "10" {
+		t.Errorf("limit query param = %q, want %q", qvals.Get("limit"), "10")
+	}
+	// page and limit should NOT appear in body
+	if strings.Contains(string(receivedBody), `"page"`) {
+		t.Errorf("page should not be in body, got: %s", receivedBody)
+	}
+	if strings.Contains(string(receivedBody), `"limit"`) {
+		t.Errorf("limit should not be in body, got: %s", receivedBody)
+	}
+	// data should be in body
+	if !strings.Contains(string(receivedBody), `"data"`) {
+		t.Errorf("data should be in body, got: %s", receivedBody)
+	}
+}
+
+func TestExecuteHTTP_HeaderParams(t *testing.T) {
+	var receivedUserID, receivedTenant string
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedUserID = r.Header.Get("X-User-ID")
+		receivedTenant = r.Header.Get("X-Tenant")
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["hdr-params"] = &HandlerEntry{
+		Name: "hdr-params",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:     srv.URL,
+			Method:       "POST",
+			HeaderParams: map[string]string{"user_id": "X-User-ID", "tenant": "X-Tenant"},
+		},
+	}
+	e.toolHandlers["hdr-params-tool"] = "hdr-params"
+
+	desc := &pktools.ToolDescriptor{Name: "hdr-params-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"user_id":"abc","tenant":"t1","query":"hello"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if receivedUserID != "abc" {
+		t.Errorf("X-User-ID = %q, want %q", receivedUserID, "abc")
+	}
+	if receivedTenant != "t1" {
+		t.Errorf("X-Tenant = %q, want %q", receivedTenant, "t1")
+	}
+	// query was not promoted to header, should be in body
+	if !strings.Contains(string(receivedBody), `"query"`) {
+		t.Errorf("query should be in body, got: %s", receivedBody)
+	}
+}
+
+func TestExecuteHTTP_StaticBody(t *testing.T) {
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["static-body"] = &HandlerEntry{
+		Name: "static-body",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:   srv.URL,
+			Method:     "POST",
+			StaticBody: map[string]any{"source": "api", "version": "v2"},
+		},
+	}
+	e.toolHandlers["static-body-tool"] = "static-body"
+
+	desc := &pktools.ToolDescriptor{Name: "static-body-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"test"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var body map[string]any
+	if jsonErr := json.Unmarshal(receivedBody, &body); jsonErr != nil {
+		t.Fatalf("unmarshal body: %v (raw: %s)", jsonErr, receivedBody)
+	}
+	if body["source"] != "api" {
+		t.Errorf("source = %v, want %q", body["source"], "api")
+	}
+	if body["version"] != "v2" {
+		t.Errorf("version = %v, want %q", body["version"], "v2")
+	}
+	if body["query"] != "test" {
+		t.Errorf("query = %v, want %q", body["query"], "test")
+	}
+}
+
+func TestExecuteHTTP_Redact(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ssn":"123-45-6789","name":"Alice","age":30}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["redact-hdlr"] = &HandlerEntry{
+		Name: "redact-hdlr",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint: srv.URL,
+			Method:   "GET",
+			Redact:   []string{"ssn"},
+		},
+	}
+	e.toolHandlers["redact-tool"] = "redact-hdlr"
+
+	desc := &pktools.ToolDescriptor{Name: "redact-tool"}
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var got map[string]any
+	if jsonErr := json.Unmarshal(result, &got); jsonErr != nil {
+		t.Fatalf("unmarshal result: %v", jsonErr)
+	}
+	if got["ssn"] != "[REDACTED]" {
+		t.Errorf("ssn = %v, want [REDACTED]", got["ssn"])
+	}
+	if got["name"] != "Alice" {
+		t.Errorf("name = %v, want Alice", got["name"])
+	}
+}
+
+func TestExecuteHTTP_BodyMapping(t *testing.T) {
+	var receivedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["body-map"] = &HandlerEntry{
+		Name: "body-map",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:    srv.URL,
+			Method:      "POST",
+			BodyMapping: "{query: query, filters: {page: page}}",
+		},
+	}
+	e.toolHandlers["body-map-tool"] = "body-map"
+
+	desc := &pktools.ToolDescriptor{Name: "body-map-tool"}
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{"query":"hello","page":1}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var body map[string]any
+	if jsonErr := json.Unmarshal(receivedBody, &body); jsonErr != nil {
+		t.Fatalf("unmarshal body: %v (raw: %s)", jsonErr, receivedBody)
+	}
+	if body["query"] != "hello" {
+		t.Errorf("query = %v, want hello", body["query"])
+	}
+	filters, ok := body["filters"].(map[string]any)
+	if !ok {
+		t.Fatalf("filters not a map: %v", body["filters"])
+	}
+	// JMESPath returns numbers as float64
+	if filters["page"] != float64(1) {
+		t.Errorf("filters.page = %v, want 1", filters["page"])
+	}
+}
+
+func TestExecuteHTTP_ResponseMapping(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"items":[1,2,3]},"meta":{"page":1}}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["resp-map"] = &HandlerEntry{
+		Name: "resp-map",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:        srv.URL,
+			Method:          "GET",
+			ResponseMapping: "data.items",
+		},
+	}
+	e.toolHandlers["resp-map-tool"] = "resp-map"
+
+	desc := &pktools.ToolDescriptor{Name: "resp-map-tool"}
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var items []any
+	if jsonErr := json.Unmarshal(result, &items); jsonErr != nil {
+		t.Fatalf("unmarshal result: %v (raw: %s)", jsonErr, result)
+	}
+	if len(items) != 3 {
+		t.Errorf("items length = %d, want 3", len(items))
+	}
+	if items[0] != float64(1) || items[1] != float64(2) || items[2] != float64(3) {
+		t.Errorf("items = %v, want [1 2 3]", items)
+	}
+}
+
+func TestExecuteHTTP_CombinedFeatures(t *testing.T) {
+	var receivedPath string
+	var receivedQuery string
+	var receivedAuthHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		receivedQuery = r.URL.RawQuery
+		receivedAuthHeader = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":{"value":42},"secret":"top-secret"}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["combined"] = &HandlerEntry{
+		Name: "combined",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:        srv.URL,
+			URLTemplate:     srv.URL + "/resources/{id}",
+			Method:          "POST",
+			StaticQuery:     map[string]string{"api_key": "k1"},
+			HeaderParams:    map[string]string{"token": "Authorization"},
+			ResponseMapping: "result",
+			Redact:          []string{"secret"},
+		},
+	}
+	e.toolHandlers["combined-tool"] = "combined"
+
+	desc := &pktools.ToolDescriptor{Name: "combined-tool"}
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{"id":"99","token":"Bearer xyz","data":"payload"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if receivedPath != "/resources/99" {
+		t.Errorf("path = %q, want /resources/99", receivedPath)
+	}
+	qvals, _ := url.ParseQuery(receivedQuery)
+	if qvals.Get("api_key") != "k1" {
+		t.Errorf("api_key = %q, want k1", qvals.Get("api_key"))
+	}
+	if receivedAuthHeader != "Bearer xyz" {
+		t.Errorf("Authorization = %q, want Bearer xyz", receivedAuthHeader)
+	}
+	// ResponseMapping: "result" → {"value":42}
+	var got map[string]any
+	if jsonErr := json.Unmarshal(result, &got); jsonErr != nil {
+		t.Fatalf("unmarshal result: %v (raw: %s)", jsonErr, result)
+	}
+	if got["value"] != float64(42) {
+		t.Errorf("value = %v, want 42", got["value"])
+	}
+	// Redact on "secret" — but ResponseMapping was applied first so "secret" is not in result
+	if _, hasSecret := got["secret"]; hasSecret {
+		t.Errorf("secret should not be in result after ResponseMapping, got: %v", got)
+	}
+}
+
+func TestExecuteHTTP_RetryWithURLTemplate(t *testing.T) {
+	calls := 0
+	var lastPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		lastPath = r.URL.Path
+		if calls < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			_, _ = w.Write([]byte("bad gateway"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["retry-tmpl"] = &HandlerEntry{
+		Name: "retry-tmpl",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint:    srv.URL,
+			URLTemplate: srv.URL + "/items/{item_id}",
+			Method:      "GET",
+			RetryPolicy: &RuntimeHTTPRetryPolicy{
+				MaxAttempts:         3,
+				InitialBackoff:      Duration(1 * time.Millisecond),
+				BackoffMultiplier:   2.0,
+				MaxBackoff:          Duration(100 * time.Millisecond),
+				RetryOn:             []int32{502},
+				RetryOnNetworkError: true,
+			},
+		},
+	}
+	e.toolHandlers["retry-tmpl-tool"] = "retry-tmpl"
+
+	desc := &pktools.ToolDescriptor{Name: "retry-tmpl-tool"}
+	result, err := e.Execute(context.Background(), desc, json.RawMessage(`{"item_id":"7"}`))
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 calls (2 retries + 1 success), got %d", calls)
+	}
+	if lastPath != "/items/7" {
+		t.Errorf("URL path = %q, want /items/7", lastPath)
+	}
+	if string(result) != `{"result":"ok"}` {
+		t.Errorf("unexpected result: %s", result)
 	}
 }

--- a/internal/runtime/tools/retry.go
+++ b/internal/runtime/tools/retry.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math"
+	randv2 "math/rand/v2"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+)
+
+// retryPolicy describes exponential-backoff retry behaviour for a tool call.
+type retryPolicy struct {
+	MaxAttempts       int32
+	InitialBackoff    time.Duration
+	BackoffMultiplier float64
+	MaxBackoff        time.Duration
+}
+
+// retryWithBackoff executes fn, retrying on retryable errors according to policy.
+//
+// If MaxAttempts <= 1 the function is called once and returns immediately (fast
+// path; classify is never invoked).
+//
+// For each attempt the function is called with a child context that has
+// attemptTimeout applied when > 0.  On failure the classifier decides whether
+// to retry.  If the classifier returns a positive retryAfter hint, the sleep
+// delay is at least that value (still capped at MaxBackoff).  Context
+// cancellation during the sleep is honoured immediately.
+func retryWithBackoff(
+	ctx context.Context,
+	log logr.Logger,
+	span trace.Span,
+	policy retryPolicy,
+	attemptTimeout time.Duration,
+	classify func(error) (retryable bool, retryAfter time.Duration),
+	fn func(ctx context.Context) (json.RawMessage, error),
+) (json.RawMessage, error) {
+	// Fast path: single attempt, no retry machinery.
+	if policy.MaxAttempts <= 1 {
+		attemptCtx, cancel := withAttemptTimeout(ctx, attemptTimeout)
+		defer cancel()
+		return fn(attemptCtx)
+	}
+
+	var lastErr error
+	for attempt := int32(0); attempt < policy.MaxAttempts; attempt++ {
+		attemptCtx, cancel := withAttemptTimeout(ctx, attemptTimeout)
+		result, err := fn(attemptCtx)
+		cancel()
+
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+
+		// Do not classify or sleep after the last attempt.
+		if attempt == policy.MaxAttempts-1 {
+			break
+		}
+
+		retryable, retryAfter := classify(err)
+		if !retryable {
+			return nil, err
+		}
+
+		delay := backoffDelay(policy, int(attempt), retryAfter)
+
+		log.V(1).Info("retry attempt",
+			"attempt", attempt+1,
+			"maxAttempts", policy.MaxAttempts,
+			"delay", delay,
+			"error", err,
+		)
+		span.AddEvent("retry.attempt",
+			trace.WithAttributes(
+				attribute.Int("attempt", int(attempt+1)),
+				attribute.String("delay", delay.String()),
+				attribute.String("error", err.Error()),
+			),
+		)
+
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	log.Info("retries exhausted",
+		"attempts", policy.MaxAttempts,
+		"error", lastErr,
+	)
+	span.AddEvent("retry.exhausted",
+		trace.WithAttributes(
+			attribute.Int("attempts", int(policy.MaxAttempts)),
+			attribute.String("error", lastErr.Error()),
+		),
+	)
+	return nil, fmt.Errorf("%d attempts exhausted: %w", policy.MaxAttempts, lastErr)
+}
+
+// withAttemptTimeout returns a derived context with timeout applied when
+// timeout > 0.  The returned cancel function must always be called by the
+// caller to avoid context leaks.
+func withAttemptTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	if timeout <= 0 {
+		return ctx, func() {}
+	}
+	return context.WithTimeout(ctx, timeout)
+}
+
+// backoffDelay computes the sleep duration for a given attempt using
+// exponential back-off with ±10% jitter.  If retryAfter > 0 the result is
+// at least retryAfter (still capped at policy.MaxBackoff).
+func backoffDelay(policy retryPolicy, attempt int, retryAfter time.Duration) time.Duration {
+	base := float64(policy.InitialBackoff) * math.Pow(policy.BackoffMultiplier, float64(attempt))
+	if max := float64(policy.MaxBackoff); base > max {
+		base = max
+	}
+
+	// ±10% jitter: multiply by a random factor in [0.9, 1.1].
+	jitter := 0.9 + randv2.Float64()*0.2
+	delay := time.Duration(base * jitter)
+
+	delay = max(delay, retryAfter)
+	if delay > policy.MaxBackoff {
+		delay = policy.MaxBackoff
+	}
+	return delay
+}

--- a/internal/runtime/tools/retry_classify.go
+++ b/internal/runtime/tools/retry_classify.go
@@ -1,0 +1,189 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+// httpCallResult captures HTTP response metadata for retry classification.
+type httpCallResult struct {
+	StatusCode int
+	Headers    http.Header
+	Err        error // transport error; nil if HTTP request completed
+}
+
+// mcpToolError marks MCP application-level errors as non-retryable.
+// Transport errors are represented by other error types and are retryable.
+type mcpToolError struct {
+	message string
+}
+
+func (e *mcpToolError) Error() string { return e.message }
+
+// classifyHTTPResult determines whether an HTTP call result is retryable.
+// Returns (retryable, retryAfter) where retryAfter is parsed from the
+// Retry-After header when policy.RespectRetryAfter is true.
+func classifyHTTPResult(result httpCallResult, policy *RuntimeHTTPRetryPolicy) (bool, time.Duration) {
+	if result.Err != nil {
+		return isNetworkError(result.Err) && policy.RetryOnNetworkError, 0
+	}
+
+	if !slices.Contains(policy.RetryOn, int32(result.StatusCode)) {
+		return false, 0
+	}
+
+	var retryAfter time.Duration
+	if policy.RespectRetryAfter {
+		retryAfter = parseRetryAfter(result.Headers.Get("Retry-After"))
+	}
+	return true, retryAfter
+}
+
+// classifyGRPCError determines whether a gRPC error is retryable based on
+// the configured retryable status code names (e.g. "UNAVAILABLE").
+// Non-gRPC errors (e.g. from a circuit breaker) are never retried.
+func classifyGRPCError(err error, retryableStatusCodes []string) (bool, time.Duration) {
+	if err == nil {
+		return false, 0
+	}
+	st, ok := grpcStatus.FromError(err)
+	if !ok {
+		return false, 0
+	}
+	codeName := strings.ToUpper(st.Code().String())
+	return slices.Contains(retryableStatusCodes, codeName), 0
+}
+
+// classifyMCPError determines whether an MCP error is retryable.
+// Application-level tool errors (mcpToolError) are not retried; transport
+// errors are.
+func classifyMCPError(err error) (bool, time.Duration) {
+	if err == nil {
+		return false, 0
+	}
+	var toolErr *mcpToolError
+	if errors.As(err, &toolErr) {
+		return false, 0
+	}
+	return true, 0
+}
+
+// isNetworkError returns true for errors that represent transient network
+// conditions: context timeouts/cancellations, dial/read/write failures, and
+// DNS errors.
+func isNetworkError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	if errors.Is(err, context.Canceled) {
+		return true
+	}
+	var opErr *net.OpError
+	if errors.As(err, &opErr) {
+		return true
+	}
+	var dnsErr *net.DNSError
+	return errors.As(err, &dnsErr)
+}
+
+// parseRetryAfter parses a Retry-After header value.
+// Supports both integer-seconds and HTTP-date formats.
+// Returns 0 for empty or unparseable values.
+func parseRetryAfter(value string) time.Duration {
+	if value == "" {
+		return 0
+	}
+	// Integer seconds form: "120"
+	if secs, err := strconv.Atoi(value); err == nil {
+		return time.Duration(secs) * time.Second
+	}
+	// HTTP-date form: "Mon, 02 Jan 2006 15:04:05 GMT"
+	if t, err := http.ParseTime(value); err == nil {
+		d := time.Until(t)
+		if d < 0 {
+			return 0
+		}
+		return d
+	}
+	return 0
+}
+
+// httpRetryParams extracts a retryPolicy from an HTTPCfg.
+// Returns a single-attempt (no-retry) policy when cfg or its RetryPolicy is nil.
+// Note: the classify closure for HTTP is built in the executor because it needs
+// to capture the httpCallResult from the actual response.
+func httpRetryParams(cfg *HTTPCfg) retryPolicy {
+	if cfg == nil || cfg.RetryPolicy == nil {
+		return retryPolicy{MaxAttempts: 1}
+	}
+	p := cfg.RetryPolicy
+	return retryPolicy{
+		MaxAttempts:       p.MaxAttempts,
+		InitialBackoff:    p.InitialBackoff.Get(),
+		BackoffMultiplier: p.BackoffMultiplier,
+		MaxBackoff:        p.MaxBackoff.Get(),
+	}
+}
+
+// grpcRetryParams extracts a retryPolicy and classify function from a GRPCCfg.
+// Returns a single-attempt policy and a no-op classifier when cfg or its
+// RetryPolicy is nil.
+func grpcRetryParams(cfg *GRPCCfg) (retryPolicy, func(error) (bool, time.Duration)) {
+	if cfg == nil || cfg.RetryPolicy == nil {
+		return retryPolicy{MaxAttempts: 1}, func(_ error) (bool, time.Duration) { return false, 0 }
+	}
+	p := cfg.RetryPolicy
+	codes := p.RetryableStatusCodes
+	classify := func(err error) (bool, time.Duration) {
+		return classifyGRPCError(err, codes)
+	}
+	return retryPolicy{
+		MaxAttempts:       p.MaxAttempts,
+		InitialBackoff:    p.InitialBackoff.Get(),
+		BackoffMultiplier: p.BackoffMultiplier,
+		MaxBackoff:        p.MaxBackoff.Get(),
+	}, classify
+}
+
+// mcpRetryParams extracts a retryPolicy and classify function from an MCPCfg.
+// Returns a single-attempt policy and the standard MCP classifier when cfg or
+// its RetryPolicy is nil.
+func mcpRetryParams(cfg *MCPCfg) (retryPolicy, func(error) (bool, time.Duration)) {
+	classify := func(err error) (bool, time.Duration) {
+		return classifyMCPError(err)
+	}
+	if cfg == nil || cfg.RetryPolicy == nil {
+		return retryPolicy{MaxAttempts: 1}, classify
+	}
+	p := cfg.RetryPolicy
+	return retryPolicy{
+		MaxAttempts:       p.MaxAttempts,
+		InitialBackoff:    p.InitialBackoff.Get(),
+		BackoffMultiplier: p.BackoffMultiplier,
+		MaxBackoff:        p.MaxBackoff.Get(),
+	}, classify
+}

--- a/internal/runtime/tools/retry_classify_test.go
+++ b/internal/runtime/tools/retry_classify_test.go
@@ -1,0 +1,375 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	grpcCodes "google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+)
+
+// --- httpCallResult / classifyHTTPResult ---
+
+func TestClassifyHTTPResult_NetworkError_RetryOnNetworkErrorTrue(t *testing.T) {
+	netErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	result := httpCallResult{Err: netErr}
+	policy := &RuntimeHTTPRetryPolicy{RetryOnNetworkError: true}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+
+	if !retryable {
+		t.Error("expected retryable=true for network error with RetryOnNetworkError=true")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_NetworkError_RetryOnNetworkErrorFalse(t *testing.T) {
+	netErr := &net.OpError{Op: "dial", Err: errors.New("connection refused")}
+	result := httpCallResult{Err: netErr}
+	policy := &RuntimeHTTPRetryPolicy{RetryOnNetworkError: false}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+
+	if retryable {
+		t.Error("expected retryable=false for network error with RetryOnNetworkError=false")
+	}
+}
+
+func TestClassifyHTTPResult_Status503InRetryOn(t *testing.T) {
+	result := httpCallResult{StatusCode: 503, Headers: make(http.Header)}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{502, 503, 504}}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+
+	if !retryable {
+		t.Error("expected retryable=true for 503 in RetryOn list")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_Status400NotInRetryOn(t *testing.T) {
+	result := httpCallResult{StatusCode: 400, Headers: make(http.Header)}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{502, 503, 504}}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+
+	if retryable {
+		t.Error("expected retryable=false for 400 not in RetryOn list")
+	}
+}
+
+func TestClassifyHTTPResult_RetryAfterSeconds_RespectRetryAfterTrue(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Retry-After", "5")
+	result := httpCallResult{StatusCode: 503, Headers: headers}
+	policy := &RuntimeHTTPRetryPolicy{
+		RetryOn:           []int32{503},
+		RespectRetryAfter: true,
+	}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+
+	if !retryable {
+		t.Error("expected retryable=true")
+	}
+	if retryAfter != 5*time.Second {
+		t.Errorf("expected retryAfter=5s, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_RetryAfterHTTPDate(t *testing.T) {
+	// Set a date ~10 seconds in the future.
+	future := time.Now().Add(10 * time.Second)
+	headers := make(http.Header)
+	headers.Set("Retry-After", future.UTC().Format(http.TimeFormat))
+	result := httpCallResult{StatusCode: 429, Headers: headers}
+	policy := &RuntimeHTTPRetryPolicy{
+		RetryOn:           []int32{429},
+		RespectRetryAfter: true,
+	}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+
+	if !retryable {
+		t.Error("expected retryable=true")
+	}
+	// Allow generous window: 8s–12s to account for test execution time.
+	if retryAfter < 8*time.Second || retryAfter > 12*time.Second {
+		t.Errorf("expected retryAfter ~10s, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_RetryAfterIgnored_RespectRetryAfterFalse(t *testing.T) {
+	headers := make(http.Header)
+	headers.Set("Retry-After", "60")
+	result := httpCallResult{StatusCode: 503, Headers: headers}
+	policy := &RuntimeHTTPRetryPolicy{
+		RetryOn:           []int32{503},
+		RespectRetryAfter: false,
+	}
+
+	retryable, retryAfter := classifyHTTPResult(result, policy)
+
+	if !retryable {
+		t.Error("expected retryable=true")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0 when RespectRetryAfter=false, got %v", retryAfter)
+	}
+}
+
+func TestClassifyHTTPResult_DeadlineExceeded_RetryOnNetworkErrorTrue(t *testing.T) {
+	result := httpCallResult{Err: context.DeadlineExceeded}
+	policy := &RuntimeHTTPRetryPolicy{RetryOnNetworkError: true}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+
+	if !retryable {
+		t.Error("expected retryable=true for DeadlineExceeded with RetryOnNetworkError=true")
+	}
+}
+
+func TestClassifyHTTPResult_Status200NotRetryable(t *testing.T) {
+	result := httpCallResult{StatusCode: 200, Headers: make(http.Header)}
+	policy := &RuntimeHTTPRetryPolicy{RetryOn: []int32{503}}
+
+	retryable, _ := classifyHTTPResult(result, policy)
+
+	if retryable {
+		t.Error("expected retryable=false for 200 success")
+	}
+}
+
+// --- classifyGRPCError ---
+
+func TestClassifyGRPCError_UnavailableInList(t *testing.T) {
+	err := grpcStatus.Error(grpcCodes.Unavailable, "service unavailable")
+	retryable, retryAfter := classifyGRPCError(err, []string{"UNAVAILABLE", "RESOURCE_EXHAUSTED"})
+
+	if !retryable {
+		t.Error("expected retryable=true for UNAVAILABLE in list")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0 for gRPC, got %v", retryAfter)
+	}
+}
+
+func TestClassifyGRPCError_NotFoundNotInList(t *testing.T) {
+	err := grpcStatus.Error(grpcCodes.NotFound, "not found")
+	retryable, _ := classifyGRPCError(err, []string{"UNAVAILABLE"})
+
+	if retryable {
+		t.Error("expected retryable=false for NOT_FOUND not in list")
+	}
+}
+
+func TestClassifyGRPCError_NonGRPCError(t *testing.T) {
+	// Plain error (e.g. from circuit breaker) — not a gRPC status.
+	err := errors.New("circuit breaker open")
+	retryable, _ := classifyGRPCError(err, []string{"UNAVAILABLE"})
+
+	if retryable {
+		t.Error("expected retryable=false for non-gRPC error")
+	}
+}
+
+func TestClassifyGRPCError_NilError(t *testing.T) {
+	retryable, _ := classifyGRPCError(nil, []string{"UNAVAILABLE"})
+	if retryable {
+		t.Error("expected retryable=false for nil error")
+	}
+}
+
+// --- classifyMCPError ---
+
+func TestClassifyMCPError_TransportNetOpError(t *testing.T) {
+	err := &net.OpError{Op: "read", Err: errors.New("connection reset")}
+	retryable, retryAfter := classifyMCPError(err)
+
+	if !retryable {
+		t.Error("expected retryable=true for transport net.OpError")
+	}
+	if retryAfter != 0 {
+		t.Errorf("expected retryAfter=0, got %v", retryAfter)
+	}
+}
+
+func TestClassifyMCPError_DeadlineExceeded(t *testing.T) {
+	retryable, _ := classifyMCPError(context.DeadlineExceeded)
+	if !retryable {
+		t.Error("expected retryable=true for DeadlineExceeded")
+	}
+}
+
+func TestClassifyMCPError_NilError(t *testing.T) {
+	retryable, _ := classifyMCPError(nil)
+	if retryable {
+		t.Error("expected retryable=false for nil error")
+	}
+}
+
+func TestClassifyMCPError_MCPToolError(t *testing.T) {
+	err := &mcpToolError{message: "tool returned error: invalid input"}
+	retryable, _ := classifyMCPError(err)
+	if retryable {
+		t.Error("expected retryable=false for mcpToolError (application-level error)")
+	}
+}
+
+func TestClassifyMCPError_WrappedMCPToolError(t *testing.T) {
+	inner := &mcpToolError{message: "tool failed"}
+	wrapped := fmt.Errorf("executor: %w", inner)
+	retryable, _ := classifyMCPError(wrapped)
+	if retryable {
+		t.Error("expected retryable=false for wrapped mcpToolError")
+	}
+}
+
+// --- parseRetryAfter ---
+
+func TestParseRetryAfter_Empty(t *testing.T) {
+	if d := parseRetryAfter(""); d != 0 {
+		t.Errorf("expected 0 for empty string, got %v", d)
+	}
+}
+
+func TestParseRetryAfter_Seconds(t *testing.T) {
+	if d := parseRetryAfter("30"); d != 30*time.Second {
+		t.Errorf("expected 30s, got %v", d)
+	}
+}
+
+func TestParseRetryAfter_Unparseable(t *testing.T) {
+	if d := parseRetryAfter("not-a-date-or-number"); d != 0 {
+		t.Errorf("expected 0 for unparseable value, got %v", d)
+	}
+}
+
+// --- policy extraction helpers ---
+
+func TestHTTPRetryParams_NilCfg(t *testing.T) {
+	p := httpRetryParams(nil)
+	if p.MaxAttempts != 1 {
+		t.Errorf("expected MaxAttempts=1 for nil cfg, got %d", p.MaxAttempts)
+	}
+}
+
+func TestHTTPRetryParams_NilPolicy(t *testing.T) {
+	p := httpRetryParams(&HTTPCfg{})
+	if p.MaxAttempts != 1 {
+		t.Errorf("expected MaxAttempts=1 for nil policy, got %d", p.MaxAttempts)
+	}
+}
+
+func TestHTTPRetryParams_WithPolicy(t *testing.T) {
+	cfg := &HTTPCfg{
+		RetryPolicy: &RuntimeHTTPRetryPolicy{
+			MaxAttempts:       3,
+			InitialBackoff:    Duration(100 * time.Millisecond),
+			BackoffMultiplier: 2.0,
+			MaxBackoff:        Duration(5 * time.Second),
+		},
+	}
+	p := httpRetryParams(cfg)
+	if p.MaxAttempts != 3 {
+		t.Errorf("expected MaxAttempts=3, got %d", p.MaxAttempts)
+	}
+	if p.InitialBackoff != 100*time.Millisecond {
+		t.Errorf("expected InitialBackoff=100ms, got %v", p.InitialBackoff)
+	}
+	if p.BackoffMultiplier != 2.0 {
+		t.Errorf("expected BackoffMultiplier=2.0, got %v", p.BackoffMultiplier)
+	}
+	if p.MaxBackoff != 5*time.Second {
+		t.Errorf("expected MaxBackoff=5s, got %v", p.MaxBackoff)
+	}
+}
+
+func TestGRPCRetryParams_NilCfg(t *testing.T) {
+	p, classify := grpcRetryParams(nil)
+	if p.MaxAttempts != 1 {
+		t.Errorf("expected MaxAttempts=1 for nil cfg, got %d", p.MaxAttempts)
+	}
+	retryable, _ := classify(errors.New("some error"))
+	if retryable {
+		t.Error("expected classify to return false for nil policy")
+	}
+}
+
+func TestGRPCRetryParams_WithPolicy(t *testing.T) {
+	cfg := &GRPCCfg{
+		RetryPolicy: &RuntimeGRPCRetryPolicy{
+			MaxAttempts:          4,
+			InitialBackoff:       Duration(50 * time.Millisecond),
+			BackoffMultiplier:    1.5,
+			MaxBackoff:           Duration(2 * time.Second),
+			RetryableStatusCodes: []string{"UNAVAILABLE"},
+		},
+	}
+	p, classify := grpcRetryParams(cfg)
+	if p.MaxAttempts != 4 {
+		t.Errorf("expected MaxAttempts=4, got %d", p.MaxAttempts)
+	}
+	// Verify classifier uses the policy's status codes.
+	unavailableErr := grpcStatus.Error(grpcCodes.Unavailable, "down")
+	retryable, _ := classify(unavailableErr)
+	if !retryable {
+		t.Error("expected UNAVAILABLE to be retryable")
+	}
+}
+
+func TestMCPRetryParams_NilCfg(t *testing.T) {
+	p, classify := mcpRetryParams(nil)
+	if p.MaxAttempts != 1 {
+		t.Errorf("expected MaxAttempts=1 for nil cfg, got %d", p.MaxAttempts)
+	}
+	retryable, _ := classify(errors.New("transport error"))
+	if !retryable {
+		t.Error("expected classify to return true for transport error with nil policy")
+	}
+}
+
+func TestMCPRetryParams_WithPolicy(t *testing.T) {
+	cfg := &MCPCfg{
+		RetryPolicy: &RuntimeMCPRetryPolicy{
+			MaxAttempts:       5,
+			InitialBackoff:    Duration(200 * time.Millisecond),
+			BackoffMultiplier: 2.0,
+			MaxBackoff:        Duration(10 * time.Second),
+		},
+	}
+	p, classify := mcpRetryParams(cfg)
+	if p.MaxAttempts != 5 {
+		t.Errorf("expected MaxAttempts=5, got %d", p.MaxAttempts)
+	}
+	toolErr := &mcpToolError{message: "tool error"}
+	retryable, _ := classify(toolErr)
+	if retryable {
+		t.Error("expected mcpToolError to be non-retryable")
+	}
+}

--- a/internal/runtime/tools/retry_test.go
+++ b/internal/runtime/tools/retry_test.go
@@ -1,0 +1,377 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/trace"
+	tracenoop "go.opentelemetry.io/otel/trace/noop"
+)
+
+// newTestSpan returns a no-op trace.Span for tests.
+func newTestSpan() trace.Span {
+	tracer := tracenoop.NewTracerProvider().Tracer("test")
+	_, span := tracer.Start(context.Background(), "test")
+	return span
+}
+
+// testPolicy returns a retryPolicy suitable for fast unit tests.
+func testPolicy(maxAttempts int32) retryPolicy {
+	return retryPolicy{
+		MaxAttempts:       maxAttempts,
+		InitialBackoff:    5 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+		MaxBackoff:        50 * time.Millisecond,
+	}
+}
+
+// alwaysRetryClassify always returns retryable=true with no retryAfter override.
+func alwaysRetryClassify(_ error) (bool, time.Duration) {
+	return true, 0
+}
+
+func TestRetryWithBackoff_SuccessFirstAttempt(t *testing.T) {
+	calls := 0
+	fn := func(_ context.Context) (json.RawMessage, error) {
+		calls++
+		return json.RawMessage(`"ok"`), nil
+	}
+
+	result, err := retryWithBackoff(
+		context.Background(),
+		logr.Discard(),
+		newTestSpan(),
+		testPolicy(3),
+		0,
+		alwaysRetryClassify,
+		fn,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != `"ok"` {
+		t.Fatalf("unexpected result: %s", result)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_RetryThenSucceed(t *testing.T) {
+	calls := 0
+	fn := func(_ context.Context) (json.RawMessage, error) {
+		calls++
+		if calls < 3 {
+			return nil, errors.New("transient error")
+		}
+		return json.RawMessage(`"success"`), nil
+	}
+
+	result, err := retryWithBackoff(
+		context.Background(),
+		logr.Discard(),
+		newTestSpan(),
+		testPolicy(5),
+		0,
+		alwaysRetryClassify,
+		fn,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != `"success"` {
+		t.Fatalf("unexpected result: %s", result)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_NonRetryableError(t *testing.T) {
+	sentinel := errors.New("permanent error")
+	calls := 0
+	classifyCalls := 0
+
+	fn := func(_ context.Context) (json.RawMessage, error) {
+		calls++
+		return nil, sentinel
+	}
+	classify := func(_ error) (bool, time.Duration) {
+		classifyCalls++
+		return false, 0
+	}
+
+	_, err := retryWithBackoff(
+		context.Background(),
+		logr.Discard(),
+		newTestSpan(),
+		testPolicy(5),
+		0,
+		classify,
+		fn,
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+	if classifyCalls != 1 {
+		t.Fatalf("expected 1 classify call, got %d", classifyCalls)
+	}
+}
+
+func TestRetryWithBackoff_AllAttemptsExhausted(t *testing.T) {
+	sentinel := errors.New("always fails")
+	calls := 0
+
+	fn := func(_ context.Context) (json.RawMessage, error) {
+		calls++
+		return nil, sentinel
+	}
+
+	const maxAttempts = 4
+	_, err := retryWithBackoff(
+		context.Background(),
+		logr.Discard(),
+		newTestSpan(),
+		testPolicy(maxAttempts),
+		0,
+		alwaysRetryClassify,
+		fn,
+	)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected wrapped sentinel error, got: %v", err)
+	}
+	if calls != maxAttempts {
+		t.Fatalf("expected %d calls, got %d", maxAttempts, calls)
+	}
+}
+
+func TestRetryWithBackoff_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	calls := 0
+	fn := func(_ context.Context) (json.RawMessage, error) {
+		calls++
+		return nil, errors.New("transient")
+	}
+
+	policy := retryPolicy{
+		MaxAttempts:       10,
+		InitialBackoff:    200 * time.Millisecond, // long enough to be interrupted
+		BackoffMultiplier: 1.0,
+		MaxBackoff:        200 * time.Millisecond,
+	}
+
+	// Cancel the context shortly after the first failure triggers a sleep.
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, err := retryWithBackoff(
+		ctx,
+		logr.Discard(),
+		newTestSpan(),
+		policy,
+		0,
+		alwaysRetryClassify,
+		fn,
+	)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call before cancel, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_PerAttemptTimeout(t *testing.T) {
+	calls := 0
+	// fn blocks until its context is cancelled, simulating a slow server.
+	// On the 3rd call it returns immediately.
+	fn := func(ctx context.Context) (json.RawMessage, error) {
+		calls++
+		if calls < 3 {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return json.RawMessage(`"fast"`), nil
+	}
+
+	policy := retryPolicy{
+		MaxAttempts:       5,
+		InitialBackoff:    1 * time.Millisecond,
+		BackoffMultiplier: 1.0,
+		MaxBackoff:        5 * time.Millisecond,
+	}
+
+	result, err := retryWithBackoff(
+		context.Background(),
+		logr.Discard(),
+		newTestSpan(),
+		policy,
+		10*time.Millisecond, // per-attempt timeout
+		alwaysRetryClassify,
+		fn,
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != `"fast"` {
+		t.Fatalf("unexpected result: %s", result)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestRetryWithBackoff_SingleAttemptFastPath(t *testing.T) {
+	sentinel := errors.New("single shot error")
+	calls := 0
+	classifyCalls := 0
+
+	fn := func(_ context.Context) (json.RawMessage, error) {
+		calls++
+		return nil, sentinel
+	}
+	classify := func(_ error) (bool, time.Duration) {
+		classifyCalls++
+		return true, 0
+	}
+
+	_, err := retryWithBackoff(
+		context.Background(),
+		logr.Discard(),
+		newTestSpan(),
+		testPolicy(1), // MaxAttempts=1 → fast path
+		0,
+		classify,
+		fn,
+	)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+	if classifyCalls != 0 {
+		t.Fatalf("classify must NOT be called in fast path, got %d calls", classifyCalls)
+	}
+}
+
+func TestRetryWithBackoff_RetryAfterOverride(t *testing.T) {
+	const retryAfter = 50 * time.Millisecond
+	calls := 0
+
+	fn := func(_ context.Context) (json.RawMessage, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("rate limited")
+		}
+		return json.RawMessage(`"ok"`), nil
+	}
+	classify := func(_ error) (bool, time.Duration) {
+		return true, retryAfter
+	}
+
+	policy := retryPolicy{
+		MaxAttempts:       3,
+		InitialBackoff:    1 * time.Millisecond, // much shorter than retryAfter
+		BackoffMultiplier: 1.0,
+		MaxBackoff:        200 * time.Millisecond,
+	}
+
+	start := time.Now()
+	result, err := retryWithBackoff(
+		context.Background(),
+		logr.Discard(),
+		newTestSpan(),
+		policy,
+		0,
+		classify,
+		fn,
+	)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(result) != `"ok"` {
+		t.Fatalf("unexpected result: %s", result)
+	}
+	// Allow 10% under for scheduling jitter (50ms * 0.9 = 45ms).
+	const minElapsed = 45 * time.Millisecond
+	if elapsed < minElapsed {
+		t.Fatalf("expected at least %v delay (retryAfter override), got %v", minElapsed, elapsed)
+	}
+}
+
+func TestBackoffDelay_ExponentialGrowth(t *testing.T) {
+	policy := retryPolicy{
+		InitialBackoff:    100 * time.Millisecond,
+		BackoffMultiplier: 2.0,
+		MaxBackoff:        10 * time.Second,
+	}
+
+	// Compute expected base delays: 100ms, 200ms, 400ms, 800ms.
+	// With ±10% jitter the actual value must be within ±15% (extra tolerance for math).
+	expected := []time.Duration{
+		100 * time.Millisecond,
+		200 * time.Millisecond,
+		400 * time.Millisecond,
+		800 * time.Millisecond,
+	}
+	const tolerance = 0.15
+
+	for attempt, want := range expected {
+		got := backoffDelay(policy, attempt, 0)
+		lo := time.Duration(float64(want) * (1 - tolerance))
+		hi := time.Duration(float64(want) * (1 + tolerance))
+		if got < lo || got > hi {
+			t.Errorf("attempt %d: want %v ± %d%%, got %v", attempt, want, int(tolerance*100), got)
+		}
+	}
+
+	// Also verify MaxBackoff is respected.
+	got := backoffDelay(policy, 100, 0) // very high attempt → would overflow without cap
+	if got > policy.MaxBackoff {
+		t.Errorf("expected delay capped at %v, got %v", policy.MaxBackoff, got)
+	}
+
+	// Verify exponential growth — each value must be strictly larger than the previous.
+	for i := 1; i < len(expected); i++ {
+		d0 := float64(expected[i-1])
+		d1 := float64(expected[i])
+		ratio := d1 / d0
+		// Ratio should be close to BackoffMultiplier (2.0), allowing 15% jitter.
+		if math.Abs(ratio-policy.BackoffMultiplier) > policy.BackoffMultiplier*tolerance {
+			t.Errorf("attempt %d→%d: expected ratio ~%.1f, got %.3f", i-1, i, policy.BackoffMultiplier, ratio)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Implements retry logic with exponential backoff + jitter for all four tool executor transports (HTTP, gRPC, MCP, OpenAPI)
- Replaces PromptKit's `HTTPExecutor` with a direct `http.Client` implementation, giving full access to response headers for `Retry-After` support and status code classification
- Adds transport-specific error classifiers: HTTP status codes + network errors + `Retry-After` header parsing, gRPC status codes, MCP transport vs tool error distinction
- Retry composes with the existing gRPC circuit breaker (retry wraps breaker — each attempt goes through the breaker independently)
- Per-attempt timeout from `HandlerEntry.Timeout`, context cancellation respected between attempts
- OTel span events + structured debug logs on each retry attempt

Builds on the CRD/config plumbing from #790 — the retry policies defined in ToolRegistry CRDs are now operational at execution time.

## Architecture

```
retryWithBackoff (generic engine)
  ├─ HTTP:    doHTTPRequest → classifyHTTPResult (status codes, Retry-After)
  ├─ gRPC:    circuit breaker → gRPC call → classifyGRPCError (status codes)
  ├─ MCP:     session.CallTool → classifyMCPError (transport vs tool errors)
  └─ OpenAPI: doHTTPRequest → classifyHTTPResult (shares HTTP path)
```

## New files

| File | Purpose |
|------|---------|
| `retry.go` | Generic retry engine: `retryWithBackoff`, backoff/jitter, per-attempt timeout |
| `retry_classify.go` | HTTP/gRPC/MCP classifiers, `Retry-After` parser, policy extraction helpers |
| `http_client.go` | Direct HTTP client replacing PromptKit HTTPExecutor |

## Test plan

- [x] 9 unit tests for retry engine (success, retry-then-succeed, non-retryable, exhausted, context cancel, per-attempt timeout, fast path, retry-after override, exponential growth)
- [x] 17 unit tests for classifiers (HTTP status codes, network errors, Retry-After parsing, gRPC status codes, circuit breaker passthrough, MCP transport vs tool errors)
- [x] 7 unit tests for HTTP client (success, non-JSON wrapping, server error, POST body, headers, connection refused, GET query params)
- [x] 6 integration tests proving retry works end-to-end per transport (HTTP 502 retried / 400 not, gRPC UNAVAILABLE retried / NOT_FOUND not, MCP transport retried / tool error not)
- [x] Full `go test ./...` passes, 84% package coverage