### PR TITLE
chore(chart): bump to v0.9.0-beta.8

### DIFF
--- a/charts/omnia/Chart.yaml
+++ b/charts/omnia/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version / appVersion track the last git-tagged release. When cutting a
 # new release, bump both in a commit before tagging. The release workflow
 # also rewrites these at package-time as a safety net.
-version: 0.9.0-beta.7
-appVersion: "0.9.0-beta.7"
+version: 0.9.0-beta.8
+appVersion: "0.9.0-beta.8"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/AltairaLabs/Omnia
 sources:


### PR DESCRIPTION
Post-release Chart.yaml bump for v0.9.0-beta.8.

Opened automatically by the `release` workflow after a successful
tag build. Keeps `main`-at-rest in sync with the latest published
chart so `helm template charts/omnia` resolves real image tags.