### PR TITLE
feat(dashboard): security headers + cookie-clear attributes

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -11,6 +11,12 @@ const nextConfig: NextConfig = {
   // Note: Grafana proxy is handled by /app/grafana/[...path]/route.ts
   // This allows us to add auth headers when proxying to Grafana
 
+  // Drop the default `x-powered-by: Next.js` header so we don't leak the
+  // runtime + version to unauthenticated visitors. Other security headers
+  // (HSTS/CSP/X-Frame-Options/etc.) are applied by src/middleware.ts via
+  // lib/security-headers.ts.
+  poweredByHeader: false,
+
   // Enable source maps in production for E2E code coverage collection.
   // This allows monocart-reporter to map V8 coverage back to original source files.
   // Source maps are only served when explicitly requested, so no security impact.

--- a/dashboard/src/lib/security-headers.ts
+++ b/dashboard/src/lib/security-headers.ts
@@ -1,0 +1,85 @@
+/**
+ * Security response headers applied to every dashboard response by the
+ * Next.js middleware. The set below is the defence-in-depth baseline:
+ *
+ * - Strict-Transport-Security: forces HTTPS for two years; prevents
+ *   downgrade / SSL-strip.
+ * - Content-Security-Policy: limits script / style / connect sources to
+ *   the same origin by default. Next.js needs `'unsafe-inline'` for its
+ *   hydration scripts + runtime-injected styles until we wire nonces.
+ *   Operators can override with `OMNIA_CSP_POLICY` when they have a
+ *   tighter policy drafted for their deployment.
+ * - X-Frame-Options / frame-ancestors: prevents clickjacking via framing.
+ * - X-Content-Type-Options: blocks MIME sniffing on responses the server
+ *   did not type.
+ * - Referrer-Policy: limits referer leakage to cross-origin targets.
+ * - Permissions-Policy: disables APIs the dashboard does not use
+ *   (camera / microphone / geolocation).
+ *
+ * Notes:
+ * - HSTS is safe to emit over plaintext (browsers ignore it on non-HTTPS
+ *   responses), but is only meaningful when the edge terminates TLS.
+ * - `x-powered-by: Next.js` is disabled via `next.config.ts`
+ *   `poweredByHeader: false` — keeping the version-leak fix adjacent to
+ *   the other security-header config.
+ */
+
+import type { NextResponse } from "next/server";
+
+// Default Content-Security-Policy. Next.js inline scripts + runtime
+// styles force `'unsafe-inline'` until we add per-request nonces. WebSocket
+// agent connections use `ws:`/`wss:` same-origin.
+const DEFAULT_CSP = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob: https:",
+  "font-src 'self' data:",
+  "connect-src 'self' ws: wss:",
+  "media-src 'self' blob: data:",
+  "frame-ancestors 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join("; ");
+
+interface SecurityHeaderEnv {
+  cspPolicy?: string;
+}
+
+function envOverride(): SecurityHeaderEnv {
+  return {
+    cspPolicy: process.env.OMNIA_CSP_POLICY,
+  };
+}
+
+export const SECURITY_HEADER_NAMES = [
+  "Strict-Transport-Security",
+  "Content-Security-Policy",
+  "X-Frame-Options",
+  "X-Content-Type-Options",
+  "Referrer-Policy",
+  "Permissions-Policy",
+] as const;
+
+/**
+ * Apply the security-header baseline to a response. Intended for the
+ * Next.js middleware; middleware runs on every matched path, so the
+ * headers ride every response.
+ */
+export function applySecurityHeaders(response: NextResponse): NextResponse {
+  const env = envOverride();
+  const headers = response.headers;
+  headers.set(
+    "Strict-Transport-Security",
+    "max-age=63072000; includeSubDomains; preload",
+  );
+  headers.set("Content-Security-Policy", env.cspPolicy ?? DEFAULT_CSP);
+  headers.set("X-Frame-Options", "DENY");
+  headers.set("X-Content-Type-Options", "nosniff");
+  headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  headers.set(
+    "Permissions-Policy",
+    "camera=(), microphone=(), geolocation=(), payment=()",
+  );
+  return response;
+}

--- a/dashboard/src/middleware.test.ts
+++ b/dashboard/src/middleware.test.ts
@@ -220,4 +220,85 @@ describe("dashboard auth middleware", () => {
       expect(nextSpy).toHaveBeenCalled();
     });
   });
+
+  describe("security response headers (H-1)", () => {
+    it("applies HSTS / CSP / X-Frame-Options / nosniff / Referrer-Policy / Permissions-Policy on pass-through", async () => {
+      process.env.OMNIA_AUTH_MODE = "anonymous";
+      const resp = await middleware(makeRequest("/"));
+      expect(resp.headers.get("Strict-Transport-Security")).toContain("max-age=");
+      expect(resp.headers.get("Strict-Transport-Security")).toContain("includeSubDomains");
+      expect(resp.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+      expect(resp.headers.get("Content-Security-Policy")).toContain("frame-ancestors 'none'");
+      expect(resp.headers.get("X-Frame-Options")).toBe("DENY");
+      expect(resp.headers.get("X-Content-Type-Options")).toBe("nosniff");
+      expect(resp.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+      expect(resp.headers.get("Permissions-Policy")).toContain("camera=()");
+    });
+
+    it("applies security headers on a /login redirect (unauthenticated path response)", async () => {
+      process.env.OMNIA_AUTH_MODE = "oauth";
+      const resp = await middleware(makeRequest("/sessions/abc"));
+      expect(resp.status).toBe(307);
+      expect(resp.headers.get("Strict-Transport-Security")).toContain("max-age=");
+      expect(resp.headers.get("Content-Security-Policy")).toContain("default-src 'self'");
+    });
+
+    it("applies security headers on 401 API responses", async () => {
+      process.env.OMNIA_AUTH_MODE = "oauth";
+      const resp = await middleware(makeRequest("/api/workspaces"));
+      expect(resp.status).toBe(401);
+      expect(resp.headers.get("X-Frame-Options")).toBe("DENY");
+      expect(resp.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    });
+
+    it("respects OMNIA_CSP_POLICY override", async () => {
+      const originalPolicy = process.env.OMNIA_CSP_POLICY;
+      process.env.OMNIA_AUTH_MODE = "anonymous";
+      process.env.OMNIA_CSP_POLICY = "default-src 'self'; script-src 'self'";
+      try {
+        const resp = await middleware(makeRequest("/"));
+        expect(resp.headers.get("Content-Security-Policy")).toBe(
+          "default-src 'self'; script-src 'self'",
+        );
+      } finally {
+        if (originalPolicy === undefined) delete process.env.OMNIA_CSP_POLICY;
+        else process.env.OMNIA_CSP_POLICY = originalPolicy;
+      }
+    });
+  });
+
+  describe("cleared-session cookie security attributes (H-2)", () => {
+    beforeEach(() => {
+      process.env.OMNIA_AUTH_MODE = "oauth";
+    });
+
+    it("sets HttpOnly + SameSite + Path on the cleared cookie", async () => {
+      const resp = await middleware(
+        makeRequest("/sessions/abc", { cookie: `${COOKIE_NAME}=bogus` }),
+      );
+      const setCookie = resp.headers.get("set-cookie")!;
+      // Reflect the original cookie's security posture on the clearing
+      // Set-Cookie header, otherwise a MITM can observe that the session
+      // was cleared over plaintext and JS can read the (empty) cookie.
+      expect(setCookie).toMatch(/HttpOnly/i);
+      expect(setCookie).toMatch(/SameSite=Lax/i);
+      expect(setCookie).toMatch(/Path=\//i);
+      expect(setCookie).toMatch(/Max-Age=0|Expires=/i);
+    });
+
+    it("adds Secure in production NODE_ENV", async () => {
+      const originalEnv = process.env.NODE_ENV;
+      // Next.js typings make NODE_ENV readonly; mutate via Object.assign to
+      // keep vitest happy while still setting the runtime value.
+      Object.assign(process.env, { NODE_ENV: "production" });
+      try {
+        const resp = await middleware(
+          makeRequest("/sessions/abc", { cookie: `${COOKIE_NAME}=bogus` }),
+        );
+        expect(resp.headers.get("set-cookie")!).toMatch(/Secure/i);
+      } finally {
+        Object.assign(process.env, { NODE_ENV: originalEnv });
+      }
+    });
+  });
 });

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { unsealData } from "iron-session";
 import type { SessionData } from "@/lib/auth/types";
+import { applySecurityHeaders } from "@/lib/security-headers";
 
 /**
  * Auth middleware — enforces authentication when OMNIA_AUTH_MODE is
@@ -103,37 +104,49 @@ function unauthenticatedResponse(
     loginUrl.searchParams.set("returnTo", pathname + req.nextUrl.search);
     response = NextResponse.redirect(loginUrl);
   }
-  // Clean up the invalid cookie so the next request doesn't repeat the dance.
-  response.cookies.delete(cookieName);
+  // Clean up the invalid cookie so the next request doesn't repeat the
+  // dance. `response.cookies.delete(name)` issues a Set-Cookie with empty
+  // value + past expiry but omits HttpOnly/Secure/SameSite — we set them
+  // explicitly so the clearing cookie carries the same security attributes
+  // as the original (pen-test H-2).
+  response.cookies.set({
+    name: cookieName,
+    value: "",
+    path: "/",
+    maxAge: 0,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+  });
   return response;
 }
 
 export async function middleware(req: NextRequest) {
   const mode = process.env.OMNIA_AUTH_MODE ?? "anonymous";
   if (mode === "anonymous") {
-    return NextResponse.next();
+    return applySecurityHeaders(NextResponse.next());
   }
 
   const { pathname } = req.nextUrl;
   if (isPublicPath(pathname)) {
-    return NextResponse.next();
+    return applySecurityHeaders(NextResponse.next());
   }
 
   const cookieName = process.env.OMNIA_SESSION_COOKIE_NAME ?? "omnia_session";
 
   if (mode === "oauth" || mode === "builtin") {
     const ok = await hasValidSession(req, mode);
-    if (ok) return NextResponse.next();
-    return unauthenticatedResponse(req, cookieName);
+    if (ok) return applySecurityHeaders(NextResponse.next());
+    return applySecurityHeaders(unauthenticatedResponse(req, cookieName));
   }
 
   // proxy (and any future mode): presence-check is the safest behaviour.
   // A fresh proxy request with headers but no cookie gets through and
   // handleProxyAuth in lib/auth/index.ts mints the session.
   if (req.cookies.has(cookieName)) {
-    return NextResponse.next();
+    return applySecurityHeaders(NextResponse.next());
   }
-  return unauthenticatedResponse(req, cookieName);
+  return applySecurityHeaders(unauthenticatedResponse(req, cookieName));
 }
 
 export const config = {

--- a/docs/src/content/docs/how-to/configure-dashboard-auth.md
+++ b/docs/src/content/docs/how-to/configure-dashboard-auth.md
@@ -458,6 +458,27 @@ OMNIA_SESSION_TTL=86400
 Always set `OMNIA_SESSION_SECRET` in production. Without it, sessions won't persist across restarts and security is compromised.
 :::
 
+### Session cookie attributes
+
+The dashboard issues its session cookie with `HttpOnly` + `SameSite=Lax`, and `Secure` when `NODE_ENV=production`. The clearing `Set-Cookie` issued on logout / invalid-session paths carries the same attributes, so a transient MITM observing the clear cannot downgrade or leak the cookie value.
+
+## Security response headers
+
+Every dashboard response carries a defence-in-depth header baseline:
+
+| Header | Default | Override |
+|---|---|---|
+| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` | — |
+| `Content-Security-Policy` | `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' ws: wss:; media-src 'self' blob: data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'` | `OMNIA_CSP_POLICY` env var |
+| `X-Frame-Options` | `DENY` | — |
+| `X-Content-Type-Options` | `nosniff` | — |
+| `Referrer-Policy` | `strict-origin-when-cross-origin` | — |
+| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` | — |
+
+The default CSP includes `'unsafe-inline'` and `'unsafe-eval'` because Next.js uses inline scripts for hydration and runtime-evaluated chunks. Operators with a strict policy can override by setting `OMNIA_CSP_POLICY` in the dashboard environment — the value replaces the default wholesale.
+
+The `x-powered-by: Next.js` header is disabled via `poweredByHeader: false` in `next.config.ts`, so the runtime + framework version are not advertised in responses.
+
 ## API Keys
 
 Enable programmatic access for scripts and CI/CD:


### PR DESCRIPTION
## Summary

Closes H-1 and H-2 from the 2026-04-20 pen-test report (omnia-azure repo, `docs/local-backlog/2026-04-20-security-hardening.md`).

### H-1 — security response headers

Every dashboard response now carries a defence-in-depth baseline via a new `applySecurityHeaders(response)` helper called from the Next.js middleware on every response path:

| Header | Default |
|---|---|
| `Strict-Transport-Security` | `max-age=63072000; includeSubDomains; preload` |
| `Content-Security-Policy` | `default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' ws: wss:; media-src 'self' blob: data:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'` |
| `X-Frame-Options` | `DENY` |
| `X-Content-Type-Options` | `nosniff` |
| `Referrer-Policy` | `strict-origin-when-cross-origin` |
| `Permissions-Policy` | `camera=(), microphone=(), geolocation=(), payment=()` |

CSP is permissive by default because Next.js uses inline scripts for hydration + runtime-evaluated chunks; operators with a tighter policy can override wholesale via `OMNIA_CSP_POLICY`.

Also sets `poweredByHeader: false` in `next.config.ts` so the `x-powered-by: Next.js` header no longer leaks the framework + version.

### H-2 — cookie-clear security attributes

Switched from `response.cookies.delete(name)` — which emits `Set-Cookie: name=; Path=/; Max-Age=0` with no security attributes — to an explicit `response.cookies.set({...})` that includes `HttpOnly`, `SameSite=Lax`, `Path=/`, and `Secure` when `NODE_ENV=production`. The clearing Set-Cookie now mirrors the original cookie's posture.

## Changes

- New: `dashboard/src/lib/security-headers.ts`
- Modified: `dashboard/src/middleware.ts`, `dashboard/next.config.ts`
- Tests: `dashboard/src/middleware.test.ts` (+6 cases: 4 headers × pass/redirect/401/env-override, 2 cookie-attr assertions)
- Docs: `docs/.../how-to/configure-dashboard-auth.md` — new "Session cookie attributes" and "Security response headers" subsections, table of defaults, override env var.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on changed files
- [x] `npx vitest run` — 4106/4106 (middleware suite: 35/35, was 29)

## Related

Prior PR in this series: #938 (C-1 dashboard SA split + H-3 agent pod hardening). Next (maybe): C-3 facade WS auth — likely an upstream investigation rather than a same-repo PR.