### PR TITLE
ci: stop E2E/CI firing on Dockerfile + irrelevant chart edits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
               - '**.go'
               - 'go.mod'
               - 'go.sum'
-              - 'Dockerfile*'
               - 'api/**'
               - 'cmd/**'
               - 'config/**'

--- a/.github/workflows/test-agent-e2e.yml
+++ b/.github/workflows/test-agent-e2e.yml
@@ -5,23 +5,31 @@ on:
     branches:
       - main
     paths:
-      - 'charts/**'
+      # Chart changes that affect deployed behavior only. Excludes
+      # Chart.yaml (version bumps), README, NOTES.txt.
+      - 'charts/**/values*.yaml'
+      - 'charts/**/templates/**/*.yaml'
+      - 'charts/**/templates/**/*.tpl'
+      - 'charts/**/crds/**'
       - 'dashboard/**'
       - 'internal/**'
       - 'cmd/**'
       - 'pkg/**'
       - 'api/**'
-      - 'Dockerfile*'
+      # Dockerfile* intentionally omitted — Docker Build Matrix verifies
+      # every Dockerfile on every PR; build-only changes don't affect E2E.
       - '.github/workflows/test-agent-e2e.yml'
   pull_request:
     paths:
-      - 'charts/**'
+      - 'charts/**/values*.yaml'
+      - 'charts/**/templates/**/*.yaml'
+      - 'charts/**/templates/**/*.tpl'
+      - 'charts/**/crds/**'
       - 'dashboard/**'
       - 'internal/**'
       - 'cmd/**'
       - 'pkg/**'
       - 'api/**'
-      - 'Dockerfile*'
       - '.github/workflows/test-agent-e2e.yml'
   workflow_dispatch:  # Allow manual trigger
 

--- a/.github/workflows/test-e2e-multimodal.yml
+++ b/.github/workflows/test-e2e-multimodal.yml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - 'dashboard/**'
+      # Dashboard Dockerfile is a build-only concern; Docker Build Matrix
+      # covers it on PRs. Multimodal E2E doesn't exercise image build.
+      - '!dashboard/Dockerfile'
       - 'cmd/agent/**'
       - 'internal/agent/**'
       - 'internal/facade/**'
@@ -13,6 +16,7 @@ on:
   pull_request:
     paths:
       - 'dashboard/**'
+      - '!dashboard/Dockerfile'
       - 'cmd/agent/**'
       - 'internal/agent/**'
       - 'internal/facade/**'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -8,7 +8,6 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
-      - 'Dockerfile*'
       - 'api/**'
       - 'cmd/**'
       - 'config/**'
@@ -17,7 +16,13 @@ on:
       - 'pkg/**'
       - 'test/**'
       - 'hack/**'
-      - 'charts/**'
+      # Chart changes that affect deployed behavior. Excludes Chart.yaml
+      # (version bumps), README, NOTES.txt — those can't regress E2E.
+      # Docker Build Matrix already verifies Dockerfile changes on PRs.
+      - 'charts/**/values*.yaml'
+      - 'charts/**/templates/**/*.yaml'
+      - 'charts/**/templates/**/*.tpl'
+      - 'charts/**/crds/**'
       - 'scripts/setup-arena-e2e.sh'
       - '.github/workflows/test-e2e.yml'
   pull_request:
@@ -25,7 +30,6 @@ on:
       - '**.go'
       - 'go.mod'
       - 'go.sum'
-      - 'Dockerfile*'
       - 'api/**'
       - 'cmd/**'
       - 'config/**'
@@ -34,7 +38,10 @@ on:
       - 'pkg/**'
       - 'test/**'
       - 'hack/**'
-      - 'charts/**'
+      - 'charts/**/values*.yaml'
+      - 'charts/**/templates/**/*.yaml'
+      - 'charts/**/templates/**/*.tpl'
+      - 'charts/**/crds/**'
       - 'scripts/setup-arena-e2e.sh'
       - '.github/workflows/test-e2e.yml'
 


### PR DESCRIPTION
## Summary
Observed on #866: a PR that only changed Dockerfiles (build-cache tweaks) triggered Agent E2E, Operator E2E, Multimodal E2E, Docker Build Matrix (all 14 images — acceptable), and the full CI matrix. Most of that is noise. This PR tightens the path filters on four workflows so pure build/docs changes skip the E2E suites.

## Changes

| Workflow | Filter before | After |
|---|---|---|
| `ci.yml` → `code` filter | includes `Dockerfile*` | **removed** — codegen isn't affected by Dockerfile edits |
| `test-e2e.yml` | `Dockerfile*` + `charts/**` | **removed Dockerfile*** + narrowed `charts/**` to `values*.yaml`, `templates/**/*.{yaml,tpl}`, `crds/**` |
| `test-agent-e2e.yml` | `Dockerfile*` + `charts/**` | same as above |
| `test-e2e-multimodal.yml` | bare `dashboard/**` | `dashboard/**` + `!dashboard/Dockerfile` |

## What still catches Dockerfile bugs
`Docker Build Matrix` (`docker-build.yml`) builds every Dockerfile without pushing, on every PR that touches one. A broken Dockerfile fails there — no need for E2E to re-catch it.

## What still catches chart-regressions
- `test-helm-e2e.yml` still runs on all `charts/**` — it's the chart-dedicated test (lint + render + install).
- `ci.yml` Helm Validation still runs on all `charts/**`.
- Only the behavior-changing paths (templates, values, CRDs) trigger the expensive operator/agent E2E suites.

## Nice side effect: Chart.yaml auto-bump PRs
After the last PR's auto-bump job lands a `chore(chart): bump to vX.Y.Z` PR, it changes only `charts/omnia/Chart.yaml` (version + appVersion). With this PR merged, those no longer trigger operator E2E or agent E2E — they'll only hit helm-lint and test-helm-e2e. Saves ~40 min per release.

## Test plan
- [ ] This PR itself only touches `.github/workflows/` — should trigger minimal checks (no E2E, no docker build matrix)
- [ ] After merge, a Dockerfile-only PR should run Docker Build Matrix but skip E2E
- [ ] After merge, a `charts/omnia/README.md` edit should trigger nothing beyond docs build