### PR TITLE
perf(docker): cache go mod + per-image registry cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,9 +123,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -155,14 +152,19 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-image registry cache. GHA cache is a shared 10 GB bucket
+          # that 14 parallel matrix jobs trample in `mode=max`; a dedicated
+          # `buildcache` tag per image avoids the contention and has no
+          # repo-wide cap.
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
           # Generate in-toto SBOM + provenance attestations attached to
           # the pushed manifest. Enables `cosign verify-attestation` and
           # `syft attest` by downstream consumers without any per-repo
-          # tooling.
+          # tooling. `provenance: true` (= mode=min) keeps SLSA L2 without
+          # the layer-by-layer rescanning that `mode=max` does.
           sbom: true
-          provenance: mode=max
+          provenance: true
 
   trivy-scan:
     name: Trivy Image Scan

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,17 @@
+# syntax=docker/dockerfile:1
 # Build the manager binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# NOTE: Skipping go mod download due to local replace directives for PromptKit
-# which aren't available in the Docker build context. Dependencies will be
-# downloaded during the build step instead.
-# TODO: Re-enable once PromptKit is published to a module proxy
-# RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy the Go source (relies on .dockerignore to filter)
 COPY . .
@@ -21,7 +21,9 @@ COPY . .
 # was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
 # the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
 # by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM golang:1.26-alpine AS builder
 
@@ -6,15 +7,13 @@ RUN apk add --no-cache git ca-certificates tzdata
 
 # Set working directory
 WORKDIR /workspace
+ENV GOWORK=off
 
 # Copy go mod files first for better caching
 COPY go.mod go.sum ./
-
-# NOTE: Skipping go mod download due to local replace directives for PromptKit
-# which aren't available in the Docker build context. Dependencies will be
-# downloaded during the build step instead.
-# TODO: Re-enable once PromptKit is published to a module proxy
-# RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy source code
 COPY cmd/ cmd/
@@ -27,7 +26,9 @@ COPY ee/ ee/
 # TARGETARCH is set automatically by buildx, or passed via --build-arg
 # Default to amd64 for CI environments that don't use buildx
 ARG TARGETARCH=amd64
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build \
     -ldflags="-w -s" \
     -o agent \
     ./cmd/agent

--- a/Dockerfile.compaction
+++ b/Dockerfile.compaction
@@ -1,23 +1,25 @@
+# syntax=docker/dockerfile:1
 # Build the compaction binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# NOTE: Skipping go mod download due to local replace directives for PromptKit
-# which aren't available in the Docker build context. Dependencies will be
-# downloaded during the build step instead.
-# TODO: Re-enable once PromptKit is published to a module proxy
-# RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o compaction ./cmd/compaction
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o compaction ./cmd/compaction
 
 # Use distroless as minimal base image to package the compaction binary
 FROM gcr.io/distroless/static:nonroot

--- a/Dockerfile.doctor
+++ b/Dockerfile.doctor
@@ -1,20 +1,25 @@
+# syntax=docker/dockerfile:1
 # Build the doctor binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-ENV GOWORK=off
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o doctor ./cmd/doctor
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o doctor ./cmd/doctor
 
 # Use distroless as minimal base image to package the doctor binary
 FROM gcr.io/distroless/static:nonroot

--- a/Dockerfile.memory-api
+++ b/Dockerfile.memory-api
@@ -1,23 +1,25 @@
+# syntax=docker/dockerfile:1
 # Build the memory-api binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# NOTE: Skipping go mod download due to local replace directives for PromptKit
-# which aren't available in the Docker build context. Dependencies will be
-# downloaded during the build step instead.
-# TODO: Re-enable once PromptKit is published to a module proxy
-# RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o memory-api ./cmd/memory-api
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o memory-api ./cmd/memory-api
 
 # Use distroless as minimal base image to package the memory-api binary
 FROM gcr.io/distroless/static:nonroot

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM golang:1.26-alpine AS builder
 
@@ -12,6 +13,15 @@ ARG USE_LOCAL_PROMPTKIT=false
 
 # Copy go mod files first for better caching
 COPY go.mod go.sum ./
+
+# CI (default): download deps up-front so layer caches. Skipped for
+# USE_LOCAL_PROMPTKIT=true since that path uses a go.work that isn't
+# set up yet.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    if [ "$USE_LOCAL_PROMPTKIT" != "true" ]; then \
+        GOWORK=off go mod download; \
+    fi
 
 # Copy local PromptKit source if enabled (must be passed via build context)
 # When USE_LOCAL_PROMPTKIT=true, expects PromptKit source at ./promptkit-local/
@@ -37,7 +47,9 @@ COPY pkg/ pkg/
 COPY api/ api/
 
 # Build the runtime binary
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
     -ldflags="-w -s" \
     -o runtime \
     ./cmd/runtime

--- a/Dockerfile.session-api
+++ b/Dockerfile.session-api
@@ -1,23 +1,25 @@
+# syntax=docker/dockerfile:1
 # Build the session-api binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# NOTE: Skipping go mod download due to local replace directives for PromptKit
-# which aren't available in the Docker build context. Dependencies will be
-# downloaded during the build step instead.
-# TODO: Re-enable once PromptKit is published to a module proxy
-# RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy the Go source (relies on .dockerignore to filter)
 COPY . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o session-api ./cmd/session-api
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -ldflags="-w -s" -o session-api ./cmd/session-api
 
 # Use distroless as minimal base image to package the session-api binary
 FROM gcr.io/distroless/static:nonroot

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -7,11 +7,13 @@ WORKDIR /app
 
 # Install dependencies first (for better caching)
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
 
 # Copy source and build
 COPY . .
-RUN npm run build
+RUN --mount=type=cache,target=/app/.next/cache \
+    npm run build
 
 # Production stage
 FROM node:20-alpine AS runner
@@ -28,7 +30,8 @@ RUN addgroup --system --gid 1001 nodejs && \
 # Copy production dependencies
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/package-lock.json ./
-RUN npm ci --omit=dev
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci --omit=dev
 
 # Copy build output
 COPY --from=builder /app/public ./public

--- a/ee/Dockerfile.arena-controller
+++ b/ee/Dockerfile.arena-controller
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build the arena controller binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
@@ -25,13 +26,23 @@ RUN if [ -d "/workspace/promptkit-local/tools/arena" ]; then \
         cat go.work; \
     fi
 
+# Pre-download deps when go.work isn't in play (CI path). Skipped when
+# promptkit-local is included so the go.work above stays authoritative.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    if [ ! -f go.work ]; then \
+        GOWORK=off go mod download; \
+    fi
+
 # Copy only source directories needed for the build
 COPY api/ api/
 COPY ee/ ee/
 COPY pkg/ pkg/
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
     go build -a -o arena-controller ./ee/cmd/omnia-arena-controller
 
 FROM gcr.io/distroless/static:nonroot

--- a/ee/Dockerfile.arena-dev-console
+++ b/ee/Dockerfile.arena-dev-console
@@ -1,17 +1,25 @@
+# syntax=docker/dockerfile:1
 # Build the arena dev console binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
 # Copy only source directories needed for the build
 COPY api/ api/
 COPY ee/ ee/
 COPY pkg/ pkg/
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
     go build -a -o arena-dev-console ./ee/cmd/arena-dev-console
 
 FROM gcr.io/distroless/static:nonroot

--- a/ee/Dockerfile.arena-worker
+++ b/ee/Dockerfile.arena-worker
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build the arena worker binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
@@ -25,13 +26,23 @@ RUN if [ -d "/workspace/promptkit-local/tools/arena" ]; then \
         cat go.work; \
     fi
 
+# Pre-download deps when go.work isn't in play (CI path). Skipped when
+# promptkit-local is included so the go.work above stays authoritative.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    if [ ! -f go.work ]; then \
+        GOWORK=off go mod download; \
+    fi
+
 # Copy only source directories needed for the build
 COPY api/ api/
 COPY ee/ ee/
 COPY pkg/ pkg/
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
     go build -a -o arena-worker ./ee/cmd/arena-worker
 
 FROM gcr.io/distroless/static:nonroot

--- a/ee/Dockerfile.eval-worker
+++ b/ee/Dockerfile.eval-worker
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build the eval worker binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
@@ -25,13 +26,23 @@ RUN if [ -d "/workspace/promptkit-local/tools/arena" ]; then \
         cat go.work; \
     fi
 
+# Pre-download deps when go.work isn't in play (CI path). Skipped when
+# promptkit-local is included so the go.work above stays authoritative.
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    if [ ! -f go.work ]; then \
+        GOWORK=off go mod download; \
+    fi
+
 # Copy only source directories needed for the build
 COPY api/ api/
 COPY ee/ ee/
 COPY pkg/ pkg/
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
     go build -a -o arena-eval-worker ./ee/cmd/arena-eval-worker
 
 FROM gcr.io/distroless/static:nonroot

--- a/ee/Dockerfile.policy-proxy
+++ b/ee/Dockerfile.policy-proxy
@@ -1,10 +1,15 @@
+# syntax=docker/dockerfile:1
 # Build the policy-proxy binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
 
 # Copy only source directories needed for the build
 COPY api/ api/
@@ -12,7 +17,9 @@ COPY ee/ ee/
 COPY pkg/ pkg/
 COPY internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" \
     go build -a -o policy-proxy ./ee/cmd/policy-proxy
 
 FROM gcr.io/distroless/static:nonroot

--- a/ee/Dockerfile.promptkit-lsp
+++ b/ee/Dockerfile.promptkit-lsp
@@ -1,14 +1,22 @@
+# syntax=docker/dockerfile:1
 # Build the promptkit-lsp binary
 FROM golang:1.26 AS builder
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOWORK=off
 
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" go build -a -o promptkit-lsp ./ee/cmd/promptkit-lsp
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" go build -a -o promptkit-lsp ./ee/cmd/promptkit-lsp
 
 FROM gcr.io/distroless/static:nonroot
 WORKDIR /


### PR DESCRIPTION
## Summary
Three stacked wins on the release Docker matrix. Expected cold-build impact: modest (first run populates caches). Expected repeat-build impact: **~40–70% faster** on builds where `go.mod` / `go.sum` / `package-lock.json` haven't changed.

1. **BuildKit cache mounts on every Go/Node build step.** Every Go builder stage now pre-downloads modules and reuses `/go/pkg/mod` + `/root/.cache/go-build` across runs. The `Skipping go mod download due to local replace directives for PromptKit` comment scattered across Dockerfiles was stale — `GOWORK=off` + `go mod download` is safe in CI (only fails if you're trying to use `promptkit-local` sources). Dashboard also caches `/root/.npm` and Next.js's `.next/cache`.

2. **Per-image registry cache** (`ghcr.io/altairalabs/<image>:buildcache`). Replaces the shared `type=gha` cache, which capped at 10 GB for the whole repo and got trampled by 14 matrix jobs all writing `mode=max` in parallel. Each image now has its own cache ref in GHCR — no contention, no cap.

3. **Drop `setup-qemu-action` + reduce provenance to `true`.** QEMU does nothing on a `linux/amd64`-only build but still adds ~10s × 14 jobs. `provenance: mode=max` re-scans every layer for SLSA attestations; `true` (= `mode=min`) still satisfies SLSA L2. SBOM generation is unchanged.

## Preserved behavior
- Dockerfiles with conditional `promptkit-local` go.work setup (runtime, arena-controller, arena-worker, eval-worker) only run the pre-download when the go.work isn't set up (`if [ ! -f go.work ]` / `if [ "$USE_LOCAL_PROMPTKIT" != "true" ]`), so the local-dev path is untouched.
- `release.yml` still produces SBOM + provenance attestations (just `mode=min` instead of `mode=max`).

## First-build note
First release after merge will be slightly slower than usual (cold registry cache) — subsequent releases should be substantially faster.

## Test plan
- [ ] `Docker Build Matrix` workflow passes on this PR (verifies every Dockerfile still builds)
- [ ] Cut a prerelease tag after merge, compare wall-clock of `docker-release` job to the last few runs
- [ ] Confirm `ghcr.io/altairalabs/omnia-<image>:buildcache` tags appear after the release