### PR TITLE
chore: add body comments to 8 empty funcs flagged by go:S1186

### DIFF
--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -460,7 +460,10 @@ func detectNamespace() string {
 // for the audit logger (no-op when enterprise is disabled).
 func buildAPIMux(pool *pgxpool.Pool, registry *providers.Registry, f *flags, log logr.Logger) (http.Handler, *api.SessionService, func()) {
 	svcCfg := api.ServiceConfig{}
-	cleanup := func() {}
+	// Default cleanup is a no-op; only the enterprise audit-logger path below
+	// replaces it with a real Close() call. Keeping cleanup non-nil lets the
+	// main() defer site call it unconditionally.
+	cleanup := func() { /* no-op — replaced when enterprise audit is enabled */ }
 
 	// Enterprise: audit logger.
 	var auditLogger *audit.Logger

--- a/ee/pkg/evals/metrics.go
+++ b/ee/pkg/evals/metrics.go
@@ -179,20 +179,35 @@ func (m *WorkerMetrics) SetStreamLag(stream string, lag float64) {
 // NoOpWorkerMetrics is a no-op implementation for when metrics are disabled.
 type NoOpWorkerMetrics struct{}
 
-// RecordEventReceived is a no-op.
-func (n *NoOpWorkerMetrics) RecordEventReceived(_ string) {}
+// RecordEventReceived is a no-op for the metrics-disabled build. See
+// WorkerMetrics for the real implementation.
+func (n *NoOpWorkerMetrics) RecordEventReceived(_ string) {
+	// Intentionally empty — NoOpWorkerMetrics is the null-object impl used
+	// when worker metrics are disabled (WORKER_METRICS_DISABLED or missing
+	// Prometheus registry). All record methods drop inputs on the floor.
+}
 
-// RecordEvalExecuted is a no-op.
-func (n *NoOpWorkerMetrics) RecordEvalExecuted(_, _, _ string, _ float64) {}
+// RecordEvalExecuted is a no-op for the metrics-disabled build.
+func (n *NoOpWorkerMetrics) RecordEvalExecuted(_, _, _ string, _ float64) {
+	// Intentionally empty — see RecordEventReceived for rationale.
+}
 
-// RecordSamplingDecision is a no-op.
-func (n *NoOpWorkerMetrics) RecordSamplingDecision(_, _ string) {}
+// RecordSamplingDecision is a no-op for the metrics-disabled build.
+func (n *NoOpWorkerMetrics) RecordSamplingDecision(_, _ string) {
+	// Intentionally empty — see RecordEventReceived for rationale.
+}
 
-// RecordEventProcessing is a no-op.
-func (n *NoOpWorkerMetrics) RecordEventProcessing(_ string, _ float64) {}
+// RecordEventProcessing is a no-op for the metrics-disabled build.
+func (n *NoOpWorkerMetrics) RecordEventProcessing(_ string, _ float64) {
+	// Intentionally empty — see RecordEventReceived for rationale.
+}
 
-// RecordResultsWritten is a no-op.
-func (n *NoOpWorkerMetrics) RecordResultsWritten(_ int, _ bool) {}
+// RecordResultsWritten is a no-op for the metrics-disabled build.
+func (n *NoOpWorkerMetrics) RecordResultsWritten(_ int, _ bool) {
+	// Intentionally empty — see RecordEventReceived for rationale.
+}
 
-// SetStreamLag is a no-op.
-func (n *NoOpWorkerMetrics) SetStreamLag(_ string, _ float64) {}
+// SetStreamLag is a no-op for the metrics-disabled build.
+func (n *NoOpWorkerMetrics) SetStreamLag(_ string, _ float64) {
+	// Intentionally empty — see RecordEventReceived for rationale.
+}

--- a/internal/runtime/tools/retry.go
+++ b/internal/runtime/tools/retry.go
@@ -125,7 +125,9 @@ func retryWithBackoff(
 // caller to avoid context leaks.
 func withAttemptTimeout(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {
-		return ctx, func() {}
+		// No timeout requested; return a no-op cancel so callers can always
+		// `defer cancel()` without a nil check.
+		return ctx, func() { /* no-op cancel — no derived context to cancel */ }
 	}
 	return context.WithTimeout(ctx, timeout)
 }


### PR DESCRIPTION
## Summary

Mechanical sweep clearing **go:S1186 CRITICAL** code smells. The rule wants a comment *inside* the empty function body explaining intent; doc-comments above don't satisfy it.

**Files (8 empty funcs, 0 logic change):**

- \`ee/pkg/evals/metrics.go\` (6×): \`NoOpWorkerMetrics\` null-object impl used when metrics are disabled. First method documents the rationale; the other five reference it to avoid repetition.
- \`internal/runtime/tools/retry.go\`: \`withAttemptTimeout\` returns a no-op cancel when timeout == 0 so callers can \`defer cancel()\` unconditionally.
- \`cmd/session-api/main.go\`: \`buildAPIMux\` uses a no-op \`cleanup\` until the enterprise audit-logger path replaces it, keeping the \`main()\` defer site unconditional.

## Test plan

- [x] \`go build ./...\` (GOWORK=off) clean
- [x] \`go test ./ee/pkg/evals/... ./internal/runtime/tools/... ./cmd/session-api/... -count=1\` all pass
- [x] Pre-commit hook green
- [ ] CI green
- [ ] SonarCloud: 8 S1186 smells close