### PR TITLE
feat(runtime): log loaded skills + add skills e2e test

### DIFF
--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -190,19 +190,28 @@ func WithSkillManifest(path string) ServerOption {
 	return func(s *Server) {
 		manifest, err := skills.Read(path)
 		if err != nil {
-			// Surface as a runtime error on the next op; for now, skip silently.
-			// A startup error doesn't have a great place to land in the
-			// option-pattern API, and the manifest reader already tolerates
-			// "missing" gracefully.
+			s.log.Error(err, "skill manifest read failed", "manifestPath", path)
 			return
 		}
+		names := make([]string, 0, len(manifest.Skills))
+		paths := make([]string, 0, len(manifest.Skills))
 		for _, e := range manifest.Skills {
 			s.sdkOptions = append(s.sdkOptions, sdk.WithSkillsDir(e.ContentPath))
+			names = append(names, e.Name)
+			paths = append(paths, e.ContentPath)
 		}
+		maxActive := 0
 		if manifest.Config != nil && manifest.Config.MaxActive > 0 {
+			maxActive = int(manifest.Config.MaxActive)
 			s.sdkOptions = append(s.sdkOptions,
-				sdk.WithMaxActiveSkillsOption(int(manifest.Config.MaxActive)))
+				sdk.WithMaxActiveSkillsOption(maxActive))
 		}
+		s.log.Info("skill manifest loaded",
+			"manifestPath", path,
+			"skillCount", len(manifest.Skills),
+			"skillNames", names,
+			"skillPaths", paths,
+			"maxActive", maxActive)
 	}
 }
 

--- a/internal/runtime/server_test.go
+++ b/internal/runtime/server_test.go
@@ -19,11 +19,15 @@ package runtime
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1492,4 +1496,102 @@ func TestBuildSendOptions_AudioAndFile(t *testing.T) {
 		opts := buildSendOptions(parts, log)
 		assert.Len(t, opts, 3, "should produce three send options for mixed content")
 	})
+}
+
+func TestWithSkillManifest(t *testing.T) {
+	writeManifest := func(t *testing.T, m map[string]any) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "manifest.json")
+		data, err := json.Marshal(m)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, data, 0o600))
+		return path
+	}
+
+	newCapturingLogger := func(captured *[]string) logr.Logger {
+		return funcr.NewJSON(func(obj string) {
+			*captured = append(*captured, obj)
+		}, funcr.Options{Verbosity: 1})
+	}
+
+	t.Run("logs loaded skills with names and paths", func(t *testing.T) {
+		path := writeManifest(t, map[string]any{
+			"version": "1",
+			"skills": []map[string]any{
+				{"name": "billing", "mount_as": "billing", "content_path": "/workspace-content/billing"},
+				{"name": "refunds", "mount_as": "refunds", "content_path": "/workspace-content/refunds"},
+			},
+			"config": map[string]any{"max_active": 3},
+		})
+
+		var captured []string
+		log := newCapturingLogger(&captured)
+
+		s := NewServer(WithLogger(log), WithSkillManifest(path))
+		require.NotNil(t, s)
+
+		var found bool
+		for _, l := range captured {
+			if containsAll(l, `"msg":"skill manifest loaded"`, `"skillCount":2`, `"billing"`, `"refunds"`, `"maxActive":3`) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected skill-load log line with skill names and maxActive; got: %v", captured)
+	})
+
+	t.Run("missing file is a no-op with no error log", func(t *testing.T) {
+		var captured []string
+		log := newCapturingLogger(&captured)
+
+		s := NewServer(WithLogger(log), WithSkillManifest("/does/not/exist.json"))
+		require.NotNil(t, s)
+
+		for _, l := range captured {
+			assert.NotContains(t, l, `"msg":"skill manifest read failed"`)
+		}
+	})
+
+	t.Run("empty path is a no-op", func(t *testing.T) {
+		var captured []string
+		log := newCapturingLogger(&captured)
+
+		s := NewServer(WithLogger(log), WithSkillManifest(""))
+		require.NotNil(t, s)
+
+		for _, l := range captured {
+			assert.NotContains(t, l, `"msg":"skill manifest read failed"`)
+		}
+	})
+
+	t.Run("invalid json logs error and skips", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.json")
+		require.NoError(t, os.WriteFile(path, []byte("not json"), 0o600))
+
+		var captured []string
+		log := newCapturingLogger(&captured)
+
+		s := NewServer(WithLogger(log), WithSkillManifest(path))
+		require.NotNil(t, s)
+
+		var found bool
+		for _, l := range captured {
+			if containsAll(l, `"msg":"skill manifest read failed"`) {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected read-failed error log; got: %v", captured)
+	})
+}
+
+func containsAll(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
 }

--- a/test/e2e/skills_e2e_test.go
+++ b/test/e2e/skills_e2e_test.go
@@ -1,0 +1,328 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/altairalabs/omnia/test/utils"
+)
+
+// Skills E2E exercises the CRD + reconcile chain for the skills feature:
+// SkillSource (configmap variant) → PromptPack.spec.skills → status
+// conditions on both CRDs. It does NOT verify the runtime-side skill load
+// yet: that requires the operator pod to share a PVC with agent pods at
+// /workspace-content, which the Core deploy kustomize does not configure.
+// Runtime-log verification is tracked as a follow-up.
+var _ = Describe("Skills", Ordered, Label("skills"), func() {
+	const (
+		skillCMName       = "test-skill-content"
+		skillSourceName   = "test-skill-source"
+		skillPromptPack   = "test-skills-pack"
+		skillConfigMap    = "test-skills-pack-config"
+		skillProviderName = "test-skills-provider"
+		skillAgentRuntime = "test-skills-agent"
+	)
+
+	BeforeAll(func() {
+		if os.Getenv("ENABLE_SKILLS_E2E") != "true" {
+			Skip("ENABLE_SKILLS_E2E not set — skipping skills tests")
+		}
+
+		By("ensuring the test-agents namespace exists")
+		cmd := exec.Command("kubectl", "create", "ns", agentsNamespace)
+		_, _ = utils.Run(cmd) // ignore if exists
+	})
+
+	AfterAll(func() {
+		if skipCleanup {
+			return
+		}
+		for _, res := range []struct {
+			kind, name string
+		}{
+			{"agentruntime", skillAgentRuntime},
+			{"provider", skillProviderName},
+			{"promptpack", skillPromptPack},
+			{"configmap", skillConfigMap},
+			{"skillsource", skillSourceName},
+			{"configmap", skillCMName},
+		} {
+			cmd := exec.Command("kubectl", "delete", res.kind, res.name,
+				"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s")
+			_, _ = utils.Run(cmd)
+		}
+	})
+
+	// dumpOnFailure captures debug state for all skills-related resources when
+	// an assertion fails. Called via DeferCleanup so it runs even if the spec
+	// panics, and prints directly to GinkgoWriter so CI logs show the diagnosis.
+	dumpOnFailure := func() {
+		if !CurrentSpecReport().Failed() {
+			return
+		}
+		_, _ = fmt.Fprintf(GinkgoWriter, "\n=== DEBUG: skills e2e failure ===\n")
+		for _, q := range []string{
+			"skillsource " + skillSourceName,
+			"promptpack " + skillPromptPack,
+			"configmap " + skillCMName,
+		} {
+			parts := strings.Fields(q)
+			cmd := exec.Command("kubectl", "get", parts[0], parts[1],
+				"-n", agentsNamespace, "-o", "yaml")
+			if out, err := utils.Run(cmd); err == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "%s:\n%s\n", q, out)
+			}
+		}
+		logsCmd := exec.Command("kubectl", "logs",
+			"-n", namespace, "-l", "control-plane=controller-manager",
+			"--tail=300", "--all-containers=true")
+		if out, err := utils.Run(logsCmd); err == nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "controller-manager logs:\n%s\n", out)
+		}
+	}
+
+	It("reconciles SkillSource and PromptPack.spec.skills end-to-end", func() {
+		DeferCleanup(dumpOnFailure)
+
+		By("creating the ConfigMap with a SKILL.md")
+		// ConfigMap keys can't contain "/", so the sync layer decodes "__"
+		// back to "/" when writing to disk. Here "refunds__SKILL.md"
+		// becomes the file "refunds/SKILL.md" under the sync root.
+		skillContent := `---
+name: refund-processing
+description: Process customer refund requests using approved workflows
+allowed-tools:
+  - http_call
+---
+
+# Refund Processing
+
+When a customer requests a refund, verify the order first.
+`
+		cmYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: %s
+data:
+  refunds__SKILL.md: |
+%s
+`, skillCMName, agentsNamespace, indentLines(skillContent, "    "))
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(cmYAML)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create skill content ConfigMap")
+
+		By("creating a SkillSource of type configmap")
+		ssYAML := fmt.Sprintf(`
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: SkillSource
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  type: configmap
+  configMap:
+    name: %s
+  interval: "1h"
+  timeout: "30s"
+  targetPath: "skills/test"
+  createVersionOnSync: false
+`, skillSourceName, agentsNamespace, skillCMName)
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(ssYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create SkillSource")
+
+		By("waiting for SkillSource phase to reach Ready")
+		verifyReady := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "skillsource", skillSourceName,
+				"-n", agentsNamespace, "-o", "jsonpath={.status.phase}")
+			out, runErr := utils.Run(cmd)
+			g.Expect(runErr).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("Ready"), "SkillSource should reach Ready")
+		}
+		Eventually(verifyReady, 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("verifying SkillSource.status.skillCount is 1")
+		cmd = exec.Command("kubectl", "get", "skillsource", skillSourceName,
+			"-n", agentsNamespace, "-o", "jsonpath={.status.skillCount}")
+		out, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(Equal("1"), "SkillSource should resolve 1 skill")
+
+		By("creating a PromptPack ConfigMap")
+		packYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: %s
+data:
+  pack.json: |
+    {
+      "id": "test-skills-pack",
+      "name": "test-skills-pack",
+      "version": "1.0.0",
+      "template_engine": {"version": "v1", "syntax": "{{variable}}"},
+      "prompts": {
+        "default": {
+          "id": "default",
+          "name": "default",
+          "version": "1.0.0",
+          "system_template": "You are a test assistant with skills."
+        }
+      },
+      "tools": [
+        {"name": "http_call", "description": "Make an HTTP request"}
+      ]
+    }
+`, skillConfigMap, agentsNamespace)
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(packYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create PromptPack ConfigMap")
+
+		By("creating a PromptPack that references the SkillSource")
+		ppYAML := fmt.Sprintf(`
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: PromptPack
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  source:
+    type: configmap
+    configMapRef:
+      name: %s
+  version: "1.0.0"
+  skills:
+    - source: %s
+  skillsConfig:
+    maxActive: 2
+`, skillPromptPack, agentsNamespace, skillConfigMap, skillSourceName)
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(ppYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create PromptPack with skills")
+
+		By("waiting for PromptPack SkillsResolved condition to be True")
+		verifyCondition := func(condType, expected string) func(Gomega) {
+			return func(g Gomega) {
+				cmd := exec.Command("kubectl", "get", "promptpack", skillPromptPack,
+					"-n", agentsNamespace,
+					"-o", fmt.Sprintf("jsonpath={.status.conditions[?(@.type=='%s')].status}", condType))
+				out, runErr := utils.Run(cmd)
+				g.Expect(runErr).NotTo(HaveOccurred())
+				g.Expect(out).To(Equal(expected),
+					fmt.Sprintf("condition %s should be %s", condType, expected))
+			}
+		}
+		Eventually(verifyCondition("SkillsResolved", "True"), 2*time.Minute, 2*time.Second).Should(Succeed())
+
+		By("waiting for PromptPack SkillsValid condition to be True")
+		Eventually(verifyCondition("SkillsValid", "True"), time.Minute, 2*time.Second).Should(Succeed())
+
+		By("waiting for PromptPack SkillToolsResolved condition to be True")
+		// The skill declares allowed-tools: [http_call] and the pack declares
+		// tools: [{name: http_call}], so tool scope validation should pass.
+		Eventually(verifyCondition("SkillToolsResolved", "True"), time.Minute, 2*time.Second).Should(Succeed())
+
+		By("verifying the PromptPack reaches Active phase")
+		verifyActive := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "promptpack", skillPromptPack,
+				"-n", agentsNamespace, "-o", "jsonpath={.status.phase}")
+			out, runErr := utils.Run(cmd)
+			g.Expect(runErr).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("Active"))
+		}
+		Eventually(verifyActive, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	It("rejects a PromptPack that references a non-existent SkillSource", func() {
+		DeferCleanup(func() {
+			cmd := exec.Command("kubectl", "delete", "promptpack", "missing-skill-pack",
+				"-n", agentsNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+			cmd = exec.Command("kubectl", "delete", "configmap", "missing-skill-pack-config",
+				"-n", agentsNamespace, "--ignore-not-found")
+			_, _ = utils.Run(cmd)
+		})
+
+		By("creating a PromptPack ConfigMap")
+		packYAML := fmt.Sprintf(`
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: missing-skill-pack-config
+  namespace: %s
+data:
+  pack.json: |
+    {"id":"p","name":"p","version":"1.0.0","template_engine":{"version":"v1","syntax":"{{variable}}"},"prompts":{"default":{"id":"default","name":"default","version":"1.0.0","system_template":"t"}}}
+`, agentsNamespace)
+		cmd := exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(packYAML)
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("creating a PromptPack pointing at a non-existent SkillSource")
+		ppYAML := fmt.Sprintf(`
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: PromptPack
+metadata:
+  name: missing-skill-pack
+  namespace: %s
+spec:
+  source:
+    type: configmap
+    configMapRef:
+      name: missing-skill-pack-config
+  version: "1.0.0"
+  skills:
+    - source: does-not-exist
+`, agentsNamespace)
+		cmd = exec.Command("kubectl", "apply", "-f", "-")
+		cmd.Stdin = strings.NewReader(ppYAML)
+		_, err = utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for SkillsResolved condition to be False")
+		verifyResolvedFalse := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "promptpack", "missing-skill-pack",
+				"-n", agentsNamespace,
+				"-o", "jsonpath={.status.conditions[?(@.type=='SkillsResolved')].status}")
+			out, runErr := utils.Run(cmd)
+			g.Expect(runErr).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("False"))
+		}
+		Eventually(verifyResolvedFalse, 2*time.Minute, 2*time.Second).Should(Succeed())
+	})
+})
+
+// indentLines prefixes every non-empty line with the given indent. Used to
+// embed a multiline block into YAML literal scalar context.
+func indentLines(s, indent string) string {
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		if l != "" {
+			lines[i] = indent + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}


### PR DESCRIPTION
## Summary
- Surface skill manifest loads as a structured log line in `WithSkillManifest` so operators can see which skills the runtime registered (`skillCount`, `skillNames`, `skillPaths`, `maxActive`). Errors during manifest read now also log.
- Add `test/e2e/skills_e2e_test.go` (label `skills`, gated by `ENABLE_SKILLS_E2E=true`) that exercises the SkillSource (configmap variant) → `PromptPack.spec.skills` reconcile chain against a real kind cluster and asserts `SkillsResolved` / `SkillsValid` / `SkillToolsResolved` conditions plus a negative test for a missing source.

## Known gap
The e2e stops at the reconcile chain; it does **not** grep runtime-container logs for the new log line. That requires the operator pod to share `/workspace-content` with agent pods — the Core kustomize manifest doesn't mount that PVC on the operator, so a cross-pod filesystem-round-trip test would need either operator-deployment patching or a Helm-based Core E2E. Tracking as follow-up.

## Test plan
- [x] `go test ./internal/runtime/ -count=1` — passes, `WithSkillManifest` at 100% coverage.
- [x] `env GOWORK=off go test -tags=e2e -run xxx ./test/e2e/` — compiles.
- [ ] Future: run `ENABLE_SKILLS_E2E=true ... go test -tags=e2e -ginkgo.label-filter=skills ./test/e2e/` against a local kind cluster.