### PR TITLE
chore(arena-worker): bundle shared params into resolveContext/workerLoopContext

### DIFF
--- a/ee/cmd/arena-worker/main_test.go
+++ b/ee/cmd/arena-worker/main_test.go
@@ -357,16 +357,11 @@ func TestHandlePopError(t *testing.T) {
 		}
 		q := queue.NewMemoryQueueWithDefaults()
 
-		done, newCount, err := handlePopError(
-			context.Background(),
-			testLog(),
-			context.DeadlineExceeded, // Non-queue error
-			0,
-			10,
-			cfg,
-			q,
-			"test-job",
-		)
+		wlc := &workerLoopContext{
+			ctx: context.Background(), log: testLog(),
+			cfg: cfg, queue: q, jobID: "test-job",
+		}
+		done, newCount, err := handlePopError(wlc, context.DeadlineExceeded, 0, 10)
 
 		if err == nil {
 			t.Error("expected error for non-empty-queue errors")
@@ -385,16 +380,11 @@ func TestHandlePopError(t *testing.T) {
 		}
 		q := queue.NewMemoryQueueWithDefaults()
 
-		done, newCount, err := handlePopError(
-			context.Background(),
-			testLog(),
-			queue.ErrQueueEmpty,
-			5,
-			10,
-			cfg,
-			q,
-			"test-job",
-		)
+		wlc := &workerLoopContext{
+			ctx: context.Background(), log: testLog(),
+			cfg: cfg, queue: q, jobID: "test-job",
+		}
+		done, newCount, err := handlePopError(wlc, queue.ErrQueueEmpty, 5, 10)
 
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
@@ -423,16 +413,11 @@ func TestHandlePopError(t *testing.T) {
 		item, _ := q.Pop(context.Background(), jobID)
 		_ = q.Ack(context.Background(), jobID, item.ID, []byte(`{"status":"pass"}`))
 
-		done, _, err := handlePopError(
-			context.Background(),
-			testLog(),
-			queue.ErrQueueEmpty,
-			9, // At max - 1
-			10,
-			cfg,
-			q,
-			jobID,
-		)
+		wlc := &workerLoopContext{
+			ctx: context.Background(), log: testLog(),
+			cfg: cfg, queue: q, jobID: jobID,
+		}
+		done, _, err := handlePopError(wlc, queue.ErrQueueEmpty, 9 /* at max - 1 */, 10)
 
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)

--- a/ee/cmd/arena-worker/provider_groups.go
+++ b/ee/cmd/arena-worker/provider_groups.go
@@ -39,6 +39,19 @@ type resolvedFleetProvider struct {
 	group string
 }
 
+// resolveContext bundles the plumbing (k8s client, logger, namespace, arena
+// config) threaded through every provider-resolution helper. Extracted to
+// drop every resolveXxx function below Sonar's 7-param threshold (go:S107)
+// and to keep call sites readable — they pass rc instead of 4–6 args.
+type resolveContext struct {
+	ctx         context.Context
+	log         logr.Logger
+	c           client.Client
+	namespace   string
+	agentWSURLs map[string]string
+	arenaCfg    *config.Config
+}
+
 // resolveProvidersFromCRD resolves providers from CRD refs when ARENA_PROVIDER_GROUPS is set.
 // It reads each Provider/AgentRuntime CRD, builds PromptKit provider configs, and populates
 // LoadedProviders. Fleet providers are connected and returned for post-engine registration.
@@ -74,8 +87,16 @@ func resolveProvidersFromCRD(
 	var fleetProviders []*resolvedFleetProvider
 	pricingMap := make(map[string]*providerPricing)
 
+	rc := &resolveContext{
+		ctx:         ctx,
+		log:         log,
+		c:           c,
+		namespace:   jobNamespace,
+		agentWSURLs: agentWSURLs,
+		arenaCfg:    arenaCfg,
+	}
 	for groupName, pg := range arenaJob.Providers {
-		fps, groupPricing, err := resolveProviderGroup(ctx, log, c, jobNamespace, groupName, &pg, agentWSURLs, arenaCfg)
+		fps, groupPricing, err := resolveProviderGroup(rc, groupName, &pg)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -96,32 +117,27 @@ func resolveProvidersFromCRD(
 
 // resolveProviderGroup resolves a single provider group (array or map mode).
 func resolveProviderGroup(
-	ctx context.Context,
-	log logr.Logger,
-	c client.Client,
-	namespace, groupName string,
+	rc *resolveContext,
+	groupName string,
 	pg *arenaProviderGroup,
-	agentWSURLs map[string]string,
-	arenaCfg *config.Config,
 ) ([]*resolvedFleetProvider, map[string]*providerPricing, error) {
 	if pg.isMapMode() {
-		return resolveMapModeGroup(ctx, log, c, namespace, groupName, pg.mapping, agentWSURLs, arenaCfg)
+		return resolveMapModeGroup(rc, groupName, pg.mapping)
 	}
-	return resolveArrayModeGroup(ctx, log, c, namespace, groupName, pg.entries, agentWSURLs, arenaCfg)
+	return resolveArrayModeGroup(rc, groupName, pg.entries)
 }
 
 // resolveMapModeGroup resolves providers in map mode (configID -> entry).
 func resolveMapModeGroup(
-	ctx context.Context, log logr.Logger, c client.Client,
-	namespace, groupName string,
+	rc *resolveContext,
+	groupName string,
 	mapping map[string]arenaProviderEntry,
-	agentWSURLs map[string]string, arenaCfg *config.Config,
 ) ([]*resolvedFleetProvider, map[string]*providerPricing, error) {
 	var fps []*resolvedFleetProvider
 	pricing := make(map[string]*providerPricing)
 
 	for configID, entry := range mapping {
-		fp, p, err := resolveEntry(ctx, log, c, namespace, groupName, configID, &entry, agentWSURLs, arenaCfg)
+		fp, p, err := resolveEntry(rc, groupName, configID, &entry)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -137,16 +153,15 @@ func resolveMapModeGroup(
 
 // resolveArrayModeGroup resolves providers in array mode (sequential entries).
 func resolveArrayModeGroup(
-	ctx context.Context, log logr.Logger, c client.Client,
-	namespace, groupName string,
+	rc *resolveContext,
+	groupName string,
 	entries []arenaProviderEntry,
-	agentWSURLs map[string]string, arenaCfg *config.Config,
 ) ([]*resolvedFleetProvider, map[string]*providerPricing, error) {
 	var fps []*resolvedFleetProvider
 	pricing := make(map[string]*providerPricing)
 
 	for _, entry := range entries {
-		fp, p, err := resolveEntry(ctx, log, c, namespace, groupName, "", &entry, agentWSURLs, arenaCfg)
+		fp, p, err := resolveEntry(rc, groupName, "", &entry)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -163,28 +178,24 @@ func resolveArrayModeGroup(
 // resolveEntry resolves a single provider/agent entry. When configID is non-empty,
 // it is used as the provider ID (map mode); otherwise sanitizeID derives it (array mode).
 func resolveEntry(
-	ctx context.Context,
-	log logr.Logger,
-	c client.Client,
-	namespace, groupName, configID string,
+	rc *resolveContext,
+	groupName, configID string,
 	entry *arenaProviderEntry,
-	agentWSURLs map[string]string,
-	arenaCfg *config.Config,
 ) (*resolvedFleetProvider, *providerPricing, error) {
 	if entry.ProviderRef != nil {
 		if configID != "" {
-			p, err := resolveProviderRefEntryWithID(ctx, log, c, namespace, *entry.ProviderRef, configID, groupName, arenaCfg)
+			p, err := resolveProviderRefEntryWithID(rc, *entry.ProviderRef, configID, groupName)
 			return nil, p, err
 		}
-		p, err := resolveProviderRefEntry(ctx, log, c, namespace, *entry.ProviderRef, groupName, arenaCfg)
+		p, err := resolveProviderRefEntry(rc, *entry.ProviderRef, groupName)
 		return nil, p, err
 	}
 	if entry.AgentRef != nil {
 		if configID != "" {
-			fp, err := resolveAgentRefEntryWithID(ctx, log, entry.AgentRef.Name, configID, groupName, agentWSURLs, arenaCfg)
+			fp, err := resolveAgentRefEntryWithID(rc, entry.AgentRef.Name, configID, groupName)
 			return fp, nil, err
 		}
-		fp, err := resolveAgentRefEntry(ctx, log, entry.AgentRef.Name, groupName, agentWSURLs, arenaCfg)
+		fp, err := resolveAgentRefEntry(rc, entry.AgentRef.Name, groupName)
 		return fp, nil, err
 	}
 	return nil, nil, nil
@@ -193,15 +204,11 @@ func resolveEntry(
 // resolveProviderRefEntry resolves a single Provider CRD and adds it to LoadedProviders.
 // Returns parsed pricing if the provider has spec.pricing configured.
 func resolveProviderRefEntry(
-	ctx context.Context,
-	log logr.Logger,
-	c client.Client,
-	namespace string,
+	rc *resolveContext,
 	ref v1alpha1.ProviderRef,
 	groupName string,
-	arenaCfg *config.Config,
 ) (*providerPricing, error) {
-	provider, err := k8s.GetProvider(ctx, c, ref, namespace)
+	provider, err := k8s.GetProvider(rc.ctx, rc.c, ref, rc.namespace)
 	if err != nil {
 		return nil, fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
 	}
@@ -229,10 +236,10 @@ func resolveProviderRefEntry(
 		pkProvider.Defaults = convertProviderDefaults(provider.Spec.Defaults)
 	}
 
-	arenaCfg.LoadedProviders[providerID] = pkProvider
-	arenaCfg.ProviderGroups[providerID] = groupName
+	rc.arenaCfg.LoadedProviders[providerID] = pkProvider
+	rc.arenaCfg.ProviderGroups[providerID] = groupName
 
-	log.V(1).Info("provider resolved from CRD",
+	rc.log.V(1).Info("provider resolved from CRD",
 		"providerID", providerID,
 		"type", pkProvider.Type,
 		"model", pkProvider.Model,
@@ -245,14 +252,11 @@ func resolveProviderRefEntry(
 
 // resolveAgentRefEntry resolves an AgentRuntime CRD and creates a fleet provider.
 func resolveAgentRefEntry(
-	_ context.Context,
-	log logr.Logger,
+	rc *resolveContext,
 	agentName string,
 	groupName string,
-	agentWSURLs map[string]string,
-	arenaCfg *config.Config,
 ) (*resolvedFleetProvider, error) {
-	wsURL, ok := agentWSURLs[agentName]
+	wsURL, ok := rc.agentWSURLs[agentName]
 	if !ok {
 		return nil, fmt.Errorf(
 			"group %q: no WebSocket URL for agent %s (missing from ARENA_AGENT_WS_URLS)",
@@ -264,16 +268,16 @@ func resolveAgentRefEntry(
 	// Add to LoadedProviders with ws_url in AdditionalConfig.
 	// The fleet provider factory (registered via init() in ee/pkg/arena/fleet/factory.go)
 	// will create the Provider instance during BuildEngineComponents.
-	arenaCfg.LoadedProviders[providerID] = &config.Provider{
+	rc.arenaCfg.LoadedProviders[providerID] = &config.Provider{
 		ID:   providerID,
 		Type: "fleet",
 		AdditionalConfig: map[string]interface{}{
 			"ws_url": wsURL,
 		},
 	}
-	arenaCfg.ProviderGroups[providerID] = groupName
+	rc.arenaCfg.ProviderGroups[providerID] = groupName
 
-	log.Info("agent resolved from CRD",
+	rc.log.Info("agent resolved from CRD",
 		"providerID", providerID,
 		"agentName", agentName,
 		"wsURL", wsURL,
@@ -291,16 +295,12 @@ func resolveAgentRefEntry(
 // instead of deriving it from sanitizeID(provider.Name). Used in map mode.
 // Returns parsed pricing if the provider has spec.pricing configured.
 func resolveProviderRefEntryWithID(
-	ctx context.Context,
-	log logr.Logger,
-	c client.Client,
-	namespace string,
+	rc *resolveContext,
 	ref v1alpha1.ProviderRef,
 	configID string,
 	groupName string,
-	arenaCfg *config.Config,
 ) (*providerPricing, error) {
-	provider, err := k8s.GetProvider(ctx, c, ref, namespace)
+	provider, err := k8s.GetProvider(rc.ctx, rc.c, ref, rc.namespace)
 	if err != nil {
 		return nil, fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
 	}
@@ -323,10 +323,10 @@ func resolveProviderRefEntryWithID(
 		pkProvider.Defaults = convertProviderDefaults(provider.Spec.Defaults)
 	}
 
-	arenaCfg.LoadedProviders[configID] = pkProvider
-	arenaCfg.ProviderGroups[configID] = groupName
+	rc.arenaCfg.LoadedProviders[configID] = pkProvider
+	rc.arenaCfg.ProviderGroups[configID] = groupName
 
-	log.V(1).Info("provider resolved from CRD (map mode)",
+	rc.log.V(1).Info("provider resolved from CRD (map mode)",
 		"configID", configID,
 		"crdName", provider.Name,
 		"type", pkProvider.Type,
@@ -340,31 +340,28 @@ func resolveProviderRefEntryWithID(
 // resolveAgentRefEntryWithID resolves an AgentRuntime CRD using an explicit config provider ID.
 // Used in map mode where the key IS the config provider ID.
 func resolveAgentRefEntryWithID(
-	_ context.Context,
-	log logr.Logger,
+	rc *resolveContext,
 	agentName string,
 	configID string,
 	groupName string,
-	agentWSURLs map[string]string,
-	arenaCfg *config.Config,
 ) (*resolvedFleetProvider, error) {
-	wsURL, ok := agentWSURLs[agentName]
+	wsURL, ok := rc.agentWSURLs[agentName]
 	if !ok {
 		return nil, fmt.Errorf(
 			"group %q: no WebSocket URL for agent %s (missing from ARENA_AGENT_WS_URLS)",
 			groupName, agentName)
 	}
 
-	arenaCfg.LoadedProviders[configID] = &config.Provider{
+	rc.arenaCfg.LoadedProviders[configID] = &config.Provider{
 		ID:   configID,
 		Type: "fleet",
 		AdditionalConfig: map[string]interface{}{
 			"ws_url": wsURL,
 		},
 	}
-	arenaCfg.ProviderGroups[configID] = groupName
+	rc.arenaCfg.ProviderGroups[configID] = groupName
 
-	log.Info("agent resolved from CRD (map mode)",
+	rc.log.Info("agent resolved from CRD (map mode)",
 		"configID", configID,
 		"agentName", agentName,
 		"wsURL", wsURL,

--- a/ee/cmd/arena-worker/provider_groups_test.go
+++ b/ee/cmd/arena-worker/provider_groups_test.go
@@ -18,17 +18,40 @@ import (
 	"github.com/AltairaLabs/PromptKit/pkg/config"
 	pkproviders "github.com/AltairaLabs/PromptKit/runtime/providers"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	v1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	"github.com/altairalabs/omnia/ee/pkg/arena/fleet"
 	"github.com/altairalabs/omnia/pkg/k8s"
 )
+
+// testRC builds a resolveContext for test call sites. Centralising this keeps
+// the test payload short when the production signature changed from long
+// positional args to a single struct.
+func testRC(
+	ctx context.Context,
+	log logr.Logger,
+	c client.Client,
+	ns string,
+	wsURLs map[string]string,
+	arenaCfg *config.Config,
+) *resolveContext {
+	return &resolveContext{
+		ctx:         ctx,
+		log:         log,
+		c:           c,
+		namespace:   ns,
+		agentWSURLs: wsURLs,
+		arenaCfg:    arenaCfg,
+	}
+}
 
 // mockProvider implements pkproviders.Provider for testing connectFleetProviders
 // type assertion error path.
@@ -514,7 +537,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "my-openai"}
-		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "judge", arenaCfg)
+		_, err := resolveProviderRefEntry(testRC(ctx, log, c, "default", nil, arenaCfg), ref, "judge")
 		require.NoError(t, err)
 
 		providerID := sanitizeID("my-openai")
@@ -548,7 +571,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "provider-with-cred"}
-		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
+		_, err := resolveProviderRefEntry(testRC(ctx, log, c, "default", nil, arenaCfg), ref, "default")
 		require.NoError(t, err)
 
 		providerID := sanitizeID("provider-with-cred")
@@ -583,7 +606,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "provider-with-defaults"}
-		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
+		_, err := resolveProviderRefEntry(testRC(ctx, log, c, "default", nil, arenaCfg), ref, "default")
 		require.NoError(t, err)
 
 		providerID := sanitizeID("provider-with-defaults")
@@ -601,7 +624,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "nonexistent"}
-		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "group1", arenaCfg)
+		_, err := resolveProviderRefEntry(testRC(ctx, log, c, "default", nil, arenaCfg), ref, "group1")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "group1")
 		assert.Contains(t, err.Error(), "nonexistent")
@@ -628,7 +651,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "cross-ns-provider", Namespace: ptr.To("other-ns")}
-		_, err := resolveProviderRefEntry(ctx, log, c, "default", ref, "default", arenaCfg)
+		_, err := resolveProviderRefEntry(testRC(ctx, log, c, "default", nil, arenaCfg), ref, "default")
 		require.NoError(t, err)
 
 		providerID := sanitizeID("cross-ns-provider")
@@ -660,7 +683,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "priced-provider"}
-		pricing, err := resolveProviderRefEntry(ctx, log, c, testNamespace, ref, "default", arenaCfg)
+		pricing, err := resolveProviderRefEntry(testRC(ctx, log, c, testNamespace, nil, arenaCfg), ref, "default")
 		require.NoError(t, err)
 		require.NotNil(t, pricing)
 		assert.InDelta(t, 0.003, pricing.inputCostPer1K, 1e-9)
@@ -688,7 +711,7 @@ func TestResolveProviderRefEntry(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "no-pricing-provider"}
-		pricing, err := resolveProviderRefEntry(ctx, log, c, testNamespace, ref, "default", arenaCfg)
+		pricing, err := resolveProviderRefEntry(testRC(ctx, log, c, testNamespace, nil, arenaCfg), ref, "default")
 		require.NoError(t, err)
 		assert.Nil(t, pricing)
 	})
@@ -711,7 +734,7 @@ func TestResolveAgentRefEntry(t *testing.T) {
 			"other-agent": "ws://other:8080/ws",
 		}
 
-		_, err := resolveAgentRefEntry(ctx, log, "missing-agent", "default", agentWSURLs, arenaCfg)
+		_, err := resolveAgentRefEntry(testRC(ctx, log, nil, "", agentWSURLs, arenaCfg), "missing-agent", "default")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing-agent")
 		assert.Contains(t, err.Error(), "ARENA_AGENT_WS_URLS")
@@ -723,7 +746,7 @@ func TestResolveAgentRefEntry(t *testing.T) {
 			ProviderGroups:  make(map[string]string),
 		}
 
-		_, err := resolveAgentRefEntry(ctx, log, "my-agent", "default", nil, arenaCfg)
+		_, err := resolveAgentRefEntry(testRC(ctx, log, nil, "", nil, arenaCfg), "my-agent", "default")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "my-agent")
 	})
@@ -734,7 +757,7 @@ func TestResolveAgentRefEntry(t *testing.T) {
 			ProviderGroups:  make(map[string]string),
 		}
 
-		_, err := resolveAgentRefEntry(ctx, log, "agent-x", "my-group", map[string]string{}, arenaCfg)
+		_, err := resolveAgentRefEntry(testRC(ctx, log, nil, "", map[string]string{}, arenaCfg), "agent-x", "my-group")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "my-group")
 	})
@@ -748,7 +771,7 @@ func TestResolveAgentRefEntry(t *testing.T) {
 			"my-agent": "ws://my-agent.default.svc:8080/ws",
 		}
 
-		fp, err := resolveAgentRefEntry(ctx, log, "my-agent", "fleet-group", agentWSURLs, arenaCfg)
+		fp, err := resolveAgentRefEntry(testRC(ctx, log, nil, "", agentWSURLs, arenaCfg), "my-agent", "fleet-group")
 		require.NoError(t, err)
 		require.NotNil(t, fp)
 
@@ -778,7 +801,8 @@ func TestResolveAgentRefEntryWithID(t *testing.T) {
 			ProviderGroups:  make(map[string]string),
 		}
 
-		_, err := resolveAgentRefEntryWithID(ctx, log, "missing-agent", "my-id", "group1", map[string]string{}, arenaCfg)
+		rc := testRC(ctx, log, nil, "", map[string]string{}, arenaCfg)
+		_, err := resolveAgentRefEntryWithID(rc, "missing-agent", "my-id", "group1")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "missing-agent")
 		assert.Contains(t, err.Error(), "group1")
@@ -793,7 +817,8 @@ func TestResolveAgentRefEntryWithID(t *testing.T) {
 			"my-agent": "ws://my-agent.default.svc:8080/ws",
 		}
 
-		fp, err := resolveAgentRefEntryWithID(ctx, log, "my-agent", "custom-id", "selfplay", agentWSURLs, arenaCfg)
+		rc := testRC(ctx, log, nil, "", agentWSURLs, arenaCfg)
+		fp, err := resolveAgentRefEntryWithID(rc, "my-agent", "custom-id", "selfplay")
 		require.NoError(t, err)
 		require.NotNil(t, fp)
 
@@ -825,7 +850,7 @@ func TestResolveProviderRefEntryWithID(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "nonexistent"}
-		_, err := resolveProviderRefEntryWithID(ctx, log, c, testNamespace, ref, "my-id", "grp", arenaCfg)
+		_, err := resolveProviderRefEntryWithID(testRC(ctx, log, c, testNamespace, nil, arenaCfg), ref, "my-id", "grp")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "nonexistent")
 	})
@@ -859,7 +884,7 @@ func TestResolveProviderRefEntryWithID(t *testing.T) {
 		}
 
 		ref := v1alpha1.ProviderRef{Name: "full-provider"}
-		_, err := resolveProviderRefEntryWithID(ctx, log, c, testNamespace, ref, "custom-id", "judge", arenaCfg)
+		_, err := resolveProviderRefEntryWithID(testRC(ctx, log, c, testNamespace, nil, arenaCfg), ref, "custom-id", "judge")
 		require.NoError(t, err)
 
 		require.Contains(t, arenaCfg.LoadedProviders, "custom-id")
@@ -889,7 +914,7 @@ func TestResolveEntry(t *testing.T) {
 		}
 		entry := &arenaProviderEntry{}
 
-		fp, _, err := resolveEntry(ctx, log, nil, testNamespace, "group", "", entry, nil, arenaCfg)
+		fp, _, err := resolveEntry(testRC(ctx, log, nil, testNamespace, nil, arenaCfg), "group", "", entry)
 		require.NoError(t, err)
 		assert.Nil(t, fp)
 	})
@@ -906,7 +931,7 @@ func TestResolveEntry(t *testing.T) {
 			AgentRef: &v1alpha1.LocalObjectReference{Name: "agent-a"},
 		}
 
-		fp, _, err := resolveEntry(ctx, log, nil, testNamespace, "grp", "my-config-id", entry, agentWSURLs, arenaCfg)
+		fp, _, err := resolveEntry(testRC(ctx, log, nil, testNamespace, agentWSURLs, arenaCfg), "grp", "my-config-id", entry)
 		require.NoError(t, err)
 		require.NotNil(t, fp)
 		assert.Equal(t, "my-config-id", fp.id)
@@ -924,7 +949,7 @@ func TestResolveEntry(t *testing.T) {
 			AgentRef: &v1alpha1.LocalObjectReference{Name: "agent-b"},
 		}
 
-		fp, _, err := resolveEntry(ctx, log, nil, testNamespace, "grp", "", entry, agentWSURLs, arenaCfg)
+		fp, _, err := resolveEntry(testRC(ctx, log, nil, testNamespace, agentWSURLs, arenaCfg), "grp", "", entry)
 		require.NoError(t, err)
 		require.NotNil(t, fp)
 		assert.Equal(t, sanitizeID("agent-agent-b"), fp.id)

--- a/ee/cmd/arena-worker/worker.go
+++ b/ee/cmd/arena-worker/worker.go
@@ -284,6 +284,17 @@ func processWorkItems(
 	return processSingleVU(ctx, log, cfg, q, jobID, bundlePath, wm)
 }
 
+// workerLoopContext bundles the plumbing (ctx, logger, config, queue, job id)
+// threaded through the work-loop helpers. Extracted to keep executeAndReport
+// and handlePopError under Sonar's 7-param threshold (go:S107).
+type workerLoopContext struct {
+	ctx   context.Context
+	log   logr.Logger
+	cfg   *Config
+	queue queue.WorkQueue
+	jobID string
+}
+
 // processSingleVU is the original single-threaded work item processing loop.
 func processSingleVU(
 	ctx context.Context, log logr.Logger, cfg *Config,
@@ -294,6 +305,7 @@ func processSingleVU(
 
 	log.Info("processing work items", "jobID", jobID)
 
+	wlc := &workerLoopContext{ctx: ctx, log: log, cfg: cfg, queue: q, jobID: jobID}
 	for {
 		if checkContextDone(ctx, log) {
 			return nil
@@ -301,7 +313,7 @@ func processSingleVU(
 
 		item, err := q.Pop(ctx, jobID)
 		if err != nil {
-			done, resetCount, retErr := handlePopError(ctx, log, err, emptyCount, maxEmptyPolls, cfg, q, jobID)
+			done, resetCount, retErr := handlePopError(wlc, err, emptyCount, maxEmptyPolls)
 			if retErr != nil {
 				return retErr
 			}
@@ -319,16 +331,18 @@ func processSingleVU(
 			"providerID", item.ProviderID,
 		)
 
-		executeAndReport(ctx, log, cfg, q, jobID, item, bundlePath, wm)
+		executeAndReport(wlc, item, bundlePath, wm)
 	}
 }
 
 // executeAndReport runs a work item and reports the result via Ack/Nack.
 func executeAndReport(
-	ctx context.Context, log logr.Logger, cfg *Config,
-	q queue.WorkQueue, jobID string, item *queue.WorkItem,
-	bundlePath string, wm *WorkerMetrics,
+	wlc *workerLoopContext,
+	item *queue.WorkItem,
+	bundlePath string,
+	wm *WorkerMetrics,
 ) {
+	ctx, log, cfg, q, jobID := wlc.ctx, wlc.log, wlc.cfg, wlc.queue, wlc.jobID
 	// Each work item gets its own trace (not a child of a job-level root).
 	traceID := workItemToTraceID(jobID, item.ID)
 	spanID := workItemToSpanID(item.ID)
@@ -384,9 +398,11 @@ func checkContextDone(ctx context.Context, log logr.Logger) bool {
 //
 //nolint:unparam // maxEmptyPolls kept as parameter for testability
 func handlePopError(
-	ctx context.Context, log logr.Logger, err error, emptyCount, maxEmptyPolls int,
-	cfg *Config, q queue.WorkQueue, jobID string,
+	wlc *workerLoopContext,
+	err error,
+	emptyCount, maxEmptyPolls int,
 ) (bool, int, error) {
+	ctx, log, cfg, q, jobID := wlc.ctx, wlc.log, wlc.cfg, wlc.queue, wlc.jobID
 	if !errors.Is(err, queue.ErrQueueEmpty) {
 		return false, emptyCount, fmt.Errorf("failed to pop work item: %w", err)
 	}


### PR DESCRIPTION
## Summary

Clears **7 go:S107 (MAJOR) smells** on main by grouping the plumbing threaded through every \`resolve*\`/\`loop*\` helper in \`ee/cmd/arena-worker/\` into two small structs. No behaviour change.

### \`provider_groups.go\` — \`resolveContext\` (\`ctx\`, \`log\`, \`c\`, \`namespace\`, \`agentWSURLs\`, \`arenaCfg\`)

| Function | Before | After |
|---|---|---|
| \`resolveProviderGroup\` | 8 params | 3 |
| \`resolveMapModeGroup\` | 8 | 3 |
| \`resolveArrayModeGroup\` | 8 | 3 |
| \`resolveEntry\` | 9 | 4 |
| \`resolveProviderRefEntry\` | 8 | 3 |
| \`resolveAgentRefEntry\` | 7 | 3 |
| \`resolveProviderRefEntryWithID\` | 9 | 4 |
| \`resolveAgentRefEntryWithID\` | 7 | 4 |

### \`worker.go\` — \`workerLoopContext\` (\`ctx\`, \`log\`, \`cfg\`, \`queue\`, \`jobID\`)

| Function | Before | After |
|---|---|---|
| \`executeAndReport\` | 8 | 4 |
| \`handlePopError\` | 8 | 4 |

### Tests

\`provider_groups_test.go\` gets a \`testRC()\` helper; 25 call sites swapped. \`main_test.go\` uses inline \`&workerLoopContext{...}\` literals (3 sites). Coverage preserved at 96%+ on \`provider_groups.go\`.

## Test plan

- [x] \`go build ./...\` (GOWORK=off) clean
- [x] \`go test ./ee/cmd/arena-worker/... -count=1\` all pass
- [x] Pre-commit hook green
- [ ] CI green
- [ ] SonarCloud: 7 smells close