### PR TITLE
ci(chart): W6 wire helm-unittest + example renders into CI

### DIFF
--- a/.github/workflows/test-helm-e2e.yml
+++ b/.github/workflows/test-helm-e2e.yml
@@ -539,11 +539,32 @@ jobs:
           helm dependency build ./charts/omnia
 
       - name: Lint chart
-        # dashboard.auth.mode is schema-required (no default, by design).
-        # Pass a placeholder so the lint can proceed; real installs set it
-        # explicitly per the README.
+        # dashboard.auth.mode has no default by design. values-chart-tests.yaml
+        # supplies a valid (anonymous + allowAnonymous) mode for rendering.
         run: |
-          helm lint ./charts/omnia --set dashboard.auth.mode=oauth
+          helm lint ./charts/omnia -f ./charts/omnia/values-chart-tests.yaml
+
+      - name: helm-unittest
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.8.2 || true
+          helm unittest ./charts/omnia
+
+      - name: Render every example file
+        # Each file in charts/omnia/examples/ should render cleanly. Overlay
+        # files must be combined with values-prod-oauth.yaml per their headers.
+        run: |
+          set -e
+          cd charts/omnia
+          echo "=== standalone examples ==="
+          for f in examples/values-minimal.yaml examples/values-prod-oauth.yaml; do
+            echo "--- $f ---"
+            helm template omnia . -f "$f" > /dev/null
+          done
+          echo "=== overlay examples (combined with values-prod-oauth.yaml) ==="
+          for f in examples/values-prod-enterprise.yaml examples/values-azure-kv-csi.yaml examples/values-aws-irsa.yaml examples/values-gke-workload-identity.yaml examples/values-observability-all-in.yaml examples/values-istio-ambient.yaml; do
+            echo "--- $f (overlay on values-prod-oauth.yaml) ---"
+            helm template omnia . -f examples/values-prod-oauth.yaml -f "$f" > /dev/null
+          done
 
       - name: Validate chart metadata
         run: |

--- a/charts/omnia/tests/deployment-injection-hooks_test.yaml
+++ b/charts/omnia/tests/deployment-injection-hooks_test.yaml
@@ -1,6 +1,14 @@
 suite: deployment injection hooks
 # Covers issue #842 — extraVolumes / extraVolumeMounts / extraEnv /
 # extraEnvFrom hooks on the three chart-owned Deployments.
+#
+# Suite-wide values: the chart's _helpers.tpl omnia.validateAuth gates
+# renders on an explicit dashboard.auth.mode when dashboard.enabled=true
+# (default). Load the canonical chart-test values file so every test
+# starts from a valid auth config; individual tests can still override
+# with per-test `set:` blocks.
+values:
+  - ../values-chart-tests.yaml
 tests:
   # --- Dashboard ---
   - it: dashboard injects extraEnv onto the container


### PR DESCRIPTION
## Summary

W6 of the chart overhaul ([#895](https://github.com/AltairaLabs/Omnia/issues/895)). Fix the chart's unittest suite (broken by the mandatory auth-mode guardrail) and wire it into CI, plus add per-example render validation.

### Changes

1. **Fix `charts/omnia/tests/deployment-injection-hooks_test.yaml`.** Added suite-level `values: [../values-chart-tests.yaml]`. 8 of 26 tests were erroring because `omnia.validateAuth` aborted rendering whenever `dashboard.auth.mode` was unset — that file supplies a valid `anonymous + allowAnonymous: true` combo for rendering. All 26 tests now pass.

2. **Add `helm-unittest` step** to the `Helm Lint` job in `test-helm-e2e.yml`. Installs the plugin and runs the suite; fails on any assertion regression.

3. **Add example-render matrix** to the same job. Runs `helm template` on each `charts/omnia/examples/*.yaml`:
   - `values-minimal.yaml` + `values-prod-oauth.yaml` standalone
   - 6 overlay files combined with `values-prod-oauth.yaml` per their documented usage

4. **Tighten `helm lint`** to use `-f values-chart-tests.yaml` (matches the render-validation steps; would still pass without it, but avoids a latent trap if the schema empty-string allowance is ever tightened).

### Validated locally

- `helm unittest charts/omnia` → 26/26 pass
- All 8 example files render cleanly in the documented combinations

### Deferred to follow-up

- `helm-docs` README values-table sync check
- `kubeconform` against upstream OpenAPI schemas (need subchart schema bundle)

Refs #895