### PR TITLE
fix(security): bump trivy-action 0.28.0 -> 0.35.0 (CVE-2026-33634)

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -319,7 +319,9 @@ jobs:
           push-to-registry: true
 
       - name: Scan image (Trivy)
-        uses: aquasecurity/trivy-action@0.28.0
+        # 0.35.0 is the first version after the brief supply-chain compromise
+        # disclosed as CVE-2026-33634. Matches the pin in release.yml.
+        uses: aquasecurity/trivy-action@0.35.0
         with:
           image-ref: ${{ steps.ref.outputs.image }}@${{ steps.build.outputs.digest }}
           format: sarif


### PR DESCRIPTION
## Summary

Dependabot alert #92: `aquasecurity/trivy-action@0.28.0` is flagged for CVE-2026-33634 (Trivy supply-chain compromise). First clean version is 0.35.0, which `release.yml` already pins.

One-line bump.

Closes https://github.com/AltairaLabs/Omnia/security/dependabot/92

## Separate issue: coverage

You also flagged "all code coverage is gone" on SonarCloud. Root cause I've identified so far:

- The CI run on commit `2ace9ed3` (the docker-push-polish merge) was **cancelled by concurrency** when PR #890 merged ~immediately after. That run never pushed coverage.
- The current in-progress run on commit `a5e72464` (#890's merge) should restore coverage — `Test & Coverage`, `envtest`, and `Integration Tests` have already passed on it. Dashboard jobs still running, SonarCloud will fire after.

If coverage doesn't come back once `a5e72464` finishes, the more structural fix is to guard the sonarcloud job against skipping test artifacts — I'll open a separate PR for that. Keeping this one tight so we can merge the CVE fix immediately.