### PR TITLE
docs: fix Helm install paths and modernise getting-started

### DIFF
--- a/docs/src/content/docs/how-to/configure-authentication.md
+++ b/docs/src/content/docs/how-to/configure-authentication.md
@@ -41,7 +41,7 @@ authentication:
 Apply with Helm:
 
 ```bash
-helm upgrade --install omnia oci://ghcr.io/altairalabs/omnia \
+helm upgrade --install omnia oci://ghcr.io/altairalabs/charts/omnia \
   --namespace omnia-system \
   -f values.yaml
 ```

--- a/docs/src/content/docs/how-to/configure-otlp-ingestion.md
+++ b/docs/src/content/docs/how-to/configure-otlp-ingestion.md
@@ -38,7 +38,7 @@ sessionApi:
 Deploy the update:
 
 ```bash
-helm upgrade omnia oci://ghcr.io/altairalabs/omnia \
+helm upgrade omnia oci://ghcr.io/altairalabs/charts/omnia \
   --namespace omnia-system \
   -f values.yaml
 ```

--- a/docs/src/content/docs/how-to/setup-observability.md
+++ b/docs/src/content/docs/how-to/setup-observability.md
@@ -37,7 +37,7 @@ alloy:
 Install or upgrade with these values:
 
 ```bash
-helm upgrade --install omnia oci://ghcr.io/altairalabs/omnia \
+helm upgrade --install omnia oci://ghcr.io/altairalabs/charts/omnia \
   --namespace omnia-system \
   --create-namespace \
   -f values.yaml

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -42,8 +42,9 @@ Omnia is a Kubernetes operator that simplifies the deployment and management of 
 Install Omnia using Helm:
 
 ```bash
-helm repo add omnia https://altairalabs.github.io/omnia/charts
-helm install omnia omnia/omnia --namespace omnia-system --create-namespace
+helm repo add altaira https://charts.altairalabs.ai
+helm repo update
+helm install omnia altaira/omnia --namespace omnia-system --create-namespace
 ```
 
 Then deploy your first agent:

--- a/docs/src/content/docs/reference/helm-values.md
+++ b/docs/src/content/docs/reference/helm-values.md
@@ -11,7 +11,7 @@ This document covers all configuration options for the Omnia Helm chart.
 ## Installation
 
 ```bash
-helm install omnia oci://ghcr.io/altairalabs/omnia \
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
   --namespace omnia-system \
   --create-namespace \
   -f values.yaml
@@ -868,12 +868,12 @@ Demo agents are now deployed via a separate `omnia-demos` chart. This provides a
 
 ```bash
 # First, install the main Omnia operator
-helm install omnia oci://ghcr.io/altairalabs/omnia \
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
   --namespace omnia-system \
   --create-namespace
 
 # Then, install the demo agents
-helm install omnia-demos oci://ghcr.io/altairalabs/omnia-demos \
+helm install omnia-demos oci://ghcr.io/altairalabs/charts/omnia-demos \
   --namespace omnia-demo \
   --create-namespace
 ```
@@ -1039,12 +1039,12 @@ Quick-start demo with local Ollama LLM. Deploy using two separate charts:
 
 ```bash
 # Main chart with dashboard
-helm install omnia oci://ghcr.io/altairalabs/omnia \
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
   -n omnia-system --create-namespace \
   --set dashboard.enabled=true
 
 # Demo agents chart
-helm install omnia-demos oci://ghcr.io/altairalabs/omnia-demos \
+helm install omnia-demos oci://ghcr.io/altairalabs/charts/omnia-demos \
   -n omnia-demo --create-namespace \
   --set ollama.persistence.enabled=true
 ```

--- a/docs/src/content/docs/tutorials/arena-getting-started.md
+++ b/docs/src/content/docs/tutorials/arena-getting-started.md
@@ -22,7 +22,7 @@ Before you begin, ensure you have:
 If you don't have an API key, you can use the `omnia-demos` chart which includes a local Ollama instance:
 
 ```bash
-helm install omnia-demos oci://ghcr.io/altairalabs/omnia-demos \
+helm install omnia-demos oci://ghcr.io/altairalabs/charts/omnia-demos \
   -n omnia-demo --create-namespace \
   --set arenaDemo.enabled=true
 ```

--- a/docs/src/content/docs/tutorials/getting-started.md
+++ b/docs/src/content/docs/tutorials/getting-started.md
@@ -22,12 +22,12 @@ If you don't have an API key yet, you can try Omnia with the demo charts that us
 
 ```bash
 # Install the Omnia operator with dashboard
-helm install omnia oci://ghcr.io/altairalabs/omnia \
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia \
   -n omnia-system --create-namespace \
   --set dashboard.enabled=true
 
 # Install the demo agents (separate chart)
-helm install omnia-demos oci://ghcr.io/altairalabs/omnia-demos \
+helm install omnia-demos oci://ghcr.io/altairalabs/charts/omnia-demos \
   -n omnia-demo --create-namespace
 ```
 
@@ -35,7 +35,13 @@ This deploys a vision-capable agent using the llava:7b model running locally. No
 
 **Requirements**: 8GB+ RAM, 10GB disk for the model.
 
-Once deployed, access the dashboard at `http://localhost:3000` (after port-forwarding) and connect to the `vision-demo` agent.
+Once deployed, port-forward the dashboard and open it in your browser:
+
+```bash
+kubectl port-forward -n omnia-system svc/omnia-dashboard 3000:3000
+```
+
+Visit `http://localhost:3000` and connect to the `vision-demo` agent.
 :::
 
 ## Step 1: Install the Operator
@@ -43,11 +49,17 @@ Once deployed, access the dashboard at `http://localhost:3000` (after port-forwa
 Add the Omnia Helm repository and install the operator:
 
 ```bash
-helm repo add omnia https://altairalabs.github.io/omnia/charts
+helm repo add altaira https://charts.altairalabs.ai
 helm repo update
 
 kubectl create namespace omnia-system
-helm install omnia omnia/omnia -n omnia-system
+helm install omnia altaira/omnia -n omnia-system
+```
+
+Or install directly from the OCI registry:
+
+```bash
+helm install omnia oci://ghcr.io/altairalabs/charts/omnia -n omnia-system --create-namespace
 ```
 
 Verify the operator is running:
@@ -144,7 +156,7 @@ metadata:
   namespace: default
 type: Opaque
 stringData:
-  ANTHROPIC_API_KEY: "sk-ant-..."  # Or OPENAI_API_KEY for OpenAI
+  ANTHROPIC_API_KEY: "sk-ant-..."  # Or OPENAI_API_KEY / GEMINI_API_KEY
 ---
 apiVersion: omnia.altairalabs.ai/v1alpha1
 kind: Provider
@@ -152,10 +164,15 @@ metadata:
   name: my-provider
   namespace: default
 spec:
-  type: claude  # Or "openai", "gemini"
+  type: claude  # One of: claude, openai, gemini, ollama, mock
   model: claude-sonnet-4-20250514
-  secretRef:
-    name: llm-credentials
+  credential:
+    secretRef:
+      name: llm-credentials
+      # key is inferred from provider type:
+      #   claude  → ANTHROPIC_API_KEY
+      #   openai  → OPENAI_API_KEY
+      #   gemini  → GEMINI_API_KEY
 ```
 
 ```bash
@@ -169,7 +186,7 @@ kubectl get provider my-provider
 # Should show: my-provider   claude   claude-sonnet-4-20250514   Ready   ...
 ```
 
-> **Tip**: Don't have an API key yet? Use `handler: demo` in your AgentRuntime to test with simulated responses. See [Handler Modes](/reference/agentruntime/#handler-modes) for details.
+> **Tip**: Don't have an API key yet? Use `handler: demo` in your AgentRuntime to test with simulated responses, or set `type: mock` on the Provider for a no-network testing provider. See [Handler Modes](/reference/agentruntime/#handler-modes) for details.
 
 ## Step 4: Deploy the Agent
 
@@ -195,7 +212,12 @@ spec:
     ttl: "1h"
 ```
 
-> **Note**: The `handler: demo` setting provides simulated streaming responses for testing. For production with a real LLM, change to `handler: runtime` (the default).
+> **Note**: Handler modes are:
+> - `runtime` *(default)* — uses the runtime framework in the container for real LLM responses.
+> - `demo` — simulated streaming responses for demos without an API key.
+> - `echo` — echoes the input back; useful for testing connectivity.
+>
+> Session store types are `memory` (single-pod dev only), `redis`, and `postgres`. Redis and Postgres require a `storeRef` pointing at a Secret with connection details.
 
 ```bash
 kubectl apply -f agentruntime.yaml


### PR DESCRIPTION
## Summary
Fixes factual errors in the published docs that the getting-started tutorial surfaced:

- **Helm repo URL was fictional.** Tutorial instructed `helm repo add omnia https://altairalabs.github.io/omnia/charts` — that URL doesn't serve a Helm repo. The real HTTPS repo is \`https://charts.altairalabs.ai\` (per \`RELEASING.md:175\`).
- **OCI install path was wrong.** Docs used \`oci://ghcr.io/altairalabs/omnia\`; chart-publishing pushes to \`oci://ghcr.io/altairalabs/charts/omnia\` (\`Makefile:233\`, \`RELEASING.md:161\`). Fixed in getting-started, arena-getting-started, helm-values reference, and the three how-to pages that ship upgrade snippets.
- **Getting-started tutorial content refreshed:**
  - Demo-mode tip now has the dashboard port-forward command (was just "after port-forwarding").
  - Provider example migrated from deprecated \`spec.secretRef\` (see \`api/v1alpha1/provider_types.go:225\`) to \`spec.credential.secretRef\`.
  - Handler modes list \`runtime | demo | echo\` (was missing \`echo\`).
  - Session store types list \`memory | redis | postgres\` (was just \`memory\`).
  - Provider types mention \`ollama\` and \`mock\` alongside \`claude | openai | gemini\`.

## Test plan
- [ ] Build the docs site locally (\`cd docs && npm run build\`) and spot-check the rendered pages.
- [ ] Verify the \`helm install\` commands in Step 1 and the Demo Mode tip resolve against the real chart sources.