### PR TITLE
fix(ci): bump trivy-action to v0.35.0 (supply chain compromise)

### DIFF
--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -319,7 +319,7 @@ jobs:
           push-to-registry: true
 
       - name: Scan image (Trivy)
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.35.0
         with:
           image-ref: ${{ steps.ref.outputs.image }}@${{ steps.build.outputs.digest }}
           format: sarif


### PR DESCRIPTION
## Summary
Closes [Dependabot alert #92](https://github.com/AltairaLabs/Omnia/security/dependabot/92) — **critical**. `aquasecurity/trivy-action` versions < 0.35.0 were briefly compromised in a supply chain attack ([GHSA-69fq-xp46-6x23](https://github.com/aquasecurity/trivy/security/advisories/GHSA-69fq-xp46-6x23) / CVE-2026-33634).

- `docker-push.yml` was pinned to `0.28.0` (introduced by #889, merged earlier today).
- `release.yml` was already on `v0.35.0`.
- This PR aligns `docker-push.yml` onto the same patched pin.

No behavior change expected — same action, same inputs.

## Test plan
- [ ] Dependency Review check passes (workflow added in #890)
- [ ] Confirm alert #92 closes after merge