### PR TITLE
fix(release): lowercase owner in cache refs + trivy image-ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,19 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Compute image ref (GHCR requires lowercase)
+        id: ref
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          # github.repository_owner is mixed case (AltairaLabs) but GHCR
+          # rejects any non-lowercase component of an image reference.
+          # docker/metadata-action auto-lowercases the tags it generates,
+          # but raw interpolations into cache-from/cache-to need this
+          # manual lowercase step.
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "image=${REGISTRY}/${owner}/${IMAGE}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -137,7 +150,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}
+          images: ${{ steps.ref.outputs.image }}
           tags: |
             type=semver,pattern={{version}},value=${{ needs.parse-version.outputs.version }}
             type=semver,pattern={{major}}.{{minor}},value=${{ needs.parse-version.outputs.version }},enable=${{ needs.parse-version.outputs.is_prerelease == 'false' }}
@@ -156,8 +169,8 @@ jobs:
           # that 14 parallel matrix jobs trample in `mode=max`; a dedicated
           # `buildcache` tag per image avoids the contention and has no
           # repo-wide cap.
-          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache
-          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:buildcache,mode=max
+          cache-from: type=registry,ref=${{ steps.ref.outputs.image }}:buildcache
+          cache-to: type=registry,ref=${{ steps.ref.outputs.image }}:buildcache,mode=max
           # Generate in-toto SBOM + provenance attestations attached to
           # the pushed manifest. Enables `cosign verify-attestation` and
           # `syft attest` by downstream consumers without any per-repo
@@ -195,10 +208,18 @@ jobs:
           - omnia-policy-proxy
           - omnia-promptkit-lsp
     steps:
+      - name: Compute image ref (GHCR requires lowercase)
+        id: ref
+        env:
+          IMAGE: ${{ matrix.image }}
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "image=${REGISTRY}/${owner}/${IMAGE}" >> "$GITHUB_OUTPUT"
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@v0.35.0
         with:
-          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ matrix.image }}:${{ needs.parse-version.outputs.version }}
+          image-ref: ${{ steps.ref.outputs.image }}:${{ needs.parse-version.outputs.version }}
           format: sarif
           output: trivy-${{ matrix.image }}.sarif
           severity: HIGH,CRITICAL


### PR DESCRIPTION
## Summary
**v0.9.0-beta.7 release workflow is currently failing** (run 24604111006) — every Docker build errors with:

```
failed to configure registry cache exporter: invalid reference format:
repository name (AltairaLabs/omnia-operator) must be lowercase
```

Root cause: the per-image registry cache refs I added in #866 interpolate `${{ github.repository_owner }}` raw. That value is mixed-case (`AltairaLabs`) and GHCR rejects any non-lowercase image ref. `docker/metadata-action` auto-lowercases the tags it emits but not raw `cache-from`/`cache-to` strings.

## Fix
Mirror the pattern already in `docker-push.yml` (fixed in #886):

1. Add a step that computes lowercase owner via bash `${VAR,,}` and emits `steps.ref.outputs.image = ghcr.io/<lowercased>/<image>`.
2. Use that output in `metadata-action.images`, both `cache-from` and `cache-to`, **and the trivy-scan job's `image-ref`** (which had the same latent bug — just wasn't reached because docker-release failed before trivy-scan could run).

## Post-merge
Re-tag after this lands. Either:
- `git tag -d v0.9.0-beta.7 origin/v0.9.0-beta.7 && git push origin :v0.9.0-beta.7` then retag and push, **or**
- Move straight to `v0.9.0-beta.8` (cleaner — keeps the failed tag as historical).

## Test plan
- [ ] This PR's Docker Build Matrix verifies all 14 Dockerfiles still build (no push)
- [ ] After merge, retag or bump to `v0.9.0-beta.8` and confirm all 14 `docker-release` jobs succeed