### PR TITLE
chore(chart): bump to v0.9.0-beta.6

### DIFF
--- a/charts/omnia/Chart.yaml
+++ b/charts/omnia/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version / appVersion track the last git-tagged release. When cutting a
 # new release, bump both in a commit before tagging. The release workflow
 # also rewrites these at package-time as a safety net.
-version: 0.9.0-beta.2
-appVersion: "0.9.0-beta.2"
+version: 0.9.0-beta.6
+appVersion: "0.9.0-beta.6"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/AltairaLabs/Omnia
 sources:
@@ -22,13 +22,11 @@ keywords:
   - llm
   - promptkit
   - gateway-api
-
 annotations:
   # Gateway API CRDs are required for agent ingress
   # Install with: kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
   artifacthub.io/prerelease: "true"
   artifacthub.io/license: Apache-2.0
-
 # Optional observability stack dependencies
 dependencies:
   - name: prometheus
@@ -64,7 +62,6 @@ dependencies:
     repository: https://raw.githubusercontent.com/kubernetes-csi/csi-driver-nfs/master/charts
     condition: nfs.csiDriver.enabled
     alias: nfscsi
-
 # NOTE: Istio should be installed separately before deploying Omnia.
 # See: https://istio.io/latest/docs/setup/install/helm/
 # Install Istio with:


### PR DESCRIPTION
Post-release Chart.yaml bump for v0.9.0-beta.6.

Opened automatically by the `release` workflow after a successful
tag build. Keeps `main`-at-rest in sync with the latest published
chart so `helm template charts/omnia` resolves real image tags.