### PR TITLE
build: split core and EE webhook manifest outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ build-arena-worker: fmt vet ## Build Arena worker binary (Enterprise).
 
 .PHONY: manifests-ee
 manifests-ee: controller-gen ## Generate CRDs for Enterprise types.
-	"$(CONTROLLER_GEN)" rbac:roleName=arena-manager-role crd webhook paths="./ee/api/..." paths="./ee/internal/..." output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=ee/config/rbac
+	"$(CONTROLLER_GEN)" rbac:roleName=arena-manager-role crd webhook paths="./ee/api/..." paths="./ee/internal/..." output:crd:artifacts:config=config/crd/bases output:rbac:artifacts:config=ee/config/rbac output:webhook:artifacts:config=ee/config/webhook
 
 .PHONY: generate-ee
 generate-ee: controller-gen ## Generate code for Enterprise types.

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -10,9 +10,9 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-omnia-altairalabs-ai-v1alpha1-arenajob
+      path: /validate-omnia-altairalabs-ai-v1alpha1-skillsource
   failurePolicy: Fail
-  name: varenajob.kb.io
+  name: vskillsource.kb.io
   rules:
   - apiGroups:
     - omnia.altairalabs.ai
@@ -22,66 +22,5 @@ webhooks:
     - CREATE
     - UPDATE
     resources:
-    - arenajobs
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-omnia-altairalabs-ai-v1alpha1-arenasource
-  failurePolicy: Fail
-  name: varenasource.kb.io
-  rules:
-  - apiGroups:
-    - omnia.altairalabs.ai
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - arenasources
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-omnia-altairalabs-ai-v1alpha1-arenatemplatesource
-  failurePolicy: Fail
-  name: varenatemplatesource.kb.io
-  rules:
-  - apiGroups:
-    - omnia.altairalabs.ai
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - arenatemplatesources
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
-      path: /validate-omnia-altairalabs-ai-v1alpha1-sessionprivacypolicy
-  failurePolicy: Fail
-  name: vsessionprivacypolicy.kb.io
-  rules:
-  - apiGroups:
-    - omnia.altairalabs.ai
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    - DELETE
-    resources:
-    - sessionprivacypolicies
+    - skillsources
   sideEffects: None

--- a/ee/config/webhook/manifests.yaml
+++ b/ee/config/webhook/manifests.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-omnia-altairalabs-ai-v1alpha1-arenajob
+  failurePolicy: Fail
+  name: varenajob.kb.io
+  rules:
+  - apiGroups:
+    - omnia.altairalabs.ai
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - arenajobs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-omnia-altairalabs-ai-v1alpha1-arenasource
+  failurePolicy: Fail
+  name: varenasource.kb.io
+  rules:
+  - apiGroups:
+    - omnia.altairalabs.ai
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - arenasources
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-omnia-altairalabs-ai-v1alpha1-arenatemplatesource
+  failurePolicy: Fail
+  name: varenatemplatesource.kb.io
+  rules:
+  - apiGroups:
+    - omnia.altairalabs.ai
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - arenatemplatesources
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-omnia-altairalabs-ai-v1alpha1-sessionprivacypolicy
+  failurePolicy: Fail
+  name: vsessionprivacypolicy.kb.io
+  rules:
+  - apiGroups:
+    - omnia.altairalabs.ai
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - sessionprivacypolicies
+  sideEffects: None

--- a/internal/webhook/skillsource_webhook.go
+++ b/internal/webhook/skillsource_webhook.go
@@ -22,10 +22,7 @@ type SkillSourceValidator struct{}
 
 var skillSourceLog = logf.Log.WithName("skillsource-webhook")
 
-// kubebuilder:webhook annotation intentionally omitted until the core
-// operator wires an admission webhook server. The validator code below is
-// reachable from tests and from a future cmd/main.go SetupWebhookWithManager
-// call; reinstate the annotation when wiring lands.
+// +kubebuilder:webhook:path=/validate-omnia-altairalabs-ai-v1alpha1-skillsource,mutating=false,failurePolicy=fail,sideEffects=None,groups=omnia.altairalabs.ai,resources=skillsources,verbs=create;update,versions=v1alpha1,name=vskillsource.kb.io,admissionReviewVersions=v1
 
 var _ admission.Validator[*corev1alpha1.SkillSource] = &SkillSourceValidator{}
 


### PR DESCRIPTION
## Summary
- Direct `manifests-ee`'s controller-gen to `ee/config/webhook/` instead of `config/webhook/`. Previously both `make manifests` and `make manifests-ee` wrote to the same file non-additively, so whichever ran last silently clobbered the other's entries — which blocked adding new webhook annotations to core CRDs.
- Wire the `SkillSource` validating webhook annotation now that the output paths no longer collide.

The webhook server itself remains unwired (`webhook.enabled=false` in Helm, `config/default/kustomization.yaml`'s webhook include is still commented), so this change is purely cosmetic for the generated manifests — behavior is unchanged until a follow-up wires the server and flips those flags.

## Test plan
- [x] `make manifests manifests-ee` produces `config/webhook/manifests.yaml` (SkillSource only) and `ee/config/webhook/manifests.yaml` (arenajob/arenasource/arenatemplatesource/sessionprivacypolicy).
- [x] `go test ./internal/webhook/` passes.
- [x] `env GOWORK=off go build ./...` passes.