### PR TITLE
feat(chart): W3b expose LSP / arena-controller / operator tunables

### DIFF
--- a/charts/omnia/templates/arena-controller-deployment.yaml
+++ b/charts/omnia/templates/arena-controller-deployment.yaml
@@ -65,7 +65,7 @@ spec:
             {{- if and .Values.nfs.csiDriver.enabled (or .Values.nfs.server.enabled .Values.nfs.external.server) }}
             - --workspace-storage-class={{ include "omnia.nfsStorageClass" . }}
             {{- end }}
-            - --workspace-content-path=/workspace-content
+            - --workspace-content-path={{ .Values.enterprise.arena.controller.workspaceContentPath | default (.Values.workspaceContent.mountPath | default "/workspace-content") }}
             {{- if .Values.devMode }}
             - --dev-mode
             {{- end }}
@@ -86,6 +86,9 @@ spec:
             - --tracing-endpoint={{ $resolvedTracingEndpoint }}
             {{- end }}
             - --api-bind-address=:{{ ((.Values.enterprise.arena.controller).api).port | default 8082 }}
+            {{- with .Values.enterprise.arena.controller.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: api
               containerPort: {{ ((.Values.enterprise.arena.controller).api).port | default 8082 }}
@@ -153,5 +156,5 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: {{ .Values.enterprise.arena.controller.terminationGracePeriodSeconds | default 10 }}
 {{- end }}

--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -83,6 +83,12 @@ spec:
             - --enterprise
             - --policy-proxy-image={{ .Values.enterprise.policyProxy.image.repository }}:{{ .Values.enterprise.policyProxy.image.tag | default .Chart.AppVersion }}
             {{- end }}
+            {{- if .Values.operator.logLevel }}
+            - --zap-log-level={{ .Values.operator.logLevel }}
+            {{- end }}
+            {{- with .Values.operator.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             {{- if .Values.operator.apiBindAddress }}
             - name: api

--- a/charts/omnia/templates/ee-promptkit-lsp-deployment.yaml
+++ b/charts/omnia/templates/ee-promptkit-lsp-deployment.yaml
@@ -1,5 +1,12 @@
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.enterprise.promptkitLsp.enabled }}
+{{- $lsp := .Values.enterprise.promptkitLsp -}}
+{{- $httpPort := $lsp.port | default 8080 -}}
+{{- $healthPort := $lsp.healthPort | default 8081 -}}
+{{- $dashboardUrl := $lsp.dashboardApiUrl -}}
+{{- if not $dashboardUrl -}}
+  {{- $dashboardUrl = printf "http://%s-dashboard:%d" (include "omnia.fullname" .) (int (.Values.dashboard.service.port | default 3000)) -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,7 +15,7 @@ metadata:
     {{- include "omnia.labels" . | nindent 4 }}
     app.kubernetes.io/component: promptkit-lsp
 spec:
-  replicas: {{ .Values.enterprise.promptkitLsp.replicaCount | default 2 }}
+  replicas: {{ $lsp.replicaCount | default 2 }}
   selector:
     matchLabels:
       {{- include "omnia.selectorLabels" . | nindent 6 }}
@@ -32,40 +39,55 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: lsp
-          image: {{ .Values.enterprise.promptkitLsp.image.repository | default "ghcr.io/altairalabs/omnia-promptkit-lsp" }}:{{ .Values.enterprise.promptkitLsp.image.tag | default .Chart.AppVersion }}
-          imagePullPolicy: {{ .Values.enterprise.promptkitLsp.image.pullPolicy | default "IfNotPresent" }}
+          image: {{ $lsp.image.repository | default "ghcr.io/altairalabs/omnia-promptkit-lsp" }}:{{ $lsp.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: {{ $lsp.image.pullPolicy | default "IfNotPresent" }}
           command:
             - /promptkit-lsp
           args:
-            - --addr=:8080
-            - --health-addr=:8081
-            - --dashboard-api-url=http://{{ include "omnia.fullname" . }}-dashboard:{{ .Values.dashboard.service.port | default 3000 }}
+            - --addr=:{{ $httpPort }}
+            - --health-addr=:{{ $healthPort }}
+            - --dashboard-api-url={{ $dashboardUrl }}
             {{- if .Values.devMode }}
             - --dev-mode
             {{- end }}
+            {{- with $lsp.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
             - name: http
-              containerPort: 8080
+              containerPort: {{ $httpPort }}
               protocol: TCP
             - name: health
-              containerPort: 8081
+              containerPort: {{ $healthPort }}
               protocol: TCP
+          {{- with $lsp.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           livenessProbe:
             httpGet:
               path: /healthz
               port: health
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- with $lsp.livenessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
+            periodSeconds:       {{ .periodSeconds       | default 10 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /readyz
               port: health
-            initialDelaySeconds: 5
-            periodSeconds: 10
+            {{- with $lsp.readinessProbe }}
+            initialDelaySeconds: {{ .initialDelaySeconds | default 5 }}
+            periodSeconds:       {{ .periodSeconds       | default 10 }}
+            timeoutSeconds:      {{ .timeoutSeconds      | default 1 }}
+            failureThreshold:    {{ .failureThreshold    | default 3 }}
+            {{- end }}
           resources:
-            {{- toYaml .Values.enterprise.promptkitLsp.resources | nindent 12 }}
+            {{- toYaml $lsp.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -78,6 +100,6 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      terminationGracePeriodSeconds: 30
+      terminationGracePeriodSeconds: {{ $lsp.terminationGracePeriodSeconds | default 30 }}
 {{- end }}
 {{- end }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -106,6 +106,17 @@ enterprise:
       extraVolumes: []
       # -- Extra volumeMounts on the arena-controller container.
       extraVolumeMounts: []
+      # -- Extra command-line args appended to the arena-controller binary.
+      # Use for undocumented Go flags or feature toggles not yet surfaced by
+      # first-class values.
+      extraArgs: []
+      # -- Host path the arena-controller mounts the shared workspace content
+      # at. Defaults to `workspaceContent.mountPath` (`/workspace-content`),
+      # which matches the rest of the Omnia stack. Override only if you
+      # remount content under a non-default path inside the pod.
+      workspaceContentPath: ""
+      # -- Graceful-shutdown window in seconds.
+      terminationGracePeriodSeconds: 10
 
     # Worker configuration for ArenaJob execution
     worker:
@@ -246,6 +257,33 @@ enterprise:
     service:
       # -- PromptKit LSP service port
       port: 8080
+    # -- Container HTTP port (passed as `--addr=:<port>`).
+    port: 8080
+    # -- Container health-probe port (passed as `--health-addr=:<port>`).
+    healthPort: 8081
+    # -- Dashboard API URL the LSP calls for runtime data.
+    # Leave empty to auto-construct from the in-release dashboard Service
+    # (`http://<release>-dashboard:<dashboard.service.port>`). Set explicitly
+    # when the dashboard lives in a different release or namespace.
+    dashboardApiUrl: ""
+    # -- Extra command-line args appended to the LSP binary.
+    extraArgs: []
+    # -- Extra environment variables for the LSP container.
+    extraEnv: []
+    # -- Liveness probe tuning.
+    livenessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+    # -- Readiness probe tuning.
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
+      timeoutSeconds: 1
+      failureThreshold: 3
+    # -- Graceful-shutdown window in seconds.
+    terminationGracePeriodSeconds: 30
     resources: {}
 
 # License configuration
@@ -356,6 +394,16 @@ operator:
   # -- Bind address for the operator API server (tool testing).
   # Set to a port like ":8083" to enable, or leave empty to disable.
   apiBindAddress: ""
+
+  # -- controller-runtime zap logger verbosity. One of:
+  # "" (operator default), "debug", "info", "warn", "error". Set to "debug"
+  # when chasing a reconciler issue; revert for production.
+  logLevel: ""
+
+  # -- Extra command-line args appended to the manager binary. Use for
+  # undocumented Go flags that don't yet have a first-class values entry
+  # (e.g. reconciler worker counts, webhook cert paths).
+  extraArgs: []
 
   # -- Extra environment variables to inject into the operator container.
   # Standard Kubernetes EnvVar shape (each entry has `name` + `value` or


### PR DESCRIPTION
## Summary

W3b of the chart overhaul ([#895](https://github.com/AltairaLabs/Omnia/issues/895)). Completes the "no more hardcoded tunables" workstream — W3a covered dev-postgres / eval-worker / doctor; this finishes LSP / arena-controller / operator. All defaults preserved.

### ee-promptkit-lsp

- `enterprise.promptkitLsp.port` / `healthPort` — previously `:8080` / `:8081` baked into `--addr=` args. Multi-release setups needed to fork.
- `enterprise.promptkitLsp.dashboardApiUrl` — previously auto-constructed with `http://<release>-dashboard:<port>`; **broke in multi-release setups** where the dashboard lives elsewhere. Empty default still auto-constructs the old value; set explicitly to override.
- `enterprise.promptkitLsp.{livenessProbe,readinessProbe}` tuning
- `enterprise.promptkitLsp.terminationGracePeriodSeconds`
- `enterprise.promptkitLsp.extraArgs` / `extraEnv`

### arena-controller

- `enterprise.arena.controller.workspaceContentPath` — previously hardcoded `/workspace-content`; could drift from the operator's values-driven `workspaceContent.mountPath`. Default now falls through to the same value.
- `enterprise.arena.controller.extraArgs` — pass-through for undocumented Go flags.
- `enterprise.arena.controller.terminationGracePeriodSeconds`

### operator

- `operator.logLevel` — wires to `--zap-log-level`. Regulated-environment users can now tune verbosity without forking.
- `operator.extraArgs` — pass-through for reconciler worker counts, webhook cert paths, or other undocumented flags.

### Validated overrides

```
--set enterprise.promptkitLsp.port=9080            -> --addr=:9080
--set enterprise.promptkitLsp.dashboardApiUrl=X    -> --dashboard-api-url=X
--set operator.logLevel=debug                      -> --zap-log-level=debug
--set 'operator.extraArgs={--foo,--bar=baz}'       -> both rendered
--set enterprise.arena.controller.workspaceContentPath=/mnt/x -> --workspace-content-path=/mnt/x
```

- `helm lint --strict` clean
- `helm template` default + enterprise renders byte-identical to before

### With #900 merged, W3 complete

No more hardcoded probe timings, image tags, resources, ports, or discovery URLs in any chart-owned template. Platform teams can tune every knob via values.

Refs #895