### PR TITLE
ci(release): auto-open Chart.yaml bump PR after release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -554,12 +554,34 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-# Chart.yaml version/appVersion bumping is a MANUAL pre-release step —
-# see RELEASING.md. An earlier auto-PR job using peter-evans/create-pull-
-# request was removed because the default GITHUB_TOKEN can't create PRs
-# ("GitHub Actions is not permitted to create or approve pull requests")
-# and swapping to a PAT adds a rotation burden. The package-time `yq`
-# rewrite in the helm-release job still guarantees published charts
-# carry the correct version regardless of what's in Chart.yaml at tag
-# time — so forgetting the manual bump only means `helm template` from
-# the repo renders stale tags, not a broken release.
+  chart-bump-pr:
+    name: Open Chart.yaml bump PR
+    needs: [parse-version, github-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.OMNIA_RELEASE_TOKEN }}
+
+      - name: Bump Chart.yaml
+        run: |
+          VERSION="${{ needs.parse-version.outputs.version }}"
+          yq eval -i ".version = \"$VERSION\"" charts/omnia/Chart.yaml
+          yq eval -i ".appVersion = \"$VERSION\"" charts/omnia/Chart.yaml
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.OMNIA_RELEASE_TOKEN }}
+          branch: chore/bump-chart-${{ needs.parse-version.outputs.version }}
+          base: main
+          delete-branch: true
+          title: "chore(chart): bump to v${{ needs.parse-version.outputs.version }}"
+          commit-message: "chore(chart): bump to v${{ needs.parse-version.outputs.version }}"
+          body: |
+            Post-release Chart.yaml bump for v${{ needs.parse-version.outputs.version }}.
+
+            Opened automatically by the `release` workflow after a successful
+            tag build. Keeps `main`-at-rest in sync with the latest published
+            chart so `helm template charts/omnia` resolves real image tags.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -73,23 +73,29 @@ make test
 # Lint the Helm chart
 make helm-lint
 
-# REQUIRED: bump Chart.yaml to match the tag you're about to push.
-# The release workflow also rewrites these at package time, but
-# main-at-rest must track the released version so that local
-# `helm template` / `helm install` resolves real image tags.
+# Create and push the tag (Chart.yaml is auto-bumped by the release
+# workflow after it completes — see "Chart.yaml auto-bump" below).
 VERSION="0.9.0-beta.6"
-yq eval -i ".version = \"$VERSION\"" charts/omnia/Chart.yaml
-yq eval -i ".appVersion = \"$VERSION\"" charts/omnia/Chart.yaml
-git add charts/omnia/Chart.yaml
-git commit -m "chore(chart): bump to v$VERSION"
-git push
-
-# Create the tag from the bumped commit
 git tag -a "v$VERSION" -m "Release v$VERSION"
-
-# Push the tag
 git push origin "v$VERSION"
 ```
+
+### Chart.yaml auto-bump
+
+The release workflow's final job (`chart-bump-pr`) opens a PR against
+`main` that bumps `charts/omnia/Chart.yaml`'s `version` and `appVersion`
+to the just-released tag. Merge that PR after each release so
+`main`-at-rest tracks the latest published chart and `helm template`
+from a fresh checkout renders real image tags.
+
+The job authenticates with the `OMNIA_RELEASE_TOKEN` repo secret — a
+fine-grained PAT scoped to `AltairaLabs/Omnia` with
+`Contents: write` + `Pull requests: write`. Rotate it alongside
+`CHARTS_REPO_TOKEN`.
+
+The `helm-release` job also rewrites `version`/`appVersion` at package
+time, so a missing or failed auto-bump never produces a broken release
+— it only means `main` briefly lags the published tag.
 
 ### Pre-tag verification
 


### PR DESCRIPTION
## Summary
- Adds a `chart-bump-pr` job to `release.yml` that opens a PR against `main` bumping `charts/omnia/Chart.yaml` to the just-released version.
- Authenticates via a new `OMNIA_RELEASE_TOKEN` repo secret — a fine-grained PAT scoped to this repo with `Contents: write` + `Pull requests: write`. Same pattern as the existing `CHARTS_REPO_TOKEN`, so the "default GITHUB_TOKEN can't create PRs" constraint that removed the old auto-bump job no longer applies.
- Drops the manual Chart.yaml bump step from `RELEASING.md` and documents the new secret.

## Why
`main`-at-rest has been drifting behind the latest tag (currently `v0.9.0-beta.2` in Chart.yaml vs. `v0.9.0-beta.5` released) because the manual bump step keeps being skipped. The package-time `yq` rewrite in `helm-release` still produces correct published artifacts, but `helm template charts/omnia` from a fresh checkout renders stale image tags until someone remembers to open a bump PR. This automates that bump.

## Required before merge
Add the `OMNIA_RELEASE_TOKEN` secret to repo Actions secrets. Without it, the new job will fail checkout — which won't block the release itself (it runs after `github-release` completes), but it will leave `main` in its current drifting state.

## Test plan
- [ ] Add `OMNIA_RELEASE_TOKEN` secret
- [ ] Cut next prerelease and confirm the `chart-bump-pr` job opens a PR against `main`
- [ ] Merge the auto-opened PR; verify `charts/omnia/Chart.yaml` reflects the new version