### PR TITLE
ci: stop running E2E + CodeQL on docs-only changes

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,78 @@
+name: CodeQL
+
+# Advanced-setup CodeQL analysis for Go. Replaces the repo's previous
+# Default Setup (configured in Security → Code scanning UI) so we can
+# path-filter: no CodeQL run on helm/docs/workflow changes.
+#
+# Before merging this workflow: flip the repo from Default Setup to
+# Advanced Setup in the Security → Code scanning settings. Otherwise
+# BOTH configurations will run. See:
+#   https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    # Weekly baseline in case a PR slipped through with an unexpected filter.
+    # Runs on Monday at 07:00 UTC.
+    - cron: '0 7 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: go
+          # Build-mode auto — CodeQL runs `go build ./...` itself.
+          build-mode: autobuild
+          # Disable promptkit-local via go.work override; CI uses the
+          # published SDK (matches the rest of the Go checks).
+          config: |
+            paths-ignore:
+              - 'promptkit-local/**'
+              - 'dashboard/**'
+              - 'docs/**'
+              - 'charts/**'
+              - 'test/e2e/**'
+              - '**/*_test.go'
+              - '**/zz_generated*.go'
+              - '**/*.pb.go'
+              - '**/*.gen.go'
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:go"

--- a/.github/workflows/test-agent-e2e.yml
+++ b/.github/workflows/test-agent-e2e.yml
@@ -5,23 +5,19 @@ on:
     branches:
       - main
     paths:
-      # Chart changes that affect deployed behavior only. Excludes
-      # Chart.yaml (version bumps), README, NOTES.txt.
-      - 'charts/**/values*.yaml'
-      - 'charts/**/templates/**/*.yaml'
-      - 'charts/**/templates/**/*.tpl'
-      - 'charts/**/crds/**'
-      - 'dashboard/**'
-      - 'internal/**'
-      - 'cmd/**'
-      - 'pkg/**'
-      - 'api/**'
-      # Dockerfile* intentionally omitted — Docker Build Matrix verifies
-      # every Dockerfile on every PR; build-only changes don't affect E2E.
-      - '.github/workflows/test-agent-e2e.yml'
-  pull_request:
-    paths:
-      - 'charts/**/values*.yaml'
+      # Changes that materially affect runtime behavior only.
+      #
+      # INTENTIONALLY EXCLUDED from these filters:
+      #   - charts/**/values*.yaml        docs-only comments are common; default
+      #                                   behavioural changes should be verified
+      #                                   via a matching template edit or by
+      #                                   triggering E2E manually via
+      #                                   workflow_dispatch. `helm lint` +
+      #                                   `helm template` in the CI workflow
+      #                                   catch schema/rendering regressions.
+      #   - charts/**/*.md, README, NOTES.txt, values.schema.json  docs/schema
+      #   - hack/**                       pre-commit scripts don't affect in-cluster behavior
+      #   - Dockerfile*                   verified by Docker Build Matrix on every PR
       - 'charts/**/templates/**/*.yaml'
       - 'charts/**/templates/**/*.tpl'
       - 'charts/**/crds/**'
@@ -31,7 +27,18 @@ on:
       - 'pkg/**'
       - 'api/**'
       - '.github/workflows/test-agent-e2e.yml'
-  workflow_dispatch:  # Allow manual trigger
+  pull_request:
+    paths:
+      - 'charts/**/templates/**/*.yaml'
+      - 'charts/**/templates/**/*.tpl'
+      - 'charts/**/crds/**'
+      - 'dashboard/**'
+      - 'internal/**'
+      - 'cmd/**'
+      - 'pkg/**'
+      - 'api/**'
+      - '.github/workflows/test-agent-e2e.yml'
+  workflow_dispatch:  # Allow manual trigger for values-only PRs
 
 permissions:
   contents: read

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -15,11 +15,17 @@ on:
       - 'internal/**'
       - 'pkg/**'
       - 'test/**'
-      - 'hack/**'
-      # Chart changes that affect deployed behavior. Excludes Chart.yaml
-      # (version bumps), README, NOTES.txt — those can't regress E2E.
-      # Docker Build Matrix already verifies Dockerfile changes on PRs.
-      - 'charts/**/values*.yaml'
+      # Chart changes that materially affect runtime behavior only.
+      #
+      # INTENTIONALLY EXCLUDED:
+      #   - charts/**/values*.yaml        docs-only comments common; default
+      #                                   changes should come with a template
+      #                                   edit or use workflow_dispatch.
+      #                                   `helm lint`/`helm template` in ci.yml
+      #                                   catch schema/rendering regressions.
+      #   - charts/**/*.md, README, NOTES.txt, values.schema.json  docs/schema
+      #   - hack/**                       pre-commit scripts don't affect runtime
+      #   - Dockerfile*                   verified by Docker Build Matrix
       - 'charts/**/templates/**/*.yaml'
       - 'charts/**/templates/**/*.tpl'
       - 'charts/**/crds/**'
@@ -37,13 +43,12 @@ on:
       - 'internal/**'
       - 'pkg/**'
       - 'test/**'
-      - 'hack/**'
-      - 'charts/**/values*.yaml'
       - 'charts/**/templates/**/*.yaml'
       - 'charts/**/templates/**/*.tpl'
       - 'charts/**/crds/**'
       - 'scripts/setup-arena-e2e.sh'
       - '.github/workflows/test-e2e.yml'
+  workflow_dispatch:  # Allow manual trigger for values-only PRs
 
 permissions:
   contents: read

--- a/.github/workflows/test-helm-e2e.yml
+++ b/.github/workflows/test-helm-e2e.yml
@@ -5,12 +5,29 @@ on:
     branches:
       - main
     paths:
-      - 'charts/**'
+      # Material chart changes only.
+      #
+      # INTENTIONALLY EXCLUDED:
+      #   - charts/**/*.md, README, NOTES.txt, values.schema.json  docs/schema
+      #   - charts/**/values*.yaml        comment-only edits are common;
+      #                                   real default changes should come
+      #                                   with a template edit or use
+      #                                   workflow_dispatch.
+      - 'charts/**/templates/**/*.yaml'
+      - 'charts/**/templates/**/*.tpl'
+      - 'charts/**/crds/**'
+      - 'charts/**/Chart.yaml'
+      - 'charts/**/Chart.lock'
       - '.github/workflows/test-helm-e2e.yml'
   pull_request:
     paths:
-      - 'charts/**'
+      - 'charts/**/templates/**/*.yaml'
+      - 'charts/**/templates/**/*.tpl'
+      - 'charts/**/crds/**'
+      - 'charts/**/Chart.yaml'
+      - 'charts/**/Chart.lock'
       - '.github/workflows/test-helm-e2e.yml'
+  workflow_dispatch:  # Allow manual trigger for values-only or docs PRs
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Tightens CI path filters so doc-only chart edits and values-comment changes don't fire the ~20-minute E2E suites or the Go CodeQL analyzer.

### Changes

1. **E2E workflows** (`test-e2e`, `test-agent-e2e`, `test-helm-e2e`): drop `charts/**/values*.yaml` and `hack/**` from triggers. Real material chart changes are still covered via `templates/**/*.yaml`, `templates/**/*.tpl`, `crds/**`, `Chart.yaml`. Added `workflow_dispatch` to each so you can manually fire E2E on a values-only PR when needed.

2. **CodeQL**: new `.github/workflows/codeql.yml` (Advanced Setup) path-filtered to `**.go` / `go.mod` / `go.sum` only. Replaces the implicit Default Setup that ran `Analyze (go)` on every PR.

### One-time action required after merge

Flip the repo's CodeQL config from **Default Setup** to **Advanced Setup** in `Settings → Security → Code scanning`. Otherwise both configurations run in parallel. Docs: https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning

### Safety analysis

**What we lose:** E2E no longer fires automatically on a pure `values.yaml` default change (e.g. flipping `.enabled: true → false`).

**What catches it instead:** `ci.yml` runs `helm lint` + `helm template` + `values.schema.json` validation on every PR — catches schema violations and template-rendering regressions fast. Full `helm unittest` will land in W6.

**When you DO need E2E for a values-only change:** document on the PR, and do one of:
- `gh workflow run test-e2e.yml --ref <branch>`
- add a touching edit to a template file
- include a matching schema or Chart.yaml change

Refs #895 (addendum to W6)