### PR TITLE
fix(chart): dashboard HTTPRoute uses PathPrefix instead of regex (fixes Istio 1.24 WS drop)

### DIFF
--- a/charts/omnia/templates/dashboard/httproute.yaml
+++ b/charts/omnia/templates/dashboard/httproute.yaml
@@ -23,11 +23,16 @@ spec:
     - {{ . | quote }}
   {{- end }}
   rules:
-    # WebSocket route for agent connections (must be before catch-all)
+    # WebSocket route for agent connections (must be before catch-all).
+    # NOTE: uses PathPrefix, not RegularExpression. Istio 1.24 silently drops
+    # Gateway API regex path matches (the rule vanishes from the generated
+    # Envoy config with no warning on HTTPRoute status or in istiod logs).
+    # The /api/agents/ prefix is WS-only — the dashboard has no Next.js
+    # routes under it. See issue #936.
     - matches:
         - path:
-            type: RegularExpression
-            value: /api/agents/[^/]+/[^/]+/ws
+            type: PathPrefix
+            value: /api/agents/
       backendRefs:
         - name: {{ include "omnia.dashboard.fullname" . }}
           port: 3002
@@ -55,11 +60,12 @@ spec:
     - name: {{ $internalGatewayName }}
       namespace: {{ .Release.Namespace }}
   rules:
-    # WebSocket route for agent connections (must be before catch-all)
+    # WebSocket route for agent connections (must be before catch-all).
+    # See comment above for the PathPrefix rationale.
     - matches:
         - path:
-            type: RegularExpression
-            value: /api/agents/[^/]+/[^/]+/ws
+            type: PathPrefix
+            value: /api/agents/
       backendRefs:
         - name: {{ include "omnia.dashboard.fullname" . }}
           port: 3002


### PR DESCRIPTION
## Summary

- Replace `RegularExpression` path match with `PathPrefix` in the dashboard HTTPRoute template (both external-gateway and internal-gateway variants).
- Fixes agent WS traffic on Istio 1.24: the regex rule was being silently dropped during HTTPRoute → Envoy translation, so all `/api/agents/.../ws` traffic fell through to the catch-all and got 401'd by the Next.js auth middleware.
- Lossless — the dashboard has no Next.js routes under `/api/agents/`, only the WS proxy on port 3002.

Closes #936.

## Test plan

- [x] Applied the equivalent change to a downstream deployment on AKS (Istio 1.24) — agent console now connects cleanly.
- [x] Confirmed full Foundry round-trip end-to-end: dashboard → facade → runtime → Azure OpenAI, returning real model responses (`duration:1698ms`).
- [x] Verified via `pilot-agent request GET config_dump` that the `/api/agents/` PathPrefix rule now appears in Envoy's route config.
- [ ] Reviewer sanity-check: `grep -r "api/agents" dashboard/src/app/api/` returns no results on main — `/api/agents/` really is WS-only.
