### PR TITLE
chore(chart): W7 footgun fixes (pgbouncer pin, air-gap default, PDB guard)

### DIFF
--- a/charts/omnia/Chart.yaml
+++ b/charts/omnia/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version / appVersion track the last git-tagged release. When cutting a
 # new release, bump both in a commit before tagging. The release workflow
 # also rewrites these at package-time as a safety net.
-version: 0.9.0-beta.6
-appVersion: "0.9.0-beta.6"
+version: 0.9.0-beta.7
+appVersion: "0.9.0-beta.7"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/AltairaLabs/Omnia
 sources:

--- a/charts/omnia/templates/dev-postgres.yaml
+++ b/charts/omnia/templates/dev-postgres.yaml
@@ -139,7 +139,10 @@ spec:
               mountPath: /var/lib/postgresql/data
 {{- if $pgbouncerEnabled }}
         - name: pgbouncer
-          image: edoburu/pgbouncer:latest
+          # Dev-only sidecar. Pinned to avoid silent behavior changes on image
+          # updates; bump deliberately. Full resource + probe tuning is coming
+          # in a follow-up PR (W3 of the chart overhaul).
+          image: {{ .Values.postgres.dev.pgbouncer.image | default "edoburu/pgbouncer:1.24.0" }}
           ports:
             - containerPort: 6432
               protocol: TCP

--- a/charts/omnia/templates/pdb.yaml
+++ b/charts/omnia/templates/pdb.yaml
@@ -1,4 +1,14 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- /*
+     Refuse to render a PDB for a single-replica Deployment with the default
+     minAvailable:1. Combination makes every eviction (drain, rollout, scale-
+     up) impossible until the single replica goes Ready on the new pod. Users
+     hit this when they enable a PDB on a dev cluster with replicaCount:1 and
+     then can't roll the operator. Force the choice to be explicit.
+*/}}
+{{- if and (le (int .Values.replicaCount) 1) (or (not .Values.podDisruptionBudget.minAvailable) (eq (.Values.podDisruptionBudget.minAvailable | toString) "1")) (not .Values.podDisruptionBudget.maxUnavailable) }}
+{{- fail "podDisruptionBudget.enabled=true with replicaCount<=1 and default minAvailable:1 would block every eviction of the operator. Either set replicaCount>=2 or set podDisruptionBudget.maxUnavailable:1." }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -20,6 +30,9 @@ spec:
 {{- end }}
 ---
 {{- if and .Values.dashboard.enabled .Values.dashboard.podDisruptionBudget.enabled }}
+{{- if and (le (int .Values.dashboard.replicaCount) 1) (or (not .Values.dashboard.podDisruptionBudget.minAvailable) (eq (.Values.dashboard.podDisruptionBudget.minAvailable | toString) "1")) (not .Values.dashboard.podDisruptionBudget.maxUnavailable) }}
+{{- fail "dashboard.podDisruptionBudget.enabled=true with dashboard.replicaCount<=1 and default minAvailable:1 would block every eviction of the dashboard. Either set dashboard.replicaCount>=2 or set dashboard.podDisruptionBudget.maxUnavailable:1." }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/omnia/values-dev-enterprise.yaml
+++ b/charts/omnia/values-dev-enterprise.yaml
@@ -24,6 +24,11 @@ devMode: true
 enterprise:
   enabled: true
 
+  # Community templates default flipped to false in chart 0.9.0-beta.7 (air-gap
+  # safety). Dev Enterprise installs want them on for the fast dev loop.
+  communityTemplates:
+    enabled: true
+
   arena:
     queue:
       type: redis

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -132,8 +132,12 @@ enterprise:
 
   # Community templates source (deployed automatically when enabled)
   communityTemplates:
-    # -- Enable community templates source
-    enabled: true
+    # -- Enable community templates source. When true, the operator reconciles
+    # an ArenaTemplateSource that fetches from github.com/AltairaLabs/promptkit-templates
+    # on the configured syncInterval. Default is `false` so air-gapped and
+    # regulated installs opt in explicitly; enable it when you want the built-in
+    # template gallery to stay in sync.
+    enabled: false
     # -- Name of the ArenaTemplateSource resource
     name: community-templates
     # -- Namespace to deploy the ArenaTemplateSource
@@ -840,6 +844,9 @@ postgres:
     pgbouncer:
       # -- Enable PgBouncer connection pooling sidecar
       enabled: false
+      # -- PgBouncer sidecar image. Pinned (NOT `:latest`) to avoid silent
+      # behavior changes; dev-only, bump deliberately when you want to.
+      image: edoburu/pgbouncer:1.24.0
       poolMode: transaction
       defaultPoolSize: 20
       maxClientConn: 100


### PR DESCRIPTION
## Summary

First wave of the helm chart overhaul tracked in #895. Four small but load-bearing fixes. Additive where possible; one visible default change (version-bumped accordingly).

### Changes

1. **`enterprise.communityTemplates.enabled: true -> false`.** Previously any enterprise install reached out to `github.com/AltairaLabs/promptkit-templates` on every controller sync. Now off by default; `values-dev-enterprise.yaml` keeps it on explicitly for the dev loop. Air-gapped and regulated installs no longer have to remember to disable it.

2. **Pin `edoburu/pgbouncer:latest -> 1.24.0`.** Dev-postgres sidecar used `:latest`, a silent-breakage footgun. New `postgres.dev.pgbouncer.image` allows override.

3. **PDB + single-replica `{{ fail }}` guard.** `pdb.yaml` refuses to render when `podDisruptionBudget.enabled=true` AND replicas <=1 AND effective `minAvailable:1`. That combo blocks every eviction until the sole pod goes Ready on replacement. Error message tells users how to unstick.

4. **Chart version `0.9.0-beta.6 -> 0.9.0-beta.7`** for the visible default change.

### Validated

- [x] `helm lint --strict` clean
- [x] `helm template` default + enterprise renders cleanly
- [x] PDB guard fires with readable error when `replicaCount=1 podDisruptionBudget.enabled=true`
- [x] `values-dev-enterprise.yaml` still installs community templates (tested via `-s templates/enterprise/community-templates-source.yaml`)

### Out of scope (separate PRs in #895)

- W1 — README + values quick-start + NOTES.txt `podOverrides` sample
- W2 — `values.schema.json` completion
- W3 — Expose remaining hardcoded probe/resource/port tunables
- W4 — Unified `podOverrides` surface on chart-owned deployments
- W5 — Examples library (Azure KV CSI, IRSA, GKE WLI)
- W6 — CI lint gates (`helm-docs`, `kubeconform`, `helm unittest` — will fix pre-existing test failures then)

Refs #895