### PR TITLE
feat(dashboard): custom HTTP headers in Provider dialog

### DIFF
--- a/dashboard/src/components/providers/provider-dialog.test.tsx
+++ b/dashboard/src/components/providers/provider-dialog.test.tsx
@@ -1066,4 +1066,124 @@ describe("ProviderDialog", () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe("HTTP headers", () => {
+    it("round-trips headers via edit mode", async () => {
+      vi.useRealTimers();
+
+      const provider = createMockProvider({
+        spec: {
+          type: "claude",
+          model: "claude-sonnet-4-20250514",
+          credential: { secretRef: { name: "my-key" } },
+          headers: {
+            "HTTP-Referer": "https://my-app.example.com",
+            "X-Title": "My App",
+          },
+        },
+      });
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} provider={provider} />
+        </TestWrapper>
+      );
+
+      expect(
+        (screen.getByLabelText("Header 1 name") as HTMLInputElement).value
+      ).toBe("HTTP-Referer");
+      expect(
+        (screen.getByLabelText("Header 1 value") as HTMLInputElement).value
+      ).toBe("https://my-app.example.com");
+      expect(
+        (screen.getByLabelText("Header 2 name") as HTMLInputElement).value
+      ).toBe("X-Title");
+
+      fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+      await waitFor(() => {
+        expect(mockUpdateProvider).toHaveBeenCalledWith(
+          "test-provider",
+          expect.objectContaining({
+            headers: {
+              "HTTP-Referer": "https://my-app.example.com",
+              "X-Title": "My App",
+            },
+          })
+        );
+      });
+    });
+
+    it("adds and removes header rows and submits non-empty entries only", async () => {
+      vi.useRealTimers();
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      await user.type(screen.getByLabelText("Name"), "gw-provider");
+      await user.type(screen.getByLabelText("Secret Name"), "my-key");
+
+      // Expand the HTTP Headers section
+      fireEvent.click(screen.getByRole("button", { name: /http headers/i }));
+
+      // Add two header rows
+      fireEvent.click(screen.getByRole("button", { name: /add header/i }));
+      fireEvent.click(screen.getByRole("button", { name: /add header/i }));
+
+      await user.type(screen.getByLabelText("Header 1 name"), "HTTP-Referer");
+      await user.type(
+        screen.getByLabelText("Header 1 value"),
+        "https://my-app.example.com"
+      );
+
+      // Leave row 2 empty — it should be pruned.
+
+      // Add a third, fill it, then delete row 2 (still empty) for good measure
+      fireEvent.click(screen.getByRole("button", { name: /add header/i }));
+      await user.type(screen.getByLabelText("Header 3 name"), "X-Title");
+      await user.type(screen.getByLabelText("Header 3 value"), "My App");
+
+      fireEvent.click(screen.getByRole("button", { name: /remove header 2/i }));
+
+      fireEvent.click(screen.getByRole("button", { name: /create provider/i }));
+
+      await waitFor(() => {
+        expect(mockCreateProvider).toHaveBeenCalledWith(
+          "gw-provider",
+          expect.objectContaining({
+            headers: {
+              "HTTP-Referer": "https://my-app.example.com",
+              "X-Title": "My App",
+            },
+          })
+        );
+      });
+    });
+
+    it("omits spec.headers entirely when the section has no entries", async () => {
+      vi.useRealTimers();
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper>
+          <ProviderDialog open={true} onOpenChange={vi.fn()} />
+        </TestWrapper>
+      );
+
+      await user.type(screen.getByLabelText("Name"), "no-headers-provider");
+      await user.type(screen.getByLabelText("Secret Name"), "my-key");
+
+      fireEvent.click(screen.getByRole("button", { name: /create provider/i }));
+
+      await waitFor(() => {
+        expect(mockCreateProvider).toHaveBeenCalled();
+      });
+
+      expect(mockCreateProvider.mock.calls[0][1]).not.toHaveProperty("headers");
+    });
+  });
 });

--- a/dashboard/src/components/providers/provider-dialog.tsx
+++ b/dashboard/src/components/providers/provider-dialog.tsx
@@ -28,7 +28,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { AlertCircle, Loader2, ChevronDown } from "lucide-react";
+import { AlertCircle, Loader2, ChevronDown, Plus, Trash2 } from "lucide-react";
 import type { Provider, ProviderSpec } from "@/types/generated/provider";
 
 // --- Types ---
@@ -67,6 +67,8 @@ interface FormState {
   authServiceAccountEmail: string;
   authSecretName: string;
   authSecretKey: string;
+  // Custom HTTP headers (gateway providers like OpenRouter, tenant routing, etc.)
+  headerEntries: Array<{ id: string; key: string; value: string }>;
 }
 
 // --- Constants ---
@@ -139,6 +141,15 @@ function isLocal(type: ProviderSpec["type"]): boolean {
   return LOCAL_TYPES.has(type);
 }
 
+// Monotonic counter for stable React keys on added header rows; reset only
+// on full page reload, which is fine because the dialog itself remounts via
+// `formResetKey` whenever it opens.
+let nextHeaderEntryId = 0;
+function makeHeaderEntryId(): string {
+  nextHeaderEntryId += 1;
+  return `h-${nextHeaderEntryId}`;
+}
+
 function getInitialFormState(provider?: Provider | null): FormState {
   if (provider) {
     const spec = provider.spec;
@@ -176,6 +187,11 @@ function getInitialFormState(provider?: Provider | null): FormState {
       authServiceAccountEmail: auth?.serviceAccountEmail ?? "",
       authSecretName: auth?.credentialsSecretRef?.name ?? "",
       authSecretKey: auth?.credentialsSecretRef?.key ?? "",
+      headerEntries: Object.entries(spec.headers ?? {}).map(([key, value]) => ({
+        id: makeHeaderEntryId(),
+        key,
+        value,
+      })),
     };
   }
 
@@ -206,6 +222,7 @@ function getInitialFormState(provider?: Provider | null): FormState {
     authServiceAccountEmail: "",
     authSecretName: "",
     authSecretKey: "",
+    headerEntries: [],
   };
 }
 
@@ -301,6 +318,15 @@ function buildDefaults(form: FormState): ProviderSpec["defaults"] | undefined {
   return Object.keys(defaults).length > 0 ? defaults : undefined;
 }
 
+function buildHeaders(form: FormState): ProviderSpec["headers"] | undefined {
+  const headers: Record<string, string> = {};
+  for (const { key, value } of form.headerEntries) {
+    const k = key.trim();
+    if (k) headers[k] = value;
+  }
+  return Object.keys(headers).length > 0 ? headers : undefined;
+}
+
 function buildPricing(form: FormState): ProviderSpec["pricing"] | undefined {
   const pricing: NonNullable<ProviderSpec["pricing"]> = {};
   if (form.inputCostPer1K) pricing.inputCostPer1K = form.inputCostPer1K;
@@ -360,6 +386,9 @@ function buildSpec(form: FormState): ProviderSpec {
 
   spec.defaults = buildDefaults(form);
   spec.pricing = buildPricing(form);
+
+  const headers = buildHeaders(form);
+  if (headers) spec.headers = headers;
 
   return spec;
 }
@@ -569,6 +598,86 @@ function PricingFields({
             />
           </div>
         </div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function HeadersFields({
+  form,
+  updateForm,
+}: Readonly<{
+  form: FormState;
+  updateForm: <K extends keyof FormState>(key: K, value: FormState[K]) => void;
+}>) {
+  const [open, setOpen] = useState(form.headerEntries.length > 0);
+
+  const updateEntry = (index: number, field: "key" | "value", next: string) => {
+    const entries = form.headerEntries.map((entry, i) =>
+      i === index ? { ...entry, [field]: next } : entry,
+    );
+    updateForm("headerEntries", entries);
+  };
+
+  const addEntry = () => {
+    updateForm("headerEntries", [
+      ...form.headerEntries,
+      { id: makeHeaderEntryId(), key: "", value: "" },
+    ]);
+  };
+
+  const removeEntry = (index: number) => {
+    updateForm(
+      "headerEntries",
+      form.headerEntries.filter((_, i) => i !== index),
+    );
+  };
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen}>
+      <CollapsibleTrigger asChild>
+        <Button variant="ghost" className="w-full justify-between px-0 font-semibold">
+          HTTP Headers
+          <ChevronDown className={`h-4 w-4 transition-transform ${open ? "rotate-180" : ""}`} />
+        </Button>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="space-y-3 pt-2">
+        <p className="text-sm text-muted-foreground">
+          Custom HTTP headers sent on every provider request. Used by gateway providers
+          (e.g., OpenRouter&rsquo;s <code>HTTP-Referer</code> / <code>X-Title</code>) or tenant
+          routing. Collisions with built-in provider headers are rejected by PromptKit.
+        </p>
+        {form.headerEntries.map((entry, index) => (
+          <div key={entry.id} className="flex gap-2 items-start">
+            <Input
+              aria-label={`Header ${index + 1} name`}
+              placeholder="HTTP-Referer"
+              value={entry.key}
+              onChange={(e) => updateEntry(index, "key", e.target.value)}
+              className="flex-1"
+            />
+            <Input
+              aria-label={`Header ${index + 1} value`}
+              placeholder="https://my-app.example.com"
+              value={entry.value}
+              onChange={(e) => updateEntry(index, "value", e.target.value)}
+              className="flex-1"
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              aria-label={`Remove header ${index + 1}`}
+              onClick={() => removeEntry(index)}
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          </div>
+        ))}
+        <Button type="button" variant="outline" size="sm" onClick={addEntry}>
+          <Plus className="h-4 w-4 mr-1" />
+          Add header
+        </Button>
       </CollapsibleContent>
     </Collapsible>
   );
@@ -1023,6 +1132,9 @@ function ProviderDialogForm({
 
           {/* Pricing (collapsible) */}
           <PricingFields form={formState} updateForm={updateForm} />
+
+          {/* Headers (collapsible) */}
+          <HeadersFields form={formState} updateForm={updateForm} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary

Expose `spec.headers` in the Provider dialog as a collapsible "HTTP Headers" section with add/remove rows. The CRD field has shipped since PR #912 but the dashboard never surfaced it, so users had to hand-author manifests for gateway providers (OpenRouter's `HTTP-Referer` / `X-Title`, tenant routing in shared vLLM deployments, etc).

- New collapsible section after Pricing.
- Round-trips cleanly through edit mode.
- Prunes empty keys on submit; omits `spec.headers` entirely when no entries.
- Stable React keys per row via a monotonic counter — no array-index keys.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on `provider-dialog.tsx` (9 pre-existing warnings in unrelated files)
- [x] `npx vitest run` — 37/37 tests pass
- [x] Per-file coverage on `provider-dialog.tsx`: 91.5% (was 91.3%)
- [x] 3 new vitest cases: edit-mode round-trip, add/remove rows + empty pruning, omit-when-empty

## Notes

Pure dashboard change. No CRD, Go, or docs churn. Builds on top of the #913 refactor that just landed.