### PR TITLE
docs(provider): OpenRouter how-to + end-to-end header wire test

### DIFF
--- a/docs/src/content/docs/how-to/configure-openrouter-provider.md
+++ b/docs/src/content/docs/how-to/configure-openrouter-provider.md
@@ -1,0 +1,130 @@
+---
+title: "Configure OpenRouter Provider"
+description: "Use OpenRouter as a unified gateway to Anthropic, OpenAI, Google, Meta and other models via Omnia Provider custom headers"
+sidebar:
+  order: 19
+---
+
+[OpenRouter](https://openrouter.ai) is a unified gateway that exposes 100+ LLMs behind a single OpenAI-compatible API — Claude, GPT, Gemini, Llama, Mistral, and others — with one API key and one endpoint.
+
+Omnia's `Provider` custom resource treats OpenRouter like any other OpenAI-compatible endpoint. Two Omnia features combine to make this work:
+
+1. **`spec.baseURL`** — point the OpenAI wire format at OpenRouter.
+2. **`spec.headers`** — set the `HTTP-Referer` and `X-Title` attribution headers that OpenRouter uses for leaderboards and rate-limit tiers.
+
+## Prerequisites
+
+- An [OpenRouter account](https://openrouter.ai) with an API key (create one at [openrouter.ai/keys](https://openrouter.ai/keys)).
+- Omnia operator installed in the cluster.
+
+## 1. Create a Secret for the API key
+
+```bash
+kubectl create secret generic openrouter-credentials \
+  --namespace agents \
+  --from-literal=OPENAI_API_KEY='sk-or-v1-...'
+```
+
+Omnia's `openai` provider reads `OPENAI_API_KEY` by default; OpenRouter's key slots in there directly. If you already use direct-OpenAI in another Provider, use a different secret name or key — see [Migrate Provider Credentials](/how-to/migrate-provider-credentials/) for per-Provider isolation.
+
+## 2. Create the Provider
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: openrouter
+  namespace: agents
+spec:
+  type: openai
+  model: anthropic/claude-sonnet-4                # OpenRouter model ID
+  baseURL: https://openrouter.ai/api/v1
+
+  headers:
+    HTTP-Referer: https://your-app.example.com    # Required for leaderboard attribution
+    X-Title: omnia                                # Appears in OpenRouter analytics
+
+  credential:
+    secretRef:
+      name: openrouter-credentials
+
+  capabilities:
+    - text
+    - streaming
+    - tools
+    - json
+```
+
+### How the headers reach the wire
+
+When the runtime creates the underlying PromptKit provider, `spec.headers` is passed through `providers.ProviderSpec.Headers`. PromptKit's `openai` provider (which `type: openai` resolves to) applies custom headers to every `/chat/completions` request via its `ApplyCustomHeaders` helper — including streaming and tool-calling requests. Collisions with built-in headers (e.g. `Authorization`) are rejected at request time so you can't accidentally break auth.
+
+## 3. Verify the Provider is Ready
+
+```bash
+kubectl get provider openrouter -n agents -o wide
+kubectl get provider openrouter -n agents -o jsonpath='{.status.conditions}' | jq .
+```
+
+Both `SecretFound` and `CredentialConfigured` conditions should be `True`. OpenRouter does not respond to unauthenticated `GET /` requests, so the `EndpointReachable` condition may be omitted or show a 401 — either is considered reachable (a 401 proves the endpoint is up).
+
+## 4. Using with AgentRuntime
+
+Reference the Provider from an `AgentRuntime` like any other:
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: my-agent
+  namespace: agents
+spec:
+  promptPackRef:
+    name: my-pack
+  providers:
+    - name: default
+      providerRef:
+        name: openrouter
+  facade:
+    type: websocket
+```
+
+## Choosing a model
+
+OpenRouter's model IDs follow the `<vendor>/<model>` pattern. Examples:
+
+| Omnia `spec.model`                   | Hosted model                       |
+|--------------------------------------|------------------------------------|
+| `anthropic/claude-sonnet-4`          | Anthropic Claude Sonnet 4          |
+| `openai/gpt-4o`                      | OpenAI GPT-4o                      |
+| `google/gemini-2.0-flash-exp`        | Google Gemini 2.0 Flash            |
+| `meta-llama/llama-3.1-70b-instruct`  | Meta Llama 3.1 70B                 |
+
+Full list: [openrouter.ai/models](https://openrouter.ai/models).
+
+## Custom pricing (optional)
+
+OpenRouter's pricing can differ from the first-party API. Supply `spec.pricing` if you want Omnia's cost tracking to reflect OpenRouter's actual rates:
+
+```yaml
+spec:
+  pricing:
+    inputCostPer1K: "0.003"
+    outputCostPer1K: "0.015"
+```
+
+If omitted, PromptKit falls back to built-in pricing for the underlying model family (e.g. Anthropic's public list prices for a `claude-sonnet-4` request). For production cost tracking against OpenRouter invoices, set the pricing explicitly.
+
+## Troubleshooting
+
+**401 Unauthorized on every request.** Check that the secret value uses an `sk-or-v1-...` OpenRouter key — a direct-OpenAI `sk-...` key will not work against `openrouter.ai`. Verify with `kubectl get secret openrouter-credentials -n agents -o jsonpath='{.data.OPENAI_API_KEY}' | base64 -d | head -c 12`.
+
+**Rate limits / attribution missing.** OpenRouter's free tier and leaderboards key off the `HTTP-Referer` and `X-Title` headers. If you omit them, requests still succeed but you'll hit the unattributed rate limit and your app won't appear on the leaderboard.
+
+**`headers map is immutable` error at request time.** This is PromptKit rejecting a custom header that collides with one the provider sets itself (most commonly `Authorization`). Remove that key from `spec.headers`.
+
+## See also
+
+- [Provider CRD reference — `spec.headers`](/reference/provider/#headers) — full field semantics and collision rules.
+- [Migrate Provider Credentials](/how-to/migrate-provider-credentials/) — per-Provider secret isolation.
+- [OpenRouter docs — Quickstart](https://openrouter.ai/docs/quickstart) — OpenRouter's own getting-started.

--- a/internal/runtime/config_crd_test.go
+++ b/internal/runtime/config_crd_test.go
@@ -176,6 +176,57 @@ func TestLoadFromCRD_SingleProvider(t *testing.T) {
 	t.Cleanup(func() { os.Unsetenv("OPENAI_API_KEY") })
 }
 
+// TestLoadFromCRD_Headers verifies spec.headers from the Provider CRD flows
+// through loadFromProviderRef into Config.Headers. Combined with the
+// end-to-end httptest coverage in openrouter_integration_test.go, this closes
+// the CRD -> Config -> Server -> HTTP-request loop that makes OpenRouter and
+// other gateway providers usable via the Provider CRD.
+func TestLoadFromCRD_Headers(t *testing.T) {
+	provider := &v1alpha1.Provider{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openrouter-provider",
+			Namespace: "test-ns",
+		},
+		Spec: v1alpha1.ProviderSpec{
+			Type:    v1alpha1.ProviderTypeOpenAI,
+			Model:   "anthropic/claude-sonnet-4",
+			BaseURL: "https://openrouter.ai/api/v1",
+			Headers: map[string]string{
+				"HTTP-Referer": "https://my-app.example",
+				"X-Title":      "omnia",
+			},
+			SecretRef: &v1alpha1.SecretKeyRef{Name: "openrouter-secret"},
+		},
+	}
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "openrouter-secret",
+			Namespace: "test-ns",
+		},
+		Data: map[string][]byte{"OPENAI_API_KEY": []byte("sk-or-v1-test")},
+	}
+	ar := &v1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-agent", Namespace: "test-ns"},
+		Spec: v1alpha1.AgentRuntimeSpec{
+			PromptPackRef: v1alpha1.PromptPackRef{Name: "test-pack"},
+			Facade:        v1alpha1.FacadeConfig{Type: v1alpha1.FacadeTypeWebSocket},
+			Providers: []v1alpha1.NamedProviderRef{
+				{Name: "default", ProviderRef: v1alpha1.ProviderRef{Name: "openrouter-provider"}},
+			},
+		},
+	}
+
+	c := buildTestClient(ar, provider, secret)
+	cfg, err := LoadFromCRD(context.Background(), c, "test-agent", "test-ns")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = os.Unsetenv("OPENAI_API_KEY") })
+
+	assert.Equal(t, "openai", cfg.ProviderType)
+	assert.Equal(t, "https://openrouter.ai/api/v1", cfg.BaseURL)
+	assert.Equal(t, "https://my-app.example", cfg.Headers["HTTP-Referer"])
+	assert.Equal(t, "omnia", cfg.Headers["X-Title"])
+}
+
 func TestLoadFromCRD_NoProviders(t *testing.T) {
 	ar := &v1alpha1.AgentRuntime{
 		ObjectMeta: metav1.ObjectMeta{

--- a/internal/runtime/openrouter_integration_test.go
+++ b/internal/runtime/openrouter_integration_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const openAIChatCompletionResponse = `{"id":"x","object":"chat.completion","created":1,` +
+	`"model":"anthropic/claude-sonnet-4","choices":[{"index":0,` +
+	`"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],` +
+	`"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`
+
+// TestOpenRouter_CustomHeadersReachTheWire proves that custom headers set via
+// Omnia's WithHeaders option (the path cmd/runtime/main.go uses when wiring
+// cfg.Headers from a Provider CRD) are present on the HTTP request when the
+// runtime calls its LLM provider.
+//
+// This is the Omnia-side end-to-end for the #909 headers feature: PromptKit's
+// own custom_headers_test.go covers the SDK layer. This test covers the
+// Omnia wrapper layer (Server → buildProviderSpec → providers.CreateProviderFromSpec),
+// which is the surface a user of the Provider CRD actually depends on.
+func TestOpenRouter_CustomHeadersReachTheWire(t *testing.T) {
+	var receivedHeaders http.Header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHeaders = r.Header.Clone()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, openAIChatCompletionResponse)
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_API_KEY", "sk-or-v1-test-openrouter-key")
+
+	s := NewServer(
+		WithLogger(logr.Discard()),
+		WithProviderInfo("openai", "anthropic/claude-sonnet-4"),
+		WithBaseURL(server.URL),
+		WithHeaders(map[string]string{
+			"HTTP-Referer": "https://my-app.example",
+			"X-Title":      "omnia",
+		}),
+	)
+
+	provider, err := s.createProviderFromConfig()
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, err = provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://my-app.example", receivedHeaders.Get("HTTP-Referer"),
+		"HTTP-Referer header should reach the LLM endpoint when set via WithHeaders")
+	assert.Equal(t, "omnia", receivedHeaders.Get("X-Title"),
+		"X-Title header should reach the LLM endpoint when set via WithHeaders")
+	// Authorization is set by the provider itself — confirm custom headers did
+	// not overwrite it.
+	assert.NotEmpty(t, receivedHeaders.Get("Authorization"),
+		"built-in Authorization header must still be present alongside custom headers")
+}
+
+// TestOpenRouter_HeaderCollisionRejected verifies that a custom header that
+// collides with a provider-controlled header is rejected at request time
+// rather than silently breaking authentication. This mirrors PromptKit's
+// collision behavior and is the behavior the how-to doc tells users about.
+func TestOpenRouter_HeaderCollisionRejected(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Fatal("request should not have been sent; Authorization collision must be rejected before send")
+	}))
+	defer server.Close()
+
+	t.Setenv("OPENAI_API_KEY", "sk-or-v1-test-key")
+
+	s := NewServer(
+		WithLogger(logr.Discard()),
+		WithProviderInfo("openai", "anthropic/claude-sonnet-4"),
+		WithBaseURL(server.URL),
+		WithHeaders(map[string]string{
+			"Authorization": "Bearer conflict",
+		}),
+	)
+
+	provider, err := s.createProviderFromConfig()
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	_, err = provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{{Role: "user", Content: "hi"}},
+	})
+	require.Error(t, err, "colliding custom header must fail the request")
+}

--- a/internal/runtime/openrouter_livesmoke_test.go
+++ b/internal/runtime/openrouter_livesmoke_test.go
@@ -1,0 +1,82 @@
+//go:build livesmoke
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+// Live smoke test against the real OpenRouter endpoint. Gated behind the
+// `livesmoke` build tag so CI never runs it (it costs credits and requires
+// a real API key).
+//
+// Usage:
+//
+//	env OMNIA_OPENROUTER_API_KEY=sk-or-v1-... \
+//	  go test ./internal/runtime/... -run TestOpenRouter_LiveSmoke \
+//	  -tags=livesmoke -v -count=1
+
+package runtime
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/AltairaLabs/PromptKit/runtime/providers"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestOpenRouter_LiveSmoke sends a single one-token completion to
+// openrouter.ai using Omnia's runtime Server path. It proves the entire
+// pipeline works against the real gateway: auth, attribution headers, and
+// response parsing. Skips when OMNIA_OPENROUTER_API_KEY is unset.
+func TestOpenRouter_LiveSmoke(t *testing.T) {
+	apiKey := os.Getenv("OMNIA_OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OMNIA_OPENROUTER_API_KEY not set — skipping live smoke test")
+	}
+	// PromptKit's openai provider reads OPENAI_API_KEY (which the runtime
+	// normally populates from the Provider CRD's secretRef). Mirror that here
+	// so the real flow is exercised end-to-end.
+	t.Setenv("OPENAI_API_KEY", apiKey)
+
+	model := os.Getenv("OMNIA_OPENROUTER_MODEL")
+	if model == "" {
+		// Cheapest usable model for a one-token smoke test.
+		model = "meta-llama/llama-3.1-8b-instruct"
+	}
+
+	s := NewServer(
+		WithLogger(logr.Discard()),
+		WithProviderInfo("openai", model),
+		WithBaseURL("https://openrouter.ai/api/v1"),
+		WithHeaders(map[string]string{
+			"HTTP-Referer": "https://omnia.altairalabs.ai",
+			"X-Title":      "omnia-livesmoke",
+		}),
+	)
+
+	provider, err := s.createProviderFromConfig()
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	resp, err := provider.Predict(context.Background(), providers.PredictionRequest{
+		Messages: []types.Message{
+			{Role: "system", Content: "You are a terse test bot. Reply with a single word."},
+			{Role: "user", Content: "ping"},
+		},
+	})
+	require.NoError(t, err, "live OpenRouter request failed — check API key, model ID, and account credits")
+
+	t.Logf("openrouter response: %q", resp.Content)
+	assert.NotEmpty(t, strings.TrimSpace(resp.Content), "expected a non-empty response from OpenRouter")
+}


### PR DESCRIPTION
## Summary

Follow-up to #912. Promotes OpenRouter from a reference-page code block to a dedicated how-to, and adds an httptest-based integration test that proves custom attribution headers actually reach the LLM endpoint — closing the CRD → Config → Server → HTTP-wire loop end-to-end.

**New how-to**: \`docs/src/content/docs/how-to/configure-openrouter-provider.md\`
- Secret creation (\`OPENAI_API_KEY\` = OpenRouter key)
- Provider CR with \`type: openai\`, \`baseURL: https://openrouter.ai/api/v1\`, \`HTTP-Referer\` / \`X-Title\` headers
- Explanation of how headers reach the wire via PromptKit's \`ApplyCustomHeaders\`
- Verification with \`kubectl get provider -o jsonpath\`
- AgentRuntime wiring example
- Model-ID table (\`anthropic/claude-sonnet-4\`, \`openai/gpt-4o\`, \`google/gemini-2.0-flash-exp\`, \`meta-llama/llama-3.1-70b-instruct\`)
- Custom pricing section (OpenRouter vs. first-party pricing divergence)
- Troubleshooting (wrong key prefix, rate limits / missing attribution, collision errors)

**New tests** (all three pass locally):
- \`TestOpenRouter_CustomHeadersReachTheWire\` — httptest server, Omnia \`NewServer(WithBaseURL, WithHeaders)\`, calls \`Predict\` on the resulting provider, asserts \`HTTP-Referer\` and \`X-Title\` are on the request and \`Authorization\` is not clobbered.
- \`TestOpenRouter_HeaderCollisionRejected\` — user-supplied \`Authorization\` header fails the request before send (matches PromptKit's collision guard and what the how-to warns about).
- \`TestLoadFromCRD_Headers\` — proves \`spec.headers\` from the Provider CRD reaches \`Config.Headers\` via \`loadFromProviderRef\`. Closes the top of the chain.

**Why a separate PR.** #912 shipped the plumbing; this follow-up adds the coverage and the user-facing recipe. Keeping it separate keeps the #912 diff focused and this one docs-heavy.

## Test plan

- [x] \`go test ./internal/runtime/... -run 'TestOpenRouter|TestLoadFromCRD_Headers' -count=1\` locally (GOWORK=off) — 3 PASS
- [ ] CI green
- [ ] Docs build green