### PR TITLE
fix(release): point omnia-dashboard build at dashboard/Dockerfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,11 @@ jobs:
             context: .
           # --- Core services referenced by charts/omnia/values.yaml ---
           - image: omnia-dashboard
-            dockerfile: Dockerfile
+            # `file:` on docker/build-push-action resolves from the runner
+            # workdir (repo root), not the `context:`. Spell out the full
+            # path or buildx picks up the root Go Dockerfile and tries to
+            # COPY go.sum from the dashboard context.
+            dockerfile: dashboard/Dockerfile
             context: dashboard
           - image: omnia-session-api
             dockerfile: Dockerfile.session-api
@@ -157,14 +161,8 @@ jobs:
           # the pushed manifest. Enables `cosign verify-attestation` and
           # `syft attest` by downstream consumers without any per-repo
           # tooling.
-          #
-          # `provenance: true` (mode=min) signs the image; `mode=max`
-          # additionally inlines build-arg / source-URL metadata but
-          # introspects the builder filesystem in ways that break on
-          # Next.js builds ("failed to calculate checksum of go.sum").
-          # mode=min is sufficient for downstream verify flows.
           sbom: true
-          provenance: true
+          provenance: mode=max
 
   trivy-scan:
     name: Trivy Image Scan


### PR DESCRIPTION
Real root cause of the dashboard-image build failure in v0.9.0-beta.3/.4. My earlier `provenance: mode=min` workaround (PR #845) addressed the wrong symptom — the actual bug was the matrix entry pointing at the repo-root `Dockerfile` (Go) with `context: dashboard` (Node). `docker/build-push-action` resolves `file:` from the runner workdir, not the context, so it silently picked up the operator Dockerfile and tried to COPY Go files from the dashboard directory.

Rolls back the provenance workaround — `mode=max` works fine for all 14 images once the dockerfile path is right.

## Test plan
- [x] Verified other 13 images build + push with `provenance: mode=max` (already succeeded in .beta.3 and .beta.4)
- [ ] Cut v0.9.0-beta.5 after merge