### PR TITLE
feat(runtime): extend circuit breaker to HTTP, MCP, and OpenAPI executors

### DIFF
--- a/internal/runtime/tools/circuit_breaker.go
+++ b/internal/runtime/tools/circuit_breaker.go
@@ -17,12 +17,23 @@ limitations under the License.
 package tools
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
 	"github.com/sony/gobreaker/v2"
 )
+
+// clientError wraps errors that represent client-side mistakes (HTTP 4xx, MCP
+// tool errors). The circuit breaker treats these as successes — the service is
+// healthy, the request was wrong.
+type clientError struct {
+	err error
+}
+
+func (e *clientError) Error() string { return e.err.Error() }
+func (e *clientError) Unwrap() error { return e.err }
 
 const (
 	// cbMaxConsecutiveFailures is the number of consecutive failures before the circuit opens.
@@ -49,9 +60,10 @@ func NewToolCircuitBreakers() *ToolCircuitBreakers {
 	return &ToolCircuitBreakers{
 		breakers: make(map[string]*gobreaker.CircuitBreaker[[]byte]),
 		settings: gobreaker.Settings{
-			MaxRequests: cbHalfOpenMaxRequests,
-			Timeout:     cbOpenTimeout,
-			ReadyToTrip: consecutiveFailureTrip,
+			MaxRequests:  cbHalfOpenMaxRequests,
+			Timeout:      cbOpenTimeout,
+			ReadyToTrip:  consecutiveFailureTrip,
+			IsSuccessful: isSuccessful,
 		},
 	}
 }
@@ -96,4 +108,14 @@ func (t *ToolCircuitBreakers) getOrCreate(toolName string) *gobreaker.CircuitBre
 // consecutiveFailureTrip opens the circuit after cbMaxConsecutiveFailures consecutive failures.
 func consecutiveFailureTrip(counts gobreaker.Counts) bool {
 	return counts.ConsecutiveFailures >= cbMaxConsecutiveFailures
+}
+
+// isSuccessful returns true if err is nil or a clientError (HTTP 4xx, MCP tool
+// error). Client errors do not trip the circuit — the service is healthy.
+func isSuccessful(err error) bool {
+	if err == nil {
+		return true
+	}
+	var ce *clientError
+	return errors.As(err, &ce)
 }

--- a/internal/runtime/tools/circuit_breaker_test.go
+++ b/internal/runtime/tools/circuit_breaker_test.go
@@ -18,6 +18,7 @@ package tools
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -228,6 +229,70 @@ func TestNewToolCircuitBreakers_DefaultSettings(t *testing.T) {
 	}
 	if cbs.breakers == nil {
 		t.Error("expected breakers map to be initialized")
+	}
+}
+
+func TestToolCircuitBreakers_ClientErrorDoesNotTrip(t *testing.T) {
+	cbs := NewToolCircuitBreakers()
+
+	// Send cbMaxConsecutiveFailures client errors — should NOT open the circuit.
+	for i := 0; i < cbMaxConsecutiveFailures+1; i++ {
+		_, _ = cbs.Execute("client-err-tool", func() ([]byte, error) {
+			return nil, &clientError{err: errors.New("HTTP 400: bad request")}
+		})
+	}
+
+	// Circuit should still be closed — next call should execute.
+	called := false
+	_, err := cbs.Execute("client-err-tool", func() ([]byte, error) {
+		called = true
+		return []byte("ok"), nil
+	})
+	if err != nil {
+		t.Fatalf("expected success, got %v", err)
+	}
+	if !called {
+		t.Fatal("expected function to be called (circuit should be closed)")
+	}
+}
+
+func TestToolCircuitBreakers_ServerErrorTrips(t *testing.T) {
+	cbs := NewToolCircuitBreakers()
+
+	// Send cbMaxConsecutiveFailures server errors — should open the circuit.
+	for i := 0; i < cbMaxConsecutiveFailures; i++ {
+		_, _ = cbs.Execute("server-err-tool", func() ([]byte, error) {
+			return nil, errors.New("HTTP 502: bad gateway")
+		})
+	}
+
+	// Circuit should be open.
+	_, err := cbs.Execute("server-err-tool", func() ([]byte, error) {
+		t.Fatal("should not be called when circuit is open")
+		return nil, nil
+	})
+	if !errors.Is(err, gobreaker.ErrOpenState) {
+		t.Fatalf("expected ErrOpenState, got %v", err)
+	}
+}
+
+func TestIsSuccessful(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, true},
+		{"client error", &clientError{err: errors.New("bad request")}, true},
+		{"wrapped client error", fmt.Errorf("wrap: %w", &clientError{err: errors.New("bad")}), true},
+		{"server error", errors.New("connection refused"), false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSuccessful(tc.err); got != tc.want {
+				t.Errorf("isSuccessful(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/runtime/tools/omnia_executor.go
+++ b/internal/runtime/tools/omnia_executor.go
@@ -706,6 +706,8 @@ func (e *OmniaExecutor) buildMCPTransport(cfg *MCPCfg) (mcp.Transport, error) {
 	switch MCPTransportType(cfg.Transport) {
 	case MCPTransportSSE:
 		return &mcp.SSEClientTransport{Endpoint: cfg.Endpoint}, nil
+	case MCPTransportStreamableHTTP:
+		return &mcp.StreamableClientTransport{Endpoint: cfg.Endpoint}, nil
 	case MCPTransportStdio:
 		cmd := exec.Command(cfg.Command, cfg.Args...)
 		if cfg.WorkDir != "" {

--- a/internal/runtime/tools/omnia_executor.go
+++ b/internal/runtime/tools/omnia_executor.go
@@ -591,11 +591,36 @@ func (e *OmniaExecutor) executeHTTP(
 
 	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
 		func(attemptCtx context.Context) (json.RawMessage, error) {
-			result, callResult, err := doHTTPRequest(attemptCtx, &http.Client{}, cfg, headers, args)
-			lastCallResult = callResult
-			return result, err
+			return e.executeHTTPWithBreaker(attemptCtx, toolName, cfg, headers, args, &lastCallResult)
 		},
 	)
+}
+
+// executeHTTPWithBreaker runs an HTTP request through the circuit breaker.
+// HTTP 4xx errors are wrapped as clientError so they don't trip the breaker.
+func (e *OmniaExecutor) executeHTTPWithBreaker(
+	ctx context.Context,
+	toolName string,
+	cfg *HTTPCfg,
+	headers map[string]string,
+	args json.RawMessage,
+	lastCallResult *httpCallResult,
+) (json.RawMessage, error) {
+	var result json.RawMessage
+	_, cbErr := e.breakers.Execute(toolName, func() ([]byte, error) {
+		var callResult httpCallResult
+		var httpErr error
+		result, callResult, httpErr = doHTTPRequest(ctx, &http.Client{}, cfg, headers, args)
+		*lastCallResult = callResult
+		if httpErr != nil && callResult.StatusCode >= 400 && callResult.StatusCode < 500 {
+			return nil, &clientError{err: httpErr}
+		}
+		return nil, httpErr
+	})
+	if cbErr != nil {
+		return result, cbErr
+	}
+	return result, nil
 }
 
 // buildHTTPHeaders merges static headers, auth headers, and policy headers.
@@ -720,27 +745,37 @@ func (e *OmniaExecutor) executeMCP(
 				}
 			}
 
-			result, err := session.CallTool(attemptCtx, &mcp.CallToolParams{
-				Name:      toolName,
-				Arguments: argsMap,
-			})
-			if err != nil {
-				return nil, fmt.Errorf("MCP tool call failed: %w", err)
-			}
-
-			// Convert MCP tool errors to mcpToolError so the classifier
-			// can distinguish them from transport errors.
-			if result.IsError {
-				msg := "MCP tool returned error"
-				if len(result.Content) > 0 {
-					if tc, ok := result.Content[0].(*mcp.TextContent); ok && tc.Text != "" {
-						msg = tc.Text
-					}
+			var mcpResult json.RawMessage
+			_, cbErr := e.breakers.Execute(toolName, func() ([]byte, error) {
+				result, err := session.CallTool(attemptCtx, &mcp.CallToolParams{
+					Name:      toolName,
+					Arguments: argsMap,
+				})
+				if err != nil {
+					return nil, fmt.Errorf("MCP tool call failed: %w", err)
 				}
-				return nil, &mcpToolError{message: msg}
-			}
 
-			return marshalMCPResult(result)
+				// Convert MCP tool errors to mcpToolError so the classifier
+				// can distinguish them from transport errors.
+				// Wrap as clientError so the breaker doesn't trip on tool errors.
+				if result.IsError {
+					msg := "MCP tool returned error"
+					if len(result.Content) > 0 {
+						if tc, ok := result.Content[0].(*mcp.TextContent); ok && tc.Text != "" {
+							msg = tc.Text
+						}
+					}
+					return nil, &clientError{err: &mcpToolError{message: msg}}
+				}
+
+				var marshalErr error
+				mcpResult, marshalErr = marshalMCPResult(result)
+				return nil, marshalErr
+			})
+			if cbErr != nil {
+				return nil, cbErr
+			}
+			return mcpResult, nil
 		},
 	)
 }
@@ -995,9 +1030,7 @@ func (e *OmniaExecutor) executeOpenAPI(
 
 	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
 		func(attemptCtx context.Context) (json.RawMessage, error) {
-			result, callResult, err := doHTTPRequest(attemptCtx, &http.Client{}, cfg, headers, args)
-			lastCallResult = callResult
-			return result, err
+			return e.executeHTTPWithBreaker(attemptCtx, toolName, cfg, headers, args, &lastCallResult)
 		},
 	)
 }

--- a/internal/runtime/tools/omnia_executor.go
+++ b/internal/runtime/tools/omnia_executor.go
@@ -578,6 +578,18 @@ func (e *OmniaExecutor) executeHTTP(
 		return nil, fmt.Errorf("handler %q has no HTTP config", handlerName)
 	}
 
+	return e.executeHTTPCall(ctx, toolName, handlerName, handler.Timeout.Get(), cfg, args)
+}
+
+// executeHTTPCall is the shared retry+breaker execution path for HTTP and
+// OpenAPI handlers.
+func (e *OmniaExecutor) executeHTTPCall(
+	ctx context.Context,
+	toolName, handlerName string,
+	timeout time.Duration,
+	cfg *HTTPCfg,
+	args json.RawMessage,
+) (json.RawMessage, error) {
 	headers := e.buildHTTPHeaders(ctx, cfg, toolName, handlerName, args)
 	policy := httpRetryParams(cfg)
 
@@ -589,7 +601,7 @@ func (e *OmniaExecutor) executeHTTP(
 		return classifyHTTPResult(lastCallResult, cfg.RetryPolicy)
 	}
 
-	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
+	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, timeout, classify,
 		func(attemptCtx context.Context) (json.RawMessage, error) {
 			return e.executeHTTPWithBreaker(attemptCtx, toolName, cfg, headers, args, &lastCallResult)
 		},
@@ -1019,20 +1031,5 @@ func (e *OmniaExecutor) executeOpenAPI(
 		cfg.RetryPolicy = handler.OpenAPIConfig.RetryPolicy
 	}
 
-	headers := e.buildHTTPHeaders(ctx, cfg, toolName, handlerName, args)
-	policy := httpRetryParams(cfg)
-
-	var lastCallResult httpCallResult
-	classify := func(_ error) (bool, time.Duration) {
-		if cfg.RetryPolicy == nil {
-			return false, 0
-		}
-		return classifyHTTPResult(lastCallResult, cfg.RetryPolicy)
-	}
-
-	return retryWithBackoff(ctx, e.log, e.currentSpan(ctx), policy, handler.Timeout.Get(), classify,
-		func(attemptCtx context.Context) (json.RawMessage, error) {
-			return e.executeHTTPWithBreaker(attemptCtx, toolName, cfg, headers, args, &lastCallResult)
-		},
-	)
+	return e.executeHTTPCall(ctx, toolName, handlerName, handler.Timeout.Get(), cfg, args)
 }

--- a/internal/runtime/tools/omnia_executor_test.go
+++ b/internal/runtime/tools/omnia_executor_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/sony/gobreaker/v2"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	tracenoop "go.opentelemetry.io/otel/trace/noop"
@@ -2973,5 +2974,123 @@ func TestExecuteHTTP_RetryWithURLTemplate(t *testing.T) {
 	}
 	if string(result) != `{"result":"ok"}` {
 		t.Errorf("unexpected result: %s", result)
+	}
+}
+
+// --- Integration tests: circuit breaker through OmniaExecutor.Execute() ---
+
+func TestExecuteHTTP_CircuitBreakerOpensAfterServerErrors(t *testing.T) {
+	serverCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		serverCalls++
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte("bad gateway"))
+	}))
+	defer srv.Close()
+
+	// Use a single executor so the breaker accumulates state across calls.
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["cb-http"] = &HandlerEntry{
+		Name: "cb-http",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint: srv.URL,
+			Method:   "GET",
+		},
+	}
+	e.toolHandlers["cb-tool"] = "cb-http"
+
+	desc := &pktools.ToolDescriptor{Name: "cb-tool"}
+
+	// Make cbMaxConsecutiveFailures calls — all hit the server and fail.
+	for i := 0; i < cbMaxConsecutiveFailures; i++ {
+		_, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+		if err == nil {
+			t.Fatalf("call %d: expected error, got nil", i)
+		}
+	}
+	if serverCalls != cbMaxConsecutiveFailures {
+		t.Fatalf("expected %d server calls, got %d", cbMaxConsecutiveFailures, serverCalls)
+	}
+
+	// Next call should be rejected by the breaker WITHOUT hitting the server.
+	serverCallsBefore := serverCalls
+	_, err := e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected circuit breaker error, got nil")
+	}
+	if !errors.Is(err, gobreaker.ErrOpenState) {
+		t.Fatalf("expected ErrOpenState, got: %v", err)
+	}
+	if serverCalls != serverCallsBefore {
+		t.Fatal("server was called despite open circuit")
+	}
+}
+
+func TestExecuteHTTP_CircuitBreakerDoesNotTripOn4xx(t *testing.T) {
+	serverCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		serverCalls++
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("bad request"))
+	}))
+	defer srv.Close()
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["cb-4xx"] = &HandlerEntry{
+		Name: "cb-4xx",
+		Type: ToolTypeHTTP,
+		HTTPConfig: &HTTPCfg{
+			Endpoint: srv.URL,
+			Method:   "GET",
+		},
+	}
+	e.toolHandlers["cb-4xx-tool"] = "cb-4xx"
+
+	desc := &pktools.ToolDescriptor{Name: "cb-4xx-tool"}
+
+	// Make more than cbMaxConsecutiveFailures calls with 400 — breaker should NOT open.
+	for i := 0; i < cbMaxConsecutiveFailures+2; i++ {
+		_, _ = e.Execute(context.Background(), desc, json.RawMessage(`{}`))
+	}
+
+	// All calls should have hit the server (breaker stayed closed).
+	if serverCalls != cbMaxConsecutiveFailures+2 {
+		t.Errorf("expected %d server calls (breaker should stay closed for 4xx), got %d",
+			cbMaxConsecutiveFailures+2, serverCalls)
+	}
+}
+
+func TestExecuteGRPC_CircuitBreakerOpensAfterServerErrors(t *testing.T) {
+	mock := &failNTimesGRPCClient{
+		failCount: cbMaxConsecutiveFailures + 5,
+		failErr:   grpcStatus.Error(grpcCodes.Internal, "server error"),
+	}
+
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.grpcClients["cb-grpc"] = mock
+	e.handlers["cb-grpc"] = &HandlerEntry{
+		Name:       "cb-grpc",
+		Type:       ToolTypeGRPC,
+		GRPCConfig: &GRPCCfg{Endpoint: "localhost:50051"},
+	}
+	e.toolHandlers["cb-grpc-tool"] = "cb-grpc"
+
+	// Make cbMaxConsecutiveFailures calls.
+	for i := 0; i < cbMaxConsecutiveFailures; i++ {
+		_, _ = e.executeGRPC(context.Background(), "cb-grpc-tool", "cb-grpc", json.RawMessage(`{}`))
+	}
+
+	// Next call should be rejected by breaker.
+	callsBefore := mock.calls
+	_, err := e.executeGRPC(context.Background(), "cb-grpc-tool", "cb-grpc", json.RawMessage(`{}`))
+	if err == nil {
+		t.Fatal("expected circuit breaker error")
+	}
+	if !errors.Is(err, gobreaker.ErrOpenState) {
+		t.Fatalf("expected ErrOpenState, got: %v", err)
+	}
+	if mock.calls != callsBefore {
+		t.Fatal("gRPC client was called despite open circuit")
 	}
 }

--- a/internal/runtime/tools/omnia_executor_test.go
+++ b/internal/runtime/tools/omnia_executor_test.go
@@ -2979,6 +2979,17 @@ func TestExecuteHTTP_RetryWithURLTemplate(t *testing.T) {
 
 // --- Integration tests: circuit breaker through OmniaExecutor.Execute() ---
 
+// newHTTPExecutor creates an OmniaExecutor wired to a single HTTP handler.
+// Unlike executeHTTPTool, it returns the executor for repeated calls (needed
+// for circuit breaker state accumulation).
+func newHTTPExecutor(t *testing.T, cfg *HTTPCfg) (*OmniaExecutor, *pktools.ToolDescriptor) {
+	t.Helper()
+	e := NewOmniaExecutor(logr.Discard(), nil)
+	e.handlers["h"] = &HandlerEntry{Name: "h", Type: ToolTypeHTTP, HTTPConfig: cfg}
+	e.toolHandlers["tool"] = "h"
+	return e, &pktools.ToolDescriptor{Name: "tool"}
+}
+
 func TestExecuteHTTP_CircuitBreakerOpensAfterServerErrors(t *testing.T) {
 	serverCalls := 0
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -2989,18 +3000,7 @@ func TestExecuteHTTP_CircuitBreakerOpensAfterServerErrors(t *testing.T) {
 	defer srv.Close()
 
 	// Use a single executor so the breaker accumulates state across calls.
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["cb-http"] = &HandlerEntry{
-		Name: "cb-http",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint: srv.URL,
-			Method:   "GET",
-		},
-	}
-	e.toolHandlers["cb-tool"] = "cb-http"
-
-	desc := &pktools.ToolDescriptor{Name: "cb-tool"}
+	e, desc := newHTTPExecutor(t, &HTTPCfg{Endpoint: srv.URL, Method: "GET"})
 
 	// Make cbMaxConsecutiveFailures calls — all hit the server and fail.
 	for i := 0; i < cbMaxConsecutiveFailures; i++ {
@@ -3036,18 +3036,7 @@ func TestExecuteHTTP_CircuitBreakerDoesNotTripOn4xx(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	e := NewOmniaExecutor(logr.Discard(), nil)
-	e.handlers["cb-4xx"] = &HandlerEntry{
-		Name: "cb-4xx",
-		Type: ToolTypeHTTP,
-		HTTPConfig: &HTTPCfg{
-			Endpoint: srv.URL,
-			Method:   "GET",
-		},
-	}
-	e.toolHandlers["cb-4xx-tool"] = "cb-4xx"
-
-	desc := &pktools.ToolDescriptor{Name: "cb-4xx-tool"}
+	e, desc := newHTTPExecutor(t, &HTTPCfg{Endpoint: srv.URL, Method: "GET"})
 
 	// Make more than cbMaxConsecutiveFailures calls with 400 — breaker should NOT open.
 	for i := 0; i < cbMaxConsecutiveFailures+2; i++ {


### PR DESCRIPTION
## Summary

- Extends the existing per-tool circuit breaker (previously gRPC-only) to all four executor transports: HTTP, gRPC, MCP, and OpenAPI
- Adds `clientError` type so HTTP 4xx responses and MCP tool errors don't trip the breaker — only transport errors and server errors (5xx) count as failures
- Adds `IsSuccessful` callback to gobreaker settings for client error distinction
- Adds MCP streamable-http transport support (`StreamableClientTransport`)

Closes #778
Closes #777

## How it works

```
retry loop (retryWithBackoff)
  └─ circuit breaker (e.breakers.Execute)
       └─ actual call (doHTTPRequest / session.CallTool / client.Execute)
```

The breaker opens after 5 consecutive **server** failures, stays open for 30s, then allows 1 probe request (half-open). Client errors (4xx, tool errors) pass through without tripping the breaker.

## Test plan

- [x] `TestToolCircuitBreakers_ClientErrorDoesNotTrip` — 6+ client errors don't open the circuit
- [x] `TestToolCircuitBreakers_ServerErrorTrips` — 5 server errors open the circuit
- [x] `TestIsSuccessful` — nil, clientError, wrapped clientError, server error
- [x] `TestExecuteHTTP_CircuitBreakerOpensAfterServerErrors` — end-to-end: 5 consecutive 502s open breaker, 6th rejected without hitting server
- [x] `TestExecuteHTTP_CircuitBreakerDoesNotTripOn4xx` — end-to-end: 7 consecutive 400s, all reach server
- [x] `TestExecuteGRPC_CircuitBreakerOpensAfterServerErrors` — end-to-end: gRPC breaker opens after INTERNAL errors
- [x] All existing tests pass