### PR TITLE
fix(dashboard): remove bundled npm from runner image (clears 14 Trivy alerts)

### DIFF
--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -31,7 +31,14 @@ RUN addgroup --system --gid 1001 nodejs && \
 COPY --from=builder /app/package.json ./
 COPY --from=builder /app/package-lock.json ./
 RUN --mount=type=cache,target=/root/.npm \
-    npm ci --omit=dev
+    npm ci --omit=dev && \
+    # Remove the bundled npm CLI once /app/node_modules is resolved.
+    # `node server.js` is the only entrypoint at runtime; the CLI's own
+    # transitive deps (tar, minimatch, glob, cross-spawn, etc.) are
+    # unused attack surface and trip Trivy scans on every release.
+    rm -rf /usr/local/lib/node_modules/npm \
+           /usr/local/bin/npm \
+           /usr/local/bin/npx
 
 # Copy build output
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary
Clears all 14 Trivy alerts against the `omnia-dashboard` image. Every one of them is a CVE in the **npm CLI's own bundled transitive dependencies** (tar, minimatch, glob, cross-spawn, diff, brace-expansion) living at `/usr/local/lib/node_modules/npm/...` inside the `node:20-alpine` base.

| | Before | After |
|---|---:|---:|
| Trivy alerts (omnia-dashboard) | 14 (8 high, 1 medium, 2 low + 3 others) | 0 expected |
| Runtime image size | — | ~30-50MB smaller |
| Runtime behaviour | `node server.js` | `node server.js` (unchanged) |

## Why it's safe
- The dashboard container starts via `node server.js`. `npm` is never invoked at runtime.
- `/app/node_modules` (the dashboard's actual production deps, already cleared by #887's overrides) is resolved by `npm ci --omit=dev` **during the runner stage build**, before the `rm -rf`.
- Deleting `/usr/local/lib/node_modules/npm` + the `/usr/local/bin/npm` and `/usr/local/bin/npx` symlinks after that install leaves `node` intact and removes the vuln attack surface entirely.

## Validation
Local docker build:
- `docker build -f dashboard/Dockerfile dashboard` — succeeds
- Inside the resulting image: `node` present, `npm`/`npx` absent, `/app/{node_modules,public,.next,server.js,lib}` all present
- Container starts cleanly with 0 errors in the logs

## Test plan
- [ ] `Docker Build Matrix` verifies the Dockerfile still builds
- [ ] After merge, `Docker Push (main)` runs a fresh Trivy scan against the new image and uploads to GitHub Security
- [ ] Confirm the 14 `trivy-omnia-dashboard` code-scanning alerts close (or drop dramatically)

## Closes
- trivy-omnia-dashboard: CVE-2024-21538, CVE-2025-5889, CVE-2025-64756, CVE-2026-23745, CVE-2026-23950, CVE-2026-24001, CVE-2026-24842, CVE-2026-26960, CVE-2026-26996, CVE-2026-27903, CVE-2026-27904, CVE-2026-29786, CVE-2026-31802, CVE-2026-33750