### PR TITLE
fix(ci): lowercase owner in docker-push image refs

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -199,6 +199,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Compute image ref (GHCR requires lowercase)
+        id: ref
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          # github.repository_owner is mixed case (AltairaLabs) but GHCR
+          # rejects any non-lowercase component of an image reference. Bash
+          # ,, lowercases. We reuse the lowercased ref for the metadata
+          # action's images input AND the manual cache-from/cache-to refs.
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "image=${REGISTRY}/${owner}/${IMAGE}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -213,7 +225,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          images: ${{ steps.ref.outputs.image }}
           tags: |
             type=sha,format=long,prefix=
             type=sha,format=short,prefix=
@@ -228,8 +240,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ steps.ref.outputs.image }}:buildcache
+          cache-to: type=registry,ref=${{ steps.ref.outputs.image }}:buildcache,mode=max
           provenance: true
           sbom: true
 


### PR DESCRIPTION
## Summary

Every job in the first `Docker Push (main)` run (commit \`ec5f5e09\`) failed with:

> invalid reference format: repository name (AltairaLabs/omnia-operator) must be lowercase

\`\${{ github.repository_owner }}\` is \`AltairaLabs\` — mixed case. GHCR rejects it. The \`docker/metadata-action\` auto-lowercases its \`images:\` input for tags, but the \`cache-from\` / \`cache-to\` refs I built by hand kept the mixed case and blew up buildx.

## Fix

Adds a \`ref\` step at the start of each matrix job:

\`\`\`yaml
- name: Compute image ref (GHCR requires lowercase)
  id: ref
  env: { IMAGE: \${{ matrix.image }} }
  run: |
    owner="\${GITHUB_REPOSITORY_OWNER,,}"
    echo "image=\${REGISTRY}/\${owner}/\${IMAGE}" >> "\$GITHUB_OUTPUT"
\`\`\`

Then uses \`\${{ steps.ref.outputs.image }}\` for both the metadata action's \`images:\` input and the cache refs.

## Test plan
- [ ] Merge → `docker-push.yml` runs again (workflow file itself is a shared-path trigger, so full 14-image rebuild). Expect all green.