### PR TITLE
chore: document intentional detached ctx sites; suppress godre:S8239/S8242

### DIFF
--- a/ee/cmd/arena-worker/vu_pool.go
+++ b/ee/cmd/arena-worker/vu_pool.go
@@ -238,6 +238,8 @@ func (p *VUPool) executeAndReport(ctx context.Context, log logr.Logger, item *qu
 		SpanID:     spanID,
 		TraceFlags: trace.FlagsSampled,
 	})
+	// Per-item trace root — NOT a child of the pool context. Same pattern as
+	// worker.go's processItem. Bounded by maxItemTimeout on the next line.
 	itemCtx := trace.ContextWithRemoteSpanContext(context.Background(), remoteCtx)
 	itemCtx, itemCancel := context.WithTimeout(itemCtx, maxItemTimeout)
 	itemCtx, span := otel.Tracer("omnia-arena-worker").Start(itemCtx, "arena.work-item",

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -337,6 +337,9 @@ func executeAndReport(
 		SpanID:     spanID,
 		TraceFlags: trace.FlagsSampled,
 	})
+	// Per-item trace root — NOT a child of the job context. This keeps traces
+	// small and queryable via arena.job attribute. Lifetime is bounded by
+	// maxItemTimeout on the next line.
 	itemCtx := trace.ContextWithRemoteSpanContext(context.Background(), remoteCtx)
 	itemCtx, itemCancel := context.WithTimeout(itemCtx, maxItemTimeout)
 	itemCtx, span := otel.Tracer("omnia-arena-worker").Start(itemCtx, "arena.work-item",

--- a/ee/internal/controller/arenasource_controller.go
+++ b/ee/internal/controller/arenasource_controller.go
@@ -326,7 +326,9 @@ func (r *ArenaSourceReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		r.Recorder.Event(source, corev1.EventTypeNormal, EventReasonFetchStarted, "Started fetching artifact")
 	}
 
-	// Start async fetch
+	// Start async fetch — detached from the Reconcile ctx because the
+	// goroutine must outlive the reconciliation loop that scheduled it.
+	// Lifetime bounded by the caller-supplied timeout.
 	fetchCtx, cancel := context.WithTimeout(context.Background(), timeout)
 	job := &fetchJob{
 		startTime: time.Now(),

--- a/internal/facade/session.go
+++ b/internal/facade/session.go
@@ -179,6 +179,7 @@ func sessionIDToTraceID(sessionID string) trace.TraceID {
 func (s *Server) processRegularMessage(ctx context.Context, c *Connection, sessionID string, msg *ClientMessage, writer *connResponseWriter, log logr.Logger) error {
 	// Store user message with a detached context so it completes even if
 	// the WebSocket connection closes before the HTTP call returns.
+	// Lifetime is bounded by the 30s timeout; detachment is intentional.
 	storeCtx, storeCancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer storeCancel()
 	if err := s.sessionStore.AppendMessage(storeCtx, sessionID, session.Message{

--- a/internal/memory/api/service.go
+++ b/internal/memory/api/service.go
@@ -126,6 +126,9 @@ func (s *MemoryService) emitAuditEvent(ctx context.Context, entry *MemoryAuditEn
 		entry.UserAgent = meta.UserAgent
 	}
 	logger := s.auditLogger
+	// Detached background context is intentional: the audit-log write must
+	// complete even if the request context is cancelled (client disconnect,
+	// deadline exceeded). Losing an audit event is worse than wasting work.
 	go logger.LogEvent(context.Background(), entry)
 }
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -139,7 +139,7 @@ sonar.cpd.exclusions=**/migrations/*.sql,internal/memory/api/*.go,internal/memor
 # e26: Allow storage limits check in EE kustomize (overridden by Helm at deploy time)
 # e27: Allow recursive COPY in Dockerfiles (build context is source-only via .dockerignore)
 # e28: Allow path traversal in render.go - paths are validated via validateTempPath which checks /tmp or /var/folders prefix
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23,e24,e25,e26,e27,e28,e29,e30,e31,e32,e33,e34,e35
 sonar.issue.ignore.multicriteria.e1.ruleKey=go:S1135
 sonar.issue.ignore.multicriteria.e1.resourceKey=**/*.go
 sonar.issue.ignore.multicriteria.e2.ruleKey=godre:S1172
@@ -201,6 +201,33 @@ sonar.issue.ignore.multicriteria.e28.resourceKey=ee/cmd/omnia-arena-controller/a
 # deployments. Suppress plsql:S1192 for the migrations directory only.
 sonar.issue.ignore.multicriteria.e29.ruleKey=plsql:S1192
 sonar.issue.ignore.multicriteria.e29.resourceKey=**/migrations/**/*.sql
+# e30-e35: Allow context.Background() in these intentionally-detached code paths.
+# godre:S8239 assumes any context.Background() call inside a function receiving
+# ctx is a bug. These sites deliberately detach from the caller's context to
+# outlive the request/reconciliation loop or to preserve only trace propagation
+# without cancellation. Each call site carries an inline justification comment.
+# e30: memory-api audit logger — goroutine must outlive the request
+sonar.issue.ignore.multicriteria.e30.ruleKey=godre:S8239
+sonar.issue.ignore.multicriteria.e30.resourceKey=internal/memory/api/service.go
+# e31: facade session + recording writer — detach so storage completes even if
+# the WebSocket connection closes and to preserve span context for async recording
+sonar.issue.ignore.multicriteria.e31.ruleKey=godre:S8239
+sonar.issue.ignore.multicriteria.e31.resourceKey=internal/facade/*.go
+# e32: arena-worker per-item tracing — each work item is its own trace root,
+# not a child of the job-level context
+sonar.issue.ignore.multicriteria.e32.ruleKey=godre:S8239
+sonar.issue.ignore.multicriteria.e32.resourceKey=ee/cmd/arena-worker/**
+# e33: arena source controllers — async template/artifact fetch outlives the
+# reconcile call that scheduled it
+sonar.issue.ignore.multicriteria.e33.ruleKey=godre:S8239
+sonar.issue.ignore.multicriteria.e33.resourceKey=ee/internal/controller/arena*source_controller.go
+# e34: godre:S8242 (context.Context field) — legit on stream/writer wrappers
+# that implement interfaces requiring Context() access, where the embedded
+# field is how we override the context. Each site is documented inline.
+sonar.issue.ignore.multicriteria.e34.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e34.resourceKey=internal/facade/recording_writer.go
+sonar.issue.ignore.multicriteria.e35.ruleKey=godre:S8242
+sonar.issue.ignore.multicriteria.e35.resourceKey=internal/runtime/interceptor.go
 
 # Quality gate settings
 # Quality gate check is handled by SonarSource/sonarqube-quality-gate-action in CI


### PR DESCRIPTION
## Summary

Sonar flags 10 \`godre:S8239\` / \`godre:S8242\` cases. **All 10 are intentional patterns** — converting to the caller's ctx would break correctness. Adds inline justification comments at 5 call sites that didn't already have them, and narrowly-scoped Sonar suppressions (\`e30\`-\`e35\`) in \`sonar-project.properties\`.

### S8239 — \`context.Background()\` inside ctx-receiving funcs

| File | Intent |
|---|---|
| \`internal/memory/api/service.go\` | audit-log goroutine — must survive request cancellation |
| \`internal/facade/session.go\` | user-message store — must complete even when the WebSocket disconnects |
| \`internal/facade/recording_writer.go\` | \`detachedTraceContext\` — preserves only the span context, not cancellation |
| \`ee/cmd/arena-worker/worker.go\` + \`vu_pool.go\` | per-item trace root (not a child of the job-level context) |
| \`ee/internal/controller/arena*source_controller.go\` | async fetch outlives the reconcile call that scheduled it |

### S8242 — \`context.Context\` field on struct

| File | Intent |
|---|---|
| \`internal/runtime/interceptor.go\` | \`policyServerStream\` wraps \`grpc.ServerStream\`; ctx field is the canonical way to override \`Context()\` on the gRPC API |
| \`internal/facade/recording_writer.go\` | \`traceCtx\` preserves span propagation for async recording tasks |

### Rules added

- \`e30\`: \`godre:S8239\` on \`internal/memory/api/service.go\`
- \`e31\`: \`godre:S8239\` on \`internal/facade/*.go\`
- \`e32\`: \`godre:S8239\` on \`ee/cmd/arena-worker/**\`
- \`e33\`: \`godre:S8239\` on \`ee/internal/controller/arena*source_controller.go\`
- \`e34\`: \`godre:S8242\` on \`internal/facade/recording_writer.go\`
- \`e35\`: \`godre:S8242\` on \`internal/runtime/interceptor.go\`

Rest of the codebase remains covered — future regressions in other packages still fail the gate.

**Closes all 10 open S8239/S8242 smells on main.**

## Test plan

- [x] \`go build ./...\` (GOWORK=off) clean
- [x] Pre-commit hook green
- [ ] CI green
- [ ] SonarCloud: 10 smells close