### PR TITLE
fix(sessions): replay details expand/collapse

### DIFF
--- a/dashboard/src/app/sessions/[id]/page.test.tsx
+++ b/dashboard/src/app/sessions/[id]/page.test.tsx
@@ -45,6 +45,11 @@ vi.mock("@/hooks/sessions", () => ({
   })),
 }));
 
+// Mock adjacent-session nav hook (uses React Query + workspace context — easier to stub).
+vi.mock("@/hooks/use-adjacent-sessions", () => ({
+  useAdjacentSessions: () => ({ prevId: null, nextId: null, position: null, total: 0 }),
+}));
+
 // Mock auth and memory hooks (needed by MemorySidebar imported by the page)
 vi.mock("@/hooks/use-auth", () => ({
   useAuth: () => ({ user: { id: "test-user" }, isAuthenticated: true }),

--- a/dashboard/src/app/sessions/[id]/page.test.tsx
+++ b/dashboard/src/app/sessions/[id]/page.test.tsx
@@ -46,8 +46,9 @@ vi.mock("@/hooks/sessions", () => ({
 }));
 
 // Mock adjacent-session nav hook (uses React Query + workspace context — easier to stub).
+// Tests can override this via vi.mocked(useAdjacentSessions).mockReturnValueOnce(...).
 vi.mock("@/hooks/use-adjacent-sessions", () => ({
-  useAdjacentSessions: () => ({ prevId: null, nextId: null, position: null, total: 0 }),
+  useAdjacentSessions: vi.fn(() => ({ prevId: null, nextId: null, position: null, total: 0 })),
 }));
 
 // Mock auth and memory hooks (needed by MemorySidebar imported by the page)
@@ -530,6 +531,82 @@ describe("SessionDetailPage", () => {
       // ReplayTab renders the Play button and scrubber slider when timeline is non-empty.
       expect(screen.getByRole("button", { name: /play/i })).toBeInTheDocument();
       expect(screen.getByRole("slider")).toBeInTheDocument();
+    });
+  });
+
+  describe("adjacent session navigation", () => {
+    const setupAdjacent = async (
+      adjacent: { prevId: string | null; nextId: string | null; position: number | null; total: number },
+    ) => {
+      const { useSessionDetail } = await import("@/hooks");
+      vi.mocked(useSessionDetail).mockReturnValue({
+        data: mockSession,
+        isLoading: false,
+        error: null,
+      } as any);
+      const { useAdjacentSessions } = await import("@/hooks/use-adjacent-sessions");
+      vi.mocked(useAdjacentSessions).mockReturnValue(adjacent);
+    };
+
+    it("hides prev/next controls when there are no adjacent sessions", async () => {
+      await setupAdjacent({ prevId: null, nextId: null, position: null, total: 0 });
+      await renderPage();
+      expect(screen.queryByRole("button", { name: /previous session/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /next session/i })).not.toBeInTheDocument();
+    });
+
+    it("renders position label and both buttons enabled in the middle of the list", async () => {
+      await setupAdjacent({ prevId: "sess-a", nextId: "sess-b", position: 2, total: 5 });
+      await renderPage();
+      expect(screen.getByText("2 / 5")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /previous session/i })).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: /next session/i })).not.toBeDisabled();
+    });
+
+    it("disables the prev button at the top of the list", async () => {
+      await setupAdjacent({ prevId: null, nextId: "sess-b", position: 1, total: 5 });
+      await renderPage();
+      expect(screen.getByRole("button", { name: /previous session/i })).toBeDisabled();
+      expect(screen.getByRole("button", { name: /next session/i })).not.toBeDisabled();
+    });
+
+    it("disables the next button at the bottom of the list", async () => {
+      await setupAdjacent({ prevId: "sess-a", nextId: null, position: 5, total: 5 });
+      await renderPage();
+      expect(screen.getByRole("button", { name: /previous session/i })).not.toBeDisabled();
+      expect(screen.getByRole("button", { name: /next session/i })).toBeDisabled();
+    });
+
+    it("navigates to prev/next session on button click", async () => {
+      const user = userEvent.setup();
+      await setupAdjacent({ prevId: "sess-prev", nextId: "sess-next", position: 3, total: 10 });
+      await renderPage();
+      await user.click(screen.getByRole("button", { name: /previous session/i }));
+      expect(mockPush).toHaveBeenCalledWith("/sessions/sess-prev");
+      await user.click(screen.getByRole("button", { name: /next session/i }));
+      expect(mockPush).toHaveBeenCalledWith("/sessions/sess-next");
+    });
+
+    it("navigates on ArrowLeft / ArrowRight key presses", async () => {
+      const user = userEvent.setup();
+      await setupAdjacent({ prevId: "sess-prev", nextId: "sess-next", position: 3, total: 10 });
+      await renderPage();
+      await user.keyboard("{ArrowLeft}");
+      expect(mockPush).toHaveBeenCalledWith("/sessions/sess-prev");
+      await user.keyboard("{ArrowRight}");
+      expect(mockPush).toHaveBeenCalledWith("/sessions/sess-next");
+    });
+
+    it("ignores arrow keys when typing in an input", async () => {
+      const user = userEvent.setup();
+      await setupAdjacent({ prevId: "sess-prev", nextId: "sess-next", position: 3, total: 10 });
+      await renderPage();
+      const input = document.createElement("input");
+      document.body.appendChild(input);
+      input.focus();
+      await user.keyboard("{ArrowLeft}");
+      expect(mockPush).not.toHaveBeenCalledWith("/sessions/sess-prev");
+      document.body.removeChild(input);
     });
   });
 });

--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { use, useState } from "react";
+import { use, useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Header } from "@/components/layout";
@@ -43,8 +43,11 @@ import {
   XCircle,
   Shield,
   Play,
+  ChevronLeft,
+  ChevronRight,
 } from "lucide-react";
 import { useSessionDetail, useSessionAllMessages, useSessionEvalResults, useSessionToolCalls, useSessionProviderCalls, useSessionRuntimeEvents } from "@/hooks/sessions";
+import { useAdjacentSessions } from "@/hooks/use-adjacent-sessions";
 import { MemorySidebar } from "@/components/memories/memory-sidebar";
 import type { Message, Session, ToolCall, ProviderCall, RuntimeEvent, EvalResult } from "@/types";
 import { EvalResultsBadge } from "@/components/sessions/eval-results-badge";
@@ -342,6 +345,27 @@ export default function SessionDetailPage({
     ? buildSessionDashboardUrl(grafana, id, session.agentName, session.agentNamespace)
     : null;
 
+  const { prevId, nextId, position, total } = useAdjacentSessions(id);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const target = e.target as HTMLElement | null;
+      if (target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable)) {
+        return;
+      }
+      if (e.key === "ArrowLeft" && prevId) {
+        e.preventDefault();
+        router.push(`/sessions/${prevId}`);
+      } else if (e.key === "ArrowRight" && nextId) {
+        e.preventDefault();
+        router.push(`/sessions/${nextId}`);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [prevId, nextId, router]);
+
   if (isLoading) {
     return <DetailSkeleton />;
   }
@@ -464,11 +488,40 @@ export default function SessionDetailPage({
         title={
           <div className="flex items-center gap-3 min-w-0">
             <Button variant="ghost" size="icon" className="shrink-0" asChild>
-              <Link href="/sessions">
+              <Link href="/sessions" aria-label="Back to sessions list">
                 <ArrowLeft className="h-4 w-4" />
               </Link>
             </Button>
             <span className="truncate">Session {session.id}</span>
+            {position !== null && total > 1 && (
+              <div className="flex items-center gap-0.5 shrink-0">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => prevId && router.push(`/sessions/${prevId}`)}
+                  disabled={!prevId}
+                  aria-label="Previous session"
+                  title="Previous session (←)"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+                <span className="text-xs text-muted-foreground tabular-nums px-1">
+                  {position} / {total}
+                </span>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => nextId && router.push(`/sessions/${nextId}`)}
+                  disabled={!nextId}
+                  aria-label="Next session"
+                  title="Next session (→)"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </div>
+            )}
           </div>
         }
       />

--- a/dashboard/src/components/sessions/replay/replay-details.tsx
+++ b/dashboard/src/components/sessions/replay/replay-details.tsx
@@ -17,7 +17,6 @@ import {
   CheckCircle2,
   AlertCircle,
 } from "lucide-react";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { toElapsedMs } from "@/lib/sessions/replay";
 import type { TimelineEvent, TimelineEventKind } from "@/lib/sessions/timeline";
 import { cn } from "@/lib/utils";
@@ -198,24 +197,22 @@ export function ReplayDetails({ startedAt, currentTimeMs, events }: ReplayDetail
       <div className="border-b bg-muted/30 px-3 py-1.5 text-[10px] font-semibold uppercase tracking-wide text-muted-foreground">
         Details ({visible.length})
       </div>
-      <ScrollArea className="flex-1">
-        <div>
-          {visible.map(({ event, elapsedMs }) => (
-            <div
-              key={event.id}
-              ref={event.id === currentId ? currentRowRef : undefined}
-            >
-              <LogRow
-                event={event}
-                elapsedMs={elapsedMs}
-                isCurrent={event.id === currentId}
-                expanded={expandedIds.has(event.id)}
-                onToggle={() => toggle(event.id)}
-              />
-            </div>
-          ))}
-        </div>
-      </ScrollArea>
+      <div className="flex-1 overflow-y-auto">
+        {visible.map(({ event, elapsedMs }) => (
+          <div
+            key={event.id}
+            ref={event.id === currentId ? currentRowRef : undefined}
+          >
+            <LogRow
+              event={event}
+              elapsedMs={elapsedMs}
+              isCurrent={event.id === currentId}
+              expanded={expandedIds.has(event.id)}
+              onToggle={() => toggle(event.id)}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 }

--- a/dashboard/src/components/sessions/replay/replay-tab.test.tsx
+++ b/dashboard/src/components/sessions/replay/replay-tab.test.tsx
@@ -67,9 +67,8 @@ describe("ReplayTab", () => {
         runtimeEvents={[]}
       />
     );
-    const drawer = screen.getByTestId("replay-details-drawer");
-    expect(drawer).toHaveAttribute("aria-hidden", "true");
-    expect(drawer.className).toContain("w-0");
+    expect(screen.queryByTestId("replay-details-drawer")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /show details/i })).toBeInTheDocument();
   });
 
   it("toggles the details drawer open and closed", () => {
@@ -82,14 +81,11 @@ describe("ReplayTab", () => {
         runtimeEvents={[]}
       />
     );
-    const toggle = screen.getByRole("button", { name: /show details/i });
-    fireEvent.click(toggle);
-    const drawer = screen.getByTestId("replay-details-drawer");
-    expect(drawer).toHaveAttribute("aria-hidden", "false");
-    expect(drawer.className).toContain("w-96");
+    fireEvent.click(screen.getByRole("button", { name: /show details/i }));
+    expect(screen.getByTestId("replay-details-drawer")).toBeInTheDocument();
 
     fireEvent.click(screen.getByRole("button", { name: /hide details/i }));
-    expect(screen.getByTestId("replay-details-drawer")).toHaveAttribute("aria-hidden", "true");
+    expect(screen.queryByTestId("replay-details-drawer")).not.toBeInTheDocument();
   });
 
   it("renders a friendly empty state when the session has no events", () => {

--- a/dashboard/src/components/sessions/replay/replay-tab.tsx
+++ b/dashboard/src/components/sessions/replay/replay-tab.tsx
@@ -11,7 +11,6 @@ import { ReplayDetails } from "./replay-details";
 import { useReplayPlayback } from "@/hooks/use-replay-playback";
 import { sessionDurationMs } from "@/lib/sessions/replay";
 import { extractTimelineEvents } from "@/lib/sessions/timeline";
-import { cn } from "@/lib/utils";
 import type { Session, Message, ToolCall, ProviderCall, RuntimeEvent } from "@/types/session";
 
 interface ReplayTabProps {
@@ -91,7 +90,7 @@ export function ReplayTab({
       />
 
       {/* Main + drawer */}
-      <div className="relative flex flex-1 min-h-0">
+      <div className="flex flex-1 min-h-0">
         <div className="flex flex-1 min-w-0 flex-col p-4">
           <div className="mb-2 flex items-center justify-end">
             <Button
@@ -121,22 +120,18 @@ export function ReplayTab({
           </div>
         </div>
 
-        <aside
-          data-testid="replay-details-drawer"
-          aria-hidden={!detailsOpen}
-          className={cn(
-            "flex-shrink-0 overflow-hidden border-l bg-background transition-[width] duration-200 ease-out",
-            detailsOpen ? "w-96" : "w-0",
-          )}
-        >
-          <div className="h-full w-96 p-4">
+        {detailsOpen && (
+          <aside
+            data-testid="replay-details-drawer"
+            className="w-96 flex-shrink-0 border-l bg-background p-4"
+          >
             <ReplayDetails
               startedAt={session.startedAt}
               currentTimeMs={currentTimeMs}
               events={timeline}
             />
-          </div>
-        </aside>
+          </aside>
+        )}
       </div>
     </div>
   );

--- a/dashboard/src/hooks/use-adjacent-sessions.test.tsx
+++ b/dashboard/src/hooks/use-adjacent-sessions.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useAdjacentSessions } from "./use-adjacent-sessions";
+
+vi.mock("./use-sessions", () => ({
+  useSessions: vi.fn(),
+}));
+
+const useSessionsMock = vi.mocked(await import("./use-sessions")).useSessions as unknown as ReturnType<
+  typeof vi.fn
+>;
+
+function setSessionList(ids: string[]) {
+  useSessionsMock.mockReturnValue({
+    data: {
+      sessions: ids.map((id) => ({ id })),
+      total: ids.length,
+      hasMore: false,
+    },
+  } as never);
+}
+
+describe("useAdjacentSessions", () => {
+  it("returns null ids when the list is empty", () => {
+    setSessionList([]);
+    const { result } = renderHook(() => useAdjacentSessions("anything"));
+    expect(result.current).toEqual({ prevId: null, nextId: null, position: null, total: 0 });
+  });
+
+  it("returns null ids when currentId is not in the list", () => {
+    setSessionList(["a", "b", "c"]);
+    const { result } = renderHook(() => useAdjacentSessions("zzz"));
+    expect(result.current).toEqual({ prevId: null, nextId: null, position: null, total: 3 });
+  });
+
+  it("returns only nextId for the first session", () => {
+    setSessionList(["a", "b", "c"]);
+    const { result } = renderHook(() => useAdjacentSessions("a"));
+    expect(result.current.prevId).toBe(null);
+    expect(result.current.nextId).toBe("b");
+    expect(result.current.position).toBe(1);
+    expect(result.current.total).toBe(3);
+  });
+
+  it("returns both prev and next for a middle session", () => {
+    setSessionList(["a", "b", "c"]);
+    const { result } = renderHook(() => useAdjacentSessions("b"));
+    expect(result.current).toEqual({ prevId: "a", nextId: "c", position: 2, total: 3 });
+  });
+
+  it("returns only prevId for the last session", () => {
+    setSessionList(["a", "b", "c"]);
+    const { result } = renderHook(() => useAdjacentSessions("c"));
+    expect(result.current.prevId).toBe("b");
+    expect(result.current.nextId).toBe(null);
+  });
+});

--- a/dashboard/src/hooks/use-adjacent-sessions.ts
+++ b/dashboard/src/hooks/use-adjacent-sessions.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useMemo } from "react";
+import { useSessions } from "./use-sessions";
+
+export interface AdjacentSessions {
+  /** Session id immediately above the current one in the list (newer). */
+  readonly prevId: string | null;
+  /** Session id immediately below the current one in the list (older). */
+  readonly nextId: string | null;
+  /** 1-based position of the current session, or null if not in the list. */
+  readonly position: number | null;
+  /** Total sessions in the loaded list. */
+  readonly total: number;
+}
+
+/**
+ * Resolve the previous / next session ids relative to `currentId` using the
+ * same default session list the list page shows. If the current session is
+ * not in the list (filter / pagination / archived), returns null both ways
+ * so callers can hide the nav rather than point to something stale.
+ */
+export function useAdjacentSessions(currentId: string | undefined): AdjacentSessions {
+  const { data } = useSessions();
+
+  return useMemo(() => {
+    const sessions = data?.sessions ?? [];
+    if (!currentId || sessions.length === 0) {
+      return { prevId: null, nextId: null, position: null, total: sessions.length };
+    }
+    const idx = sessions.findIndex((s) => s.id === currentId);
+    if (idx === -1) {
+      return { prevId: null, nextId: null, position: null, total: sessions.length };
+    }
+    return {
+      prevId: idx > 0 ? sessions[idx - 1].id : null,
+      nextId: idx < sessions.length - 1 ? sessions[idx + 1].id : null,
+      position: idx + 1,
+      total: sessions.length,
+    };
+  }, [data?.sessions, currentId]);
+}


### PR DESCRIPTION
## Summary

Replace Radix ScrollArea with a plain `overflow-y-auto` div in `ReplayDetails`. The expand/collapse toggle wasn't responding to clicks reliably in the browser; the most likely culprit was Radix's portal/viewport wrapper interfering with click propagation on rapidly re-rendering rows during playback.

Same scroll UX. No portal, no event-capture surprises.

## Test plan
- [x] Existing 8 tests pass
- [x] 100% per-file coverage maintained
- [ ] Manual: open Replay tab → toggle Details drawer → click any row → expanded metadata appears