### PR TITLE
chore(dashboard): mechanical TS smell sweep (sort->toSorted, readonly, etc)

### DIFF
--- a/dashboard/src/app/sessions/[id]/page.tsx
+++ b/dashboard/src/app/sessions/[id]/page.tsx
@@ -459,7 +459,7 @@ export default function SessionDetailPage({
         });
       }
       exportItems
-        .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+        .toSorted((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
         .forEach((item) => item.render());
 
       content = lines.join("\n");
@@ -955,7 +955,7 @@ function AggregatedEvalSection({ title, evals }: Readonly<{ title: string; evals
         </TableHeader>
         <TableBody>
           {evals
-            .sort((a, b) => a.passRate - b.passRate)
+            .toSorted((a, b) => a.passRate - b.passRate)
             .map((e) => (
               <AggregatedEvalRow key={e.key} eval_={e} />
             ))}

--- a/dashboard/src/app/workspaces/[name]/settings/access-tab.tsx
+++ b/dashboard/src/app/workspaces/[name]/settings/access-tab.tsx
@@ -33,6 +33,11 @@ const WORKSPACE_ROLES: WorkspaceRole[] = ["viewer", "editor", "owner"];
 const ELEVATED_ROLES: WorkspaceRole[] = ["editor", "owner"];
 const DEFAULT_ROLE: WorkspaceRole = "viewer";
 
+function formatExpiry(expires?: string): string {
+  if (!expires) return "Never";
+  return new Date(expires).toLocaleDateString();
+}
+
 interface AccessTabProps {
   workspace: Workspace;
   onPatch: (updates: Partial<WorkspaceSpec>) => void;
@@ -208,11 +213,6 @@ function DirectGrantsCard({ workspace, onPatch }: AccessTabProps) {
     });
     setNewUser("");
     setNewRole(DEFAULT_ROLE);
-  }
-
-  function formatExpiry(expires?: string): string {
-    if (!expires) return "Never";
-    return new Date(expires).toLocaleDateString();
   }
 
   return (

--- a/dashboard/src/components/arena/job-wizard.tsx
+++ b/dashboard/src/components/arena/job-wizard.tsx
@@ -989,7 +989,7 @@ export function JobWizard({
         </div>
       )}
 
-      {!toolRegistriesLoading && toolRegistryList && toolRegistryList.length === 0 && (
+      {!toolRegistriesLoading && toolRegistryList?.length === 0 && (
         <p className="text-xs text-muted-foreground italic">
           No tool registries found in this workspace.
         </p>

--- a/dashboard/src/components/error-boundary.tsx
+++ b/dashboard/src/components/error-boundary.tsx
@@ -39,7 +39,7 @@ export class ErrorBoundary extends React.Component<
     this.props.onError?.(error, errorInfo);
   }
 
-  private handleReset = (): void => {
+  private readonly handleReset = (): void => {
     this.setState({ hasError: false, error: null });
   };
 

--- a/dashboard/src/hooks/use-arena-stats.ts
+++ b/dashboard/src/hooks/use-arena-stats.ts
@@ -28,7 +28,7 @@ async function fetchArenaStats(workspace: string): Promise<ArenaStatsData> {
   if (jobsResponse.ok) {
     const jobs: ArenaJob[] = await jobsResponse.json();
     recentJobs = jobs
-      .sort((a, b) => {
+      .toSorted((a, b) => {
         const timeA = a.metadata?.creationTimestamp || "";
         const timeB = b.metadata?.creationTimestamp || "";
         return timeB.localeCompare(timeA);

--- a/dashboard/src/hooks/use-dev-console.ts
+++ b/dashboard/src/hooks/use-dev-console.ts
@@ -61,7 +61,7 @@ function assembleMediaAttachment(
   mimeType: string,
   chunks: MediaChunkInfo[]
 ): FileAttachment {
-  const sorted = chunks.sort((a, b) => a.sequence - b.sequence);
+  const sorted = chunks.toSorted((a, b) => a.sequence - b.sequence);
   const binaryParts = sorted
     .map((c) => c.data)
     .filter(Boolean)

--- a/dashboard/src/hooks/use-memory-mutations.ts
+++ b/dashboard/src/hooks/use-memory-mutations.ts
@@ -54,7 +54,7 @@ function triggerDownload(memories: object[], filename: string): void {
   a.download = filename;
   document.body.appendChild(a);
   a.click();
-  document.body.removeChild(a);
+  a.remove();
   URL.revokeObjectURL(url);
 }
 


### PR DESCRIPTION
## Summary

Clears 7 MAJOR typescript code smells on main via direct mechanical swaps. Design-flavoured ones (nested ternaries, boolean-to-behaviour params, function duplication) deferred to a follow-up that needs real thought.

| File | Change | Rule |
|---|---|---|
| \`dashboard/src/hooks/use-arena-stats.ts\` | \`.sort\` → \`.toSorted\` | S4043 |
| \`dashboard/src/hooks/use-dev-console.ts\` | \`.sort\` → \`.toSorted\` | S4043 |
| \`dashboard/src/app/sessions/[id]/page.tsx\` | \`.sort\` → \`.toSorted\` (x2) | S4043 |
| \`dashboard/src/components/error-boundary.tsx\` | \`handleReset\` → \`readonly handleReset\` | S2933 |
| \`dashboard/src/hooks/use-memory-mutations.ts\` | \`document.body.removeChild(a)\` → \`a.remove()\` | S7762 |
| \`dashboard/src/components/arena/job-wizard.tsx\` | optional-chain tidy (\`toolRegistryList && .length === 0\` → \`toolRegistryList?.length === 0\`) | S6582 |
| \`dashboard/src/app/workspaces/[name]/settings/access-tab.tsx\` | move \`formatExpiry\` to module scope | S7721 |

No logic changes.

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm run lint\` clean (pre-existing warnings only, no new)
- [x] \`npx vitest run\` — 77 tests PASS
- [ ] CI green
- [ ] SonarCloud: 7 smells close