### PR TITLE
feat(controller): auto-allow operator namespace in workspace NetworkPolicy

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -277,6 +277,7 @@ func main() {
 			MemoryImagePullPolicy:  corev1.PullPolicy(memoryAPIImagePullPolicy),
 		},
 		AgentWorkspaceReaderClusterRole: agentWorkspaceReaderClusterRole,
+		OperatorNamespace:               os.Getenv("POD_NAMESPACE"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, errUnableToCreateController, logKeyController, "Workspace")
 		os.Exit(1)

--- a/docs/src/content/docs/explanation/multi-tenancy.md
+++ b/docs/src/content/docs/explanation/multi-tenancy.md
@@ -401,10 +401,13 @@ graph TB
 | Default Rule | Direction | Purpose |
 |--------------|-----------|---------|
 | DNS (port 53) | Egress | Allow pods to resolve DNS |
+| Operator namespace (`omnia-system` by default) | Both | Allow dashboard, operator, and Prometheus to reach workspace pods and vice-versa |
 | Same namespace | Both | Allow intra-workspace communication |
-| Shared namespaces | Both | Allow access to shared Providers/Tools |
+| Shared namespaces (label `omnia.altairalabs.ai/shared: true`) | Both | Allow access to shared Providers/Tools |
 | External IPs (0.0.0.0/0) | Egress | Allow LLM API calls |
 | Private IPs (10.x, 172.16.x, 192.168.x) | Blocked | Prevent cross-tenant access |
+
+The **operator namespace** rule matches by the kube-controller-injected `kubernetes.io/metadata.name` label, so no manual labelling is required. It's read from the operator pod's `POD_NAMESPACE` environment variable at startup; if the operator is running outside a pod (e.g., in an envtest harness), the rule is omitted and the shared-namespace label or custom `allowFrom`/`allowTo` become the only cross-namespace paths.
 
 :::tip[Why these IP ranges?]
 The blocked private IP ranges are [RFC 1918](https://datatracker.ietf.org/doc/html/rfc1918) addresses:

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -96,6 +96,15 @@ type WorkspaceReconciler struct {
 	// get/list/watch on Workspaces. Per-workspace service pods (session-api,
 	// memory-api) need this to resolve their config from the Workspace CRD.
 	AgentWorkspaceReaderClusterRole string
+
+	// OperatorNamespace is the namespace where the operator + dashboard run
+	// (typically "omnia-system"). When a Workspace enables network isolation,
+	// the generated NetworkPolicy auto-allows traffic to/from this namespace
+	// so the dashboard, operator, and Prometheus scrape can reach workspace
+	// pods without the user having to label namespaces. Populated from
+	// POD_NAMESPACE at operator startup; empty string disables the auto-
+	// allow (useful in tests).
+	OperatorNamespace string
 }
 
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=workspaces,verbs=get;list;watch;create;update;patch;delete
@@ -840,12 +849,33 @@ func (r *WorkspaceReconciler) updateStorageStatusIfPVCExists(
 // buildIngressRules builds the ingress rules for the NetworkPolicy
 func (r *WorkspaceReconciler) buildIngressRules(workspace *omniav1alpha1.Workspace) []networkingv1.NetworkPolicyIngressRule {
 	policy := workspace.Spec.NetworkPolicy
-	// Pre-allocate: 1 for same namespace + 1 for shared (if enabled) + custom rules
+	// Pre-allocate: 1 for same namespace + 1 for shared (if enabled) +
+	// 1 for operator namespace (if known) + custom rules.
 	capacity := 1 + len(policy.AllowFrom)
 	if policy.AllowSharedNamespaces == nil || *policy.AllowSharedNamespaces {
 		capacity++
 	}
+	if r.OperatorNamespace != "" {
+		capacity++
+	}
 	rules := make([]networkingv1.NetworkPolicyIngressRule, 0, capacity)
+
+	// Allow from the operator namespace (dashboard, operator, Prometheus).
+	// Matches by the kube-controller-injected namespace label so users
+	// don't have to apply `omnia.altairalabs.ai/shared: true` by hand.
+	if r.OperatorNamespace != "" {
+		rules = append(rules, networkingv1.NetworkPolicyIngressRule{
+			From: []networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": r.OperatorNamespace,
+						},
+					},
+				},
+			},
+		})
+	}
 
 	// Allow from shared namespaces (default true)
 	if policy.AllowSharedNamespaces == nil || *policy.AllowSharedNamespaces {
@@ -886,12 +916,17 @@ func (r *WorkspaceReconciler) buildIngressRules(workspace *omniav1alpha1.Workspa
 // buildEgressRules builds the egress rules for the NetworkPolicy
 func (r *WorkspaceReconciler) buildEgressRules(workspace *omniav1alpha1.Workspace) []networkingv1.NetworkPolicyEgressRule {
 	policy := workspace.Spec.NetworkPolicy
-	// Pre-allocate: 1 for DNS + 1 for same namespace + 1 for shared (if enabled) + 1 for external (if enabled) + custom rules
+	// Pre-allocate: 1 for DNS + 1 for same namespace + 1 for shared (if
+	// enabled) + 1 for external (if enabled) + 1 for operator namespace
+	// (if known) + custom rules.
 	capacity := 2 + len(policy.AllowTo)
 	if policy.AllowSharedNamespaces == nil || *policy.AllowSharedNamespaces {
 		capacity++
 	}
 	if policy.AllowExternalAPIs == nil || *policy.AllowExternalAPIs {
+		capacity++
+	}
+	if r.OperatorNamespace != "" {
 		capacity++
 	}
 	rules := make([]networkingv1.NetworkPolicyEgressRule, 0, capacity)
@@ -915,6 +950,27 @@ func (r *WorkspaceReconciler) buildEgressRules(workspace *omniav1alpha1.Workspac
 			{Protocol: &protocolTCP, Port: &dnsPort53},
 		},
 	})
+
+	// Allow egress to the operator namespace — the session-api and
+	// memory-api pods in a workspace need to reach Postgres / Redis /
+	// tracing collectors / other chart-managed services running alongside
+	// the operator and dashboard. Chart installs may co-locate Postgres
+	// in `omnia-system` as a StatefulSet; operator managed-DB clusters
+	// will still route through here for the tracing collector and any
+	// enterprise Redis sidecar.
+	if r.OperatorNamespace != "" {
+		rules = append(rules, networkingv1.NetworkPolicyEgressRule{
+			To: []networkingv1.NetworkPolicyPeer{
+				{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"kubernetes.io/metadata.name": r.OperatorNamespace,
+						},
+					},
+				},
+			},
+		})
+	}
 
 	// Allow to shared namespaces (default true)
 	if policy.AllowSharedNamespaces == nil || *policy.AllowSharedNamespaces {

--- a/internal/controller/workspace_controller_test.go
+++ b/internal/controller/workspace_controller_test.go
@@ -915,6 +915,142 @@ var _ = Describe("Workspace Controller", func() {
 				return errors.IsNotFound(err)
 			}, timeout, interval).Should(BeTrue())
 		})
+
+		It("auto-allows traffic to/from the operator namespace when configured", func() {
+			By("creating an isolated Workspace with the operator-aware reconciler")
+			operatorReconciler := &WorkspaceReconciler{
+				Client:            k8sClient,
+				Scheme:            k8sClient.Scheme(),
+				OperatorNamespace: "omnia-system",
+			}
+			workspace := &omniav1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workspaceKey.Name,
+				},
+				Spec: omniav1alpha1.WorkspaceSpec{
+					DisplayName: "Isolated + Operator-aware",
+					Environment: omniav1alpha1.WorkspaceEnvironmentDevelopment,
+					Namespace: omniav1alpha1.NamespaceConfig{
+						Name:   namespaceName,
+						Create: true,
+					},
+					NetworkPolicy: &omniav1alpha1.WorkspaceNetworkPolicy{
+						Isolate: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
+
+			By("reconciling the Workspace")
+			_, err := operatorReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: workspaceKey})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = operatorReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: workspaceKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("verifying the NetworkPolicy admits traffic from the operator namespace")
+			npName := fmt.Sprintf("workspace-%s-isolation", workspaceKey.Name)
+			np := &networkingv1.NetworkPolicy{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{
+				Name:      npName,
+				Namespace: namespaceName,
+			}, np)).To(Succeed())
+
+			matchesOperatorNs := func(peers []networkingv1.NetworkPolicyPeer) bool {
+				for _, peer := range peers {
+					if peer.NamespaceSelector == nil {
+						continue
+					}
+					if peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] == "omnia-system" {
+						return true
+					}
+				}
+				return false
+			}
+
+			By("asserting ingress includes a rule from omnia-system")
+			foundIngress := false
+			for _, rule := range np.Spec.Ingress {
+				if matchesOperatorNs(rule.From) {
+					foundIngress = true
+					break
+				}
+			}
+			Expect(foundIngress).To(BeTrue(), "expected ingress rule from operator namespace omnia-system")
+
+			By("asserting egress includes a rule to omnia-system")
+			foundEgress := false
+			for _, rule := range np.Spec.Egress {
+				if matchesOperatorNs(rule.To) {
+					foundEgress = true
+					break
+				}
+			}
+			Expect(foundEgress).To(BeTrue(), "expected egress rule to operator namespace omnia-system")
+		})
+
+		It("omits the operator-namespace rules when OperatorNamespace is empty (e.g. test harness)", func() {
+			By("creating an isolated Workspace with a reconciler missing OperatorNamespace")
+			bareReconciler := &WorkspaceReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			workspace := &omniav1alpha1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: workspaceKey.Name,
+				},
+				Spec: omniav1alpha1.WorkspaceSpec{
+					DisplayName: "Isolated, no operator NS",
+					Environment: omniav1alpha1.WorkspaceEnvironmentDevelopment,
+					Namespace: omniav1alpha1.NamespaceConfig{
+						Name:   namespaceName,
+						Create: true,
+					},
+					NetworkPolicy: &omniav1alpha1.WorkspaceNetworkPolicy{
+						Isolate: true,
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, workspace)).To(Succeed())
+
+			_, err := bareReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: workspaceKey})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = bareReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: workspaceKey})
+			Expect(err).NotTo(HaveOccurred())
+
+			npName := fmt.Sprintf("workspace-%s-isolation", workspaceKey.Name)
+			np := &networkingv1.NetworkPolicy{}
+			Expect(k8sClient.Get(ctx, client.ObjectKey{
+				Name:      npName,
+				Namespace: namespaceName,
+			}, np)).To(Succeed())
+
+			hasMetadataNameSelector := func(peers []networkingv1.NetworkPolicyPeer) bool {
+				for _, peer := range peers {
+					if peer.NamespaceSelector == nil {
+						continue
+					}
+					if _, has := peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"]; has {
+						// kube-system DNS rule is allowed; everything else with
+						// `kubernetes.io/metadata.name` is a sign the operator-ns
+						// rule leaked in.
+						if peer.NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"] != "kube-system" {
+							return true
+						}
+					}
+				}
+				return false
+			}
+
+			for _, rule := range np.Spec.Ingress {
+				Expect(hasMetadataNameSelector(rule.From)).To(BeFalse(),
+					"ingress must not include a metadata.name selector when OperatorNamespace is empty")
+			}
+			for _, rule := range np.Spec.Egress {
+				// The DNS rule uses metadata.name=kube-system, which the helper ignores.
+				Expect(hasMetadataNameSelector(rule.To)).To(BeFalse(),
+					"egress must not include a non-DNS metadata.name selector when OperatorNamespace is empty")
+			}
+		})
 	})
 })
 


### PR DESCRIPTION
## Summary

Closes the last upstream-Omnia piece of pen-test finding C-2 (from `omnia-azure/docs/local-backlog/2026-04-20-security-hardening.md`).

### Why

Workspace network isolation has been shipped for a while — setting `spec.networkPolicy.isolate: true` on a Workspace generates a NetworkPolicy with DNS + same-ns + shared-ns + external-APIs-except-RFC1918 baked in. But enabling it today silently breaks dashboard → facade, operator → session-api/memory-api, and Prometheus scrapes, because nothing labels the operator namespace as `omnia.altairalabs.ai/shared: true`. Production hardening ≈ "I turned it on and the cluster stopped working".

### What changes

`WorkspaceReconciler` learns its own pod namespace from `POD_NAMESPACE` (new `OperatorNamespace` field wired at startup). When set and isolation is enabled, the generated NetworkPolicy gains:

- Ingress rule matching `kubernetes.io/metadata.name=<OperatorNamespace>` (kube-controller-injected label — no manual labelling).
- Egress rule matching the same namespace (session-api / memory-api reach Postgres / Redis / tracing collectors colocated with the operator).

When `OperatorNamespace` is empty (envtest harness, standalone runs), the rules are omitted — existing behaviour preserved.

### Scope bounds

Not in this PR (filed as follow-up):

- Istio overlay (PeerAuthentication STRICT + AuthorizationPolicy) — optional, keyed off `istio.enabled`.
- Default-deny ingress on the `omnia-system` namespace itself.
- Egress hardening keyed off bound Provider CRs (in-cluster vLLM / Ollama currently fall inside the broad "external APIs" rule — fine for most production, wrong for in-cluster providers).

### Tests

Two new envtest cases in the `Network Isolation` context:
- auto-allows traffic to/from the operator namespace when configured
- omits the operator-namespace rules when `OperatorNamespace` is empty

Existing 7 specs unchanged and green — 9/9 now. Coverage on `workspace_controller.go`: 81.0%.

### Docs

`docs/src/content/docs/explanation/multi-tenancy.md` — added an operator-namespace row to the default-rule table and a paragraph explaining the `kubernetes.io/metadata.name` match + `POD_NAMESPACE` source.

## Test plan

- [x] `golangci-lint run ./...` clean
- [x] `go test ./internal/controller/...` 541 specs pass
- [x] envtest `Network Isolation` context 9/9 pass
- [x] Per-file coverage ≥ 80%
- [x] Pre-commit green (incl. helm lint + template rendering)

## Related

Prior security-hardening PRs: #938 (C-1 + H-3), #939 (H-1 + H-2). Parked: C-3 (facade WS auth, design in `Omnia/docs/local-backlog/2026-04-21-c3-facade-ws-auth.md`).