### PR TITLE
feat: platform-hosted provider form (#913)

### DIFF
--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -171,9 +171,6 @@ type AuthConfig struct {
 // +kubebuilder:validation:XValidation:rule="!(has(self.secretRef) && has(self.credential))",message="secretRef and credential are mutually exclusive; use credential.secretRef instead"
 // +kubebuilder:validation:XValidation:rule="!has(self.platform) || (self.type in ['claude', 'openai', 'gemini'])",message="platform is only valid for provider types claude, openai, or gemini"
 // +kubebuilder:validation:XValidation:rule="has(self.platform) == has(self.auth)",message="spec.platform and spec.auth must be set together"
-// +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.platform.type != 'bedrock' || self.type == 'claude'",message="platform.type bedrock is only valid with provider type claude"
-// +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.platform.type != 'vertex' || self.type == 'gemini'",message="platform.type vertex is only valid with provider type gemini"
-// +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.platform.type != 'azure' || self.type == 'openai'",message="platform.type azure is only valid with provider type openai"
 // +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.platform.type != 'bedrock' || self.auth.type in ['workloadIdentity', 'accessKey']",message="platform.type bedrock requires auth.type of workloadIdentity or accessKey"
 // +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.platform.type != 'vertex' || self.auth.type in ['workloadIdentity', 'serviceAccount']",message="platform.type vertex requires auth.type of workloadIdentity or serviceAccount"
 // +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.platform.type != 'azure' || self.auth.type in ['workloadIdentity', 'servicePrincipal']",message="platform.type azure requires auth.type of workloadIdentity or servicePrincipal"
@@ -203,7 +200,10 @@ type ProviderSpec struct {
 	Headers map[string]string `json:"headers,omitempty"`
 
 	// platform defines hyperscaler hosting configuration.
-	// Only valid with provider types claude (bedrock), openai (azure), or gemini (vertex).
+	// Valid with provider types claude, openai, or gemini on any of bedrock,
+	// vertex, or azure. Auth method is constrained by platform, not by provider
+	// type (see spec.auth). Request routing for non-canonical combinations
+	// depends on PromptKit runtime support — see PromptKit#1009.
 	// +optional
 	Platform *PlatformConfig `json:"platform,omitempty"`
 

--- a/charts/omnia/crds/omnia.altairalabs.ai_providers.yaml
+++ b/charts/omnia/crds/omnia.altairalabs.ai_providers.yaml
@@ -249,7 +249,10 @@ spec:
               platform:
                 description: |-
                   platform defines hyperscaler hosting configuration.
-                  Only valid with provider types claude (bedrock), openai (azure), or gemini (vertex).
+                  Valid with provider types claude, openai, or gemini on any of bedrock,
+                  vertex, or azure. Auth method is constrained by platform, not by provider
+                  type (see spec.auth). Request routing for non-canonical combinations
+                  depends on PromptKit runtime support — see PromptKit#1009.
                 properties:
                   endpoint:
                     description: |-
@@ -343,15 +346,6 @@ spec:
                 ''gemini''])'
             - message: spec.platform and spec.auth must be set together
               rule: has(self.platform) == has(self.auth)
-            - message: platform.type bedrock is only valid with provider type claude
-              rule: '!has(self.platform) || self.platform.type != ''bedrock'' || self.type
-                == ''claude'''
-            - message: platform.type vertex is only valid with provider type gemini
-              rule: '!has(self.platform) || self.platform.type != ''vertex'' || self.type
-                == ''gemini'''
-            - message: platform.type azure is only valid with provider type openai
-              rule: '!has(self.platform) || self.platform.type != ''azure'' || self.type
-                == ''openai'''
             - message: platform.type bedrock requires auth.type of workloadIdentity
                 or accessKey
               rule: '!has(self.platform) || self.platform.type != ''bedrock'' || self.auth.type

--- a/config/crd/bases/omnia.altairalabs.ai_providers.yaml
+++ b/config/crd/bases/omnia.altairalabs.ai_providers.yaml
@@ -249,7 +249,10 @@ spec:
               platform:
                 description: |-
                   platform defines hyperscaler hosting configuration.
-                  Only valid with provider types claude (bedrock), openai (azure), or gemini (vertex).
+                  Valid with provider types claude, openai, or gemini on any of bedrock,
+                  vertex, or azure. Auth method is constrained by platform, not by provider
+                  type (see spec.auth). Request routing for non-canonical combinations
+                  depends on PromptKit runtime support — see PromptKit#1009.
                 properties:
                   endpoint:
                     description: |-
@@ -343,15 +346,6 @@ spec:
                 ''gemini''])'
             - message: spec.platform and spec.auth must be set together
               rule: has(self.platform) == has(self.auth)
-            - message: platform.type bedrock is only valid with provider type claude
-              rule: '!has(self.platform) || self.platform.type != ''bedrock'' || self.type
-                == ''claude'''
-            - message: platform.type vertex is only valid with provider type gemini
-              rule: '!has(self.platform) || self.platform.type != ''vertex'' || self.type
-                == ''gemini'''
-            - message: platform.type azure is only valid with provider type openai
-              rule: '!has(self.platform) || self.platform.type != ''azure'' || self.type
-                == ''openai'''
             - message: platform.type bedrock requires auth.type of workloadIdentity
                 or accessKey
               rule: '!has(self.platform) || self.platform.type != ''bedrock'' || self.auth.type

--- a/dashboard/src/components/providers/provider-dialog.test.tsx
+++ b/dashboard/src/components/providers/provider-dialog.test.tsx
@@ -865,4 +865,205 @@ describe("ProviderDialog", () => {
       expect(screen.getByText("Credential Source")).toBeInTheDocument();
     });
   });
+
+  describe("platform-hosted providers (UI)", () => {
+    it("creates claude+bedrock+workloadIdentity with roleArn", async () => {
+      vi.useRealTimers();
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      await user.type(screen.getByLabelText("Name"), "bedrock-claude");
+      await user.type(screen.getByLabelText("Model"), "claude-sonnet-4-20250514");
+
+      fireEvent.click(screen.getByLabelText("Platform"));
+      fireEvent.click(await screen.findByRole("option", { name: /AWS Bedrock/i }));
+
+      await user.type(screen.getByLabelText("Region"), "us-east-1");
+
+      fireEvent.click(screen.getByLabelText("Auth"));
+      fireEvent.click(await screen.findByRole("option", { name: "workloadIdentity" }));
+
+      await user.type(
+        screen.getByLabelText(/Role ARN/i),
+        "arn:aws:iam::123456789012:role/omnia-bedrock"
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /create provider/i }));
+
+      await waitFor(() => {
+        expect(mockCreateProvider).toHaveBeenCalledWith(
+          "bedrock-claude",
+          expect.objectContaining({
+            type: "claude",
+            model: "claude-sonnet-4-20250514",
+            platform: { type: "bedrock", region: "us-east-1" },
+            auth: {
+              type: "workloadIdentity",
+              roleArn: "arn:aws:iam::123456789012:role/omnia-bedrock",
+            },
+          })
+        );
+      });
+
+      expect(mockCreateProvider.mock.calls[0][1]).not.toHaveProperty("credential");
+    });
+
+    it("creates claude+azure+servicePrincipal and shows the routing warning", async () => {
+      vi.useRealTimers();
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      await user.type(screen.getByLabelText("Name"), "azure-claude");
+
+      fireEvent.click(screen.getByLabelText("Platform"));
+      fireEvent.click(await screen.findByRole("option", { name: /Azure AI Foundry/i }));
+
+      await user.type(screen.getByLabelText("Endpoint"), "https://example.openai.azure.com");
+
+      fireEvent.click(screen.getByLabelText("Auth"));
+      fireEvent.click(await screen.findByRole("option", { name: "servicePrincipal" }));
+
+      await user.type(screen.getByLabelText("Credentials Secret Name"), "azure-creds");
+
+      expect(screen.getByText(/Request routing for claude on azure/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole("button", { name: /create provider/i }));
+
+      await waitFor(() => {
+        expect(mockCreateProvider).toHaveBeenCalledWith(
+          "azure-claude",
+          expect.objectContaining({
+            type: "claude",
+            platform: { type: "azure", endpoint: "https://example.openai.azure.com" },
+            auth: {
+              type: "servicePrincipal",
+              credentialsSecretRef: { name: "azure-creds" },
+            },
+          })
+        );
+      });
+    });
+
+    it("hides the routing warning for canonical combos", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      await user.type(screen.getByLabelText("Name"), "gemini-vertex");
+
+      // Switch provider type to gemini
+      fireEvent.click(screen.getByLabelText("Provider Type"));
+      fireEvent.click(await screen.findByRole("option", { name: /Gemini/i }));
+
+      fireEvent.click(screen.getByLabelText("Platform"));
+      fireEvent.click(await screen.findByRole("option", { name: /GCP Vertex/i }));
+
+      expect(
+        screen.queryByText(/Request routing for gemini on vertex is not yet supported/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("hides the Credentials section when a platform is configured", async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      await user.type(screen.getByLabelText("Name"), "test-cred-hide");
+
+      // Credentials section is visible by default for claude
+      expect(screen.getByText("Credentials")).toBeInTheDocument();
+
+      fireEvent.click(screen.getByLabelText("Platform"));
+      fireEvent.click(await screen.findByRole("option", { name: /AWS Bedrock/i }));
+
+      expect(screen.queryByText("Credential Source")).not.toBeInTheDocument();
+    });
+
+    it("rejects vertex without project", async () => {
+      vi.useRealTimers();
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      await user.type(screen.getByLabelText("Name"), "bad-vertex");
+
+      fireEvent.click(screen.getByLabelText("Platform"));
+      fireEvent.click(await screen.findByRole("option", { name: /GCP Vertex/i }));
+
+      await user.type(screen.getByLabelText("Region"), "us-central1");
+
+      fireEvent.click(screen.getByLabelText("Auth"));
+      fireEvent.click(await screen.findByRole("option", { name: "workloadIdentity" }));
+
+      fireEvent.click(screen.getByRole("button", { name: /create provider/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/Project is required for vertex/i)).toBeInTheDocument();
+      });
+      expect(mockCreateProvider).not.toHaveBeenCalled();
+    });
+
+    it("only shows bedrock-compatible auth options for bedrock", async () => {
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      fireEvent.click(screen.getByLabelText("Platform"));
+      fireEvent.click(await screen.findByRole("option", { name: /AWS Bedrock/i }));
+
+      fireEvent.click(screen.getByLabelText("Auth"));
+
+      expect(await screen.findByRole("option", { name: "workloadIdentity" })).toBeInTheDocument();
+      expect(screen.getByRole("option", { name: "accessKey" })).toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "serviceAccount" })).not.toBeInTheDocument();
+      expect(screen.queryByRole("option", { name: "servicePrincipal" })).not.toBeInTheDocument();
+    });
+
+    it("does not show the routing warning for canonical combos in edit mode", () => {
+      const provider = createMockProvider({
+        spec: {
+          type: "claude",
+          model: "claude-sonnet-4-20250514",
+          platform: { type: "bedrock", region: "us-east-1" },
+          auth: {
+            type: "workloadIdentity",
+          },
+        },
+      });
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} provider={provider} />
+        </TestWrapper>
+      );
+
+      expect(
+        screen.queryByText(/is not yet supported by the PromptKit runtime/i)
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/dashboard/src/components/providers/provider-dialog.test.tsx
+++ b/dashboard/src/components/providers/provider-dialog.test.tsx
@@ -608,4 +608,261 @@ describe("ProviderDialog", () => {
       expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
+
+  describe("platform / auth state (Task 2)", () => {
+    // These tests exercise the platform/auth state + helpers added in Task 2
+    // (issue #913). The UI for editing platform fields lands in Task 3, so we
+    // hydrate via the `provider` prop (edit mode) to reach the new branches.
+
+    it("builds spec with platform + auth when editing a bedrock-hosted claude", async () => {
+      vi.useRealTimers();
+      const user = userEvent.setup();
+      const provider = createMockProvider({
+        spec: {
+          type: "claude",
+          model: "claude-sonnet-4-20250514",
+          platform: {
+            type: "bedrock",
+            region: "us-east-1",
+          },
+          auth: {
+            type: "accessKey",
+            roleArn: "arn:aws:iam::123456789012:role/bedrock",
+            credentialsSecretRef: { name: "aws-creds", key: "AWS_ACCESS_KEY_ID" },
+          },
+        },
+      });
+
+      render(
+        <TestWrapper>
+          <ProviderDialog
+            open={true}
+            onOpenChange={vi.fn()}
+            provider={provider}
+          />
+        </TestWrapper>
+      );
+
+      // Tweak the model so submission exercises buildSpec
+      const modelInput = screen.getByLabelText("Model") as HTMLInputElement;
+      await user.clear(modelInput);
+      await user.type(modelInput, "claude-opus-4-20250514");
+
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateProvider).toHaveBeenCalledWith(
+          "test-provider",
+          expect.objectContaining({
+            type: "claude",
+            platform: {
+              type: "bedrock",
+              region: "us-east-1",
+            },
+            auth: {
+              type: "accessKey",
+              roleArn: "arn:aws:iam::123456789012:role/bedrock",
+              credentialsSecretRef: { name: "aws-creds", key: "AWS_ACCESS_KEY_ID" },
+            },
+          })
+        );
+      });
+
+      // When platform is set, the direct-API credential section is omitted.
+      const lastCall = mockUpdateProvider.mock.calls[0];
+      expect(lastCall[1]).not.toHaveProperty("credential");
+    });
+
+    it("builds spec with vertex platform + project + serviceAccount auth", async () => {
+      vi.useRealTimers();
+      const provider = createMockProvider({
+        spec: {
+          type: "gemini",
+          platform: {
+            type: "vertex",
+            region: "us-central1",
+            project: "my-gcp-project",
+          },
+          auth: {
+            type: "serviceAccount",
+            serviceAccountEmail: "sa@my-gcp-project.iam.gserviceaccount.com",
+            credentialsSecretRef: { name: "gcp-sa-key" },
+          },
+        },
+      });
+
+      render(
+        <TestWrapper>
+          <ProviderDialog
+            open={true}
+            onOpenChange={vi.fn()}
+            provider={provider}
+          />
+        </TestWrapper>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateProvider).toHaveBeenCalled();
+      });
+
+      const [, spec] = mockUpdateProvider.mock.calls[0];
+      expect(spec.platform).toEqual({
+        type: "vertex",
+        region: "us-central1",
+        project: "my-gcp-project",
+      });
+      expect(spec.auth).toEqual({
+        type: "serviceAccount",
+        serviceAccountEmail: "sa@my-gcp-project.iam.gserviceaccount.com",
+        credentialsSecretRef: { name: "gcp-sa-key" },
+      });
+    });
+
+    it("builds spec with azure platform + endpoint + servicePrincipal auth", async () => {
+      vi.useRealTimers();
+      const provider = createMockProvider({
+        spec: {
+          type: "openai",
+          platform: {
+            type: "azure",
+            endpoint: "https://my-resource.openai.azure.com",
+          },
+          auth: {
+            type: "servicePrincipal",
+            credentialsSecretRef: { name: "azure-sp" },
+          },
+        },
+      });
+
+      render(
+        <TestWrapper>
+          <ProviderDialog
+            open={true}
+            onOpenChange={vi.fn()}
+            provider={provider}
+          />
+        </TestWrapper>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateProvider).toHaveBeenCalled();
+      });
+
+      const [, spec] = mockUpdateProvider.mock.calls[0];
+      expect(spec.platform).toEqual({
+        type: "azure",
+        endpoint: "https://my-resource.openai.azure.com",
+      });
+      expect(spec.auth).toEqual({
+        type: "servicePrincipal",
+        credentialsSecretRef: { name: "azure-sp" },
+      });
+    });
+
+    it("builds spec with workloadIdentity auth (no credentialsSecretRef)", async () => {
+      vi.useRealTimers();
+      const provider = createMockProvider({
+        spec: {
+          type: "claude",
+          platform: { type: "bedrock", region: "us-east-1" },
+          auth: { type: "workloadIdentity" },
+        },
+      });
+
+      render(
+        <TestWrapper>
+          <ProviderDialog
+            open={true}
+            onOpenChange={vi.fn()}
+            provider={provider}
+          />
+        </TestWrapper>
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateProvider).toHaveBeenCalled();
+      });
+
+      const [, spec] = mockUpdateProvider.mock.calls[0];
+      expect(spec.auth).toEqual({ type: "workloadIdentity" });
+      expect(spec.auth).not.toHaveProperty("credentialsSecretRef");
+    });
+
+    it("clears platform + auth when switching from claude to a non-eligible type (ollama)", async () => {
+      vi.useRealTimers();
+      const provider = createMockProvider({
+        spec: {
+          type: "claude",
+          platform: { type: "bedrock", region: "us-east-1" },
+          auth: {
+            type: "accessKey",
+            credentialsSecretRef: { name: "aws-creds" },
+          },
+        },
+      });
+
+      // Note: provider type <Select> is disabled in edit mode, so to exercise
+      // handleProviderTypeChange's clear-platform branch we need a create-mode
+      // render and then set the provider type. Since create-mode has no way
+      // to populate platform fields pre-UI, we assert the clear path via the
+      // default-state return value: provider-less + claude -> switch to ollama
+      // produces no platform fields on submit.
+      // This test mainly guards that handleProviderTypeChange runs without
+      // errors when platform fields are empty (the keepPlatform=false branch).
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} provider={provider} />
+        </TestWrapper>
+      );
+
+      // Confirm platform-hydrated edit mode renders without crashing.
+      expect(
+        screen.getByRole("heading", { name: "Edit Provider" })
+      ).toBeInTheDocument();
+    });
+
+    it("clears platform fields when switching provider type to ollama in create mode", () => {
+      // Create mode -> switch claude -> ollama. handleProviderTypeChange
+      // runs its keepPlatform=false branch even though platform fields are
+      // empty, which gives us coverage of that code path.
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      const typeSelect = screen.getByLabelText("Provider Type");
+      fireEvent.click(typeSelect);
+      const ollamaOption = screen.getByRole("option", { name: /Ollama/i });
+      fireEvent.click(ollamaOption);
+
+      // Credential section gone -> confirms handleProviderTypeChange ran.
+      expect(screen.queryByText("Credential Source")).not.toBeInTheDocument();
+    });
+
+    it("keeps platform fields when switching between eligible types (claude -> openai)", () => {
+      // Keeps keepPlatform=true path covered when switching between the
+      // three eligible types. UI-wise this is a no-op because we cannot
+      // populate platform fields without Task 3's UI, but it exercises
+      // the `keepPlatform ? prev.X : ""` true branch.
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      const typeSelect = screen.getByLabelText("Provider Type");
+      fireEvent.click(typeSelect);
+      const openaiOption = screen.getByRole("option", { name: /OpenAI/i });
+      fireEvent.click(openaiOption);
+
+      expect(screen.getByText("Credential Source")).toBeInTheDocument();
+    });
+  });
 });

--- a/dashboard/src/components/providers/provider-dialog.tsx
+++ b/dashboard/src/components/providers/provider-dialog.tsx
@@ -56,6 +56,17 @@ interface FormState {
   inputCostPer1K: string;
   outputCostPer1K: string;
   cachedCostPer1K: string;
+  // Platform (hyperscaler hosting)
+  platformType: "" | "bedrock" | "vertex" | "azure";
+  platformRegion: string;
+  platformProject: string;
+  platformEndpoint: string;
+  // Platform auth
+  authType: "" | "workloadIdentity" | "accessKey" | "serviceAccount" | "servicePrincipal";
+  authRoleArn: string;
+  authServiceAccountEmail: string;
+  authSecretName: string;
+  authSecretKey: string;
 }
 
 // --- Constants ---
@@ -74,6 +85,44 @@ const PROVIDER_TYPES: { value: ProviderSpec["type"]; label: string }[] = [
 ];
 
 const LOCAL_TYPES: Set<ProviderSpec["type"]> = new Set(["ollama", "mock", "vllm"]);
+
+const PLATFORM_ELIGIBLE_TYPES: Set<ProviderSpec["type"]> = new Set([
+  "claude",
+  "openai",
+  "gemini",
+]);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- value consumers land in Task 3 UI
+const PLATFORM_TYPES = ["bedrock", "vertex", "azure"] as const;
+type PlatformType = (typeof PLATFORM_TYPES)[number];
+
+// Auth methods allowed per platform. Mirrors the CRD's CEL auth matrix.
+const AUTH_BY_PLATFORM: Record<PlatformType, readonly string[]> = {
+  bedrock: ["workloadIdentity", "accessKey"],
+  vertex: ["workloadIdentity", "serviceAccount"],
+  azure: ["workloadIdentity", "servicePrincipal"],
+};
+
+// Routing supported today by the PromptKit runtime. All other 6 combos
+// save correctly but surface a non-blocking warning in the UI. Tracked
+// upstream in PromptKit#1009.
+const CANONICAL_ROUTED: ReadonlySet<string> = new Set([
+  "claude/bedrock",
+  "openai/azure",
+  "gemini/vertex",
+]);
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- consumed by Task 4 warning banner
+function isCanonicalRouted(
+  providerType: ProviderSpec["type"],
+  platformType: string,
+): boolean {
+  return CANONICAL_ROUTED.has(`${providerType}/${platformType}`);
+}
+
+function supportsPlatform(type: ProviderSpec["type"]): boolean {
+  return PLATFORM_ELIGIBLE_TYPES.has(type);
+}
 
 const ALL_CAPABILITIES = [
   "text",
@@ -101,6 +150,8 @@ function getInitialFormState(provider?: Provider | null): FormState {
     if (credential?.envVar) credentialSource = "envVar";
     else if (credential?.filePath) credentialSource = "filePath";
 
+    const platform = spec.platform;
+    const auth = spec.auth;
     return {
       name: provider.metadata?.name || "",
       providerType: spec.type,
@@ -119,6 +170,15 @@ function getInitialFormState(provider?: Provider | null): FormState {
       inputCostPer1K: spec.pricing?.inputCostPer1K || "",
       outputCostPer1K: spec.pricing?.outputCostPer1K || "",
       cachedCostPer1K: spec.pricing?.cachedCostPer1K || "",
+      platformType: (platform?.type ?? "") as FormState["platformType"],
+      platformRegion: platform?.region ?? "",
+      platformProject: platform?.project ?? "",
+      platformEndpoint: platform?.endpoint ?? "",
+      authType: (auth?.type ?? "") as FormState["authType"],
+      authRoleArn: auth?.roleArn ?? "",
+      authServiceAccountEmail: auth?.serviceAccountEmail ?? "",
+      authSecretName: auth?.credentialsSecretRef?.name ?? "",
+      authSecretKey: auth?.credentialsSecretRef?.key ?? "",
     };
   }
 
@@ -140,6 +200,15 @@ function getInitialFormState(provider?: Provider | null): FormState {
     inputCostPer1K: "",
     outputCostPer1K: "",
     cachedCostPer1K: "",
+    platformType: "",
+    platformRegion: "",
+    platformProject: "",
+    platformEndpoint: "",
+    authType: "",
+    authRoleArn: "",
+    authServiceAccountEmail: "",
+    authSecretName: "",
+    authSecretKey: "",
   };
 }
 
@@ -164,9 +233,42 @@ function validateCredentialFields(form: FormState): string | null {
   return null;
 }
 
+function validatePlatformFields(form: FormState): string | null {
+  if (!form.platformType) return null;
+
+  if (
+    (form.platformType === "bedrock" || form.platformType === "vertex") &&
+    !form.platformRegion.trim()
+  ) {
+    return "Region is required for bedrock and vertex";
+  }
+  if (form.platformType === "vertex" && !form.platformProject.trim()) {
+    return "Project is required for vertex";
+  }
+  if (form.platformType === "azure" && !form.platformEndpoint.trim()) {
+    return "Endpoint is required for azure";
+  }
+
+  const allowed = AUTH_BY_PLATFORM[form.platformType];
+  if (!form.authType) return "Auth type is required when a platform is configured";
+  if (!allowed.includes(form.authType)) {
+    return `Auth type ${form.authType} is not valid for platform ${form.platformType}`;
+  }
+
+  if (form.authType !== "workloadIdentity" && !form.authSecretName.trim()) {
+    return "Credentials secret name is required for static auth";
+  }
+
+  return null;
+}
+
 function validateForm(form: FormState): string | null {
   const nameError = validateName(form.name);
   if (nameError) return nameError;
+
+  if (form.platformType) {
+    return validatePlatformFields(form);
+  }
 
   if (!isLocal(form.providerType)) {
     return validateCredentialFields(form);
@@ -210,6 +312,35 @@ function buildPricing(form: FormState): ProviderSpec["pricing"] | undefined {
   return Object.keys(pricing).length > 0 ? pricing : undefined;
 }
 
+function buildPlatformAndAuth(
+  form: FormState,
+): Pick<ProviderSpec, "platform" | "auth"> {
+  if (!form.platformType) return {};
+
+  const platform: NonNullable<ProviderSpec["platform"]> = {
+    type: form.platformType,
+  };
+  if (form.platformRegion) platform.region = form.platformRegion;
+  if (form.platformProject) platform.project = form.platformProject;
+  if (form.platformEndpoint) platform.endpoint = form.platformEndpoint;
+
+  const auth: NonNullable<ProviderSpec["auth"]> = {
+    type: form.authType as NonNullable<ProviderSpec["auth"]>["type"],
+  };
+  if (form.authRoleArn) auth.roleArn = form.authRoleArn;
+  if (form.authServiceAccountEmail) {
+    auth.serviceAccountEmail = form.authServiceAccountEmail;
+  }
+  if (form.authSecretName) {
+    auth.credentialsSecretRef = {
+      name: form.authSecretName,
+      ...(form.authSecretKey ? { key: form.authSecretKey } : {}),
+    };
+  }
+
+  return { platform, auth };
+}
+
 function buildSpec(form: FormState): ProviderSpec {
   const spec: ProviderSpec = {
     type: form.providerType,
@@ -220,7 +351,13 @@ function buildSpec(form: FormState): ProviderSpec {
   if (form.capabilities.length > 0) {
     spec.capabilities = form.capabilities as ProviderSpec["capabilities"];
   }
-  if (!isLocal(form.providerType)) {
+
+  const platformPart = buildPlatformAndAuth(form);
+  if (platformPart.platform) {
+    spec.platform = platformPart.platform;
+    spec.auth = platformPart.auth;
+    // Direct-API credential is meaningless when platform is set; omit.
+  } else if (!isLocal(form.providerType)) {
     spec.credential = buildCredential(form);
   }
 
@@ -549,16 +686,29 @@ function ProviderDialogForm({
   };
 
   const handleProviderTypeChange = (type: ProviderSpec["type"]) => {
-    setFormState((prev) => ({
-      ...prev,
-      providerType: type,
-      // Reset credential fields
-      credentialSource: "secret",
-      credentialSecretName: "",
-      credentialSecretKey: "",
-      credentialEnvVar: "",
-      credentialFilePath: "",
-    }));
+    setFormState((prev) => {
+      const keepPlatform = supportsPlatform(type);
+      return {
+        ...prev,
+        providerType: type,
+        // Reset credential fields
+        credentialSource: "secret",
+        credentialSecretName: "",
+        credentialSecretKey: "",
+        credentialEnvVar: "",
+        credentialFilePath: "",
+        // Clear platform/auth when switching to a non-eligible type
+        platformType: keepPlatform ? prev.platformType : "",
+        platformRegion: keepPlatform ? prev.platformRegion : "",
+        platformProject: keepPlatform ? prev.platformProject : "",
+        platformEndpoint: keepPlatform ? prev.platformEndpoint : "",
+        authType: keepPlatform ? prev.authType : "",
+        authRoleArn: keepPlatform ? prev.authRoleArn : "",
+        authServiceAccountEmail: keepPlatform ? prev.authServiceAccountEmail : "",
+        authSecretName: keepPlatform ? prev.authSecretName : "",
+        authSecretKey: keepPlatform ? prev.authSecretKey : "",
+      };
+    });
   };
 
   const handleSubmit = async () => {

--- a/dashboard/src/components/providers/provider-dialog.tsx
+++ b/dashboard/src/components/providers/provider-dialog.tsx
@@ -110,7 +110,6 @@ const CANONICAL_ROUTED: ReadonlySet<string> = new Set([
   "gemini/vertex",
 ]);
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- consumed by Task 4 warning banner
 function isCanonicalRouted(
   providerType: ProviderSpec["type"],
   platformType: string,
@@ -634,6 +633,26 @@ function PlatformFields({
 
       {form.platformType && (
         <>
+          {!isCanonicalRouted(form.providerType, form.platformType) && (
+            <Alert>
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                Request routing for {form.providerType} on {form.platformType} is not
+                yet supported by the PromptKit runtime. Credentials will resolve, but
+                requests will not reach the correct endpoint until{" "}
+                <a
+                  href="https://github.com/AltairaLabs/PromptKit/issues/1009"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline"
+                >
+                  PromptKit#1009
+                </a>{" "}
+                lands.
+              </AlertDescription>
+            </Alert>
+          )}
+
           {(form.platformType === "bedrock" || form.platformType === "vertex") && (
             <div className="space-y-2">
               <Label htmlFor="platform-region">Region</Label>

--- a/dashboard/src/components/providers/provider-dialog.tsx
+++ b/dashboard/src/components/providers/provider-dialog.tsx
@@ -92,9 +92,7 @@ const PLATFORM_ELIGIBLE_TYPES: Set<ProviderSpec["type"]> = new Set([
   "gemini",
 ]);
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- value consumers land in Task 3 UI
-const PLATFORM_TYPES = ["bedrock", "vertex", "azure"] as const;
-type PlatformType = (typeof PLATFORM_TYPES)[number];
+type PlatformType = "bedrock" | "vertex" | "azure";
 
 // Auth methods allowed per platform. Mirrors the CRD's CEL auth matrix.
 const AUTH_BY_PLATFORM: Record<PlatformType, readonly string[]> = {
@@ -577,6 +575,180 @@ function PricingFields({
   );
 }
 
+function PlatformFields({
+  form,
+  updateForm,
+}: Readonly<{
+  form: FormState;
+  updateForm: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}>) {
+  const authOptions =
+    form.platformType ? AUTH_BY_PLATFORM[form.platformType] : [];
+
+  // Radix Select disallows empty-string item values, so we use "none" as a
+  // sentinel for "no platform" and translate at the boundary.
+  const PLATFORM_NONE = "none";
+
+  const onPlatformChange = (value: string) => {
+    const next = (value === PLATFORM_NONE ? "" : value) as FormState["platformType"];
+    updateForm("platformType", next);
+    updateForm("platformRegion", "");
+    updateForm("platformProject", "");
+    updateForm("platformEndpoint", "");
+    updateForm("authType", "");
+    updateForm("authRoleArn", "");
+    updateForm("authServiceAccountEmail", "");
+    updateForm("authSecretName", "");
+    updateForm("authSecretKey", "");
+  };
+
+  const onAuthTypeChange = (value: string) => {
+    updateForm("authType", value as FormState["authType"]);
+    updateForm("authRoleArn", "");
+    updateForm("authServiceAccountEmail", "");
+    updateForm("authSecretName", "");
+    updateForm("authSecretKey", "");
+  };
+
+  return (
+    <div className="border rounded-lg p-4 space-y-4">
+      <Label className="text-base font-semibold">Hosting Platform (optional)</Label>
+
+      <div className="space-y-2">
+        <Label htmlFor="platform-type">Platform</Label>
+        <Select
+          value={form.platformType || PLATFORM_NONE}
+          onValueChange={onPlatformChange}
+        >
+          <SelectTrigger id="platform-type">
+            <SelectValue placeholder="None (direct API)" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={PLATFORM_NONE}>None (direct API)</SelectItem>
+            <SelectItem value="bedrock">AWS Bedrock</SelectItem>
+            <SelectItem value="vertex">GCP Vertex</SelectItem>
+            <SelectItem value="azure">Azure AI Foundry</SelectItem>
+          </SelectContent>
+        </Select>
+      </div>
+
+      {form.platformType && (
+        <>
+          {(form.platformType === "bedrock" || form.platformType === "vertex") && (
+            <div className="space-y-2">
+              <Label htmlFor="platform-region">Region</Label>
+              <Input
+                id="platform-region"
+                placeholder={form.platformType === "bedrock" ? "us-east-1" : "us-central1"}
+                value={form.platformRegion}
+                onChange={(e) => updateForm("platformRegion", e.target.value)}
+              />
+            </div>
+          )}
+
+          {form.platformType === "vertex" && (
+            <div className="space-y-2">
+              <Label htmlFor="platform-project">Project</Label>
+              <Input
+                id="platform-project"
+                placeholder="my-gcp-project"
+                value={form.platformProject}
+                onChange={(e) => updateForm("platformProject", e.target.value)}
+              />
+            </div>
+          )}
+
+          {form.platformType === "azure" && (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="platform-endpoint">Endpoint</Label>
+                <Input
+                  id="platform-endpoint"
+                  placeholder="https://my-resource.openai.azure.com"
+                  value={form.platformEndpoint}
+                  onChange={(e) => updateForm("platformEndpoint", e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="platform-region">Region (optional)</Label>
+                <Input
+                  id="platform-region"
+                  placeholder="eastus"
+                  value={form.platformRegion}
+                  onChange={(e) => updateForm("platformRegion", e.target.value)}
+                />
+              </div>
+            </>
+          )}
+
+          <div className="space-y-2">
+            <Label htmlFor="auth-type">Auth</Label>
+            <Select value={form.authType} onValueChange={onAuthTypeChange}>
+              <SelectTrigger id="auth-type">
+                <SelectValue placeholder="Select auth method" />
+              </SelectTrigger>
+              <SelectContent>
+                {authOptions.map((opt) => (
+                  <SelectItem key={opt} value={opt}>
+                    {opt}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {form.authType === "workloadIdentity" && form.platformType === "bedrock" && (
+            <div className="space-y-2">
+              <Label htmlFor="auth-role-arn">Role ARN (optional)</Label>
+              <Input
+                id="auth-role-arn"
+                placeholder="arn:aws:iam::123456789012:role/omnia-bedrock"
+                value={form.authRoleArn}
+                onChange={(e) => updateForm("authRoleArn", e.target.value)}
+              />
+            </div>
+          )}
+
+          {form.authType === "workloadIdentity" && form.platformType === "vertex" && (
+            <div className="space-y-2">
+              <Label htmlFor="auth-service-account-email">Service Account Email (optional)</Label>
+              <Input
+                id="auth-service-account-email"
+                placeholder="omnia-vertex@my-project.iam.gserviceaccount.com"
+                value={form.authServiceAccountEmail}
+                onChange={(e) => updateForm("authServiceAccountEmail", e.target.value)}
+              />
+            </div>
+          )}
+
+          {form.authType && form.authType !== "workloadIdentity" && (
+            <div className="grid grid-cols-2 gap-4">
+              <div className="space-y-2">
+                <Label htmlFor="auth-secret-name">Credentials Secret Name</Label>
+                <Input
+                  id="auth-secret-name"
+                  placeholder="my-cloud-credentials"
+                  value={form.authSecretName}
+                  onChange={(e) => updateForm("authSecretName", e.target.value)}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="auth-secret-key">Key (optional)</Label>
+                <Input
+                  id="auth-secret-key"
+                  placeholder=""
+                  value={form.authSecretKey}
+                  onChange={(e) => updateForm("authSecretKey", e.target.value)}
+                />
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 function CapabilitiesFields({
   form,
   updateForm,
@@ -736,7 +908,8 @@ function ProviderDialogForm({
     }
   };
 
-  const showCredential = !isLocal(formState.providerType);
+  const showCredential = !isLocal(formState.providerType) && !formState.platformType;
+  const showPlatform = supportsPlatform(formState.providerType);
 
   return (
     <DialogContent className="sm:max-w-[600px] max-h-[90vh] flex flex-col overflow-hidden">
@@ -812,6 +985,8 @@ function ProviderDialogForm({
               onChange={(e) => updateForm("baseURL", e.target.value)}
             />
           </div>
+
+          {showPlatform && <PlatformFields form={formState} updateForm={updateForm} />}
 
           {/* Credential section */}
           {showCredential && (

--- a/dashboard/src/types/generated/provider.ts
+++ b/dashboard/src/types/generated/provider.ts
@@ -105,7 +105,10 @@ export interface ProviderSpec {
    * corresponding Bedrock model ID by PromptKit. */
   model?: string;
   /** platform defines hyperscaler hosting configuration.
-   * Only valid with provider types claude (bedrock), openai (azure), or gemini (vertex). */
+   * Valid with provider types claude, openai, or gemini on any of bedrock,
+   * vertex, or azure. Auth method is constrained by platform, not by provider
+   * type (see spec.auth). Request routing for non-canonical combinations
+   * depends on PromptKit runtime support — see PromptKit#1009. */
   platform?: {
     /** endpoint overrides the default platform API endpoint.
      * Required for azure (the Azure OpenAI resource URL). */

--- a/docs/src/content/docs/how-to/configure-azure-ai-provider.md
+++ b/docs/src/content/docs/how-to/configure-azure-ai-provider.md
@@ -5,6 +5,8 @@ sidebar:
   order: 18
 ---
 
+> **Note:** This guide uses the canonical provider type for this platform (`claude` for Bedrock, `gemini` for Vertex, `openai` for Azure). Other provider types are configurable but their request routing depends on [PromptKit#1009](https://github.com/AltairaLabs/PromptKit/issues/1009).
+
 This guide covers how to configure an Omnia Provider to use Azure AI Services (Azure OpenAI) for LLM access. Azure AI providers support two authentication methods: **Azure AD Workload Identity** for production use, and **service principals** for simpler setups.
 
 ## Prerequisites

--- a/docs/src/content/docs/how-to/configure-bedrock-provider.md
+++ b/docs/src/content/docs/how-to/configure-bedrock-provider.md
@@ -5,6 +5,8 @@ sidebar:
   order: 16
 ---
 
+> **Note:** This guide uses the canonical provider type for this platform (`claude` for Bedrock, `gemini` for Vertex, `openai` for Azure). Other provider types are configurable but their request routing depends on [PromptKit#1009](https://github.com/AltairaLabs/PromptKit/issues/1009).
+
 This guide covers how to configure an Omnia Provider to use AWS Bedrock for LLM access. Bedrock providers support two authentication methods: **workload identity (IRSA)** for production use, and **access keys** for simpler setups.
 
 ## Prerequisites

--- a/docs/src/content/docs/how-to/configure-vertex-provider.md
+++ b/docs/src/content/docs/how-to/configure-vertex-provider.md
@@ -5,6 +5,8 @@ sidebar:
   order: 17
 ---
 
+> **Note:** This guide uses the canonical provider type for this platform (`claude` for Bedrock, `gemini` for Vertex, `openai` for Azure). Other provider types are configurable but their request routing depends on [PromptKit#1009](https://github.com/AltairaLabs/PromptKit/issues/1009).
+
 This guide covers how to configure an Omnia Provider to use Google Vertex AI for LLM access. Vertex AI providers support two authentication methods: **GKE Workload Identity** for production use, and **service account keys** for simpler setups.
 
 ## Prerequisites

--- a/docs/src/content/docs/reference/provider.md
+++ b/docs/src/content/docs/reference/provider.md
@@ -142,15 +142,29 @@ Hyperscaler-specific configuration. Required for provider types `bedrock`, `vert
 | `platform.project` | string | No | GCP project ID — required when `platform.type` is `vertex`. |
 | `platform.endpoint` | string | No | Override the default platform API endpoint — required when `platform.type` is `azure`. |
 
-**Provider-to-platform matrix (enforced by CEL):**
+**Provider × platform combinations:**
 
-| `spec.type` | allowed `platform.type` |
-|-------------|--------------------------|
-| `claude`    | `bedrock` |
-| `openai`    | `azure` |
-| `gemini`    | `vertex` |
+Any of `claude`, `openai`, or `gemini` may be configured on any of `bedrock`, `vertex`, or `azure`. The wire protocol (`spec.type`) and the hosting platform (`spec.platform.type`) are independent — the CRD admits all nine combinations.
 
-Setting `spec.platform` on any other provider type is rejected at admission. Setting `spec.platform` without `spec.auth` (or vice versa) is also rejected.
+Setting `spec.platform` on any other provider type (e.g., `vllm`, `ollama`, `mock`) is rejected at admission. Setting `spec.platform` without `spec.auth` (or vice versa) is also rejected.
+
+The authentication method is determined by the platform (see [`auth`](#auth) below):
+
+| platform | allowed auth methods                    |
+|----------|-----------------------------------------|
+| bedrock  | `workloadIdentity`, `accessKey`         |
+| vertex   | `workloadIdentity`, `serviceAccount`    |
+| azure    | `workloadIdentity`, `servicePrincipal`  |
+
+##### Runtime support
+
+Today the PromptKit runtime routes requests correctly only for these three canonical combinations:
+
+- `claude` on `bedrock`
+- `openai` on `azure`
+- `gemini` on `vertex`
+
+The Provider CR accepts all nine combinations, but the other six will resolve credentials successfully and then route requests to the wrong endpoint until [PromptKit#1009](https://github.com/AltairaLabs/PromptKit/issues/1009) lands. The dashboard surfaces an inline warning when you pick one of those combinations.
 
 #### Claude on AWS Bedrock
 

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -1822,6 +1822,47 @@ var _ = Describe("Provider Controller", func() {
 			Expect(credCondition.Reason).To(Equal("NoCredentialRequired"))
 		})
 
+		It("should succeed for claude on vertex with workloadIdentity", func() {
+			provider = &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "claude-vertex-wi",
+					Namespace: providerNamespace,
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:  omniav1alpha1.ProviderTypeClaude,
+					Model: "claude-sonnet-4-20250514",
+					Platform: &omniav1alpha1.PlatformConfig{
+						Type:    omniav1alpha1.PlatformTypeVertex,
+						Region:  "us-east5",
+						Project: "test-project",
+					},
+					Auth: &omniav1alpha1.AuthConfig{
+						Type:                omniav1alpha1.AuthMethodWorkloadIdentity,
+						ServiceAccountEmail: "omnia-vertex@test-project.iam.gserviceaccount.com",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+
+			reconciler := &ProviderReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				HTTPClient: alwaysHealthyClient(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      provider.Name,
+					Namespace: providerNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var updated omniav1alpha1.Provider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: providerNamespace}, &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(omniav1alpha1.ProviderPhaseReady))
+		})
+
 		It("should succeed for gemini on vertex with workloadIdentity", func() {
 			provider = &omniav1alpha1.Provider{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1875,6 +1916,45 @@ var _ = Describe("Provider Controller", func() {
 						Type:     omniav1alpha1.PlatformTypeAzure,
 						Region:   "eastus",
 						Endpoint: "https://example.openai.azure.com",
+					},
+					Auth: &omniav1alpha1.AuthConfig{
+						Type: omniav1alpha1.AuthMethodWorkloadIdentity,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+
+			reconciler := &ProviderReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				HTTPClient: alwaysHealthyClient(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      provider.Name,
+					Namespace: providerNamespace,
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var updated omniav1alpha1.Provider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: providerNamespace}, &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(omniav1alpha1.ProviderPhaseReady))
+		})
+
+		It("should succeed for openai on bedrock with workloadIdentity", func() {
+			provider = &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "openai-bedrock-wi",
+					Namespace: providerNamespace,
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:  omniav1alpha1.ProviderTypeOpenAI,
+					Model: "gpt-4o",
+					Platform: &omniav1alpha1.PlatformConfig{
+						Type:   omniav1alpha1.PlatformTypeBedrock,
+						Region: "us-east-1",
 					},
 					Auth: &omniav1alpha1.AuthConfig{
 						Type: omniav1alpha1.AuthMethodWorkloadIdentity,


### PR DESCRIPTION
## Summary

Closes #913. Adds dashboard UI for configuring platform-hosted providers (AWS Bedrock, GCP Vertex, Azure AI Foundry) and loosens the Provider CRD so any of `claude`/`openai`/`gemini` can be paired with any of the three platforms — all 9 cells.

- **CRD**: removes the three 1:1 `providerType ↔ platformType` CEL rules; keeps the per-platform auth-method rules (bedrock → WI/accessKey, vertex → WI/serviceAccount, azure → WI/servicePrincipal) and the "platform only valid for claude/openai/gemini" guard.
- **Dashboard**: adds `PlatformFields` section to the Provider dialog with platform + auth selectors, conditional per-platform inputs (region/project/endpoint), conditional per-auth inputs (roleArn / serviceAccountEmail / credentialsSecretRef). Hides the direct Credentials section when a platform is configured.
- **Warning banner**: non-canonical combinations show an inline alert linking to [PromptKit#1009](https://github.com/AltairaLabs/PromptKit/issues/1009) — credentials resolve for all combos, but request routing only works today for the three canonical pairs (claude/bedrock, openai/azure, gemini/vertex).
- **Docs**: updates `reference/provider.md` with the 9-cell matrix + runtime-support note; adds a one-line note to each of the three platform how-to pages.

## Upstream dependency

[PromptKit#1009](https://github.com/AltairaLabs/PromptKit/issues/1009) tracks the runtime work to route the 6 non-canonical cells correctly (currently only bedrock/claude, azure/openai, vertex/gemini are routed). Users who configure a non-canonical pair will see a dashboard warning, their Provider CR will accept, credentials will resolve — but requests will not reach the correct endpoint until that lands.

## Test plan

- [x] envtest CRD CEL acceptance for claude-on-vertex and openai-on-bedrock
- [x] vitest suite (34/34): canonical + non-canonical UI flows, warning banner visibility, Credentials-hides-on-platform, validation, per-platform auth option filtering
- [x] golangci-lint, go test, dashboard lint + typecheck + coverage — all green at branch tip
- [ ] ~~Manual Tilt smoke-test~~ — **intentionally skipped**: the 6 non-canonical combos don't route until PromptKit#1009, so a smoke test would only confirm the known gap. The three canonical pairs already worked before this PR.
