### PR TITLE
feat(chart): W4a unified podOverrides on operator deployment

### DIFF
--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -1,6 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 {{- $resolvedTracingEndpoint := include "omnia.tracing.endpoint" . | trim }}
+{{- $po := .Values.operator.podOverrides | default dict }}
 metadata:
   name: {{ include "omnia.fullname" . }}-controller-manager
   labels:
@@ -25,15 +26,25 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with $po.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
+        {{- with $po.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "omnia.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: controller-manager
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- $pullSecrets := concat (.Values.imagePullSecrets | default list) ($po.imagePullSecrets | default list) }}
+      {{- with $pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "omnia.serviceAccountName" . }}
+      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.serviceAccountName" .) }}
+      {{- with $po.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
         {{- if not (hasKey .Values.podSecurityContext "fsGroup") }}
@@ -125,45 +136,59 @@ spec:
             failureThreshold: {{ .Values.probes.readiness.failureThreshold | default 3 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- with .Values.operator.extraEnv }}
+          {{- $env := concat (.Values.operator.extraEnv | default list) ($po.extraEnv | default list) }}
+          {{- with $env }}
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.operator.extraEnvFrom }}
+          {{- $envFrom := concat (.Values.operator.extraEnvFrom | default list) ($po.extraEnvFrom | default list) }}
+          {{- with $envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if or .Values.workspaceContent.enabled .Values.operator.extraVolumeMounts }}
+          {{- $vmMounts := concat (.Values.operator.extraVolumeMounts | default list) ($po.extraVolumeMounts | default list) }}
+          {{- if or .Values.workspaceContent.enabled $vmMounts }}
           volumeMounts:
             {{- if .Values.workspaceContent.enabled }}
             - name: workspace-content
               mountPath: {{ .Values.workspaceContent.mountPath | default "/workspace-content" }}
             {{- end }}
-            {{- with .Values.operator.extraVolumeMounts }}
+            {{- with $vmMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- end }}
-      {{- if or .Values.workspaceContent.enabled .Values.operator.extraVolumes }}
+      {{- $volumes := concat (.Values.operator.extraVolumes | default list) ($po.extraVolumes | default list) }}
+      {{- if or .Values.workspaceContent.enabled $volumes }}
       volumes:
         {{- if .Values.workspaceContent.enabled }}
         - name: workspace-content
           persistentVolumeClaim:
             claimName: {{ .Values.workspaceContent.persistence.existingClaim | default (printf "%s-workspace-content" (include "omnia.fullname" .)) }}
         {{- end }}
-        {{- with .Values.operator.extraVolumes }}
+        {{- with $volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- /* nodeSelector: user keys merged over chart-wide defaults (user wins). */}}
+      {{- $nodeSelector := mergeOverwrite (deepCopy (.Values.nodeSelector | default dict)) ($po.nodeSelector | default dict) }}
+      {{- with $nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- /* affinity: podOverrides replaces chart-wide when set. */}}
+      {{- $affinity := $po.affinity | default .Values.affinity }}
+      {{- with $affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- /* tolerations: append podOverrides to chart-wide. */}}
+      {{- $tolerations := concat (.Values.tolerations | default list) ($po.tolerations | default list) }}
+      {{- with $tolerations }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: 30

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -436,6 +436,37 @@ operator:
   # -- Extra volumeMounts on the operator container.
   extraVolumeMounts: []
 
+  # -- Pod-level customization for the chart-owned operator Deployment.
+  # Same shape as the CRD `PodOverrides` struct (api/v1alpha1/shared_types.go)
+  # so users have one mental model for BOTH chart-owned pods AND
+  # operator-generated CRD pods.
+  #
+  # Additive on top of the legacy `operator.extraEnv`/`extraEnvFrom`/
+  # `extraVolumes`/`extraVolumeMounts` values (kept for backward compat).
+  # `serviceAccountName` here overrides the chart-wide `serviceAccount.name`
+  # on the operator pod only — useful when the operator needs a different
+  # IRSA/WLI identity than other chart components.
+  #
+  # Docs: https://omnia.altairalabs.ai/docs/how-to/configure-pod-overrides
+  podOverrides: {}
+  # Example:
+  #   podOverrides:
+  #     serviceAccountName: omnia-operator-wli
+  #     priorityClassName: system-cluster-critical
+  #     imagePullSecrets:
+  #       - name: ecr-creds
+  #     labels:
+  #       azure.workload.identity/use: "true"
+  #     annotations:
+  #       iam.gke.io/gcp-service-account: omnia-operator@my-project.iam.gserviceaccount.com
+  #     topologySpreadConstraints:
+  #       - maxSkew: 1
+  #         topologyKey: topology.kubernetes.io/zone
+  #         whenUnsatisfiable: ScheduleAnyway
+  #         labelSelector:
+  #           matchLabels:
+  #             app.kubernetes.io/component: controller-manager
+
 # Leader election configuration
 leaderElection:
   # -- Enable leader election for HA


### PR DESCRIPTION
## Summary

W4a of the chart overhaul ([#895](https://github.com/AltairaLabs/Omnia/issues/895)). Adds `operator.podOverrides:` — same shape as the CRD `PodOverrides` struct (shipped in #865) so users have **one mental model** for both chart-owned pods and operator-generated CRD pods.

### Fields on `operator.podOverrides`

| Field | Merge semantics |
|---|---|
| `serviceAccountName` | Overrides chart-wide SA on the operator pod only |
| `labels` | Merged; chart's operator labels win on collision (Service selectors depend on them) |
| `annotations` | Merged; user annotations win on collision |
| `nodeSelector` | Merged with `.Values.nodeSelector`; user wins per-key |
| `tolerations` | Appended to `.Values.tolerations` |
| `affinity` | Replaces `.Values.affinity` when set |
| `priorityClassName` | New — no existing equivalent |
| `topologySpreadConstraints` | New — no existing equivalent |
| `imagePullSecrets` | Appended to chart-wide `.Values.imagePullSecrets` |
| `extraEnv` / `extraEnvFrom` | Appended to `.Values.operator.extraEnv` / `...EnvFrom` |
| `extraVolumes` / `extraVolumeMounts` | Appended to legacy hooks |

### Backward compatibility

Zero breaking change. All existing values (`.Values.operator.extraEnv`, `.Values.nodeSelector`, etc.) keep working exactly as before. `podOverrides` is purely additive; setting both paths produces the union (or user-wins on map collisions).

### Scope

**Operator deployment only.** W4b will apply the same pattern to dashboard, arena-controller, eval-worker, promptkit-lsp, and doctor. Each has its own quirks (e.g. arena-controller has a different SA helper, promptkit-lsp has port args); wiring them in isolation keeps diffs reviewable.

### Validated

- `helm lint --strict` clean; default + enterprise render unchanged
- All 5 example overrides propagate correctly:
  `serviceAccountName=wli-sa`, `priorityClassName=system-cluster-critical`, `imagePullSecrets[0].name=ecr`, `labels.azure.workload.identity/use=true`, `nodeSelector.gpu=a100`

Refs #895