### PR TITLE
fix(dashboard): copy /app/lib into runtime image

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -34,6 +34,8 @@ RUN npm ci --omit=dev
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next ./.next
 COPY --from=builder /app/server.js ./server.js
+# server.js requires modules from /app/lib at runtime (e.g. auth-boot-guard)
+COPY --from=builder /app/lib ./lib
 
 USER nextjs
 


### PR DESCRIPTION
## Summary
- `dashboard/Dockerfile` runner stage copies `server.js` individually but never copies the surrounding `lib/` directory
- `server.js` requires `./lib/auth-boot-guard` at startup (added in #856 for Azure/Entra readiness)
- The v0.9.0-beta.6 dashboard image crash-loops on boot:
  ```
  Error: Cannot find module './lib/auth-boot-guard'
  Require stack:
  - /app/server.js
  ```
- Fix: add `COPY --from=builder /app/lib ./lib` in the runner stage

Reproduced installing `omnia-0.9.0-beta.6` on AKS — pod in CrashLoopBackOff, rolled back to beta.5. With this fix the runtime image will have the module and boot cleanly.

## Test plan
- [ ] CI builds the new `omnia-dashboard` image on this PR (release-matrix)
- [ ] Smoke: `docker run --rm ghcr.io/altairalabs/omnia-dashboard:<pr-tag>` no longer throws `MODULE_NOT_FOUND`
- [ ] After merge + beta.7 (or equivalent) release, re-install on AKS and confirm dashboard reaches `Running` 1/1