### PR TITLE
feat(chart): W4b podOverrides on dashboard / arena-controller / eval-worker / LSP / doctor

### DIFF
--- a/charts/omnia/templates/arena-controller-deployment.yaml
+++ b/charts/omnia/templates/arena-controller-deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.enterprise.enabled }}
+{{- $po := .Values.enterprise.arena.controller.podOverrides | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,15 +20,25 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with $po.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
+        {{- with $po.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "omnia.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: arena-controller
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- $pullSecrets := concat (.Values.imagePullSecrets | default list) ($po.imagePullSecrets | default list) }}
+      {{- with $pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "omnia.serviceAccountName" . }}
+      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.serviceAccountName" .) }}
+      {{- with $po.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         runAsNonRoot: {{ .Values.enterprise.arena.controller.podSecurityContext.runAsNonRoot | default true }}
         runAsUser: {{ .Values.enterprise.arena.controller.podSecurityContext.runAsUser | default 65532 }}
@@ -119,11 +130,13 @@ spec:
             periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
           resources:
             {{- toYaml .Values.enterprise.arena.controller.resources | default .Values.resources | nindent 12 }}
-          {{- with .Values.enterprise.arena.controller.extraEnv }}
+          {{- $env := concat (.Values.enterprise.arena.controller.extraEnv | default list) ($po.extraEnv | default list) }}
+          {{- with $env }}
           env:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.enterprise.arena.controller.extraEnvFrom }}
+          {{- $envFrom := concat (.Values.enterprise.arena.controller.extraEnvFrom | default list) ($po.extraEnvFrom | default list) }}
+          {{- with $envFrom }}
           envFrom:
             {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -132,7 +145,8 @@ spec:
               mountPath: /workspace-content
             - name: tmp
               mountPath: /tmp
-            {{- with .Values.enterprise.arena.controller.extraVolumeMounts }}
+            {{- $vm := concat (.Values.enterprise.arena.controller.extraVolumeMounts | default list) ($po.extraVolumeMounts | default list) }}
+            {{- with $vm }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
@@ -141,19 +155,27 @@ spec:
             claimName: {{ include "omnia.fullname" . }}-workspace-content
         - name: tmp
           emptyDir: {}
-        {{- with .Values.enterprise.arena.controller.extraVolumes }}
+        {{- $vols := concat (.Values.enterprise.arena.controller.extraVolumes | default list) ($po.extraVolumes | default list) }}
+        {{- with $vols }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.nodeSelector }}
+      {{- $nodeSel := mergeOverwrite (deepCopy (.Values.nodeSelector | default dict)) ($po.nodeSelector | default dict) }}
+      {{- with $nodeSel }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- $aff := $po.affinity | default .Values.affinity }}
+      {{- with $aff }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- $tols := concat (.Values.tolerations | default list) ($po.tolerations | default list) }}
+      {{- with $tols }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.enterprise.arena.controller.terminationGracePeriodSeconds | default 10 }}

--- a/charts/omnia/templates/dashboard/deployment.yaml
+++ b/charts/omnia/templates/dashboard/deployment.yaml
@@ -1,5 +1,6 @@
 {{- include "omnia.validateAuth" . -}}
 {{- if .Values.dashboard.enabled }}
+{{- $po := .Values.dashboard.podOverrides | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -18,14 +19,24 @@ spec:
         {{- with .Values.dashboard.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with $po.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
+        {{- with $po.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "omnia.dashboard.selectorLabels" . | nindent 8 }}
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- $pullSecrets := concat (.Values.imagePullSecrets | default list) ($po.imagePullSecrets | default list) }}
+      {{- with $pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "omnia.serviceAccountName" . }}
+      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.serviceAccountName" .) }}
+      {{- with $po.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.dashboard.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
@@ -52,7 +63,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "omnia.dashboard.fullname" . }}
-            {{- with .Values.dashboard.extraEnvFrom }}
+            {{- $ef := concat (.Values.dashboard.extraEnvFrom | default list) ($po.extraEnvFrom | default list) }}
+            {{- with $ef }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           env:
@@ -132,6 +144,9 @@ spec:
             {{- with .Values.dashboard.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with $po.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           {{- with .Values.dashboard.startupProbe }}
@@ -165,7 +180,8 @@ spec:
             - name: workspace-content
               mountPath: {{ .Values.workspaceContent.mountPath | default "/workspace-content" }}
             {{- end }}
-            {{- with .Values.dashboard.extraVolumeMounts }}
+            {{- $vmMounts := concat (.Values.dashboard.extraVolumeMounts | default list) ($po.extraVolumeMounts | default list) }}
+            {{- with $vmMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
       volumes:
@@ -179,19 +195,27 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.workspaceContent.persistence.existingClaim | default (printf "%s-workspace-content" (include "omnia.fullname" .)) }}
         {{- end }}
-        {{- with .Values.dashboard.extraVolumes }}
+        {{- $vols := concat (.Values.dashboard.extraVolumes | default list) ($po.extraVolumes | default list) }}
+        {{- with $vols }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.dashboard.nodeSelector }}
+      {{- $nodeSel := mergeOverwrite (deepCopy (.Values.dashboard.nodeSelector | default dict)) ($po.nodeSelector | default dict) }}
+      {{- with $nodeSel }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.dashboard.affinity }}
+      {{- $aff := $po.affinity | default .Values.dashboard.affinity }}
+      {{- with $aff }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.dashboard.tolerations }}
+      {{- $tols := concat (.Values.dashboard.tolerations | default list) ($po.tolerations | default list) }}
+      {{- with $tols }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/charts/omnia/templates/doctor/deployment.yaml
+++ b/charts/omnia/templates/doctor/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.doctor.enabled }}
+{{- $po := .Values.doctor.podOverrides | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -12,10 +13,24 @@ spec:
       {{- include "omnia.doctor.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with $po.annotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       labels:
+        {{- with $po.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "omnia.doctor.selectorLabels" . | nindent 8 }}
     spec:
-      serviceAccountName: {{ include "omnia.doctor.fullname" . }}
+      {{- with $po.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.doctor.fullname" .) }}
+      {{- with $po.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -75,10 +90,42 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.doctor.resources | nindent 12 }}
+          {{- with $po.extraEnv }}
+          env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $po.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $po.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop:
                 - ALL
+      {{- with $po.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/omnia/templates/ee-promptkit-lsp-deployment.yaml
+++ b/charts/omnia/templates/ee-promptkit-lsp-deployment.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.enterprise.enabled }}
 {{- if .Values.enterprise.promptkitLsp.enabled }}
 {{- $lsp := .Values.enterprise.promptkitLsp -}}
+{{- $po := $lsp.podOverrides | default dict -}}
 {{- $httpPort := $lsp.port | default 8080 -}}
 {{- $healthPort := $lsp.healthPort | default 8081 -}}
 {{- $dashboardUrl := $lsp.dashboardApiUrl -}}
@@ -26,15 +27,25 @@ spec:
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+        {{- with $po.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       labels:
+        {{- with $po.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "omnia.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: promptkit-lsp
     spec:
-      {{- with .Values.imagePullSecrets }}
+      {{- $pullSecrets := concat (.Values.imagePullSecrets | default list) ($po.imagePullSecrets | default list) }}
+      {{- with $pullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "omnia.serviceAccountName" . }}
+      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.serviceAccountName" .) }}
+      {{- with $po.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -60,8 +71,17 @@ spec:
             - name: health
               containerPort: {{ $healthPort }}
               protocol: TCP
-          {{- with $lsp.extraEnv }}
+          {{- $env := concat ($lsp.extraEnv | default list) ($po.extraEnv | default list) }}
+          {{- with $env }}
           env:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $po.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $po.extraVolumeMounts }}
+          volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           securityContext:
@@ -88,16 +108,27 @@ spec:
             {{- end }}
           resources:
             {{- toYaml $lsp.resources | nindent 12 }}
-      {{- with .Values.nodeSelector }}
+      {{- with $po.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- $nodeSel := mergeOverwrite (deepCopy (.Values.nodeSelector | default dict)) ($po.nodeSelector | default dict) }}
+      {{- with $nodeSel }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.affinity }}
+      {{- $aff := $po.affinity | default .Values.affinity }}
+      {{- with $aff }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- $tols := concat (.Values.tolerations | default list) ($po.tolerations | default list) }}
+      {{- with $tols }}
       tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ $lsp.terminationGracePeriodSeconds | default 30 }}

--- a/charts/omnia/templates/eval-worker/deployment.yaml
+++ b/charts/omnia/templates/eval-worker/deployment.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.enterprise.enabled .Values.enterprise.evalWorker.enabled }}
+{{- $po := .Values.enterprise.evalWorker.podOverrides | default dict }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -13,13 +14,26 @@ spec:
   template:
     metadata:
       labels:
+        {{- with $po.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "omnia.evalWorker.selectorLabels" . | nindent 8 }}
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
+        {{- with $po.annotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
-      serviceAccountName: {{ include "omnia.evalWorker.fullname" . }}
+      {{- with $po.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.evalWorker.fullname" .) }}
+      {{- with $po.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 65532
@@ -85,6 +99,17 @@ spec:
             {{- with .Values.enterprise.evalWorker.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- with $po.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $po.extraEnvFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $po.extraVolumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -115,5 +140,25 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+      {{- with $po.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $po.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: {{ .Values.enterprise.evalWorker.terminationGracePeriodSeconds | default 30 }}
 {{- end }}

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -117,6 +117,10 @@ enterprise:
       workspaceContentPath: ""
       # -- Graceful-shutdown window in seconds.
       terminationGracePeriodSeconds: 10
+      # -- Pod-level overrides. Same shape as CRD PodOverrides
+      # (docs/how-to/configure-pod-overrides). Additive on top of the
+      # legacy extraEnv/extraEnvFrom/extraVolumes/extraVolumeMounts above.
+      podOverrides: {}
 
     # Worker configuration for ArenaJob execution
     worker:
@@ -245,6 +249,13 @@ enterprise:
       failureThreshold: 3
     # -- Graceful-shutdown window in seconds for the eval-worker pod.
     terminationGracePeriodSeconds: 30
+    # -- Pod-level overrides. Same shape as CRD PodOverrides
+    # (docs/how-to/configure-pod-overrides). Additive on top of the legacy
+    # extraEnv above; all new fields (serviceAccountName, priorityClassName,
+    # imagePullSecrets, labels, annotations, nodeSelector, tolerations,
+    # affinity, topologySpreadConstraints, extraEnvFrom, extraVolumes,
+    # extraVolumeMounts) are supplied here.
+    podOverrides: {}
 
   # Policy proxy sidecar for ToolPolicy enforcement
   policyProxy:
@@ -300,6 +311,10 @@ enterprise:
     # -- Graceful-shutdown window in seconds.
     terminationGracePeriodSeconds: 30
     resources: {}
+    # -- Pod-level overrides for the PromptKit LSP Deployment. Same shape
+    # as CRD PodOverrides (docs/how-to/configure-pod-overrides). Additive
+    # on top of legacy `extraEnv` / `extraArgs` above.
+    podOverrides: {}
 
 # License configuration
 license:
@@ -624,6 +639,13 @@ dashboard:
 
   # -- Extra volumeMounts on the dashboard container.
   extraVolumeMounts: []
+
+  # -- Pod-level overrides for the dashboard Deployment. Same shape as
+  # CRD PodOverrides (docs/how-to/configure-pod-overrides). Additive on
+  # top of the legacy dashboard.extraEnv/extraEnvFrom/extraVolumes/
+  # extraVolumeMounts and the existing dashboard.nodeSelector/affinity/
+  # tolerations values.
+  podOverrides: {}
 
   # Pod Disruption Budget for HA deployments
   podDisruptionBudget:
@@ -1079,6 +1101,9 @@ doctor:
     periodSeconds: 10
     timeoutSeconds: 1
     failureThreshold: 3
+  # -- Pod-level overrides for the doctor Deployment. Same shape as CRD
+  # PodOverrides (docs/how-to/configure-pod-overrides).
+  podOverrides: {}
 
 # ============================================================================
 # Session Privacy Configuration


### PR DESCRIPTION
## Summary

Completes W4 of the chart overhaul ([#895](https://github.com/AltairaLabs/Omnia/issues/895)). Extends the `podOverrides` pattern from W4a (#906) to the remaining 5 chart-owned deployments.

### New values

- `dashboard.podOverrides`
- `enterprise.arena.controller.podOverrides`
- `enterprise.evalWorker.podOverrides`
- `enterprise.promptkitLsp.podOverrides`
- `doctor.podOverrides`

Each block accepts the same 13 fields as the CRD `PodOverrides` struct (`api/v1alpha1/shared_types.go`) — `serviceAccountName`, `labels`, `annotations`, `nodeSelector`, `tolerations`, `affinity`, `priorityClassName`, `topologySpreadConstraints`, `imagePullSecrets`, `extraEnv`, `extraEnvFrom`, `extraVolumes`, `extraVolumeMounts`.

### Merge semantics (unchanged from W4a)

| Field | Merge |
|---|---|
| `serviceAccountName`, `affinity`, `priorityClassName` | User replaces default |
| `labels` | Chart operator-set wins on collision (Service selectors) |
| `annotations` | User wins on collision |
| `nodeSelector` | Merged per-key via `mergeOverwrite` (user wins) |
| `tolerations`, `imagePullSecrets`, `topologySpreadConstraints`, `extraEnv`, `extraEnvFrom`, `extraVolumes`, `extraVolumeMounts` | Appended |

### Zero breaking change

Every existing value continues to work. All legacy `*.extraEnv/extraEnvFrom/extraVolumes/extraVolumeMounts` + per-deployment `nodeSelector/affinity/tolerations` are preserved; `podOverrides` is additive.

### Validated

- `helm lint --strict` clean; default + enterprise render unchanged
- `--set <component>.podOverrides.serviceAccountName=X` propagates correctly on all 5 deployments (verified in test output)

### Chart overhaul: W4 complete

With #906 + this PR, chart customers have **one mental model** for pod customization across all seven of Omnia's pod-generating surfaces:
- Chart-owned: operator, dashboard, arena-controller, eval-worker, promptkit-lsp, doctor (via `*.podOverrides` values)
- Operator-generated: facade+runtime, session-api, memory-api, arena workers, dev console (via CRD `spec.podOverrides`)

### Proposal state after this merges

| Workstream | Status |
|---|---|
| W1 docs | ✅ Merged |
| W2 schema (#898) | In flight |
| W3a + W3b tunables | ✅ Merged |
| W4a podOverrides on operator (#906) | In flight |
| W4b podOverrides on 5 other deployments (this PR) | In flight |
| W5 examples | ✅ Merged |
| W6 CI gates (#905) | In flight |
| W7 footguns | ✅ Merged |
| ci-filters (addendum) | ✅ Merged |

Refs #895