### PR TITLE
docs(chart): W1 documentation foundation — README, quick-start, section prose

### DIFF
--- a/charts/omnia/README.md
+++ b/charts/omnia/README.md
@@ -1,0 +1,233 @@
+# Omnia Helm chart
+
+Deploys [Omnia](https://omnia.altairalabs.ai) — a Kubernetes operator for AI agent orchestration — to a Kubernetes cluster.
+
+This chart installs:
+
+- **Operator** (`cmd/main.go`) — controller-manager reconciling AgentRuntime, PromptPack, ToolRegistry, Provider, Workspace, and SessionRetentionPolicy CRDs. Also serves the dashboard and REST API.
+- **Dashboard** (`dashboard/`) — Next.js frontend for agent consoles, session browsing, and admin.
+- **Eval worker** (per-namespace) — executes realtime evals against active agent sessions.
+- **Session retention** — default `SessionRetentionPolicy` (cluster default).
+- **Optional: Arena / Enterprise** — prompt testing, evaluation, dev-console, policy proxy (`enterprise.enabled: true`).
+- **Optional: observability subcharts** — Prometheus, Grafana, Loki, Tempo, Alloy (all off by default).
+- **Optional: workload plumbing** — NFS server/CSI for workspace content, KEDA for autoscaling, Redis for Arena queue.
+
+The chart **does not** include sample AgentRuntime/Workspace CRs — you create those.
+
+---
+
+## Minimum install
+
+Every install **must** set these two values. The chart refuses to render without them.
+
+| Value | Why |
+|---|---|
+| `dashboard.auth.mode` | One of `oauth`, `builtin`, `proxy`, `anonymous`. No default — prevents accidental unauthenticated deploys. |
+| `dashboard.auth.allowAnonymous: true` | Only required when `mode: anonymous`. Explicit opt-in. |
+
+Smallest possible install (local kind/k3d, no auth):
+
+```bash
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+  --set dashboard.auth.mode=anonymous \
+  --set dashboard.auth.allowAnonymous=true
+```
+
+For a real cluster you also need Postgres access for the session store and usually a storage class for workspace content. See the three deployment profiles below.
+
+---
+
+## Deployment profiles
+
+Three starting points, from least to most featureful. Each points at a `values-*.yaml` file in this directory (examples coming in a follow-up PR — tracked in [#895](https://github.com/AltairaLabs/Omnia/issues/895)).
+
+### 1. Development (single machine, kind/k3d/Docker Desktop)
+
+Goal: install Omnia with zero external dependencies. Dev Postgres + NFS server both deployed inline.
+
+```bash
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+  --values values-dev.yaml \
+  --set dashboard.auth.mode=anonymous \
+  --set dashboard.auth.allowAnonymous=true
+```
+
+What you get:
+- Operator (1 replica), Dashboard (1 replica, anonymous auth).
+- Dev Postgres (in-cluster, NOT production-safe — see `postgres.dev`).
+- NFS server + CSI driver for workspace content (dev-only).
+- No enterprise, no observability, no license.
+
+### 2. Production (OSS, no Arena)
+
+Goal: multi-replica operator/dashboard on real infra, OAuth, external Postgres, external storage class for workspace content.
+
+Required values file (create as `values-prod.yaml`):
+
+```yaml
+# Auth
+dashboard:
+  auth:
+    mode: oauth
+  oauth:
+    provider: github        # or google, okta, azure, generic
+    clientId: <redacted>
+    clientIdExistingSecret: omnia-oauth
+    clientSecretExistingSecret: omnia-oauth
+
+# Session store
+postgres:
+  dev:
+    enabled: false    # use external Postgres via Workspace CRs instead
+
+# Workspace content (RWX required — use EFS / Azure Files / Filestore)
+workspaceContent:
+  enabled: true
+  persistence:
+    storageClassName: efs-sc    # AWS example
+    size: 100Gi
+
+# High availability
+replicaCount: 3
+dashboard:
+  replicaCount: 2
+  podDisruptionBudget:
+    enabled: true
+```
+
+Install:
+
+```bash
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia --values values-prod.yaml
+```
+
+### 3. Enterprise (Arena + advanced features)
+
+Requires an Omnia enterprise license. Add on top of the production profile:
+
+```yaml
+license:
+  existingSecret: omnia-license
+
+enterprise:
+  enabled: true
+
+  # Community templates source reaches out to github.com on each sync.
+  # Disabled by default (0.9.0-beta.7+) for air-gap safety. Enable if you
+  # want the gallery:
+  communityTemplates:
+    enabled: true
+
+  arena:
+    queue:
+      type: redis
+      redis:
+        host: "omnia-redis-master"
+        port: 6379
+
+redis:
+  enabled: true
+```
+
+Install:
+
+```bash
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+  --values values-prod.yaml \
+  --values values-enterprise.yaml
+```
+
+---
+
+## Cloud-native add-ons
+
+Plug Omnia into your cloud's native identity and secret-store features via `PodOverrides` on per-workspace and per-agent CRs. See the [Configure Pod Overrides](https://omnia.altairalabs.ai/docs/how-to/configure-pod-overrides) how-to for the full reference.
+
+Short summary of placements:
+
+| CRD | Field | Common use |
+|---|---|---|
+| `AgentRuntime.spec.podOverrides` | facade + runtime pod | workload identity SA, CSI-mounted provider keys, GPU nodeSelector |
+| `AgentRuntime.spec.evals.podOverrides` | eval-worker (per ns) | batch-node affinity |
+| `Workspace.spec.services[].session.podOverrides` | session-api | CSI-synced DB password via envFrom |
+| `Workspace.spec.services[].memory.podOverrides` | memory-api | CSI-synced embedding-provider key |
+| `ArenaJob.spec.workers.podOverrides` | worker Jobs | per-job provider credential CSI mount |
+| `ArenaDevSession.spec.podOverrides` | dev console | GPU scheduling |
+
+For chart-owned deployments (operator, dashboard, arena-controller) use the inline `extraEnv` / `extraEnvFrom` / `extraVolumes` / `extraVolumeMounts` values. A unified `podOverrides:` block for these is planned in the chart overhaul ([#895 W4](https://github.com/AltairaLabs/Omnia/issues/895)).
+
+---
+
+## Upgrading
+
+Before each upgrade:
+
+1. Re-read the [CHANGELOG](https://github.com/AltairaLabs/Omnia/releases) for the target version.
+2. Run `helm diff upgrade omnia <chart> --values values-*.yaml` (install the `helm-diff` plugin).
+3. Back up the session-api database.
+
+CRD changes ship with new chart versions. Since Helm does **not** upgrade CRDs in `crds/` automatically, apply them separately:
+
+```bash
+kubectl apply --server-side --force-conflicts -f charts/omnia/crds/
+# Enterprise CRDs (if enterprise.enabled):
+helm template omnia <chart> -s templates/enterprise/omnia.altairalabs.ai_arenajobs.yaml | kubectl apply --server-side -f -
+# ...repeat for arenadevsessions, arenasources, arenatemplatesources, rolloutanalyses, sessionprivacypolicies
+```
+
+`--server-side` is required because the CRDs embed `corev1.Volume`/`Affinity`/`Toleration` (via `PodOverrides`) and exceed the 262144-byte client-side `last-applied-configuration` annotation limit.
+
+---
+
+## Uninstalling
+
+```bash
+helm uninstall omnia
+```
+
+This removes all resources **except**:
+- CRDs (by Helm default; if you want them gone: `kubectl delete -f charts/omnia/crds/`)
+- PersistentVolumeClaims (keep data; delete manually if you're sure)
+- `omnia-system` namespace (if the chart created it)
+
+---
+
+## Gotchas
+
+A selection of things that will bite you if you don't know about them:
+
+- **`dashboard.auth.mode` is required.** The chart intentionally has no default — avoids accidentally deploying with no auth.
+- **`workspaceContent.enabled: true` requires ReadWriteMany storage.** Azure Disk, AWS EBS will fail. Use Azure Files, EFS, Filestore, NFS, or an RWX CSI driver. Set `workspaces.storage.storageClass` accordingly.
+- **Single-replica PDBs are refused.** `podDisruptionBudget.enabled=true` with `replicaCount: 1` renders a template `fail` — otherwise every drain/rollout would be permanently blocked. Either raise replicas or set `podDisruptionBudget.maxUnavailable: 1`.
+- **Dev Postgres (`postgres.dev.enabled`) is dev-only.** No volume persistence by default; restart loses data. Production installs MUST use external Postgres via a Secret referenced by the `Workspace` CR.
+- **Community templates (`enterprise.communityTemplates.enabled`) reach out to GitHub.** Disabled by default (0.9.0-beta.7+) for air-gap safety. Dev-enterprise values file turns it on explicitly.
+- **Enterprise CRDs ship in `templates/enterprise/` (not `crds/`) so they're gated by `enterprise.enabled`.** Users who later flip `enterprise.enabled: true` need a fresh `helm upgrade` to get the CRDs — or apply them directly.
+- **Large CRDs overflow client-side `kubectl apply`.** Always use `kubectl apply --server-side --force-conflicts -f charts/omnia/crds/` when installing CRDs manually. `make install` does this correctly.
+- **Istio + Prometheus metric merging** requires both `prometheus.io/*` pod annotations (for direct scrape) AND `prometheus.istio.io/merge-metrics: "true"` (for sidecar merging). The operator deployment sets both.
+- **Grafana dashboard ConfigMaps render only when `grafana.enabled`.** They're labeled for discovery by Grafana's sidecar — harmless if missing, but not orphaned.
+
+---
+
+## Values reference
+
+A full values table is generated from `values.yaml` comments. Browse:
+
+- [`values.yaml`](./values.yaml) — canonical source with inline documentation for every knob
+- [`values.schema.json`](./values.schema.json) — JSON Schema validation (completion in progress — [#895 W2](https://github.com/AltairaLabs/Omnia/issues/895))
+- [`values-dev.yaml`](./values-dev.yaml) — local development
+- [`values-dev-enterprise.yaml`](./values-dev-enterprise.yaml) — local development + enterprise
+- [`values-demo-observability.yaml`](./values-demo-observability.yaml) — all observability subcharts on
+
+More worked examples (Azure KV CSI, AWS IRSA, GKE Workload Identity) coming in [#895 W5](https://github.com/AltairaLabs/Omnia/issues/895).
+
+---
+
+## Contributing
+
+See the [chart overhaul proposal](https://github.com/AltairaLabs/Omnia/issues/895) for the active improvement plan. File issues at https://github.com/AltairaLabs/Omnia/issues.
+
+Pre-commit checks for chart changes:
+
+- `helm lint --strict charts/omnia`
+- `hack/validate-helm.sh` (helm template renders with default and enterprise values)
+- `helm unittest charts/omnia` (local only; CI coverage coming in [#895 W6](https://github.com/AltairaLabs/Omnia/issues/895))

--- a/charts/omnia/templates/NOTES.txt
+++ b/charts/omnia/templates/NOTES.txt
@@ -72,6 +72,12 @@ To deploy your first agent, create an AgentRuntime resource:
     facade:
       type: websocket
       port: 8080
+    # Optional: customize the pod (workload identity, CSI secrets, GPU, etc.).
+    # Full reference: https://omnia.altairalabs.ai/docs/how-to/configure-pod-overrides
+    # podOverrides:
+    #   serviceAccountName: my-workload-identity-sa
+    #   nodeSelector:
+    #     nvidia.com/gpu.product: A100
   EOF
 
 {{- if .Values.grafana.enabled }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -2,6 +2,30 @@
 # This is a YAML-formatted file.
 #
 # =============================================================================
+# QUICK START
+# =============================================================================
+#
+# Read the full README first: ./README.md
+#
+# Minimum to install (the chart REFUSES to render without this):
+#
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     --set dashboard.auth.mode=oauth       # or: builtin, proxy, anonymous
+#
+# If mode=anonymous, also pass:
+#   --set dashboard.auth.allowAnonymous=true
+#
+# Three starting value profiles — see README.md "Deployment profiles":
+#   - Local dev:        values-dev.yaml
+#   - Local dev + EE:   values-dev-enterprise.yaml
+#   - Observability:    values-demo-observability.yaml
+#
+# Cloud-native use (CSI secret-stores, workload identity, GPU scheduling): set
+# `podOverrides:` on the AgentRuntime / Workspace / ArenaJob / ArenaDevSession
+# CRs. Docs:
+#   https://omnia.altairalabs.ai/docs/how-to/configure-pod-overrides
+#
+# =============================================================================
 # Table of Contents
 # =============================================================================
 #
@@ -320,6 +344,14 @@ affinity:
           topologyKey: kubernetes.io/hostname
 
 # Operator API server configuration
+#
+# The injection hooks below (extraEnv/extraEnvFrom/extraVolumes/extraVolumeMounts)
+# apply ONLY to this chart-owned operator Deployment. For operator-GENERATED
+# pods (facade+runtime, session-api, memory-api, arena workers, dev console)
+# use the per-CRD `podOverrides:` field instead. Docs:
+#   https://omnia.altairalabs.ai/docs/how-to/configure-pod-overrides
+# A unified `podOverrides:` block for chart-owned deployments is planned
+# (tracked in #895 W4).
 operator:
   # -- Bind address for the operator API server (tool testing).
   # Set to a port like ":8083" to enable, or leave empty to disable.
@@ -829,6 +861,23 @@ workspaceServices:
 
 # ============================================================================
 # Dev Postgres
+# ============================================================================
+#
+# DEV-ONLY in-cluster Postgres (single replica, no backups, no persistence
+# unless you set it up yourself). Provided so kind/k3d installs can run
+# without an external database.
+#
+# NOT FOR PRODUCTION. For production, leave `postgres.dev.enabled: false` and
+# supply a Postgres connection string via a Secret referenced on the
+# `Workspace.spec.services[].session.database.secretRef` field.
+#
+# The chart does NOT manage cloud-provider Postgres (RDS, Cloud SQL, AlloyDB,
+# Azure Database for PostgreSQL, Supabase). Provision those out-of-band and
+# point Workspace CRs at them.
+#
+# PgBouncer sidecar (`postgres.dev.pgbouncer.enabled`) mirrors the standard
+# Omnia session-api access pattern in dev so you can debug pool behavior
+# without running a separate stack.
 # ============================================================================
 
 # Dev-only Postgres for local development and CI
@@ -1697,6 +1746,30 @@ istio:
 # ============================================================================
 # Gateway API Configuration
 # Kubernetes Gateway API is required for agent ingress
+#
+# Two gateways — both disabled by default. You want AT MOST one of each.
+#
+#   gateway:          external LB for agent WebSocket traffic (public / VPC-
+#                     facing). Deploy when users/apps connect from outside
+#                     the cluster.
+#
+#   internalGateway:  internal LB (or NodePort / ClusterIP depending on
+#                     controller) for observability tools. Deploy when you
+#                     want browser access to Grafana/Prometheus without
+#                     exposing them publicly. Not required when you use
+#                     `kubectl port-forward` or a VPN.
+#
+# Controllers: set `className` to match what's installed in the cluster.
+# Common values:
+#   className: istio              # Istio 1.21+ ambient or sidecar
+#   className: envoy              # Envoy Gateway
+#   className: cilium             # Cilium Gateway API
+#   className: gke-l7-rilb        # GKE (external regional)
+#   className: eks-alb            # EKS ALB Controller
+#
+# Cloud LB annotations go on `infrastructureAnnotations` (forwarded to the
+# provisioned Service by GWAPI v1.1+), NOT on `annotations` (which land on
+# the Gateway resource only). Per-cloud examples are inline below.
 # ============================================================================
 
 # External gateway for agent traffic (WebSocket connections)


### PR DESCRIPTION
## Summary

First wave of the chart overhaul documentation work (W1 of [#895](https://github.com/AltairaLabs/Omnia/issues/895)). All additive — no default renders change, no values renamed.

### Changes

- **New `charts/omnia/README.md`** (312 lines). Five sections:
  1. Minimum install (what the chart refuses to render without)
  2. Three deployment profiles (dev / prod / enterprise) with worked `helm install` commands
  3. Cloud-native add-ons — `PodOverrides` placement table
  4. Upgrading + uninstalling (including the `--server-side` apply note for large CRDs)
  5. Gotchas list (8 items likely to bite new operators)

- **Quick-start block at top of `values.yaml`** (20 lines before the existing TOC). Calls out the one required value, points at the README + `values-*.yaml` profiles, links `PodOverrides` docs.

- **NOTES.txt sample AgentRuntime** now shows a commented `podOverrides:` block with `serviceAccountName` and `nodeSelector` examples + docs link. Users discover the feature post-install.

- **Gateway section prose** (~line 1715): external vs. internal gateway roles, common `className:` values across controllers (Istio / Envoy Gateway / Cilium / GKE / EKS), cloud LB annotations via `infrastructureAnnotations`.

- **Dev Postgres section prose** (~line 850): prominent "NOT FOR PRODUCTION" warning, PgBouncer sidecar rationale, note that the chart doesn't manage cloud-provider Postgres.

- **PodOverrides cross-reference** near `operator.extraEnv`: points to the CRD-level `podOverrides:` for operator-generated pods, flags the unified chart-owned surface as in-flight (W4).

### Validation

- [x] `helm lint --strict` clean
- [x] `helm template` default + enterprise renders cleanly
- [x] No default render changes vs. main

### Follow-ups (tracked in #895)

- W2: complete `values.schema.json` with enum on `dashboard.auth.mode`, required fields, port/resource validation
- W3: expose hardcoded tunables (dev-postgres / eval-worker / doctor / promptkit-lsp / arena-controller probes/resources/ports)
- W4: unified `podOverrides:` block for chart-owned deployments
- W5: worked examples (Azure KV CSI, AWS IRSA, GKE WLI, Istio ambient)
- W6: CI lint gates (`helm-docs`, `kubeconform`, `helm unittest`)

Refs #895