### PR TITLE
feat(security): dedicated dashboard ServiceAccount + agent pod hardening

### DIFF
--- a/charts/omnia/templates/_helpers.tpl
+++ b/charts/omnia/templates/_helpers.tpl
@@ -137,13 +137,22 @@ Dashboard image
 {{- end }}
 
 {{/*
-Dashboard service account name
+Dashboard service account name.
+
+The dashboard has its own ServiceAccount bound to a narrower ClusterRole
+(omnia-dashboard-role, see templates/dashboard/clusterrole.yaml) so that a
+dashboard compromise cannot escalate via the operator's manager ClusterRole.
+
+Lookup order:
+  1. .Values.dashboard.serviceAccount.name (explicit override)
+  2. Computed: "<release>-dashboard"
+  3. "default" when dashboard.serviceAccount.create=false and no name set.
 */}}
 {{- define "omnia.dashboard.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "omnia.dashboard.fullname" .) .Values.serviceAccount.name }}
+{{- if .Values.dashboard.serviceAccount.create }}
+{{- default (include "omnia.dashboard.fullname" .) .Values.dashboard.serviceAccount.name }}
 {{- else }}
-{{- default "default" .Values.serviceAccount.name }}
+{{- default "default" .Values.dashboard.serviceAccount.name }}
 {{- end }}
 {{- end }}
 

--- a/charts/omnia/templates/dashboard/clusterrole.yaml
+++ b/charts/omnia/templates/dashboard/clusterrole.yaml
@@ -1,0 +1,74 @@
+{{- if and .Values.dashboard.enabled .Values.rbac.create -}}
+# Scoped ClusterRole for the dashboard ServiceAccount. Distinct from the
+# operator's manager role so that a dashboard-side compromise cannot:
+#   - Create ClusterRoleBindings (privilege escalation).
+#   - Create ServiceAccounts (identity fabrication; tokens can still be
+#     minted for *existing* SAs via serviceaccounts/token create — that's
+#     needed by the workspace token exchange).
+#   - Mutate Deployments / Roles / Services / autoscalers / network policies
+#     (cluster infrastructure; the operator owns those).
+#
+# Resource set is the minimum the Next.js dashboard actually calls against
+# the kube API. Verify via:
+#   grep -rE "k8sClient\.(list|get|create|patch|delete)" dashboard/src
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "omnia.fullname" . }}-dashboard-role
+  labels:
+    {{- include "omnia.dashboard.labels" . | nindent 4 }}
+rules:
+  # Namespace listing: workspace switcher + namespace-picker UIs.
+  - apiGroups: [""]
+    resources: [namespaces]
+    verbs: [get, list, watch]
+  # Secret metadata (values never leave the server; code filters by the
+  # `omnia.altairalabs.ai/type=credentials` label. RBAC can't enforce label
+  # filters, so the guarantee is at the application layer — see
+  # dashboard/src/lib/k8s/secrets.ts).
+  - apiGroups: [""]
+    resources: [secrets]
+    verbs: [get, list]
+  # Workspace-scoped token exchange: mint tokens for *existing* workspace
+  # ServiceAccounts pre-created by the operator. Dashboard cannot create
+  # the ServiceAccount itself — just mint a token bound to its role.
+  - apiGroups: [""]
+    resources: [serviceaccounts/token]
+    verbs: [create]
+  # Pods + pod logs: agent log viewer, liveness displays.
+  - apiGroups: [""]
+    resources: [pods, pods/log]
+    verbs: [get, list, watch]
+  # Events: surface reconcile errors in the UI.
+  - apiGroups: [""]
+    resources: [events]
+    verbs: [get, list, watch]
+  # ConfigMaps: PromptPack bodies are stored as ConfigMaps; dashboard writes
+  # these when the user edits a prompt pack.
+  - apiGroups: [""]
+    resources: [configmaps]
+    verbs: [get, list, watch, create, update, patch, delete]
+  # Omnia CRDs: the full set the dashboard surfaces for CRUD.
+  - apiGroups: [omnia.altairalabs.ai]
+    resources:
+      - agentruntimes
+      - agentpolicies
+      - promptpacks
+      - providers
+      - sessionretentionpolicies
+      - skillsources
+      - toolpolicies
+      - toolregistries
+      - workspaces
+    verbs: [get, list, watch, create, update, patch, delete]
+  # CRD status subresources: the dashboard reads controller-written status
+  # fields for phase/condition displays.
+  - apiGroups: [omnia.altairalabs.ai]
+    resources:
+      - agentruntimes/status
+      - promptpacks/status
+      - providers/status
+      - toolregistries/status
+      - workspaces/status
+    verbs: [get]
+{{- end }}

--- a/charts/omnia/templates/dashboard/clusterrolebinding.yaml
+++ b/charts/omnia/templates/dashboard/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.dashboard.enabled .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "omnia.fullname" . }}-dashboard-rolebinding
+  labels:
+    {{- include "omnia.dashboard.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "omnia.fullname" . }}-dashboard-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "omnia.dashboard.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/omnia/templates/dashboard/deployment.yaml
+++ b/charts/omnia/templates/dashboard/deployment.yaml
@@ -33,7 +33,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.serviceAccountName" .) }}
+      serviceAccountName: {{ $po.serviceAccountName | default (include "omnia.dashboard.serviceAccountName" .) }}
       {{- with $po.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/omnia/templates/dashboard/serviceaccount.yaml
+++ b/charts/omnia/templates/dashboard/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.dashboard.enabled .Values.dashboard.serviceAccount.create -}}
+# Dedicated ServiceAccount for the dashboard Deployment. Separate from the
+# operator's ServiceAccount (see charts/omnia/templates/serviceaccount.yaml)
+# so a compromise in the dashboard (SSRF, RCE, auth bypass) does not grant
+# cluster-admin — the dashboard's bound ClusterRole is the narrower
+# omnia-dashboard-role (see ./clusterrole.yaml).
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "omnia.dashboard.serviceAccountName" . }}
+  labels:
+    {{- include "omnia.dashboard.labels" . | nindent 4 }}
+  {{- with .Values.dashboard.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/omnia/tests/dashboard-rbac_test.yaml
+++ b/charts/omnia/tests/dashboard-rbac_test.yaml
@@ -1,0 +1,127 @@
+suite: dashboard RBAC is scoped separately from the operator
+release:
+  name: omnia
+values:
+  - ../values-chart-tests.yaml
+templates:
+  - templates/dashboard/serviceaccount.yaml
+  - templates/dashboard/clusterrole.yaml
+  - templates/dashboard/clusterrolebinding.yaml
+  - templates/dashboard/deployment.yaml
+  - templates/dashboard/configmap.yaml
+  - templates/serviceaccount.yaml
+  - templates/clusterrole.yaml
+  - templates/clusterrolebinding.yaml
+tests:
+  - it: creates a dedicated dashboard ServiceAccount
+    template: templates/dashboard/serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: omnia-dashboard
+
+  - it: dashboard ServiceAccount is distinct from the operator ServiceAccount
+    template: templates/serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ServiceAccount
+      - notEqual:
+          path: metadata.name
+          value: omnia-dashboard
+
+  - it: dashboard Deployment binds the scoped ServiceAccount
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: omnia-dashboard
+
+  - it: dashboard ClusterRole does NOT grant clusterrolebindings create
+    template: templates/dashboard/clusterrole.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: ClusterRole
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [rbac.authorization.k8s.io]
+            resources: [clusterrolebindings]
+            verbs: [create]
+
+  - it: dashboard ClusterRole does NOT grant serviceaccounts create (only token)
+    template: templates/dashboard/clusterrole.yaml
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [serviceaccounts]
+            verbs: [create]
+      # It SHOULD grant serviceaccounts/token create — workspace token exchange.
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [serviceaccounts/token]
+            verbs: [create]
+
+  - it: dashboard ClusterRole grants read-only access to secrets (metadata only)
+    template: templates/dashboard/clusterrole.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [secrets]
+            verbs: [get, list]
+
+  - it: dashboard ClusterRoleBinding points at the scoped role, not the manager role
+    template: templates/dashboard/clusterrolebinding.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: roleRef.name
+          value: omnia-dashboard-role
+      - equal:
+          path: subjects[0].name
+          value: omnia-dashboard
+
+  - it: disabling dashboard omits all dashboard RBAC
+    set:
+      dashboard.enabled: false
+    template: templates/dashboard/serviceaccount.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: disabling rbac.create omits ClusterRole + binding but keeps the ServiceAccount
+    set:
+      rbac.create: false
+    template: templates/dashboard/clusterrole.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: operator ClusterRoleBinding still binds the operator ServiceAccount (unchanged)
+    template: templates/clusterrolebinding.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: roleRef.name
+          value: omnia-manager-role
+      - equal:
+          path: subjects[0].name
+          value: omnia

--- a/charts/omnia/values.schema.json
+++ b/charts/omnia/values.schema.json
@@ -241,6 +241,15 @@
         "replicaCount": { "type": "integer", "minimum": 1 },
         "image":        { "$ref": "#/$defs/image" },
         "resources":    { "$ref": "#/$defs/resources" },
+        "serviceAccount": {
+          "type": "object",
+          "description": "Dedicated ServiceAccount for the dashboard with a narrower ClusterRole than the operator's manager role.",
+          "properties": {
+            "create": { "type": "boolean" },
+            "annotations": { "type": "object" },
+            "name": { "type": "string" }
+          }
+        },
         "service": {
           "type": "object",
           "properties": {

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -545,6 +545,21 @@ dashboard:
   # -- Enable dashboard deployment
   enabled: true
 
+  # -- Dedicated ServiceAccount for the dashboard, bound to a scoped
+  # ClusterRole (omnia-dashboard-role) distinct from the operator's
+  # manager role. See templates/dashboard/{serviceaccount,clusterrole,
+  # clusterrolebinding}.yaml.
+  serviceAccount:
+    # -- Whether to create the dashboard ServiceAccount. Set to false when
+    # binding an externally-managed SA (e.g., cloud workload identity).
+    create: true
+    # -- Annotations to add to the dashboard ServiceAccount. Use this for
+    # cloud workload-identity bindings (AWS IRSA, GCP WI, Azure AD WI).
+    annotations: {}
+    # -- Override the generated ServiceAccount name. Leave empty to use
+    # "<release>-dashboard" (or "default" when create=false).
+    name: ""
+
   # -- Hide enterprise features completely instead of showing upgrade prompts
   # When false (default): Shows enterprise features with upgrade prompts when enterprise.enabled=false
   # When true: Hides enterprise features entirely from the UI

--- a/docs/src/content/docs/explanation/multi-tenancy.md
+++ b/docs/src/content/docs/explanation/multi-tenancy.md
@@ -192,6 +192,16 @@ The controller creates actual RoleBindings for ServiceAccounts, allowing direct 
 
 ## Token Management
 
+### Dashboard ServiceAccount
+
+The dashboard runs as its own `omnia-dashboard` ServiceAccount, separate from the operator's `omnia` ServiceAccount and bound to a narrower ClusterRole (`omnia-dashboard-role`). The dashboard role grants only what the Next.js server actually calls against the Kubernetes API:
+
+- **Read-only** on namespaces, pods, pod logs, events, secrets (metadata; values never leave the server).
+- **CRUD** on Omnia CRDs and ConfigMaps (the dashboard's core job).
+- **`serviceaccounts/token` create** for the token-exchange flow below — needed to mint tokens for *existing* workspace ServiceAccounts but not to create new ones.
+
+Notably **absent**: `clusterrolebindings` create, `serviceaccounts` create, Deployment/Service/autoscaler mutations, networking.k8s.io/istio.io writes. Those live on the operator's role. A server-side compromise in the dashboard (RCE, SSRF, auth bypass) is therefore scoped to data mutations the dashboard already mediates — it cannot self-promote to cluster-admin.
+
 ### Short-Lived Tokens
 
 The dashboard uses the Kubernetes TokenRequest API to get short-lived ServiceAccount tokens:

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -40,6 +40,47 @@ import (
 // Annotation key for config hash - changes to this trigger pod rollouts
 const annotationConfigHash = "omnia.altairalabs.ai/config-hash"
 
+// agentPodUserID is the uid/gid used by the facade and runtime container images
+// (both Dockerfile.agent and Dockerfile.runtime declare USER 65532:65532 on a
+// scratch base). Reflecting it in the pod SecurityContext lets PodSecurity
+// admission enforce runAsNonRoot and makes fsGroup ownership of mounted
+// volumes explicit.
+const agentPodUserID int64 = 65532
+
+// hardenedPodSecurityContext returns a restricted-profile-compliant PodSecurityContext
+// for workspace agent pods (facade + runtime). Matches the controller and dashboard
+// hardening so agent pods are not the soft spot in a restricted namespace.
+func hardenedPodSecurityContext() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		RunAsUser:    ptr.To(agentPodUserID),
+		RunAsGroup:   ptr.To(agentPodUserID),
+		FSGroup:      ptr.To(agentPodUserID),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// hardenedContainerSecurityContext returns a restricted-profile-compliant
+// container SecurityContext: no privilege escalation, read-only root, all
+// capabilities dropped, seccomp RuntimeDefault. Applied to facade + runtime
+// containers; the policy-proxy sidecar (injected separately) configures its
+// own SecurityContext.
+func hardenedContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		RunAsNonRoot:             ptr.To(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
 func (r *AgentRuntimeReconciler) reconcileDeployment(
 	ctx context.Context,
 	agentRuntime *omniav1alpha1.AgentRuntime,
@@ -269,6 +310,17 @@ func (r *AgentRuntimeReconciler) buildDeploymentSpec(
 		ServiceAccountName: facadeServiceAccountName(agentRuntime),
 		Containers:         containers,
 		Volumes:            volumes,
+		SecurityContext:    hardenedPodSecurityContext(),
+	}
+
+	// Apply hardened container SecurityContext to facade + runtime. The
+	// policy-proxy sidecar (injected separately by buildPolicyProxyContainer)
+	// sets its own SecurityContext and is skipped here.
+	for i := range podSpec.Containers {
+		if podSpec.Containers[i].Name == PolicyProxyContainerName {
+			continue
+		}
+		podSpec.Containers[i].SecurityContext = hardenedContainerSecurityContext()
 	}
 
 	// Termination grace period: 45s allows the 30s shutdown timeout to complete

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -1142,3 +1142,114 @@ func TestBuildDeploymentSpec_PodOverrides_SkipsPolicyProxy(t *testing.T) {
 		}
 	}
 }
+
+func TestHardenedPodSecurityContext(t *testing.T) {
+	sc := hardenedPodSecurityContext()
+	require.NotNil(t, sc)
+	require.NotNil(t, sc.RunAsNonRoot)
+	assert.True(t, *sc.RunAsNonRoot)
+	require.NotNil(t, sc.RunAsUser)
+	assert.Equal(t, int64(65532), *sc.RunAsUser)
+	require.NotNil(t, sc.RunAsGroup)
+	assert.Equal(t, int64(65532), *sc.RunAsGroup)
+	require.NotNil(t, sc.FSGroup)
+	assert.Equal(t, int64(65532), *sc.FSGroup)
+	require.NotNil(t, sc.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, sc.SeccompProfile.Type)
+}
+
+func TestHardenedContainerSecurityContext(t *testing.T) {
+	sc := hardenedContainerSecurityContext()
+	require.NotNil(t, sc)
+	require.NotNil(t, sc.AllowPrivilegeEscalation)
+	assert.False(t, *sc.AllowPrivilegeEscalation)
+	require.NotNil(t, sc.ReadOnlyRootFilesystem)
+	assert.True(t, *sc.ReadOnlyRootFilesystem)
+	require.NotNil(t, sc.RunAsNonRoot)
+	assert.True(t, *sc.RunAsNonRoot)
+	require.NotNil(t, sc.Capabilities)
+	assert.Equal(t, []corev1.Capability{"ALL"}, sc.Capabilities.Drop)
+	require.Empty(t, sc.Capabilities.Add)
+	require.NotNil(t, sc.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, sc.SeccompProfile.Type)
+}
+
+func TestBuildDeploymentSpec_HardenedSecurityContext(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, omniav1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			Facade: omniav1alpha1.FacadeConfig{Type: omniav1alpha1.FacadeTypeWebSocket},
+		},
+	}
+	pp := newTestPromptPack()
+	r := &AgentRuntimeReconciler{Scheme: scheme, Client: fake.NewClientBuilder().WithScheme(scheme).Build()}
+
+	dep := &appsv1.Deployment{}
+	r.buildDeploymentSpec(context.Background(), dep, ar, pp, nil, "", nil)
+
+	// Pod-level SecurityContext is hardened
+	spec := dep.Spec.Template.Spec
+	require.NotNil(t, spec.SecurityContext, "pod SecurityContext must be set")
+	require.NotNil(t, spec.SecurityContext.RunAsNonRoot)
+	assert.True(t, *spec.SecurityContext.RunAsNonRoot)
+	require.NotNil(t, spec.SecurityContext.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, spec.SecurityContext.SeccompProfile.Type)
+
+	// Every container has hardened container-level SecurityContext
+	require.NotEmpty(t, spec.Containers)
+	for _, c := range spec.Containers {
+		require.NotNilf(t, c.SecurityContext, "container %s missing SecurityContext", c.Name)
+		require.NotNilf(t, c.SecurityContext.ReadOnlyRootFilesystem, "container %s missing ReadOnlyRootFilesystem", c.Name)
+		assert.Truef(t, *c.SecurityContext.ReadOnlyRootFilesystem, "container %s must have ReadOnlyRootFilesystem=true", c.Name)
+		require.NotNilf(t, c.SecurityContext.AllowPrivilegeEscalation, "container %s missing AllowPrivilegeEscalation", c.Name)
+		assert.Falsef(t, *c.SecurityContext.AllowPrivilegeEscalation, "container %s must have AllowPrivilegeEscalation=false", c.Name)
+		require.NotNilf(t, c.SecurityContext.Capabilities, "container %s missing Capabilities", c.Name)
+		assert.Equalf(t, []corev1.Capability{"ALL"}, c.SecurityContext.Capabilities.Drop, "container %s must drop ALL capabilities", c.Name)
+	}
+}
+
+func TestBuildDeploymentSpec_PolicyProxyKeepsOwnSecurityContext(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, omniav1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			Facade: omniav1alpha1.FacadeConfig{Type: omniav1alpha1.FacadeTypeWebSocket},
+		},
+	}
+	pp := newTestPromptPack()
+	r := &AgentRuntimeReconciler{
+		Scheme:           scheme,
+		Client:           fake.NewClientBuilder().WithScheme(scheme).Build(),
+		PolicyProxyImage: "ghcr.io/altairalabs/omnia-policy-proxy:test",
+	}
+
+	dep := &appsv1.Deployment{}
+	r.buildDeploymentSpec(context.Background(), dep, ar, pp, nil, "", nil)
+
+	// Locate the policy-proxy sidecar and check its SecurityContext is its own,
+	// not hardenedContainerSecurityContext — the sidecar configures its own SC.
+	var policyProxy *corev1.Container
+	for i := range dep.Spec.Template.Spec.Containers {
+		c := &dep.Spec.Template.Spec.Containers[i]
+		if c.Name == PolicyProxyContainerName {
+			policyProxy = c
+			break
+		}
+	}
+	require.NotNil(t, policyProxy, "policy-proxy sidecar must be injected when PolicyProxyImage is set")
+	// Either the policy-proxy has no hardened SC (it sets its own or runs with
+	// a different profile) or it has one — but the buildDeploymentSpec loop
+	// must not overwrite with hardenedContainerSecurityContext.
+	// The test's intent is "not our hardened context"; a different SC or nil is acceptable.
+	hardened := hardenedContainerSecurityContext()
+	if policyProxy.SecurityContext != nil {
+		assert.NotEqual(t, hardened, policyProxy.SecurityContext, "policy-proxy must not be overwritten with the facade/runtime hardened SC")
+	}
+}


### PR DESCRIPTION
## Summary

Closes two findings from the 2026-04-20 pen-test report against the demo AKS deployment.

### C-1 — dashboard SA split

The dashboard shared the operator's `omnia` ServiceAccount, which is bound to `omnia-manager-role` — cluster-admin-equivalent (create ClusterRoleBindings, create ServiceAccount tokens, cluster-wide secrets, CRD mutations). Any server-side RCE/SSRF/auth-bypass in the Next.js dashboard had full cluster blast radius.

Now the dashboard runs as a dedicated `omnia-dashboard` ServiceAccount bound to a narrower `omnia-dashboard-role` with only the API verbs the dashboard actually uses:

- namespaces (get/list/watch)
- secrets (get/list — metadata only; values never leave the server, code filters by `omnia.altairalabs.ai/type=credentials`)
- serviceaccounts/token (create — workspace token exchange)
- pods, pods/log, events (get/list/watch)
- configmaps CRUD (PromptPack bodies)
- Omnia CRDs CRUD + status get

Notably absent: `clusterrolebindings`, `serviceaccounts` create, Deployment/Service/autoscaler mutations, networking.k8s.io/istio.io writes. Those stay on the operator's role.

### H-3 — agent pod hardening

Workspace agent pods (facade + runtime) ran with an empty `SecurityContext` — default-root, writable filesystem, default caps, no seccomp. The operator and dashboard pods are already hardened; agent pods were the soft spot despite being the containers most likely to process untrusted prompts/tool output.

AgentRuntime-managed pods now get restricted-profile defaults on both the PodSpec and every non-policy-proxy container: \`runAsNonRoot=true\`, \`runAsUser/Group/FSGroup=65532\` (matches the Dockerfile \`USER\` directives), \`readOnlyRootFilesystem=true\`, \`allowPrivilegeEscalation=false\`, \`capabilities.drop=[ALL]\`, \`seccompProfile.type=RuntimeDefault\`. The policy-proxy sidecar sets its own SC and is skipped.

## Changes

- 3 new chart templates under \`charts/omnia/templates/dashboard/\` (serviceaccount, clusterrole, clusterrolebinding).
- \`dashboard.serviceAccount.{create,annotations,name}\` in values.yaml + schema.
- Dashboard deployment template switches to \`omnia.dashboard.serviceAccountName\`.
- \`internal/controller/deployment_builder.go\` — new \`hardenedPodSecurityContext\` / \`hardenedContainerSecurityContext\` helpers applied in \`buildDeploymentSpec\`.
- docs/explanation/multi-tenancy.md — new subsection documenting the split.

## Test plan

- [x] 4 Go unit tests (helpers + buildDeploymentSpec paths, policy-proxy is not clobbered).
- [x] 10 helm unittest assertions for RBAC separation.
- [x] \`golangci-lint run ./...\` clean.
- [x] \`helm lint\` + \`helm template\` + \`helm unittest\` all green (36/36).
- [x] \`go test ./internal/controller/...\` passes (full envtest suite).

## Related

- Pen-test report: omnia-azure repo, \`docs/local-backlog/2026-04-20-security-hardening.md\`.
- Next PRs in this series: H-1/H-2 (dashboard headers + cookies), C-3 (facade WS auth — larger, may just be an upstream investigation).