### PR TITLE
feat(chart): W3a expose dev-postgres / eval-worker / doctor tunables

### DIFF
--- a/charts/omnia/templates/dev-postgres.yaml
+++ b/charts/omnia/templates/dev-postgres.yaml
@@ -100,7 +100,8 @@ spec:
     spec:
       containers:
         - name: postgres
-          image: pgvector/pgvector:pg17
+          image: "{{ .Values.postgres.dev.image.repository | default "pgvector/pgvector" }}:{{ .Values.postgres.dev.image.tag | default "pg17" }}"
+          imagePullPolicy: {{ .Values.postgres.dev.image.pullPolicy | default "IfNotPresent" }}
           env:
             - name: POSTGRES_USER
               value: omnia
@@ -125,23 +126,23 @@ spec:
           readinessProbe:
             exec:
               command: ["pg_isready", "-U", "omnia"]
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            {{- with .Values.postgres.dev.readinessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
+            periodSeconds:       {{ .periodSeconds       | default 5 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
+          {{- with .Values.postgres.dev.resources }}
           resources:
-            limits:
-              cpu: 500m
-              memory: 256Mi
-            requests:
-              cpu: 100m
-              memory: 128Mi
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: data
               mountPath: /var/lib/postgresql/data
 {{- if $pgbouncerEnabled }}
         - name: pgbouncer
           # Dev-only sidecar. Pinned to avoid silent behavior changes on image
-          # updates; bump deliberately. Full resource + probe tuning is coming
-          # in a follow-up PR (W3 of the chart overhaul).
+          # updates; bump deliberately via `postgres.dev.pgbouncer.image`.
           image: {{ .Values.postgres.dev.pgbouncer.image | default "edoburu/pgbouncer:1.24.0" }}
           ports:
             - containerPort: 6432
@@ -149,15 +150,16 @@ spec:
           readinessProbe:
             tcpSocket:
               port: 6432
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            {{- with .Values.postgres.dev.pgbouncer.readinessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
+            periodSeconds:       {{ .periodSeconds       | default 5 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
+          {{- with .Values.postgres.dev.pgbouncer.resources }}
           resources:
-            limits:
-              cpu: 200m
-              memory: 128Mi
-            requests:
-              cpu: 50m
-              memory: 64Mi
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - name: pgbouncer-config
               mountPath: /etc/pgbouncer

--- a/charts/omnia/templates/doctor/deployment.yaml
+++ b/charts/omnia/templates/doctor/deployment.yaml
@@ -57,14 +57,22 @@ spec:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- with .Values.doctor.livenessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
+            periodSeconds:       {{ .periodSeconds       | default 10 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /healthz
               port: http
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- with .Values.doctor.readinessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
+            periodSeconds:       {{ .periodSeconds       | default 10 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.doctor.resources | nindent 12 }}
           securityContext:

--- a/charts/omnia/templates/eval-worker/deployment.yaml
+++ b/charts/omnia/templates/eval-worker/deployment.yaml
@@ -89,14 +89,22 @@ spec:
             httpGet:
               path: /healthz
               port: metrics
-            initialDelaySeconds: 5
-            periodSeconds: 15
+            {{- with .Values.enterprise.evalWorker.livenessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
+            periodSeconds:       {{ .periodSeconds       | default 15 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /readyz
               port: metrics
-            initialDelaySeconds: 3
-            periodSeconds: 10
+            {{- with .Values.enterprise.evalWorker.readinessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 3 }}
+            periodSeconds:       {{ .periodSeconds       | default 10 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
           {{- with .Values.enterprise.evalWorker.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
@@ -107,4 +115,5 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+      terminationGracePeriodSeconds: {{ .Values.enterprise.evalWorker.terminationGracePeriodSeconds | default 30 }}
 {{- end }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -220,6 +220,21 @@ enterprise:
     #       name: llm-provider-keys
     #       key: openai-api-key
 
+    # -- Liveness probe tuning for the eval-worker container.
+    livenessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 15
+      timeoutSeconds: 1
+      failureThreshold: 3
+    # -- Readiness probe tuning for the eval-worker container.
+    readinessProbe:
+      initialDelaySeconds: 3
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+    # -- Graceful-shutdown window in seconds for the eval-worker pod.
+    terminationGracePeriodSeconds: 30
+
   # Policy proxy sidecar for ToolPolicy enforcement
   policyProxy:
     image:
@@ -890,6 +905,27 @@ postgres:
     secretName: omnia-postgres
     # -- Key in the secret containing the connection string
     secretKey: connection-string
+    # -- Postgres container image. Pinned to pgvector (required for memory-api
+    # embeddings). Bump `tag` deliberately when upstream Postgres majors move.
+    image:
+      repository: pgvector/pgvector
+      tag: pg17
+      pullPolicy: IfNotPresent
+    # -- Postgres container resource requests/limits. The 500m/256Mi default
+    # is sized for kind/k3d; bump for serious dev workloads.
+    resources:
+      limits:
+        cpu: 500m
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 128Mi
+    # -- Postgres readiness probe (uses `pg_isready` exec).
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 5
+      timeoutSeconds: 1
+      failureThreshold: 3
     pgbouncer:
       # -- Enable PgBouncer connection pooling sidecar
       enabled: false
@@ -900,6 +936,20 @@ postgres:
       defaultPoolSize: 20
       maxClientConn: 100
       maxDbConnections: 20
+      # -- PgBouncer sidecar resource requests/limits.
+      resources:
+        limits:
+          cpu: 200m
+          memory: 128Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+      # -- PgBouncer readiness probe (TCP check on port 6432).
+      readinessProbe:
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 1
+        failureThreshold: 3
 
 # ============================================================================
 # Doctor Configuration
@@ -938,6 +988,18 @@ doctor:
     requests:
       cpu: 100m
       memory: 128Mi
+  # -- Liveness probe tuning for the doctor container.
+  livenessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
+  # -- Readiness probe tuning for the doctor container.
+  readinessProbe:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 1
+    failureThreshold: 3
 
 # ============================================================================
 # Session Privacy Configuration


### PR DESCRIPTION
## Summary

W3a of the chart overhaul ([#895](https://github.com/AltairaLabs/Omnia/issues/895)). Replace hardcoded image tags, resources, probe timings, and termination grace periods on three chart-owned components with values-driven defaults. **All defaults preserved** — zero render change for users who don't set overrides.

### dev-postgres

Adds: `postgres.dev.image.{repository,tag,pullPolicy}`, `postgres.dev.resources`, `postgres.dev.readinessProbe`, `postgres.dev.pgbouncer.resources`, `postgres.dev.pgbouncer.readinessProbe`.

Previously hardcoded: `pgvector/pgvector:pg17`, `500m/256Mi` Postgres resources, `200m/128Mi` PgBouncer resources, probe delays of 5s / 5s.

### eval-worker

Adds: `enterprise.evalWorker.livenessProbe`, `enterprise.evalWorker.readinessProbe`, `enterprise.evalWorker.terminationGracePeriodSeconds`.

### doctor

Adds: `doctor.livenessProbe`, `doctor.readinessProbe`.

### Validated

- [x] `helm lint --strict` clean
- [x] `helm template` default render unchanged (same resource count, same defaults)
- [x] Override works: `--set postgres.dev.readinessProbe.periodSeconds=42` → `periodSeconds: 42` in the rendered StatefulSet

### Follow-up (W3b)

- `ee-promptkit-lsp-deployment.yaml` port / dashboard-URL / probes / terminationGracePeriodSeconds
- `arena-controller-deployment.yaml` workspace-content-path / extraArgs / terminationGracePeriodSeconds
- Operator `--zap-log-level` / extraArgs pass-through

Kept separate to keep the diff reviewable.

Refs #895