### PR TITLE
docs(chart): W5 examples library — 8 worked values files

### DIFF
--- a/charts/omnia/examples/README.md
+++ b/charts/omnia/examples/README.md
@@ -1,0 +1,56 @@
+# Omnia chart — values examples
+
+Worked values files for common deployment shapes. Each is intended as a starting point — copy, edit the `# EDIT:` markers, deploy.
+
+| File | Scenario |
+|---|---|
+| `values-minimal.yaml` | Smallest possible install. In-cluster dev-postgres, NFS, anonymous dashboard. Works on kind / k3d / Docker Desktop. |
+| `values-prod-oauth.yaml` | OSS production: OAuth, external Postgres, external RWX storage. Multi-replica operator + dashboard. |
+| `values-prod-enterprise.yaml` | Enterprise production: license + Arena + Redis queue. Layer on top of `values-prod-oauth.yaml`. |
+| `values-azure-kv-csi.yaml` | Azure Workload Identity + Key Vault via CSI secret-store driver. Overlay — combine with `values-prod-oauth.yaml`. |
+| `values-aws-irsa.yaml` | AWS IRSA + S3 cold archive + Secrets Manager CSI. Overlay. |
+| `values-gke-workload-identity.yaml` | GKE Workload Identity + Cloud SQL + GCS. Overlay. |
+| `values-observability-all-in.yaml` | Enables Prometheus, Grafana, Loki, Tempo, Alloy subcharts. Overlay. |
+| `values-istio-ambient.yaml` | Istio ambient mode + Gateway API. Overlay. |
+
+## How to combine
+
+Helm applies `-f` arguments left-to-right; later files override earlier ones.
+
+```bash
+# Dev (local)
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+  -f charts/omnia/examples/values-minimal.yaml
+
+# OSS prod on AWS with IRSA
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+  -f charts/omnia/examples/values-prod-oauth.yaml \
+  -f charts/omnia/examples/values-aws-irsa.yaml
+
+# Enterprise on Azure with KV + observability
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+  -f charts/omnia/examples/values-prod-oauth.yaml \
+  -f charts/omnia/examples/values-prod-enterprise.yaml \
+  -f charts/omnia/examples/values-azure-kv-csi.yaml \
+  -f charts/omnia/examples/values-observability-all-in.yaml
+```
+
+## Secrets
+
+These examples **do not embed secrets** — every place a credential would go is marked `EDIT:` or references a `*-existingSecret` field. Use one of:
+
+- `kubectl create secret` (quick start)
+- Sealed Secrets / SOPS / External Secrets Operator (GitOps)
+- CSI secret-store driver from your cloud (see `values-azure-kv-csi.yaml`, `values-aws-irsa.yaml`)
+
+Never commit real credentials.
+
+## Testing
+
+Before shipping:
+
+```bash
+helm template omnia charts/omnia -f charts/omnia/examples/<file>.yaml | kubeconform -strict -ignore-missing-schemas
+```
+
+The [#895 W6](https://github.com/AltairaLabs/Omnia/issues/895) CI gates will run this on every PR once landed.

--- a/charts/omnia/examples/values-aws-irsa.yaml
+++ b/charts/omnia/examples/values-aws-irsa.yaml
@@ -1,0 +1,98 @@
+# AWS IRSA + Secrets Manager CSI. OVERLAY on `values-prod-oauth.yaml`.
+#
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     -f charts/omnia/examples/values-prod-oauth.yaml \
+#     -f charts/omnia/examples/values-aws-irsa.yaml
+#
+# Pre-reqs:
+#   - EKS cluster with OIDC provider enabled
+#   - IAM roles created and trust-policied for each of the SAs below
+#   - AWS Secrets Manager CSI driver installed
+#   - SecretProviderClass resources that sync from Secrets Manager into
+#     Kubernetes Secrets (omnia-oauth, omnia-dashboard-session, etc.)
+
+# --- IRSA annotations on the chart-owned ServiceAccount ------------------
+serviceAccount:
+  create: true
+  annotations:
+    # EDIT: replace with your IAM role ARN
+    eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/omnia-operator"
+
+# --- Operator + dashboard mount secrets from CSI -------------------------
+
+dashboard:
+  extraVolumes:
+    - name: aws-sm
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: omnia-dashboard-spc
+  extraVolumeMounts:
+    - name: aws-sm
+      mountPath: /mnt/aws-sm
+      readOnly: true
+  extraEnvFrom:
+    - secretRef:
+        name: omnia-oauth
+    - secretRef:
+        name: omnia-dashboard-session
+
+operator:
+  extraVolumes:
+    - name: aws-sm
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: omnia-operator-spc
+  extraVolumeMounts:
+    - name: aws-sm
+      mountPath: /mnt/aws-sm
+      readOnly: true
+
+# --- Workspace content on EFS (RWX) ---------------------------------------
+workspaceContent:
+  enabled: true
+  persistence:
+    storageClass: efs-sc
+    accessModes:
+      - ReadWriteMany
+    size: 100Gi
+
+# --- Image pull from ECR --------------------------------------------------
+# Use IRSA for pull too — or attach imagePullSecrets here:
+#   imagePullSecrets:
+#     - name: ecr-creds
+
+# --- CRD pods ------------------------------------------------------------
+#
+# Set podOverrides on Workspace + AgentRuntime to get IRSA on the
+# operator-generated pods. Minimum needed on each Workspace service:
+#
+# apiVersion: omnia.altairalabs.ai/v1alpha1
+# kind: Workspace
+# metadata:
+#   name: prod
+# spec:
+#   services:
+#     - name: default
+#       mode: managed
+#       session:
+#         database:
+#           secretRef:
+#             name: session-db   # synced by a Workspace-level SPC
+#         podOverrides:
+#           serviceAccountName: omnia-session-irsa
+#           extraVolumes:
+#             - name: aws-sm
+#               csi:
+#                 driver: secrets-store.csi.k8s.io
+#                 readOnly: true
+#                 volumeAttributes:
+#                   secretProviderClass: session-db-spc
+#           extraEnvFrom:
+#             - secretRef:
+#                 name: session-db
+#       memory:
+#         # same shape

--- a/charts/omnia/examples/values-azure-kv-csi.yaml
+++ b/charts/omnia/examples/values-azure-kv-csi.yaml
@@ -1,0 +1,108 @@
+# Azure Key Vault via CSI Secret Store + Workload Identity.
+#
+# OVERLAY on `values-prod-oauth.yaml`. Example:
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     -f charts/omnia/examples/values-prod-oauth.yaml \
+#     -f charts/omnia/examples/values-azure-kv-csi.yaml
+#
+# Pre-reqs in the cluster:
+#   - Azure CSI secret-store driver installed
+#   - AKS workload-identity addon enabled
+#   - A ServiceAccount federated to a User-Assigned Managed Identity:
+#       kubectl apply -f - <<EOF
+#       apiVersion: v1
+#       kind: ServiceAccount
+#       metadata:
+#         name: omnia-wli
+#         namespace: <release-namespace>
+#         annotations:
+#           azure.workload.identity/client-id: "<MI client-id>"
+#       EOF
+#   - A SecretProviderClass in the release namespace that mounts your
+#     Key Vault secrets; populate .secretObjects so CSI syncs into a
+#     K8s Secret (say, `omnia-oauth`, `omnia-dashboard-session`).
+#     Example SPC: https://omnia.altairalabs.ai/docs/how-to/azure-kv-csi
+
+# --- Chart-owned deployments ----------------------------------------------
+#
+# Dashboard + operator mount the CSI volume so rotation is automatic.
+
+dashboard:
+  extraVolumes:
+    - name: azure-kv
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: omnia-dashboard-spc
+  extraVolumeMounts:
+    - name: azure-kv
+      mountPath: /mnt/azure-kv
+      readOnly: true
+  # envFrom pulls the K8s Secret that the SPC `secretObjects` created.
+  extraEnvFrom:
+    - secretRef:
+        name: omnia-oauth
+    - secretRef:
+        name: omnia-dashboard-session
+
+operator:
+  extraVolumes:
+    - name: azure-kv
+      csi:
+        driver: secrets-store.csi.k8s.io
+        readOnly: true
+        volumeAttributes:
+          secretProviderClass: omnia-operator-spc
+  extraVolumeMounts:
+    - name: azure-kv
+      mountPath: /mnt/azure-kv
+      readOnly: true
+
+# --- Workload identity on chart-owned Service Accounts ---------------------
+serviceAccount:
+  create: true
+  annotations:
+    azure.workload.identity/use: "true"
+  # Optional: reuse an externally-managed SA instead of creating one.
+  # name: omnia-wli
+
+# Pod labels required by AKS workload identity
+# (applied via the per-pod annotations mechanism — the operator SA above is
+# sufficient for the chart-owned pods)
+
+# --- CRD pods (facade/runtime, session-api, memory-api, arena workers) ----
+#
+# Set `podOverrides:` on the relevant CRs, NOT here. Example AgentRuntime:
+#
+# apiVersion: omnia.altairalabs.ai/v1alpha1
+# kind: AgentRuntime
+# metadata:
+#   name: my-agent
+# spec:
+#   promptPackRef:
+#     name: my-promptpack
+#   facade:
+#     type: websocket
+#   podOverrides:
+#     serviceAccountName: omnia-wli
+#     labels:
+#       azure.workload.identity/use: "true"
+#     extraVolumes:
+#       - name: azure-kv
+#         csi:
+#           driver: secrets-store.csi.k8s.io
+#           readOnly: true
+#           volumeAttributes:
+#             secretProviderClass: agent-provider-spc
+#     extraVolumeMounts:
+#       - name: azure-kv
+#         mountPath: /mnt/azure-kv
+#         readOnly: true
+#     extraEnvFrom:
+#       - secretRef:
+#           name: agent-provider-keys
+#
+# Workspace.spec.services[].session.podOverrides + .memory.podOverrides take
+# the same shape — use them to inject DB passwords from Key Vault into the
+# per-workspace session-api / memory-api pods.

--- a/charts/omnia/examples/values-gke-workload-identity.yaml
+++ b/charts/omnia/examples/values-gke-workload-identity.yaml
@@ -1,0 +1,61 @@
+# GKE Workload Identity + Cloud SQL + GCS. OVERLAY on `values-prod-oauth.yaml`.
+#
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     -f charts/omnia/examples/values-prod-oauth.yaml \
+#     -f charts/omnia/examples/values-gke-workload-identity.yaml
+#
+# Pre-reqs:
+#   - GKE cluster with Workload Identity enabled
+#   - Google Service Account (GSA) bound to the Kubernetes SA below
+#     via `iam.gke.io/gcp-service-account` annotation
+#   - Google Cloud Secret Manager CSI driver (optional) OR External Secrets
+#     Operator syncing into K8s Secrets
+#   - Filestore or similar RWX storage class provisioned
+
+# --- Workload Identity SA -------------------------------------------------
+serviceAccount:
+  create: true
+  annotations:
+    # EDIT: replace with your GSA email
+    iam.gke.io/gcp-service-account: "omnia-operator@my-project.iam.gserviceaccount.com"
+
+# --- Cloud SQL connection (via Auth Proxy sidecar on each Workspace pod) ---
+#
+# Cloud SQL auth proxy is typically injected as a podOverrides sidecar on
+# each session-api / memory-api pod rather than chart-wide. Example on a
+# Workspace CR (set podOverrides on each managed service):
+#
+#   spec:
+#     services:
+#       - name: default
+#         session:
+#           database:
+#             secretRef:
+#               name: session-db-creds
+#           podOverrides:
+#             serviceAccountName: omnia-session-wli
+#             # Cloud SQL Auth Proxy would normally be a sidecar — for that
+#             # you need per-container injection which PodOverrides doesn't
+#             # yet cover. Workaround: connect session-api directly via
+#             # private IP using Workspace.spec.services[].session.database
+#             # pointing at a Secret that contains the private-IP connection
+#             # string.
+
+# --- Workspace content on Filestore ---------------------------------------
+workspaceContent:
+  enabled: true
+  persistence:
+    # EDIT: must match your Filestore StorageClass
+    storageClass: filestore-sc
+    accessModes:
+      - ReadWriteMany
+    size: 100Gi
+
+# --- Artifact Registry image pull -----------------------------------------
+# IRSA-equivalent on GKE: Workload Identity already covers Artifact Registry
+# pulls for the SA, no imagePullSecrets needed in typical setups.
+
+# --- CRD pods -----------------------------------------------------------
+# Same podOverrides pattern as the AWS / Azure examples. Set
+# `serviceAccountName` on the CRD's podOverrides to federate cloud identity
+# into the operator-generated pods.

--- a/charts/omnia/examples/values-istio-ambient.yaml
+++ b/charts/omnia/examples/values-istio-ambient.yaml
@@ -1,0 +1,56 @@
+# Istio ambient mode (sidecarless) + Gateway API.
+# OVERLAY on `values-prod-oauth.yaml`:
+#
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     -f charts/omnia/examples/values-prod-oauth.yaml \
+#     -f charts/omnia/examples/values-istio-ambient.yaml
+#
+# Pre-reqs in the cluster:
+#   - Istio 1.22+ installed with ambient profile (`istioctl install --set profile=ambient`)
+#   - Gateway API v1.1+ CRDs installed
+#   - ztunnel + waypoint running in the dataplane
+
+# --- Opt pods into the ambient mesh -----------------------------------------
+#
+# Ambient mode reads the label `istio.io/dataplane-mode: ambient` on the
+# pod's NAMESPACE or pod itself. The simplest path: label the release
+# namespace once post-install:
+#
+#   kubectl label namespace <release-ns> istio.io/dataplane-mode=ambient
+#
+# If you prefer per-pod opt-in, use podAnnotations / podOverrides
+# (example below).
+
+# --- Gateway (ambient-ready) ------------------------------------------------
+gateway:
+  enabled: true
+  className: istio                # Istio's Gateway controller
+  listeners:
+    http:
+      port: 80
+      protocol: HTTP
+    https:
+      enabled: true
+      port: 443
+      protocol: HTTPS
+      tlsSecretName: omnia-tls    # EDIT
+  annotations:
+    # Force ambient-mode routing for this gateway instance
+    networking.istio.io/traffic-distribution: "PreferClose"
+
+# --- Internal gateway (observability tools) ---------------------------------
+internalGateway:
+  enabled: true
+  className: istio
+
+# --- Chart-owned pods join ambient mesh via label --------------------------
+#
+# These labels propagate to the pod and let ztunnel adopt them as waypoint
+# clients. Ambient doesn't need a sidecar, so no init-container noise.
+
+dashboard:
+  extraEnv: []  # keep as-is; ambient is an L7 concern, not a container concern
+
+# Nothing else to set — ambient is configured at the namespace / ztunnel level.
+# Omnia's operator-generated pods (facade/runtime, session-api, etc.)
+# inherit the namespace's dataplane mode automatically.

--- a/charts/omnia/examples/values-minimal.yaml
+++ b/charts/omnia/examples/values-minimal.yaml
@@ -1,0 +1,54 @@
+# Smallest possible Omnia install — works on kind / k3d / Docker Desktop.
+#
+# What you get:
+#   - Operator (1 replica), dashboard (1 replica, anonymous auth)
+#   - Dev Postgres + PgBouncer in-cluster (NOT FOR PRODUCTION — no persistence)
+#   - No enterprise, no observability, no external storage
+#
+# Install:
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     -f charts/omnia/examples/values-minimal.yaml
+#
+# For anything closer to production use, start from `values-prod-oauth.yaml`.
+
+replicaCount: 1
+
+# Disable PDBs — with replicaCount:1 a PDB+minAvailable:1 would
+# permanently block every eviction.
+podDisruptionBudget:
+  enabled: false
+
+dashboard:
+  replicaCount: 1
+  podDisruptionBudget:
+    enabled: false
+  auth:
+    # Anonymous mode — disables authentication entirely. DEV ONLY.
+    mode: anonymous
+    # Explicit opt-in required when mode=anonymous.
+    allowAnonymous: true
+
+postgres:
+  dev:
+    enabled: true
+    pgbouncer:
+      enabled: true
+
+# All optional subcharts off — default behavior, listed here for clarity.
+enterprise:
+  enabled: false
+prometheus:
+  enabled: false
+grafana:
+  enabled: false
+loki:
+  enabled: false
+tempo:
+  enabled: false
+alloy:
+  enabled: false
+nfs:
+  server:
+    enabled: false
+  csiDriver:
+    enabled: false

--- a/charts/omnia/examples/values-observability-all-in.yaml
+++ b/charts/omnia/examples/values-observability-all-in.yaml
@@ -1,0 +1,68 @@
+# Enable the full observability stack (Prometheus, Grafana, Loki, Tempo, Alloy).
+# OVERLAY on any base profile:
+#
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     -f charts/omnia/examples/values-prod-oauth.yaml \
+#     -f charts/omnia/examples/values-observability-all-in.yaml
+#
+# Each subchart has its own tuning surface; this file just enables them with
+# opinionated defaults suitable for a small-to-medium prod cluster.
+#
+# For large clusters you almost certainly want a pre-existing observability
+# platform (managed Prometheus, Grafana Cloud, Datadog, etc.) — skip this
+# file and configure Omnia's `tracing.endpoint` + metrics scrape directly.
+
+observability:
+  enabled: true
+
+tracing:
+  enabled: true
+  # Tempo endpoint auto-constructed when tempo.enabled=true below.
+  # Override to point at Grafana Cloud / Honeycomb / etc.
+  endpoint: ""
+
+prometheus:
+  enabled: true
+  server:
+    retention: 15d
+    persistentVolume:
+      size: 20Gi
+      # EDIT: storage class
+      storageClass: ""
+  serviceMonitor:
+    enabled: true
+
+grafana:
+  enabled: true
+  # EDIT: admin password OR reference an existing secret via adminPassword: ""
+  # and provide an externalSecret above.
+  adminPassword: "CHANGE_ME"
+  persistence:
+    enabled: true
+    size: 2Gi
+
+loki:
+  enabled: true
+  # minio-backed in single-binary mode for getting started; plug into S3/GCS
+  # for serious installs.
+  singleBinary:
+    replicas: 1
+    persistence:
+      enabled: true
+      size: 20Gi
+
+tempo:
+  enabled: true
+  persistence:
+    enabled: true
+    size: 20Gi
+
+alloy:
+  enabled: true
+
+# Internal gateway to expose Grafana / Prometheus inside the cluster
+# (or behind a VPN). Do NOT enable external gateway for these unless you
+# have auth in front.
+internalGateway:
+  enabled: true
+  className: istio

--- a/charts/omnia/examples/values-prod-enterprise.yaml
+++ b/charts/omnia/examples/values-prod-enterprise.yaml
@@ -1,0 +1,57 @@
+# Enterprise features. OVERLAY on `values-prod-oauth.yaml`:
+#
+#   helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
+#     -f charts/omnia/examples/values-prod-oauth.yaml \
+#     -f charts/omnia/examples/values-prod-enterprise.yaml
+#
+# Pre-reqs:
+#   1. An Omnia Enterprise license. Generate at https://omnia.altairalabs.ai/trial
+#      or via your license server.
+#
+# Secrets to create before install:
+#   kubectl create secret generic omnia-license \
+#     --from-literal=license=<JWT>
+
+license:
+  existingSecret: omnia-license
+
+enterprise:
+  enabled: true
+
+  # Community templates fetch from github.com on each sync — disabled by
+  # default for air-gap safety. Enable if you want the gallery.
+  communityTemplates:
+    enabled: false   # EDIT: true if you want community prompt templates
+
+  arena:
+    # Redis-backed queue; use `memory` for single-replica dev only.
+    queue:
+      type: redis
+      redis:
+        host: "omnia-redis-master"
+        port: 6379
+
+  # LSP server powers autocomplete + validation in the dev console.
+  promptkitLsp:
+    enabled: true
+    replicaCount: 2
+
+  # Eval worker for realtime session evals (non-PromptKit agents).
+  evalWorker:
+    enabled: true
+
+# --- Dependencies ---------------------------------------------------------
+
+# Arena queue backing store
+redis:
+  enabled: true
+  architecture: standalone
+  auth:
+    # EDIT: enable auth in real production via secret
+    enabled: false
+  master:
+    persistence:
+      enabled: true
+      size: 8Gi
+      # EDIT: RWO storage class
+      storageClass: ""

--- a/charts/omnia/examples/values-prod-oauth.yaml
+++ b/charts/omnia/examples/values-prod-oauth.yaml
@@ -1,0 +1,99 @@
+# Production OSS Omnia: OAuth, external Postgres, external RWX storage,
+# multi-replica operator + dashboard. No enterprise / Arena.
+#
+# Pre-reqs before install:
+#   1. An OAuth client (GitHub App, Google OAuth, Okta, Azure AD, or generic).
+#   2. A Postgres instance reachable from the cluster (RDS, Cloud SQL,
+#      AlloyDB, Azure Database for PostgreSQL, etc.). Pgvector extension
+#      required for memory-api embeddings.
+#   3. An RWX storage class in the cluster (EFS, Azure Files, Filestore, etc.).
+#
+# Secrets to create OUT-OF-BAND before install:
+#   kubectl create secret generic omnia-oauth \
+#     --from-literal=client-id=<client-id> \
+#     --from-literal=client-secret=<client-secret>
+#   kubectl create secret generic omnia-dashboard-session \
+#     --from-literal=session-secret=<random-base64>
+
+# --- Operator / Dashboard HA ------------------------------------------------
+
+replicaCount: 3
+
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 2
+
+dashboard:
+  replicaCount: 2
+  podDisruptionBudget:
+    enabled: true
+
+  # --- OAuth ---------------------------------------------------------------
+  auth:
+    mode: oauth
+    sessionSecretExistingSecret: omnia-dashboard-session  # key: session-secret
+  oauth:
+    # EDIT: provider + details
+    provider: github
+    clientIdExistingSecret: omnia-oauth          # key: client-id
+    clientSecretExistingSecret: omnia-oauth      # key: client-secret
+
+  # Persistent dashboard storage for session cookies across restarts
+  persistence:
+    enabled: true
+    size: 1Gi
+    # EDIT: your RWO storage class (ebs-gp3, pd-standard, etc.)
+    storageClass: ""
+
+  # Behind an external load balancer / ingress — use Gateway API
+  service:
+    type: ClusterIP
+
+# --- No dev-postgres in production ----------------------------------------
+postgres:
+  dev:
+    enabled: false
+
+# --- Workspace content requires RWX ----------------------------------------
+workspaceContent:
+  enabled: true
+  persistence:
+    # EDIT: set to your cluster's RWX class
+    #   AWS:   efs-sc              (with EFS CSI driver)
+    #   Azure: azurefile-csi-nfs   (with Azure File NFS CSI)
+    #   GCP:   filestore-sc        (with Filestore CSI)
+    storageClass: ""
+    accessModes:
+      - ReadWriteMany
+    size: 100Gi
+
+# --- External gateway (public) --------------------------------------------
+gateway:
+  enabled: true
+  # EDIT: className must match your cluster's Gateway controller
+  #   Istio:         istio
+  #   Envoy Gateway: envoy
+  #   GKE:           gke-l7-rilb
+  #   EKS ALB:       eks-alb
+  className: istio
+  listeners:
+    http:
+      port: 80
+      protocol: HTTP
+    https:
+      enabled: true
+      port: 443
+      protocol: HTTPS
+      # EDIT: TLS secret name in the release namespace
+      tlsSecretName: omnia-tls
+
+# --- Optional: subcharts off by default ------------------------------------
+# Overlay `values-observability-all-in.yaml` if you want them on.
+prometheus: { enabled: false }
+grafana:    { enabled: false }
+loki:       { enabled: false }
+tempo:      { enabled: false }
+alloy:      { enabled: false }
+
+enterprise:
+  enabled: false


### PR DESCRIPTION
## Summary

W5 of the chart overhaul ([#895](https://github.com/AltairaLabs/Omnia/issues/895)). Adds `charts/omnia/examples/` with worked values files for the common deployment shapes.

| File | Scenario | Use |
|------|---------|-----|
| `values-minimal.yaml` | kind/k3d/Docker Desktop | standalone |
| `values-prod-oauth.yaml` | OSS production (OAuth + external Postgres + RWX) | base |
| `values-prod-enterprise.yaml` | Enterprise + Arena + Redis | overlay |
| `values-azure-kv-csi.yaml` | Azure Workload Identity + KV CSI | overlay |
| `values-aws-irsa.yaml` | AWS IRSA + EFS + Secrets Manager CSI | overlay |
| `values-gke-workload-identity.yaml` | GKE WLI + Filestore | overlay |
| `values-observability-all-in.yaml` | Prometheus/Grafana/Loki/Tempo/Alloy | overlay |
| `values-istio-ambient.yaml` | Istio ambient mesh + Gateway API | overlay |

Plus `examples/README.md` that explains how to combine the files, secret-management patterns, and where to test renders.

### Validation

All 8 files render cleanly via `helm template`:
- `values-minimal.yaml` and `values-prod-oauth.yaml` standalone
- The 6 overlay files combined with `values-prod-oauth.yaml` (their documented usage)

Overlays intentionally do NOT set `dashboard.auth.mode` — they don't stand alone. Each file header + `examples/README.md` makes this explicit.

### Secrets

Every credential placeholder is marked `EDIT:` or references an `existingSecret` field. No real secrets committed. Secret management patterns discussed in the README (Sealed Secrets, SOPS, External Secrets Operator, CSI secret-stores).

### Follow-up (W6)

CI gates will enforce:
- `helm template <example> | kubeconform` per file
- `helm lint --strict` per file
- `helm-docs` sync check on any `values.yaml` change

Refs #895