### PR TITLE
chore: extract ~9 duplicated string literals; exempt migrations from S1192

### DIFF
--- a/ee/cmd/omnia-arena-controller/api/server.go
+++ b/ee/cmd/omnia-arena-controller/api/server.go
@@ -21,6 +21,10 @@ import (
 	"github.com/altairalabs/omnia/internal/httputil"
 )
 
+// msgMethodNotAllowed is the plaintext body returned for HTTP 405 responses.
+// Extracted to satisfy go:S1192 (duplicated 3x across route handlers).
+const msgMethodNotAllowed = "Method not allowed"
+
 // Server provides HTTP API endpoints for arena operations.
 type Server struct {
 	addr             string
@@ -94,7 +98,7 @@ type RenderTemplateResponse struct {
 // Uses PromptKit's Generator to render templates.
 func (s *Server) handleRenderTemplate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 
@@ -167,7 +171,7 @@ type PreviewFile struct {
 // then returns the file contents without persisting them.
 func (s *Server) handlePreviewTemplate(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 
@@ -233,7 +237,7 @@ func toLicenseResponse(l *license.License) licenseResponse {
 // Returns the current license information for the dashboard.
 func (s *Server) handleGetLicense(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {
-		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		http.Error(w, msgMethodNotAllowed, http.StatusMethodNotAllowed)
 		return
 	}
 

--- a/ee/cmd/omnia-arena-controller/main.go
+++ b/ee/cmd/omnia-arena-controller/main.go
@@ -49,6 +49,11 @@ import (
 const logKeyController = "controller"
 const errUnableToCreateController = "unable to create controller"
 
+// msgUnableToCreateWebhook is the structured-log message used when a
+// webhook registration call fails in main(). Extracted to satisfy
+// go:S1192 (duplicated 3x for each registered webhook).
+const msgUnableToCreateWebhook = "unable to create webhook"
+
 var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
@@ -334,17 +339,17 @@ func main() {
 	// Setup webhooks (only when webhook server is enabled)
 	if enableWebhooks {
 		if err := arenawebhook.SetupSessionPrivacyPolicyWebhookWithManager(mgr); err != nil {
-			setupLog.Error(err, "unable to create webhook", "webhook", "SessionPrivacyPolicy")
+			setupLog.Error(err, msgUnableToCreateWebhook, "webhook", "SessionPrivacyPolicy")
 			os.Exit(1)
 		}
 
 		if enableLicenseWebhooks {
 			if err := arenawebhook.SetupArenaSourceWebhookWithManager(mgr, licenseValidator); err != nil {
-				setupLog.Error(err, "unable to create webhook", "webhook", "ArenaSource")
+				setupLog.Error(err, msgUnableToCreateWebhook, "webhook", "ArenaSource")
 				os.Exit(1)
 			}
 			if err := arenawebhook.SetupArenaJobWebhookWithManager(mgr, licenseValidator); err != nil {
-				setupLog.Error(err, "unable to create webhook", "webhook", "ArenaJob")
+				setupLog.Error(err, msgUnableToCreateWebhook, "webhook", "ArenaJob")
 				os.Exit(1)
 			}
 			setupLog.Info("license validation webhooks enabled")

--- a/internal/controller/tools_config.go
+++ b/internal/controller/tools_config.go
@@ -33,6 +33,11 @@ import (
 	runtimetools "github.com/altairalabs/omnia/internal/runtime/tools"
 )
 
+// errFmtHandler wraps per-handler build errors (HTTP/gRPC/MCP/OpenAPI)
+// so downstream callers can attribute failures to the owning handler. Extracted
+// to silence go:S1192 (was duplicated across every handler-type branch).
+const errFmtHandler = "handler %q: %w"
+
 // ToolConfig represents the tools configuration file format for the runtime.
 // This is passed to the runtime container as a YAML file.
 type ToolConfig struct {
@@ -538,27 +543,27 @@ func buildHandlerEntry(h *omniav1alpha1.HandlerDefinition, endpoint string) (Han
 	case omniav1alpha1.HandlerTypeHTTP:
 		cfg, err := buildHTTPConfig(h, endpoint)
 		if err != nil {
-			return entry, fmt.Errorf("handler %q: %w", h.Name, err)
+			return entry, fmt.Errorf(errFmtHandler, h.Name, err)
 		}
 		entry.HTTPConfig = cfg
 		entry.Tool = buildToolDefinition(h.Tool)
 	case omniav1alpha1.HandlerTypeGRPC:
 		cfg, err := buildGRPCConfig(h, endpoint)
 		if err != nil {
-			return entry, fmt.Errorf("handler %q: %w", h.Name, err)
+			return entry, fmt.Errorf(errFmtHandler, h.Name, err)
 		}
 		entry.GRPCConfig = cfg
 		entry.Tool = buildToolDefinition(h.Tool)
 	case omniav1alpha1.HandlerTypeMCP:
 		cfg, err := buildMCPConfig(h)
 		if err != nil {
-			return entry, fmt.Errorf("handler %q: %w", h.Name, err)
+			return entry, fmt.Errorf(errFmtHandler, h.Name, err)
 		}
 		entry.MCPConfig = cfg
 	case omniav1alpha1.HandlerTypeOpenAPI:
 		cfg, err := buildOpenAPIConfig(h)
 		if err != nil {
-			return entry, fmt.Errorf("handler %q: %w", h.Name, err)
+			return entry, fmt.Errorf(errFmtHandler, h.Name, err)
 		}
 		entry.OpenAPIConfig = cfg
 	case omniav1alpha1.HandlerTypeClient:

--- a/internal/doctor/checks/infrastructure.go
+++ b/internal/doctor/checks/infrastructure.go
@@ -11,7 +11,17 @@ import (
 	"github.com/altairalabs/omnia/internal/doctor"
 )
 
-const healthTimeout = 5 * time.Second
+const (
+	healthTimeout = 5 * time.Second
+
+	// healthzPath is the liveness probe path used across infrastructure checks.
+	// Extracted to satisfy go:S1192 (3x duplication).
+	healthzPath = "/healthz"
+
+	// detailNotConfigured is the Detail string used on skip results when a
+	// service URL is unset. Extracted to satisfy go:S1192 (3x duplication).
+	detailNotConfigured = "not configured"
+)
 
 // InfrastructureChecks returns liveness health checks for all provided services.
 func InfrastructureChecks(services map[string]string) []doctor.Check {
@@ -28,13 +38,13 @@ func OllamaCheck(url string) doctor.Check {
 }
 
 func healthCheck(name, baseURL string) doctor.Check {
-	return probeCheck(name, baseURL, "/healthz", "Healthy")
+	return probeCheck(name, baseURL, healthzPath, "Healthy")
 }
 
 // OperatorAPICheck returns a check that verifies the operator API server responds.
 // It GETs /healthz and expects HTTP 200.
 func OperatorAPICheck(baseURL string) doctor.Check {
-	return probeCheck("OperatorAPI", baseURL, "/healthz", "Healthy")
+	return probeCheck("OperatorAPI", baseURL, healthzPath, "Healthy")
 }
 
 // DashboardCheck returns a check that verifies the dashboard responds.
@@ -54,7 +64,7 @@ func ArenaControllerCheck(baseURL string) doctor.Check {
 			if baseURL == "" {
 				return doctor.TestResult{
 					Status: doctor.StatusSkip,
-					Detail: "not configured",
+					Detail: detailNotConfigured,
 				}
 			}
 
@@ -62,7 +72,7 @@ func ArenaControllerCheck(baseURL string) doctor.Check {
 			ctx, cancel := context.WithTimeout(ctx, healthTimeout)
 			defer cancel()
 
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/healthz", nil)
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+healthzPath, nil)
 			if err != nil {
 				return doctor.TestResult{Status: doctor.StatusFail, Detail: err.Error()}
 			}
@@ -106,7 +116,7 @@ func TCPCheck(name, addr string) doctor.Check {
 			if addr == "" {
 				return doctor.TestResult{
 					Status: doctor.StatusSkip,
-					Detail: "not configured",
+					Detail: detailNotConfigured,
 				}
 			}
 
@@ -134,7 +144,7 @@ func probeCheck(name, baseURL, path, suffix string) doctor.Check {
 			if baseURL == "" {
 				return doctor.TestResult{
 					Status: doctor.StatusSkip,
-					Detail: "not configured",
+					Detail: detailNotConfigured,
 				}
 			}
 

--- a/internal/doctor/checks/privacy.go
+++ b/internal/doctor/checks/privacy.go
@@ -25,6 +25,10 @@ const (
 	privacyBatchDeletePath  = "/api/v1/memories/batch"
 	privacyMemoriesPath     = "/api/v1/memories"
 	privacyMemorySearchPath = "/api/v1/memories/search"
+
+	// HTTP header/media-type constants (extracted to satisfy go:S1192).
+	headerContentType = "Content-Type"
+	contentTypeJSON   = "application/json"
 )
 
 // PrivacyChecker runs privacy-related checks against the memory-api service.
@@ -122,10 +126,10 @@ func (p *PrivacyChecker) requireWorkspace() *doctor.TestResult {
 // Returns the memory ID on success, or an error.
 func (p *PrivacyChecker) saveMemory(ctx context.Context, content string, extraHeaders map[string]string) (string, int, error) {
 	payload := map[string]interface{}{
-		"type":       "doctor-privacy-test",
+		"type":       privacyTestUserID,
 		"content":    content,
 		"confidence": 0.9,
-		"scope":      map[string]string{"workspace_id": p.workspace, "user_id": "doctor-privacy-test"},
+		"scope":      map[string]string{"workspace_id": p.workspace, "user_id": privacyTestUserID},
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
@@ -136,7 +140,7 @@ func (p *PrivacyChecker) saveMemory(ctx context.Context, content string, extraHe
 	if err != nil {
 		return "", 0, err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerContentType, contentTypeJSON)
 	for k, v := range extraHeaders {
 		req.Header.Set(k, v)
 	}
@@ -165,7 +169,7 @@ func (p *PrivacyChecker) saveMemory(ctx context.Context, content string, extraHe
 // searchMemories queries the memory search endpoint for a query string.
 // Returns the raw JSON body contents of the memories array items.
 func (p *PrivacyChecker) searchMemories(ctx context.Context, query string) ([]map[string]interface{}, error) {
-	params := url.Values{"workspace": {p.workspace}, "q": {query}, "user_id": {"doctor-privacy-test"}}
+	params := url.Values{"workspace": {p.workspace}, "q": {query}, "user_id": {privacyTestUserID}}
 	searchURL := p.memoryAPIURL + privacyMemorySearchPath + "?" + params.Encode()
 	body, err := fetchBody(ctx, memoryClient(), searchURL)
 	if err != nil {
@@ -251,7 +255,7 @@ func (p *PrivacyChecker) checkOptOutRespected(ctx context.Context) doctor.TestRe
 	if err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}
 	}
-	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(headerContentType, contentTypeJSON)
 
 	resp, err := memoryClient().Do(req)
 	if err != nil {
@@ -270,7 +274,7 @@ func (p *PrivacyChecker) checkOptOutRespected(ctx context.Context) doctor.TestRe
 	defer func() {
 		delReq, _ := http.NewRequestWithContext(ctx, http.MethodDelete, optOutURL, bytes.NewReader(optOutBody))
 		if delReq != nil {
-			delReq.Header.Set("Content-Type", "application/json")
+			delReq.Header.Set(headerContentType, contentTypeJSON)
 			r, e := memoryClient().Do(delReq)
 			if e == nil {
 				r.Body.Close() //nolint:errcheck
@@ -316,7 +320,7 @@ func (p *PrivacyChecker) checkDeletionCascade(ctx context.Context) doctor.TestRe
 	}
 
 	batchURL := fmt.Sprintf("%s%s?workspace=%s&user_id=%s&limit=100",
-		p.memoryAPIURL, privacyBatchDeletePath, p.workspace, "doctor-privacy-test")
+		p.memoryAPIURL, privacyBatchDeletePath, p.workspace, privacyTestUserID)
 	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, batchURL, nil)
 	if err != nil {
 		return doctor.TestResult{Status: doctor.StatusFail, Error: err.Error()}

--- a/internal/runtime/tools/http_client.go
+++ b/internal/runtime/tools/http_client.go
@@ -35,6 +35,11 @@ import (
 const httpBodyMaxBytes = 10 * 1024 * 1024 // 10 MB
 const truncateErrorBodyLen = 512
 
+// errFmtBuildQueryParams wraps query-parameter build errors during URL
+// construction. Extracted to a const to silence go:S1192 (was duplicated
+// across every buildXxxRequest branch).
+const errFmtBuildQueryParams = "building query params: %w"
+
 // doHTTPRequest performs a direct HTTP call using the provided client, returning
 // the response body (as JSON), the raw call result for retry classification, and
 // any error.
@@ -243,7 +248,7 @@ func buildAdvancedBodyMethod(cfg *HTTPCfg, reqURL string, argsMap map[string]any
 			var err error
 			reqURL, err = appendQueryFromMap(reqURL, queryFields)
 			if err != nil {
-				return reqURL, nil, fmt.Errorf("building query params: %w", err)
+				return reqURL, nil, fmt.Errorf(errFmtBuildQueryParams, err)
 			}
 		}
 	}
@@ -267,7 +272,7 @@ func buildAdvancedNonBodyMethod(cfg *HTTPCfg, reqURL string, argsMap map[string]
 		var err error
 		reqURL, err = appendQueryFromMap(reqURL, queryMap)
 		if err != nil {
-			return reqURL, nil, fmt.Errorf("building query params: %w", err)
+			return reqURL, nil, fmt.Errorf(errFmtBuildQueryParams, err)
 		}
 	}
 	return reqURL, nil, nil
@@ -281,7 +286,7 @@ func buildSimpleBodyAndQuery(cfg *HTTPCfg, method, reqURL string, hasArgs bool, 
 		}
 		resolved, err := appendQueryFromJSON(reqURL, args)
 		if err != nil {
-			return reqURL, nil, fmt.Errorf("building query params: %w", err)
+			return reqURL, nil, fmt.Errorf(errFmtBuildQueryParams, err)
 		}
 		return resolved, nil, nil
 	}

--- a/internal/session/providers/redis/provider.go
+++ b/internal/session/providers/redis/provider.go
@@ -35,6 +35,10 @@ import (
 
 const tracerName = "omnia-redis-cache"
 
+// errFmtRedisCheckExistence wraps EXISTS-style lookup failures. Extracted
+// to satisfy go:S1192 (duplicated 4x across the provider).
+const errFmtRedisCheckExistence = "redis: check existence: %w"
+
 // Compile-time interface check.
 var _ providers.HotCacheProvider = (*Provider)(nil)
 
@@ -181,7 +185,7 @@ func (p *Provider) DeleteSession(ctx context.Context, sessionID string) error {
 	exists, err := p.client.Exists(ctx, p.sessionKey(sessionID)).Result()
 	if err != nil {
 		recordErr(span, err)
-		return fmt.Errorf("redis: check existence: %w", err)
+		return fmt.Errorf(errFmtRedisCheckExistence, err)
 	}
 	if exists == 0 {
 		return session.ErrSessionNotFound
@@ -207,7 +211,7 @@ func (p *Provider) AppendMessage(ctx context.Context, sessionID string, msg *ses
 	exists, err := p.client.Exists(ctx, sessionKey).Result()
 	if err != nil {
 		recordErr(span, err)
-		return fmt.Errorf("redis: check existence: %w", err)
+		return fmt.Errorf(errFmtRedisCheckExistence, err)
 	}
 	if exists == 0 {
 		return session.ErrSessionNotFound
@@ -264,7 +268,7 @@ func (p *Provider) GetRecentMessages(ctx context.Context, sessionID string, limi
 	exists, err := p.client.Exists(ctx, p.sessionKey(sessionID)).Result()
 	if err != nil {
 		recordErr(span, err)
-		return nil, fmt.Errorf("redis: check existence: %w", err)
+		return nil, fmt.Errorf(errFmtRedisCheckExistence, err)
 	}
 	if exists == 0 {
 		return nil, session.ErrSessionNotFound
@@ -302,7 +306,7 @@ func (p *Provider) RefreshTTL(ctx context.Context, sessionID string, ttl time.Du
 	exists, err := p.client.Exists(ctx, sessionKey).Result()
 	if err != nil {
 		recordErr(span, err)
-		return fmt.Errorf("redis: check existence: %w", err)
+		return fmt.Errorf(errFmtRedisCheckExistence, err)
 	}
 	if exists == 0 {
 		return session.ErrSessionNotFound

--- a/internal/sourcesync/syncer.go
+++ b/internal/sourcesync/syncer.go
@@ -18,6 +18,11 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
+// arenaDirName is the hidden directory under a workspace where Arena source
+// artifacts are materialized (versions/HEAD layout). Extracted to satisfy
+// go:S1192 (duplicated 5x across syncer path construction).
+const arenaDirName = ".arena"
+
 // StorageManager is the minimal interface FilesystemSyncer needs to ensure a
 // workspace PVC exists before writing artifacts. The ee/pkg/workspace
 // StorageManager type satisfies this interface.
@@ -82,10 +87,10 @@ func (s *FilesystemSyncer) SyncToFilesystem(ctx context.Context, params SyncPara
 	}
 
 	// Check if this version already exists
-	versionDir := filepath.Join(workspacePath, ".arena", "versions", version)
+	versionDir := filepath.Join(workspacePath, arenaDirName, "versions", version)
 	if _, statErr := os.Stat(versionDir); statErr == nil {
 		log.V(1).Info("Version already exists, skipping sync", "version", version)
-		contentPath = filepath.Join(params.TargetPath, ".arena", "versions", version)
+		contentPath = filepath.Join(params.TargetPath, arenaDirName, "versions", version)
 		if headErr := UpdateHEAD(workspacePath, version); headErr != nil {
 			return "", "", fmt.Errorf("failed to update HEAD: %w", headErr)
 		}
@@ -112,7 +117,7 @@ func (s *FilesystemSyncer) SyncToFilesystem(ctx context.Context, params SyncPara
 		"path", versionDir,
 	)
 
-	contentPath = filepath.Join(params.TargetPath, ".arena", "versions", version)
+	contentPath = filepath.Join(params.TargetPath, arenaDirName, "versions", version)
 	return contentPath, version, nil
 }
 
@@ -167,7 +172,7 @@ func storeVersion(artifactPath, versionDir string) error {
 
 // UpdateHEAD atomically updates the HEAD pointer to the given version.
 func UpdateHEAD(workspacePath, version string) error {
-	arenaDir := filepath.Join(workspacePath, ".arena")
+	arenaDir := filepath.Join(workspacePath, arenaDirName)
 	if err := os.MkdirAll(arenaDir, 0755); err != nil {
 		return err
 	}
@@ -187,7 +192,7 @@ func UpdateHEAD(workspacePath, version string) error {
 // GCOldVersions removes old versions exceeding maxVersions.
 // If maxVersions is <= 0, defaults to 10.
 func GCOldVersions(workspacePath string, maxVersions int) error {
-	versionsDir := filepath.Join(workspacePath, ".arena", "versions")
+	versionsDir := filepath.Join(workspacePath, arenaDirName, "versions")
 
 	entries, err := os.ReadDir(versionsDir)
 	if err != nil {

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -36,6 +36,10 @@ import (
 const (
 	// TracerName is the name of the tracer used for runtime spans.
 	TracerName = "omnia-runtime"
+
+	// msgSpanStarted is the structured-log message emitted when a new span
+	// is opened. Extracted to satisfy go:S1192 (3x duplication).
+	msgSpanStarted = "span started"
 )
 
 // GenAI semantic convention attribute keys.
@@ -223,7 +227,7 @@ func (p *Provider) StartConversationSpan(ctx context.Context, sessionID, promptP
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(attrs...),
 	)
-	p.log.V(1).Info("span started",
+	p.log.V(1).Info(msgSpanStarted,
 		"spanName", "omnia.runtime.conversation.turn",
 		"sessionID", sessionID,
 		"turnIndex", turnIndex,
@@ -243,7 +247,7 @@ func (p *Provider) StartLLMSpan(ctx context.Context, model string, system string
 			attribute.String(AttrGenAIRequestModel, model),
 		),
 	)
-	p.log.V(1).Info("span started",
+	p.log.V(1).Info(msgSpanStarted,
 		"spanName", "genai.chat",
 		"model", model,
 		"system", system,
@@ -277,7 +281,7 @@ func (p *Provider) StartToolSpan(ctx context.Context, toolName string, meta Tool
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(attrs...),
 	)
-	p.log.V(1).Info("span started",
+	p.log.V(1).Info(msgSpanStarted,
 		"spanName", "omnia.tool.call",
 		"toolName", toolName,
 		"traceID", span.SpanContext().TraceID())

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -139,7 +139,7 @@ sonar.cpd.exclusions=**/migrations/*.sql,internal/memory/api/*.go,internal/memor
 # e26: Allow storage limits check in EE kustomize (overridden by Helm at deploy time)
 # e27: Allow recursive COPY in Dockerfiles (build context is source-only via .dockerignore)
 # e28: Allow path traversal in render.go - paths are validated via validateTempPath which checks /tmp or /var/folders prefix
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1135
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.go
 sonar.issue.ignore.multicriteria.e2.ruleKey=godre:S1172
@@ -196,6 +196,11 @@ sonar.issue.ignore.multicriteria.e27.ruleKey=docker:S6470
 sonar.issue.ignore.multicriteria.e27.resourceKey=ee/Dockerfile.*
 sonar.issue.ignore.multicriteria.e28.ruleKey=gosecurity:S2083
 sonar.issue.ignore.multicriteria.e28.resourceKey=ee/cmd/omnia-arena-controller/api/render.go
+# e29: SQL migrations are immutable (checksum-verified by golang-migrate); duplicated
+# literals inside migration files cannot be refactored without breaking existing
+# deployments. Suppress plsql:S1192 for the migrations directory only.
+sonar.issue.ignore.multicriteria.e29.ruleKey=plsql:S1192
+sonar.issue.ignore.multicriteria.e29.resourceKey=**/migrations/**/*.sql
 
 # Quality gate settings
 # Quality gate check is handled by SonarSource/sonarqube-quality-gate-action in CI


### PR DESCRIPTION
## Summary

Mechanical sweep clearing **go:S1192 CRITICAL** code smells on \`main\`. Each extracted constant is named for its semantic role; no logic changes.

| File | Constant | Used |
|---|---|---|
| \`internal/runtime/tools/http_client.go\` | \`errFmtBuildQueryParams\` | 3× |
| \`internal/controller/tools_config.go\` | \`errFmtHandler\` | 4× |
| \`internal/session/providers/redis/provider.go\` | \`errFmtRedisCheckExistence\` | 4× |
| \`internal/doctor/checks/privacy.go\` | \`headerContentType\`, \`contentTypeJSON\` | 3× each; plus \`privacyTestUserID\` (already a const) now reused at the 4 hardcoded sites |
| \`internal/doctor/checks/infrastructure.go\` | \`healthzPath\`, \`detailNotConfigured\` | 3× each |
| \`ee/cmd/omnia-arena-controller/api/server.go\` | \`msgMethodNotAllowed\` | 3× |
| \`ee/cmd/omnia-arena-controller/main.go\` | \`msgUnableToCreateWebhook\` | 3× |
| \`internal/tracing/tracing.go\` | \`msgSpanStarted\` | 3× |
| \`internal/sourcesync/syncer.go\` | \`arenaDirName\` | 5× |

Separately: \`sonar-project.properties\` adds rule \`e29\` suppressing \`plsql:S1192\` on \`**/migrations/**/*.sql\` — migration files are checksum-verified by \`golang-migrate\` and cannot be refactored without breaking existing deployments. Closes 3 more migration smells.

**Clears ~12 open CRITICAL S1192 smells on main.**

## Test plan

- [x] \`go build ./...\` (GOWORK=off) clean
- [x] \`go test ./internal/runtime/tools/... ./internal/controller/... ./internal/doctor/... ./internal/session/providers/redis/... ./internal/tracing/... ./internal/sourcesync/... ./ee/cmd/omnia-arena-controller/... -count=1\` all pass
- [x] Pre-commit hook green
- [ ] CI green
- [ ] SonarCloud quality gate still \`PASSED\`; open-smell count drops