### PR TITLE
fix(sec): clamp int conversions flagged by CodeQL

### DIFF
--- a/ee/internal/controller/arenajob_controller.go
+++ b/ee/internal/controller/arenajob_controller.go
@@ -42,6 +42,7 @@ import (
 	"github.com/altairalabs/omnia/ee/pkg/license"
 	"github.com/altairalabs/omnia/ee/pkg/workspace"
 	"github.com/altairalabs/omnia/internal/podoverrides"
+	"github.com/altairalabs/omnia/pkg/intconv"
 )
 
 // Workspace label for namespace association
@@ -1337,8 +1338,8 @@ func (r *ArenaJobReconciler) updateStatusFromJob(ctx context.Context, arenaJob *
 					arenaJob.Status.Progress.Pending = 0
 				} else if r.Queue != nil {
 					if stats, err := r.Queue.GetStats(ctx, arenaJob.Name); err == nil && stats != nil {
-						arenaJob.Status.Progress.Completed = int32(stats.Passed)
-						arenaJob.Status.Progress.Failed = int32(stats.Failed)
+						arenaJob.Status.Progress.Completed = intconv.ClampInt32(stats.Passed)
+						arenaJob.Status.Progress.Failed = intconv.ClampInt32(stats.Failed)
 						arenaJob.Status.Progress.Pending = 0
 					}
 				}
@@ -1405,8 +1406,8 @@ func (r *ArenaJobReconciler) updateStatusFromJob(ctx context.Context, arenaJob *
 				// JobProgress field tag change).
 				if r.Queue != nil {
 					if stats, err := r.Queue.GetStats(ctx, arenaJob.Name); err == nil && stats != nil {
-						arenaJob.Status.Progress.Completed = int32(stats.Passed)
-						arenaJob.Status.Progress.Failed = int32(stats.Failed)
+						arenaJob.Status.Progress.Completed = intconv.ClampInt32(stats.Passed)
+						arenaJob.Status.Progress.Failed = intconv.ClampInt32(stats.Failed)
 						arenaJob.Status.Progress.Pending = 0
 					}
 				}

--- a/ee/pkg/arena/aggregator/aggregator.go
+++ b/ee/pkg/arena/aggregator/aggregator.go
@@ -18,6 +18,7 @@ import (
 
 	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
 	"github.com/altairalabs/omnia/ee/pkg/arena/queue"
+	"github.com/altairalabs/omnia/pkg/intconv"
 )
 
 // Aggregator collects and summarizes results from Arena job executions.
@@ -45,9 +46,9 @@ func StatsToResult(stats *queue.JobStats) *AggregatedResult {
 	total := stats.Passed + stats.Failed
 
 	result := &AggregatedResult{
-		TotalItems:    int(total),
-		PassedItems:   int(stats.Passed),
-		FailedItems:   int(stats.Failed),
+		TotalItems:    intconv.ClampInt(total),
+		PassedItems:   intconv.ClampInt(stats.Passed),
+		FailedItems:   intconv.ClampInt(stats.Failed),
 		TotalDuration: totalDuration,
 		TotalTokens:   stats.TotalTokens,
 		TotalCost:     stats.TotalCost,

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/altairalabs/omnia/internal/httputil"
 	"github.com/altairalabs/omnia/internal/session"
 	"github.com/altairalabs/omnia/internal/session/providers"
+	"github.com/altairalabs/omnia/pkg/intconv"
 	"github.com/altairalabs/omnia/pkg/logctx"
 )
 
@@ -412,8 +413,8 @@ func (h *Handler) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	}
 
 	limit := min(parseIntParam(r, "limit", defaultMessageLimit), maxMessageLimit)
-	before := int32(parseIntParam(r, "before", 0))
-	after := int32(parseIntParam(r, "after", 0))
+	before := intconv.ClampInt32(int64(parseIntParam(r, "before", 0)))
+	after := intconv.ClampInt32(int64(parseIntParam(r, "after", 0)))
 
 	opts := providers.MessageQueryOpts{
 		Limit:     limit + 1, // fetch one extra to determine hasMore

--- a/pkg/intconv/intconv.go
+++ b/pkg/intconv/intconv.go
@@ -1,0 +1,36 @@
+// Package intconv provides bounds-checked narrowing conversions between
+// integer types. CodeQL's go/incorrect-integer-conversion rule flags
+// bare int/int64 → int32 casts because a hostile caller can wrap the
+// value around zero on 32-bit platforms, or overflow a signed field.
+// Clamping instead of wrapping is almost always the safer choice.
+package intconv
+
+import "math"
+
+// ClampInt32 converts x to int32, saturating at math.MaxInt32 and
+// math.MinInt32 instead of wrapping. Use when the destination is an
+// int32 field (e.g. a Kubernetes API field) and the value came from
+// an unbounded source like strconv.Atoi or a uint64 counter.
+func ClampInt32(x int64) int32 {
+	if x > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if x < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int32(x)
+}
+
+// ClampInt converts x to int, saturating at math.MaxInt / math.MinInt
+// on 32-bit platforms. On 64-bit it's a no-op (int is already 64 bits).
+// Useful for consuming int64 API totals from typed counters where the
+// destination is a plain int.
+func ClampInt(x int64) int {
+	if x > math.MaxInt {
+		return math.MaxInt
+	}
+	if x < math.MinInt {
+		return math.MinInt
+	}
+	return int(x)
+}

--- a/pkg/intconv/intconv_test.go
+++ b/pkg/intconv/intconv_test.go
@@ -1,0 +1,56 @@
+package intconv
+
+import (
+	"math"
+	"testing"
+)
+
+func TestClampInt32(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   int64
+		want int32
+	}{
+		{"zero", 0, 0},
+		{"positive within range", 1 << 30, 1 << 30},
+		{"negative within range", -(1 << 30), -(1 << 30)},
+		{"max int32", math.MaxInt32, math.MaxInt32},
+		{"min int32", math.MinInt32, math.MinInt32},
+		{"just over max clamps", int64(math.MaxInt32) + 1, math.MaxInt32},
+		{"just under min clamps", int64(math.MinInt32) - 1, math.MinInt32},
+		{"max int64 clamps", math.MaxInt64, math.MaxInt32},
+		{"min int64 clamps", math.MinInt64, math.MinInt32},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClampInt32(tc.in); got != tc.want {
+				t.Errorf("ClampInt32(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClampInt(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		in   int64
+		want int
+	}{
+		{"zero", 0, 0},
+		{"small positive", 42, 42},
+		{"small negative", -42, -42},
+		{"max int", math.MaxInt, math.MaxInt},
+		{"min int", math.MinInt, math.MinInt},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := ClampInt(tc.in); got != tc.want {
+				t.Errorf("ClampInt(%d) = %d, want %d", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Clears 8 high-severity CodeQL alerts (`go/incorrect-integer-conversion`). CodeQL flags any narrowing cast from an unbounded source (e.g. `strconv.Atoi` → int32, `int64` counter → int32) because a wrapped value on 32-bit — or a malicious caller — can bypass downstream range checks. Clamping is the safer default.

## What changes

New `pkg/intconv`:
- `ClampInt32(int64) int32` — saturates at `math.MaxInt32` / `MinInt32`
- `ClampInt(int64) int` — saturates at `math.MaxInt` / `MinInt`

Full unit-test coverage: zero, normal range, boundaries, over/underflow.

Applied at the flagged call sites:
- `internal/session/api/handler.go:415-416` — BeforeSeq/AfterSeq from `parseIntParam` into int32 `MessageQueryOpts`
- `ee/pkg/arena/aggregator/aggregator.go:49-50` — `queue.JobStats` int64 counters → int `AggregatedResult` fields
- `ee/internal/controller/arenajob_controller.go:1340-1341, 1408-1409` — `queue.JobStats` int64 → int32 `JobProgress` CRD fields (×2 branches, job-succeeded and job-failed paths)

## Why clamp vs. reject vs. error

The int32 `Progress` fields in the CRD saturate at 2.1B — orders of magnitude above any realistic Arena job size. Truncation is only reached if a caller is actively trying to overflow, at which point the clamp value is still more useful (= "a lot") than either a zero or an error that'd crash the reconciler. Same logic for pagination sequence numbers.

## Validation
- `env GOWORK=off go build ./...` — clean
- `go test ./pkg/intconv/... ./internal/session/api/... ./ee/pkg/arena/aggregator/... ./ee/internal/controller/... -count=1` — all pass
- `golangci-lint run` on changed packages — 0 new issues (two pre-existing ones in files I didn't touch)

## Test plan
- [ ] CI passes
- [ ] Next CodeQL analysis closes the 8 `go/incorrect-integer-conversion` alerts

## Not addressed in this PR
Two other open CodeQL alerts are different rules (not integer conversion):
- `go/path-injection` at `ee/cmd/arena-dev-console/server/promptkit_handler.go:570`
- `go/unsafe-unzip-symlink` at `internal/sourcesync/oci.go:283`

Happy to do these in a follow-up.