### PR TITLE
fix(release): drop provenance mode=max (breaks Next.js builds)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,11 +154,17 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           # Generate in-toto SBOM + provenance attestations attached to
-          # the pushed manifest. Near-zero build overhead; enables
-          # `cosign verify-attestation` and `syft attest` by downstream
-          # consumers without any per-repo tooling.
+          # the pushed manifest. Enables `cosign verify-attestation` and
+          # `syft attest` by downstream consumers without any per-repo
+          # tooling.
+          #
+          # `provenance: true` (mode=min) signs the image; `mode=max`
+          # additionally inlines build-arg / source-URL metadata but
+          # introspects the builder filesystem in ways that break on
+          # Next.js builds ("failed to calculate checksum of go.sum").
+          # mode=min is sufficient for downstream verify flows.
           sbom: true
-          provenance: mode=max
+          provenance: true
 
   trivy-scan:
     name: Trivy Image Scan


### PR DESCRIPTION
v0.9.0-beta.3 release failed on the dashboard image with `failed to calculate checksum of go.sum: not found` — buildx's `provenance: mode=max` introspects the builder filesystem and gets confused on the Next.js build (no Go toolchain present). Drop to the default `provenance: true` (mode=min) which is sufficient for cosign verify and syft attest downstream flows.

SBOM attestation stays on. All 13 other images built + pushed successfully; only dashboard tripped the scanner.

After merge I'll delete the v0.9.0-beta.3 tag (13 of 14 images already published — incomplete release) and re-tag as v0.9.0-beta.3 fresh, OR bump to v0.9.0-beta.4 to keep the tag history clean. Will pick after this lands.

## Test plan
- [ ] CI green (this PR doesn't trigger the release workflow; verified when we re-tag)
- [x] Release YAML still parses (verified via GitHub UI preview)