### PR TITLE
fix(runtime): forward OutputSchema to PromptKit ToolDescriptor

### DIFF
--- a/internal/runtime/tools/omnia_executor.go
+++ b/internal/runtime/tools/omnia_executor.go
@@ -256,6 +256,7 @@ func (e *OmniaExecutor) buildDescriptor(toolName string, h *HandlerEntry) *pktoo
 	if h.Tool != nil {
 		desc.Description = h.Tool.Description
 		desc.InputSchema = marshalSchema(h.Tool.InputSchema)
+		desc.OutputSchema = marshalSchema(h.Tool.OutputSchema)
 	}
 
 	switch h.Type {


### PR DESCRIPTION
## Summary

- Forwards `OutputSchema` from `ToolDefCfg` to PromptKit's `ToolDescriptor` when building tool descriptors. Previously only `InputSchema` was forwarded.

Closes #779 — all config fields are now forwarded to executors:
- `Retries` removed in #790 (replaced by per-transport retry policies)
- `Timeout` applied as per-attempt timeout in #791
- `ContentType`, `QueryParams`, `HeaderParams`, `StaticQuery`, `StaticBody`, `BodyMapping`, `ResponseMapping`, `Redact`, `URLTemplate` wired in #791
- `OutputSchema` forwarded in this PR

## Test plan

- [x] Existing tests pass (one-line change, `marshalSchema` already tested)