### PR TITLE
feat(facade): mgmt-plane auth scaffolding (PR 1a, behaviour-preserving)

### DIFF
--- a/charts/omnia/templates/dashboard/signing-keypair.yaml
+++ b/charts/omnia/templates/dashboard/signing-keypair.yaml
@@ -1,0 +1,50 @@
+{{- /*
+Mgmt-plane signing keypair for the dashboard.
+
+The dashboard uses this RSA keypair to mint short-lived JWTs for the
+"Try this agent" debug view; the facade validates them with the public
+half mounted into every agent pod (see internal/controller/deployment_builder.go
+and internal/facade/auth/mgmt_plane.go).
+
+Rotation model:
+  - First install: genSelfSigned produces a 3650-day RSA cert + key.
+  - Subsequent upgrades: `lookup` fetches the existing values so we never
+    regenerate a keypair that already has pods depending on it.
+  - resource-policy: keep prevents `helm uninstall` from deleting the
+    keypair; operators who want to truly rotate must delete the Secret
+    manually, re-run `helm upgrade`, and roll dashboard + facade pods.
+
+Opt-out: set dashboard.signingKey.existingSecret to reference an
+externally-managed Secret (same shape: kubernetes.io/tls with tls.crt +
+tls.key). Required for BYO key deployments — cloud KMS / CSI drivers.
+*/ -}}
+{{- if .Values.dashboard.enabled }}
+{{- if not .Values.dashboard.signingKey.existingSecret }}
+{{- $name := printf "%s-signing-keypair" (include "omnia.dashboard.fullname" .) }}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- $cert := "" }}
+{{- $key := "" }}
+{{- if and $existing $existing.data (hasKey $existing.data "tls.crt") }}
+{{- $cert = index $existing.data "tls.crt" }}
+{{- $key = index $existing.data "tls.key" }}
+{{- else }}
+{{- $generated := genSelfSignedCert "omnia-dashboard" nil nil 3650 }}
+{{- $cert = $generated.Cert | b64enc }}
+{{- $key = $generated.Key | b64enc }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "omnia.dashboard.labels" . | nindent 4 }}
+  annotations:
+    # Never regenerate on upgrade; never delete on uninstall. Rotation is
+    # an explicit operator action (delete Secret + upgrade + roll pods).
+    "helm.sh/resource-policy": keep
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ $cert }}
+  tls.key: {{ $key }}
+{{- end }}
+{{- end }}

--- a/charts/omnia/tests/dashboard-signing-keypair_test.yaml
+++ b/charts/omnia/tests/dashboard-signing-keypair_test.yaml
@@ -1,0 +1,54 @@
+suite: dashboard mgmt-plane signing keypair
+release:
+  name: omnia
+values:
+  - ../values-chart-tests.yaml
+templates:
+  - templates/dashboard/signing-keypair.yaml
+tests:
+  - it: renders a kubernetes.io/tls Secret with tls.crt + tls.key
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: Secret
+      - equal:
+          path: type
+          value: kubernetes.io/tls
+      - equal:
+          path: metadata.name
+          value: omnia-dashboard-signing-keypair
+      - exists:
+          path: data["tls.crt"]
+      - exists:
+          path: data["tls.key"]
+
+  - it: annotates the Secret so Helm never deletes or regenerates it
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: keep
+
+  - it: carries the standard dashboard labels
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/component"]
+          value: dashboard
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: omnia-dashboard
+
+  - it: is suppressed when dashboard.enabled=false
+    set:
+      dashboard.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is suppressed when an existingSecret is provided (BYO keypair)
+    set:
+      dashboard.signingKey.existingSecret: my-own-signing-keypair
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/omnia/values.schema.json
+++ b/charts/omnia/values.schema.json
@@ -257,6 +257,16 @@
             "port": { "$ref": "#/$defs/port" }
           }
         },
+        "signingKey": {
+          "type": "object",
+          "description": "Management-plane JWT signing keypair. Auto-generated as a self-signed RSA keypair on first install (helm.sh/resource-policy: keep).",
+          "properties": {
+            "existingSecret": {
+              "type": "string",
+              "description": "Reference an externally-managed Secret (kubernetes.io/tls) instead of the chart-generated keypair."
+            }
+          }
+        },
         "auth": {
           "type": "object",
           "properties": {

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -662,6 +662,19 @@ dashboard:
   # tolerations values.
   podOverrides: {}
 
+  # -- Management-plane JWT signing keypair. The dashboard uses the
+  # private half to mint short-lived tokens for the "Try this agent"
+  # debug view; every facade pod validates those tokens with the public
+  # half. First install generates a self-signed 10-year RSA keypair;
+  # upgrades preserve the existing Secret (helm.sh/resource-policy: keep).
+  # Rotation is a manual operator action — delete the Secret, upgrade,
+  # and roll dashboard + facade pods.
+  signingKey:
+    # -- Reference an externally-managed Secret instead of the chart-generated
+    # keypair. The Secret must be kubernetes.io/tls with tls.crt + tls.key.
+    # Leave empty to use the chart-managed keypair.
+    existingSecret: ""
+
   # Pod Disruption Budget for HA deployments
   podDisruptionBudget:
     # -- Enable PDB for dashboard

--- a/internal/facade/auth/mgmt_plane.go
+++ b/internal/facade/auth/mgmt_plane.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// Default issuer / audience values embedded in dashboard-minted tokens.
+const (
+	DefaultMgmtPlaneIssuer   = "omnia-dashboard"
+	DefaultMgmtPlaneAudience = "omnia-facade"
+)
+
+// bearerPrefix is the case-sensitive scheme tag on Authorization: Bearer <token>.
+const bearerPrefix = "Bearer "
+
+// MgmtPlaneValidator verifies JWTs minted by the dashboard's signing key
+// and presented by an admin against the facade (for example, the "Try this
+// agent" debug view). It is one entry in the facade's auth chain.
+type MgmtPlaneValidator struct {
+	publicKey *rsa.PublicKey
+	issuer    string
+	audience  string
+}
+
+// MgmtPlaneOption tunes a MgmtPlaneValidator.
+type MgmtPlaneOption func(*MgmtPlaneValidator)
+
+// WithMgmtPlaneIssuer overrides the expected `iss` claim. Defaults to
+// DefaultMgmtPlaneIssuer.
+func WithMgmtPlaneIssuer(iss string) MgmtPlaneOption {
+	return func(v *MgmtPlaneValidator) { v.issuer = iss }
+}
+
+// WithMgmtPlaneAudience overrides the expected `aud` claim. Defaults to
+// DefaultMgmtPlaneAudience.
+func WithMgmtPlaneAudience(aud string) MgmtPlaneOption {
+	return func(v *MgmtPlaneValidator) { v.audience = aud }
+}
+
+// NewMgmtPlaneValidator constructs a validator that trusts JWTs signed by
+// the RSA public key at pubKeyPath. The file may contain either a PKIX
+// "PUBLIC KEY" PEM block or an x509 "CERTIFICATE" PEM block — Helm's
+// genSelfSigned emits the latter, operators supplying their own key may
+// use either.
+func NewMgmtPlaneValidator(pubKeyPath string, opts ...MgmtPlaneOption) (*MgmtPlaneValidator, error) {
+	data, err := os.ReadFile(pubKeyPath)
+	if err != nil {
+		return nil, fmt.Errorf("read mgmt-plane public key %q: %w", pubKeyPath, err)
+	}
+	key, err := parseRSAPublicKey(data)
+	if err != nil {
+		return nil, fmt.Errorf("parse mgmt-plane public key %q: %w", pubKeyPath, err)
+	}
+
+	v := &MgmtPlaneValidator{
+		publicKey: key,
+		issuer:    DefaultMgmtPlaneIssuer,
+		audience:  DefaultMgmtPlaneAudience,
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v, nil
+}
+
+// mgmtPlaneClaims is the dashboard-minted JWT shape.
+type mgmtPlaneClaims struct {
+	jwt.RegisteredClaims
+	Origin    string `json:"origin"`
+	Agent     string `json:"agent,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+}
+
+// Validate implements Validator. It admits requests carrying a valid
+// mgmt-plane JWT and rejects everything else with one of the typed errors.
+func (v *MgmtPlaneValidator) Validate(_ context.Context, r *http.Request) (*policy.AuthenticatedIdentity, error) {
+	tokenString, err := extractBearer(r)
+	if err != nil {
+		return nil, err
+	}
+
+	claims := &mgmtPlaneClaims{}
+	parser := jwt.NewParser(
+		jwt.WithIssuer(v.issuer),
+		jwt.WithAudience(v.audience),
+		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}),
+	)
+	token, parseErr := parser.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method %q", t.Header["alg"])
+		}
+		return v.publicKey, nil
+	})
+	if parseErr != nil {
+		if errors.Is(parseErr, jwt.ErrTokenExpired) {
+			return nil, ErrExpired
+		}
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCredential, parseErr)
+	}
+	if token == nil || !token.Valid {
+		return nil, ErrInvalidCredential
+	}
+	if claims.Origin != policy.OriginManagementPlane {
+		return nil, fmt.Errorf("%w: origin %q is not management-plane", ErrInvalidCredential, claims.Origin)
+	}
+
+	id := &policy.AuthenticatedIdentity{
+		Origin:    policy.OriginManagementPlane,
+		Subject:   claims.Subject,
+		EndUser:   claims.Subject,
+		Workspace: claims.Workspace,
+		Agent:     claims.Agent,
+		// Mgmt-plane tokens are minted only after dashboard auth admits
+		// the user; they always carry admin privileges for the agent they
+		// target. Per-user role mapping is a future extension.
+		Role: policy.RoleAdmin,
+	}
+	if claims.IssuedAt != nil {
+		id.IssuedAt = claims.IssuedAt.Time
+	}
+	if claims.ExpiresAt != nil {
+		id.ExpiresAt = claims.ExpiresAt.Time
+	}
+	return id, nil
+}
+
+// extractBearer returns the token payload from a "Bearer <token>"
+// Authorization header, or one of the sentinel errors when the header is
+// absent or malformed.
+func extractBearer(r *http.Request) (string, error) {
+	raw := r.Header.Get("Authorization")
+	if raw == "" {
+		return "", ErrNoCredential
+	}
+	if !strings.HasPrefix(raw, bearerPrefix) {
+		// Non-Bearer scheme (Basic, Negotiate, etc.) — not ours. Let the
+		// chain continue; a later validator may understand this scheme or
+		// the no-auth tail may reject.
+		return "", ErrNoCredential
+	}
+	token := strings.TrimSpace(raw[len(bearerPrefix):])
+	if token == "" {
+		return "", fmt.Errorf("%w: empty bearer token", ErrInvalidCredential)
+	}
+	return token, nil
+}
+
+// parseRSAPublicKey accepts either a PKIX "PUBLIC KEY" PEM block or an
+// x509 "CERTIFICATE" PEM block and returns the RSA public key. Helm's
+// genSelfSigned template produces certificates; operators BYO-ing a raw
+// public key may use the other form.
+func parseRSAPublicKey(data []byte) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("no PEM block found")
+	}
+
+	switch block.Type {
+	case "CERTIFICATE":
+		cert, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse certificate: %w", err)
+		}
+		key, ok := cert.PublicKey.(*rsa.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("certificate public key is %T, want *rsa.PublicKey", cert.PublicKey)
+		}
+		return key, nil
+	case "PUBLIC KEY":
+		pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKIX public key: %w", err)
+		}
+		key, ok := pub.(*rsa.PublicKey)
+		if !ok {
+			return nil, fmt.Errorf("public key is %T, want *rsa.PublicKey", pub)
+		}
+		return key, nil
+	case "RSA PUBLIC KEY":
+		key, err := x509.ParsePKCS1PublicKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS1 public key: %w", err)
+		}
+		return key, nil
+	default:
+		return nil, fmt.Errorf("unsupported PEM block type %q", block.Type)
+	}
+}

--- a/internal/facade/auth/mgmt_plane_test.go
+++ b/internal/facade/auth/mgmt_plane_test.go
@@ -1,0 +1,507 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+const (
+	testIssuer   = "omnia-dashboard"
+	testAudience = "omnia-facade"
+)
+
+// testMintOpts tunes a single token's claims. Missing fields get safe defaults.
+type testMintOpts struct {
+	issuer    string
+	audience  string
+	subject   string
+	origin    string
+	agent     string
+	workspace string
+	exp       time.Time
+	nbf       time.Time
+	iat       time.Time
+	key       *rsa.PrivateKey // override signing key
+	noClaims  bool            // mint a token with jwt.RegisteredClaims only, no origin
+}
+
+func defaultMintOpts(key *rsa.PrivateKey) testMintOpts {
+	now := time.Now()
+	return testMintOpts{
+		issuer:    testIssuer,
+		audience:  testAudience,
+		subject:   "admin@example.com",
+		origin:    policy.OriginManagementPlane,
+		agent:     "test-agent",
+		workspace: "default",
+		exp:       now.Add(5 * time.Minute),
+		nbf:       now.Add(-1 * time.Minute),
+		iat:       now,
+		key:       key,
+	}
+}
+
+type testClaims struct {
+	jwt.RegisteredClaims
+	Origin    string `json:"origin,omitempty"`
+	Agent     string `json:"agent,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+}
+
+func mintToken(t *testing.T, opts testMintOpts) string {
+	t.Helper()
+	claims := testClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    opts.issuer,
+			Subject:   opts.subject,
+			Audience:  jwt.ClaimStrings{opts.audience},
+			ExpiresAt: jwt.NewNumericDate(opts.exp),
+			NotBefore: jwt.NewNumericDate(opts.nbf),
+			IssuedAt:  jwt.NewNumericDate(opts.iat),
+		},
+	}
+	if !opts.noClaims {
+		claims.Origin = opts.origin
+		claims.Agent = opts.agent
+		claims.Workspace = opts.workspace
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(opts.key)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+func newRSAKey(t *testing.T) *rsa.PrivateKey {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate rsa key: %v", err)
+	}
+	return k
+}
+
+func writePubKeyPEM(t *testing.T, dir string, key *rsa.PublicKey) string {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(key)
+	if err != nil {
+		t.Fatalf("marshal pkix: %v", err)
+	}
+	path := filepath.Join(dir, "pub.pem")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create pub.pem: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := pem.Encode(f, &pem.Block{Type: "PUBLIC KEY", Bytes: der}); err != nil {
+		t.Fatalf("encode pub.pem: %v", err)
+	}
+	return path
+}
+
+func writeSelfSignedCertPEM(t *testing.T, dir string, key *rsa.PrivateKey) string {
+	t.Helper()
+	tpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "omnia-dashboard-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tpl, &tpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	path := filepath.Join(dir, "pub.pem")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create pub.pem: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := pem.Encode(f, &pem.Block{Type: "CERTIFICATE", Bytes: der}); err != nil {
+		t.Fatalf("encode cert: %v", err)
+	}
+	return path
+}
+
+func requestWithToken(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+// newValidator constructs an MgmtPlaneValidator with a random RSA keypair
+// written to disk as PKIX public-key PEM. Returns the validator and the
+// matching private key for the tests to sign tokens with.
+func newValidator(t *testing.T) (*auth.MgmtPlaneValidator, *rsa.PrivateKey) {
+	t.Helper()
+	key := newRSAKey(t)
+	path := writePubKeyPEM(t, t.TempDir(), &key.PublicKey)
+	v, err := auth.NewMgmtPlaneValidator(path)
+	if err != nil {
+		t.Fatalf("NewMgmtPlaneValidator: %v", err)
+	}
+	return v, key
+}
+
+func TestMgmtPlaneValidator_ValidToken(t *testing.T) {
+	t.Parallel()
+	v, key := newValidator(t)
+	token := mintToken(t, defaultMintOpts(key))
+
+	id, err := v.Validate(context.Background(), requestWithToken(token))
+	if err != nil {
+		t.Fatalf("Validate returned err: %v", err)
+	}
+	if id == nil {
+		t.Fatal("expected non-nil identity")
+	}
+	if got, want := id.Origin, policy.OriginManagementPlane; got != want {
+		t.Errorf("Origin = %q, want %q", got, want)
+	}
+	if got, want := id.Subject, "admin@example.com"; got != want {
+		t.Errorf("Subject = %q, want %q", got, want)
+	}
+	if got, want := id.EndUser, id.Subject; got != want {
+		t.Errorf("EndUser = %q, want %q (same as Subject for mgmt-plane)", got, want)
+	}
+	if got, want := id.Role, policy.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if got, want := id.Agent, "test-agent"; got != want {
+		t.Errorf("Agent = %q, want %q", got, want)
+	}
+	if got, want := id.Workspace, "default"; got != want {
+		t.Errorf("Workspace = %q, want %q", got, want)
+	}
+	if id.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt should be populated from exp claim")
+	}
+}
+
+func TestMgmtPlaneValidator_AcceptsCertificatePEM(t *testing.T) {
+	// Helm's genSelfSigned emits a certificate (tls.crt). The validator
+	// must accept that shape too, not just raw PKIX public-key PEM.
+	t.Parallel()
+	key := newRSAKey(t)
+	path := writeSelfSignedCertPEM(t, t.TempDir(), key)
+	v, err := auth.NewMgmtPlaneValidator(path)
+	if err != nil {
+		t.Fatalf("NewMgmtPlaneValidator with cert: %v", err)
+	}
+	token := mintToken(t, defaultMintOpts(key))
+	id, err := v.Validate(context.Background(), requestWithToken(token))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id == nil || id.Origin != policy.OriginManagementPlane {
+		t.Errorf("expected mgmt-plane identity, got %+v", id)
+	}
+}
+
+func TestMgmtPlaneValidator_NoAuthorizationHeader(t *testing.T) {
+	t.Parallel()
+	v, _ := newValidator(t)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil) // no header
+
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_NonBearerAuthorization(t *testing.T) {
+	t.Parallel()
+	v, _ := newValidator(t)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("non-Bearer should fall through: err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_EmptyBearerToken(t *testing.T) {
+	t.Parallel()
+	v, _ := newValidator(t)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("Authorization", "Bearer ")
+
+	_, err := v.Validate(context.Background(), r)
+	// An empty bearer token is a malformed credential, not an absence.
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_MalformedJWT(t *testing.T) {
+	t.Parallel()
+	v, _ := newValidator(t)
+	r := requestWithToken("not.a.valid.jwt")
+
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_BadSignature(t *testing.T) {
+	t.Parallel()
+	v, _ := newValidator(t)
+	otherKey := newRSAKey(t) // different key than the validator trusts
+	token := mintToken(t, defaultMintOpts(otherKey))
+
+	_, err := v.Validate(context.Background(), requestWithToken(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_WrongIssuer(t *testing.T) {
+	t.Parallel()
+	v, key := newValidator(t)
+	opts := defaultMintOpts(key)
+	opts.issuer = "someone-else"
+	token := mintToken(t, opts)
+
+	_, err := v.Validate(context.Background(), requestWithToken(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_WrongAudience(t *testing.T) {
+	t.Parallel()
+	v, key := newValidator(t)
+	opts := defaultMintOpts(key)
+	opts.audience = "some-other-audience"
+	token := mintToken(t, opts)
+
+	_, err := v.Validate(context.Background(), requestWithToken(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_WrongOrigin(t *testing.T) {
+	t.Parallel()
+	v, key := newValidator(t)
+	opts := defaultMintOpts(key)
+	opts.origin = "data-plane" // reject — the mgmt-plane validator only admits mgmt-plane tokens
+	token := mintToken(t, opts)
+
+	_, err := v.Validate(context.Background(), requestWithToken(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_MissingOriginClaim(t *testing.T) {
+	t.Parallel()
+	v, key := newValidator(t)
+	opts := defaultMintOpts(key)
+	opts.noClaims = true // RegisteredClaims only, no origin
+	token := mintToken(t, opts)
+
+	_, err := v.Validate(context.Background(), requestWithToken(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_Expired(t *testing.T) {
+	t.Parallel()
+	v, key := newValidator(t)
+	opts := defaultMintOpts(key)
+	opts.exp = time.Now().Add(-1 * time.Minute)
+	opts.iat = time.Now().Add(-10 * time.Minute)
+	opts.nbf = time.Now().Add(-10 * time.Minute)
+	token := mintToken(t, opts)
+
+	_, err := v.Validate(context.Background(), requestWithToken(token))
+	if !errors.Is(err, auth.ErrExpired) {
+		t.Errorf("err = %v, want ErrExpired", err)
+	}
+}
+
+func TestMgmtPlaneValidator_WrongSigningMethod(t *testing.T) {
+	// HMAC-signed token against an RSA validator must be rejected. If we
+	// naively handed the validator's *rsa.PublicKey to jwt.Parse it would
+	// panic or accept, depending on library version — guard explicitly.
+	t.Parallel()
+	v, _ := newValidator(t)
+	claims := jwt.RegisteredClaims{
+		Issuer:    testIssuer,
+		Subject:   "admin",
+		Audience:  jwt.ClaimStrings{testAudience},
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(5 * time.Minute)),
+	}
+	hmacToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := hmacToken.SignedString([]byte("shared-secret"))
+	if err != nil {
+		t.Fatalf("sign hmac token: %v", err)
+	}
+
+	_, err = v.Validate(context.Background(), requestWithToken(signed))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestMgmtPlaneValidator_ConstructorErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("missing file", func(t *testing.T) {
+		t.Parallel()
+		_, err := auth.NewMgmtPlaneValidator(filepath.Join(t.TempDir(), "nonexistent.pem"))
+		if err == nil {
+			t.Fatal("expected error for missing file")
+		}
+	})
+
+	t.Run("bad pem", func(t *testing.T) {
+		t.Parallel()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "bad.pem")
+		if err := os.WriteFile(path, []byte("not pem"), 0o600); err != nil {
+			t.Fatalf("write bad.pem: %v", err)
+		}
+		_, err := auth.NewMgmtPlaneValidator(path)
+		if err == nil {
+			t.Fatal("expected error for bad PEM")
+		}
+	})
+
+	t.Run("non-rsa key", func(t *testing.T) {
+		t.Parallel()
+		// Write an EC key — PKIX-parseable but not RSA.
+		dir := t.TempDir()
+		ecPEM := []byte(`-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhE0DGbdcbGP/ECD0W99dd6BlMaBL
+Rum0+43T0SPpPJUdGuzc3rI80AJ+yAv3MZD3j6SS4Qh5ET7nFyGoiPkfbw==
+-----END PUBLIC KEY-----
+`)
+		path := filepath.Join(dir, "ec.pem")
+		if err := os.WriteFile(path, ecPEM, 0o600); err != nil {
+			t.Fatalf("write ec.pem: %v", err)
+		}
+		_, err := auth.NewMgmtPlaneValidator(path)
+		if err == nil {
+			t.Fatal("expected error for non-RSA key")
+		}
+	})
+}
+
+func TestMgmtPlaneValidator_AcceptsPKCS1PublicKey(t *testing.T) {
+	// Some operators may hand-roll a PKCS1 "RSA PUBLIC KEY" PEM — the
+	// validator must accept it too.
+	t.Parallel()
+	key := newRSAKey(t)
+	der := x509.MarshalPKCS1PublicKey(&key.PublicKey)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "pkcs1.pem")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create pkcs1.pem: %v", err)
+	}
+	if err := pem.Encode(f, &pem.Block{Type: "RSA PUBLIC KEY", Bytes: der}); err != nil {
+		_ = f.Close()
+		t.Fatalf("encode pkcs1.pem: %v", err)
+	}
+	_ = f.Close()
+
+	v, err := auth.NewMgmtPlaneValidator(path)
+	if err != nil {
+		t.Fatalf("NewMgmtPlaneValidator: %v", err)
+	}
+	token := mintToken(t, defaultMintOpts(key))
+	if _, err := v.Validate(context.Background(), requestWithToken(token)); err != nil {
+		t.Errorf("PKCS1 pubkey should admit: %v", err)
+	}
+}
+
+func TestMgmtPlaneValidator_UnsupportedPEMType(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ec-priv.pem")
+	data := []byte(`-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIAP4HDzRgFNdYaqy5EZGDA4Gz7k7B1JjSoC3bM8XxBYboAoGCCqGSM49
+AwEHoUQDQgAEhE0DGbdcbGP/ECD0W99dd6BlMaBLRum0+43T0SPpPJUdGuzc3rI8
+0AJ+yAv3MZD3j6SS4Qh5ET7nFyGoiPkfbw==
+-----END EC PRIVATE KEY-----
+`)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write ec.pem: %v", err)
+	}
+	if _, err := auth.NewMgmtPlaneValidator(path); err == nil {
+		t.Error("expected error for unsupported PEM block type")
+	}
+}
+
+func TestMgmtPlaneValidator_CustomIssuerAudience(t *testing.T) {
+	// Operators may run multiple dashboards / facades and want to pin
+	// non-default issuer / audience values. Validator must honour the
+	// options.
+	t.Parallel()
+	key := newRSAKey(t)
+	path := writePubKeyPEM(t, t.TempDir(), &key.PublicKey)
+	v, err := auth.NewMgmtPlaneValidator(
+		path,
+		auth.WithMgmtPlaneIssuer("custom-iss"),
+		auth.WithMgmtPlaneAudience("custom-aud"),
+	)
+	if err != nil {
+		t.Fatalf("NewMgmtPlaneValidator: %v", err)
+	}
+
+	// Default-minted token has issuer=omnia-dashboard — wrong for this validator.
+	wrongToken := mintToken(t, defaultMintOpts(key))
+	if _, err := v.Validate(context.Background(), requestWithToken(wrongToken)); !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("default-issuer token should be rejected: err = %v", err)
+	}
+
+	opts := defaultMintOpts(key)
+	opts.issuer = "custom-iss"
+	opts.audience = "custom-aud"
+	rightToken := mintToken(t, opts)
+	if _, err := v.Validate(context.Background(), requestWithToken(rightToken)); err != nil {
+		t.Errorf("custom-issuer token should admit: %v", err)
+	}
+}

--- a/internal/facade/auth/types.go
+++ b/internal/facade/auth/types.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package auth validates credentials presented to the agent facade.
+//
+// The package exposes a small Validator interface and concrete validator
+// implementations. The facade middleware runs the configured validators
+// against every upgrade / request and, on first admit, attaches an
+// AuthenticatedIdentity (defined in pkg/policy) to the request context.
+//
+// The identity type and its origin/role constants live in pkg/policy so
+// that PropagationFields can reference them without pkg/policy gaining a
+// reverse dependency on internal/facade/auth.
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// Validator validates a single credential style. Implementations inspect
+// the request and return an AuthenticatedIdentity on admit, or one of the
+// typed errors below on reject / absence.
+type Validator interface {
+	// Validate returns an AuthenticatedIdentity when the request carries a
+	// credential this validator admits. It returns ErrNoCredential when no
+	// credential of this validator's style is present (the chain falls
+	// through to the next validator). Any other error rejects the request
+	// — the chain runner translates it to 401.
+	Validate(ctx context.Context, r *http.Request) (*policy.AuthenticatedIdentity, error)
+}
+
+// Typed errors returned by validators. Chain logic inspects these.
+var (
+	// ErrNoCredential signals the request carries no credential of this
+	// validator's style. The chain runner falls through to the next
+	// validator on this error.
+	ErrNoCredential = errors.New("auth: no credential present")
+
+	// ErrInvalidCredential signals a credential of this validator's style
+	// was presented but failed validation (bad signature, wrong issuer,
+	// unknown key id, malformed payload, etc.). The chain runner rejects
+	// the request with 401 on this error.
+	ErrInvalidCredential = errors.New("auth: invalid credential")
+
+	// ErrExpired signals the presented credential parsed and verified but
+	// has expired. The chain runner rejects with 401.
+	ErrExpired = errors.New("auth: credential expired")
+)

--- a/internal/facade/auth/types_test.go
+++ b/internal/facade/auth/types_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSentinelErrorsDistinct(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		a, b error
+	}{
+		{ErrNoCredential, ErrInvalidCredential},
+		{ErrNoCredential, ErrExpired},
+		{ErrInvalidCredential, ErrExpired},
+	}
+	for _, tc := range cases {
+		if errors.Is(tc.a, tc.b) {
+			t.Errorf("expected %v and %v to be distinct sentinel errors", tc.a, tc.b)
+		}
+	}
+}
+
+func TestSentinelErrorsMatchThemselves(t *testing.T) {
+	t.Parallel()
+
+	for _, err := range []error{ErrNoCredential, ErrInvalidCredential, ErrExpired} {
+		if !errors.Is(err, err) {
+			t.Errorf("errors.Is(%v, %v) = false, want true", err, err)
+		}
+	}
+}

--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -18,6 +18,7 @@ package facade
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"os"
@@ -32,6 +33,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"golang.org/x/time/rate"
 
+	"github.com/altairalabs/omnia/internal/facade/auth"
 	"github.com/altairalabs/omnia/internal/media"
 	"github.com/altairalabs/omnia/internal/session"
 	"github.com/altairalabs/omnia/internal/tracing"
@@ -154,7 +156,15 @@ type Server struct {
 	recordingPool   *RecordingPool
 	allowedOrigins  []string
 	policyFetcher   PolicyFetcher
-	log             logr.Logger
+	// mgmtPlaneValidator, when set, validates dashboard-minted
+	// management-plane JWTs on each upgrade request. On admit, the
+	// resulting identity flows into PropagationFields.Identity and the
+	// flat UserID/UserRoles/UserEmail fields. Nil means no mgmt-plane
+	// auth — the upgrade path is unauthenticated (the PR 1 default,
+	// preserving behaviour). Invalid/expired tokens always 401 regardless
+	// of this toggle.
+	mgmtPlaneValidator auth.Validator
+	log                logr.Logger
 
 	mu           sync.RWMutex
 	connections  map[*websocket.Conn]*Connection
@@ -210,6 +220,18 @@ func WithAllowedOrigins(origins []string) ServerOption {
 func WithPolicyFetcher(f PolicyFetcher) ServerOption {
 	return func(s *Server) {
 		s.policyFetcher = f
+	}
+}
+
+// WithMgmtPlaneValidator configures the server to run the given auth
+// Validator for management-plane JWTs on every upgrade. Admit attaches the
+// validated identity to the connection's PropagationFields. Presentation of
+// an invalid/expired token is rejected with 401. Absence of any Authorization
+// header falls through to the existing unauthenticated upgrade path (PR 1
+// preserves behaviour — PR 3 flips this default to reject).
+func WithMgmtPlaneValidator(v auth.Validator) ServerOption {
+	return func(s *Server) {
+		s.mgmtPlaneValidator = v
 	}
 }
 
@@ -326,6 +348,28 @@ func ParseAllowedOrigins(raw string) []string {
 	return origins
 }
 
+// authenticateRequest runs the configured auth chain against the request.
+// Returns the admitted identity (or nil when no validator is configured /
+// no credential was presented), or an error when a credential was presented
+// but rejected. A nil error with a nil identity means "fall through to the
+// existing unauthenticated upgrade path" — PR 1 preserves this for back-compat.
+func (s *Server) authenticateRequest(r *http.Request) (*policy.AuthenticatedIdentity, error) {
+	if s.mgmtPlaneValidator == nil {
+		return nil, nil
+	}
+	id, err := s.mgmtPlaneValidator.Validate(r.Context(), r)
+	switch {
+	case err == nil:
+		return id, nil
+	case errors.Is(err, auth.ErrNoCredential):
+		return nil, nil
+	default:
+		// ErrInvalidCredential / ErrExpired / anything else — surface as
+		// a rejection so the caller returns 401.
+		return nil, err
+	}
+}
+
 // ServeHTTP handles WebSocket upgrade requests.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.mu.RLock()
@@ -366,10 +410,38 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Extract user identity from Istio-injected headers on the upgrade request.
-	// Hash immediately — no raw user IDs are stored or propagated in the platform.
-	// Fall back to device_id query param for anonymous users (dev mode).
-	rawUserID := r.Header.Get(policy.IstioHeaderUserID)
+	// Run the auth chain (PR 1: mgmt-plane validator only). On admit the
+	// returned identity takes precedence over Istio-injected headers for
+	// user fields; on unambiguous reject (invalid/expired) 401 here and
+	// skip the upgrade entirely.
+	authIdentity, authErr := s.authenticateRequest(r)
+	if authErr != nil {
+		s.log.V(1).Info("auth rejected upgrade",
+			"reason", authErr.Error(),
+			"status", http.StatusUnauthorized,
+		)
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Extract user identity. When an auth validator admitted the request
+	// its Identity is the source of truth; otherwise fall back to the
+	// Istio-injected headers (preserved for deployments that currently
+	// rely on the chart's authentication.enabled=true gate).
+	var (
+		rawUserID string
+		userRoles string
+		userEmail string
+	)
+	if authIdentity != nil {
+		rawUserID = authIdentity.EndUser
+		userRoles = authIdentity.Role
+		userEmail = authIdentity.Claims["email"]
+	} else {
+		rawUserID = r.Header.Get(policy.IstioHeaderUserID)
+		userRoles = r.Header.Get(policy.IstioHeaderUserRoles)
+		userEmail = r.Header.Get(policy.IstioHeaderUserEmail)
+	}
 	if rawUserID == "" {
 		rawUserID = r.URL.Query().Get("device_id")
 	}
@@ -377,10 +449,9 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	s.log.V(1).Info("user identity extracted",
 		"hasRawUserID", rawUserID != "",
 		"hasUserID", userID != "",
+		"hasAuthIdentity", authIdentity != nil,
 		"headerName", policy.IstioHeaderUserID,
 	)
-	userRoles := r.Header.Get(policy.IstioHeaderUserRoles)
-	userEmail := r.Header.Get(policy.IstioHeaderUserEmail)
 	authorization := r.Header.Get("Authorization")
 	cohortID := r.Header.Get(policy.HeaderCohortID)
 	variant := r.Header.Get(policy.HeaderVariant)
@@ -430,7 +501,11 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// If no traceparent header is present, the context is unchanged (no-op).
 	connCtx = otel.GetTextMapPropagator().Extract(connCtx, propagation.HeaderCarrier(r.Header))
 
-	// Store policy propagation fields for gRPC metadata forwarding
+	// Store policy propagation fields for gRPC metadata forwarding.
+	// When an auth validator admitted the request we attach the Identity
+	// too — downstream in-process code can inspect it, but it does not
+	// travel over gRPC (the flat UserID/UserRoles/UserEmail/Claims carry
+	// what runtime needs, via ToOutboundHeaders).
 	connCtx = policy.WithPropagationFields(connCtx, &policy.PropagationFields{
 		AgentName:     agentName,
 		Namespace:     namespace,
@@ -439,6 +514,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		UserRoles:     userRoles,
 		UserEmail:     userEmail,
 		Authorization: authorization,
+		Identity:      authIdentity,
 	})
 
 	log := logctx.LoggerWithContext(s.log, connCtx)

--- a/internal/facade/server_auth_test.go
+++ b/internal/facade/server_auth_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/internal/session"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+type authTestClaims struct {
+	jwt.RegisteredClaims
+	Origin    string `json:"origin"`
+	Agent     string `json:"agent,omitempty"`
+	Workspace string `json:"workspace,omitempty"`
+}
+
+// newAuthTestValidator returns a configured MgmtPlaneValidator and the RSA
+// private key used to sign tokens for it.
+func newAuthTestValidator(t *testing.T) (*auth.MgmtPlaneValidator, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "pub.pem")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(f, &pem.Block{Type: "PUBLIC KEY", Bytes: der}))
+	require.NoError(t, f.Close())
+
+	v, err := auth.NewMgmtPlaneValidator(path)
+	require.NoError(t, err)
+	return v, key
+}
+
+func mintMgmtToken(t *testing.T, key *rsa.PrivateKey, override func(*authTestClaims)) string {
+	t.Helper()
+	now := time.Now()
+	claims := authTestClaims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    auth.DefaultMgmtPlaneIssuer,
+			Audience:  jwt.ClaimStrings{auth.DefaultMgmtPlaneAudience},
+			Subject:   "admin@example.com",
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now.Add(-time.Minute)),
+			ExpiresAt: jwt.NewNumericDate(now.Add(5 * time.Minute)),
+		},
+		Origin:    policy.OriginManagementPlane,
+		Agent:     "test-agent",
+		Workspace: "default",
+	}
+	if override != nil {
+		override(&claims)
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	signed, err := token.SignedString(key)
+	require.NoError(t, err)
+	return signed
+}
+
+// newAuthTestServer builds a Server with the given validator and a capturing
+// handler that records the propagation fields observed for each WS message.
+// The returned channel delivers one entry per HandleMessage call.
+func newAuthTestServer(t *testing.T, v auth.Validator) (*httptest.Server, <-chan policy.PropagationFields) {
+	t.Helper()
+
+	observed := make(chan policy.PropagationFields, 1)
+	handler := &mockHandler{
+		handleFunc: func(ctx context.Context, _ string, msg *ClientMessage, w ResponseWriter) error {
+			select {
+			case observed <- policy.ExtractPropagationFields(ctx):
+			default:
+			}
+			return w.WriteDone("echo: " + msg.Content)
+		},
+	}
+
+	store := session.NewMemoryStore()
+	cfg := DefaultServerConfig()
+	cfg.PingInterval = 100 * time.Millisecond
+	cfg.PongTimeout = 200 * time.Millisecond
+	server := NewServer(cfg, store, handler, logr.Discard(), WithMgmtPlaneValidator(v))
+
+	ts := httptest.NewServer(server)
+	t.Cleanup(func() {
+		ts.Close()
+		_ = store.Close()
+	})
+	return ts, observed
+}
+
+func dialWS(t *testing.T, ts *httptest.Server, header http.Header) (*websocket.Conn, *http.Response, error) {
+	t.Helper()
+	return websocket.DefaultDialer.Dial(wsURL(ts.URL)+"?agent=test-agent", header)
+}
+
+func TestServerAuth_NoValidator_AllowsUpgrade(t *testing.T) {
+	// Behaviour-preserving default: with no validator configured, upgrade
+	// proceeds even without Authorization header.
+	_, ts := newTestServer(t, nil)
+	ws, _, err := dialWS(t, ts, nil)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close() }()
+	readConnected(t, ws)
+}
+
+func TestServerAuth_ValidatorPresent_NoAuthHeader_AllowsUpgrade(t *testing.T) {
+	// PR 1 preserves the unauthenticated upgrade path even when a validator
+	// is configured. PR 3 flips this default.
+	v, _ := newAuthTestValidator(t)
+	ts, observed := newAuthTestServer(t, v)
+
+	ws, _, err := dialWS(t, ts, nil)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close() }()
+	readConnected(t, ws)
+
+	// Send a message so the handler captures propagation fields.
+	require.NoError(t, ws.WriteJSON(ClientMessage{Type: "user_message", Content: "hi"}))
+
+	select {
+	case fields := <-observed:
+		assert.Nil(t, fields.Identity, "no credential presented → no Identity attached")
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not run")
+	}
+}
+
+func TestServerAuth_ValidToken_AttachesIdentity(t *testing.T) {
+	v, key := newAuthTestValidator(t)
+	ts, observed := newAuthTestServer(t, v)
+
+	token := mintMgmtToken(t, key, nil)
+	header := http.Header{"Authorization": []string{"Bearer " + token}}
+
+	ws, _, err := dialWS(t, ts, header)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close() }()
+	readConnected(t, ws)
+	require.NoError(t, ws.WriteJSON(ClientMessage{Type: "user_message", Content: "hi"}))
+
+	select {
+	case fields := <-observed:
+		require.NotNil(t, fields.Identity, "expected Identity on PropagationFields")
+		assert.Equal(t, policy.OriginManagementPlane, fields.Identity.Origin)
+		assert.Equal(t, "admin@example.com", fields.Identity.Subject)
+		assert.Equal(t, policy.RoleAdmin, fields.Identity.Role)
+		assert.NotEmpty(t, fields.UserID, "UserID should be pseudonymised EndUser")
+		assert.Equal(t, policy.RoleAdmin, fields.UserRoles)
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not run")
+	}
+}
+
+func TestServerAuth_InvalidToken_Rejects(t *testing.T) {
+	v, key := newAuthTestValidator(t)
+	ts, _ := newAuthTestServer(t, v)
+
+	// Wrong origin — the validator admits only management-plane tokens.
+	badToken := mintMgmtToken(t, key, func(c *authTestClaims) { c.Origin = "data-plane" })
+	header := http.Header{"Authorization": []string{"Bearer " + badToken}}
+
+	_, resp, err := dialWS(t, ts, header)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestServerAuth_ExpiredToken_Rejects(t *testing.T) {
+	v, key := newAuthTestValidator(t)
+	ts, _ := newAuthTestServer(t, v)
+
+	badToken := mintMgmtToken(t, key, func(c *authTestClaims) {
+		c.IssuedAt = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
+		c.NotBefore = jwt.NewNumericDate(time.Now().Add(-1 * time.Hour))
+		c.ExpiresAt = jwt.NewNumericDate(time.Now().Add(-5 * time.Minute))
+	})
+	header := http.Header{"Authorization": []string{"Bearer " + badToken}}
+
+	_, resp, err := dialWS(t, ts, header)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestServerAuth_MalformedToken_Rejects(t *testing.T) {
+	v, _ := newAuthTestValidator(t)
+	ts, _ := newAuthTestServer(t, v)
+
+	header := http.Header{"Authorization": []string{"Bearer not.a.jwt"}}
+	_, resp, err := dialWS(t, ts, header)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestServerAuth_NonBearerScheme_FallsThrough(t *testing.T) {
+	// Non-Bearer Authorization header (Basic, Negotiate, etc.) is not a
+	// mgmt-plane credential — the chain falls through and the upgrade
+	// proceeds unauthenticated (PR 1 behaviour).
+	v, _ := newAuthTestValidator(t)
+	ts, _ := newAuthTestServer(t, v)
+
+	header := http.Header{"Authorization": []string{"Basic dXNlcjpwYXNz"}}
+	ws, _, err := dialWS(t, ts, header)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close() }()
+	readConnected(t, ws)
+}

--- a/pkg/policy/context.go
+++ b/pkg/policy/context.go
@@ -55,6 +55,12 @@ const (
 	ContextKeyClaims contextKey = "omnia-claims"
 	// ContextKeyConsentGrants holds per-request consent grants.
 	ContextKeyConsentGrants contextKey = "omnia-consent-grants"
+	// ContextKeyIdentity holds the AuthenticatedIdentity produced by the
+	// facade's auth chain. Not propagated on the wire — the flat UserID /
+	// UserRoles / UserEmail / Claims fields carry what downstream services
+	// need; Identity is retained in-process for the facade and for any
+	// handler that wants richer identity context.
+	ContextKeyIdentity contextKey = "omnia-identity"
 )
 
 // HTTP/gRPC header constants for context propagation.
@@ -125,6 +131,16 @@ type PropagationFields struct {
 	Claims        map[string]string
 	// ConsentGrants holds per-request consent category grants.
 	ConsentGrants []string
+	// Identity is the authenticated identity produced by the facade's auth
+	// chain. When non-nil, it is the source of truth for UserID /
+	// UserRoles / UserEmail / Claims — callers that build PropagationFields
+	// from an Identity should populate those flat fields from it so
+	// downstream consumers (gRPC headers, session logging) keep working
+	// unchanged.
+	//
+	// Identity itself is in-process only; it is not rehydrated from gRPC
+	// metadata on the runtime side.
+	Identity *AuthenticatedIdentity
 }
 
 // WithAgentName returns a context with the agent name set.
@@ -187,6 +203,26 @@ func WithConsentGrants(ctx context.Context, grants []string) context.Context {
 	return context.WithValue(ctx, ContextKeyConsentGrants, grants)
 }
 
+// WithIdentity returns a context with the AuthenticatedIdentity stored under
+// ContextKeyIdentity. Does nothing when id is nil.
+func WithIdentity(ctx context.Context, id *AuthenticatedIdentity) context.Context {
+	if id == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, ContextKeyIdentity, id)
+}
+
+// IdentityFromContext extracts the AuthenticatedIdentity from context, or
+// nil when no identity was attached.
+func IdentityFromContext(ctx context.Context) *AuthenticatedIdentity {
+	if v := ctx.Value(ContextKeyIdentity); v != nil {
+		if id, ok := v.(*AuthenticatedIdentity); ok {
+			return id
+		}
+	}
+	return nil
+}
+
 // ConsentGrantsFromContext extracts consent grants from context.
 func ConsentGrantsFromContext(ctx context.Context) []string {
 	if v := ctx.Value(ContextKeyConsentGrants); v != nil {
@@ -219,6 +255,9 @@ func WithPropagationFields(ctx context.Context, fields *PropagationFields) conte
 	if len(fields.ConsentGrants) > 0 {
 		ctx = WithConsentGrants(ctx, fields.ConsentGrants)
 	}
+	if fields.Identity != nil {
+		ctx = WithIdentity(ctx, fields.Identity)
+	}
 	return ctx
 }
 
@@ -245,6 +284,7 @@ func ExtractPropagationFields(ctx context.Context) PropagationFields {
 		Model:         getString(ctx, ContextKeyModel),
 		Claims:        getClaims(ctx),
 		ConsentGrants: ConsentGrantsFromContext(ctx),
+		Identity:      IdentityFromContext(ctx),
 	}
 }
 

--- a/pkg/policy/context_test.go
+++ b/pkg/policy/context_test.go
@@ -57,6 +57,49 @@ func TestWithAndExtractPropagationFields(t *testing.T) {
 	assert.Equal(t, fields.Claims, extracted.Claims)
 }
 
+func TestPropagationFields_RoundTripsIdentity(t *testing.T) {
+	t.Parallel()
+	id := &AuthenticatedIdentity{
+		Origin:    OriginManagementPlane,
+		Subject:   "admin@example.com",
+		EndUser:   "admin@example.com",
+		Workspace: "default",
+		Agent:     "test-agent",
+		Role:      RoleAdmin,
+		Claims:    map[string]string{"tier": "pro"},
+	}
+	fields := &PropagationFields{
+		AgentName: "test-agent",
+		Identity:  id,
+	}
+	ctx := WithPropagationFields(context.Background(), fields)
+
+	// ExtractPropagationFields rehydrates Identity.
+	extracted := ExtractPropagationFields(ctx)
+	require.NotNil(t, extracted.Identity)
+	assert.Equal(t, id.Subject, extracted.Identity.Subject)
+	assert.Equal(t, id.Role, extracted.Identity.Role)
+
+	// IdentityFromContext returns the same pointer (no cloning — Identity
+	// is immutable from the consumer's perspective, so aliasing is fine).
+	assert.Same(t, id, IdentityFromContext(ctx))
+}
+
+func TestWithIdentity_Nil(t *testing.T) {
+	t.Parallel()
+	// WithIdentity(ctx, nil) must be a no-op: calling it should not
+	// attach a typed-nil sentinel that breaks downstream consumers.
+	ctx := context.Background()
+	out := WithIdentity(ctx, nil)
+	assert.Equal(t, ctx, out)
+	assert.Nil(t, IdentityFromContext(out))
+}
+
+func TestIdentityFromContext_MissingReturnsNil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, IdentityFromContext(context.Background()))
+}
+
 func TestWithPropagationFields_NilFields(t *testing.T) {
 	ctx := context.Background()
 	result := WithPropagationFields(ctx, nil)

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import "time"
+
+// Origin strings identify which validator admitted a request. They flow
+// through PropagationFields and surface to ToolPolicy CEL as identity.origin.
+// Lives here (not in internal/facade/auth) so pkg/policy can refer to the
+// identity contract without importing downstream facade code.
+const (
+	OriginManagementPlane = "management-plane"
+	OriginSharedToken     = "shared-token"
+	OriginAPIKey          = "api-key"
+	OriginOIDC            = "oidc"
+	OriginEdgeTrust       = "edge-trust"
+)
+
+// Role strings identify the caller's role. Used by ToolPolicy rules.
+const (
+	RoleAdmin  = "admin"
+	RoleEditor = "editor"
+	RoleViewer = "viewer"
+)
+
+// AuthenticatedIdentity is the normalised result produced by a facade
+// Validator. It is the single contract runtime / ToolPolicy see regardless
+// of which credential style the caller presented (shared token, API key,
+// OIDC JWT, edge-injected headers, management-plane JWT).
+type AuthenticatedIdentity struct {
+	// Origin names the validator that admitted the request. One of the
+	// Origin* constants above.
+	Origin string
+
+	// Subject is the stable identifier of the token-holder (the app, key,
+	// or user that presented the credential).
+	Subject string
+
+	// EndUser identifies the human or device on whose behalf the
+	// token-holder is acting. Equals Subject for end-user tokens. For
+	// service tokens carrying an actor claim, EndUser is the actor.
+	EndUser string
+
+	// Workspace is the workspace the request targets (may be empty for
+	// validators that do not carry workspace scope).
+	Workspace string
+
+	// Agent is the agent the request targets (may be empty for validators
+	// that do not carry agent scope).
+	Agent string
+
+	// Role is the caller's role. One of RoleAdmin / RoleEditor / RoleViewer.
+	Role string
+
+	// Claims holds extra claim values the validator surfaced (OIDC claim
+	// map, edge-injected headers mapped into claims, etc.). Consumed by
+	// ToolPolicy CEL as identity.claims.<name>.
+	Claims map[string]string
+
+	// IssuedAt and ExpiresAt carry the token's validity window when the
+	// underlying credential exposes them. Zero values when not applicable.
+	IssuedAt  time.Time
+	ExpiresAt time.Time
+}

--- a/pkg/policy/identity_test.go
+++ b/pkg/policy/identity_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package policy
+
+import "testing"
+
+// These constants are a downstream contract — ToolPolicy rules compare
+// against them and session-logging consumers persist them. Pin the
+// on-the-wire values so typo-level changes show up as test failures.
+
+func TestOriginConstants(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		OriginManagementPlane: "management-plane",
+		OriginSharedToken:     "shared-token",
+		OriginAPIKey:          "api-key",
+		OriginOIDC:            "oidc",
+		OriginEdgeTrust:       "edge-trust",
+	}
+	for got, expected := range want {
+		if got != expected {
+			t.Errorf("origin constant = %q, want %q", got, expected)
+		}
+	}
+}
+
+func TestRoleConstants(t *testing.T) {
+	t.Parallel()
+
+	want := map[string]string{
+		RoleAdmin:  "admin",
+		RoleEditor: "editor",
+		RoleViewer: "viewer",
+	}
+	for got, expected := range want {
+		if got != expected {
+			t.Errorf("role constant = %q, want %q", got, expected)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

First slice of the facade-auth redesign documented in `docs/local-backlog/2026-04-21-agent-facade-auth-design.md`. Introduces the `AuthenticatedIdentity` contract and a pluggable `Validator` interface, and implements the management-plane JWT validator used by the dashboard's "Try this agent" debug view. Behaviour on `main` is preserved — the validator is opt-in at `facade.NewServer` construction time, nothing gates the WebSocket upgrade by default.

This is part of a multi-PR series closing pen-test finding C-3. PR 1b will wire the pubkey into facade pods (cross-namespace distribution + `cmd/agent/main.go`). PR 1c adds the dashboard minting endpoint and live-service token attach. PR 3 later flips the default so unauthenticated upgrades 401.

- `pkg/policy` — `AuthenticatedIdentity` struct, `Origin*`/`Role*` constants (`management-plane`, `shared-token`, `api-key`, `oidc`, `edge-trust`; `admin`/`editor`/`viewer`), `PropagationFields.Identity`, `WithIdentity`/`IdentityFromContext` helpers.
- `internal/facade/auth` — `Validator` interface, `ErrNoCredential`/`ErrInvalidCredential`/`ErrExpired` sentinels, `MgmtPlaneValidator` (RS256, RSA pub-key loaded from PEM file — accepts PKIX `PUBLIC KEY`, PKCS1 `RSA PUBLIC KEY`, and x509 `CERTIFICATE` blocks since Helm's `genSelfSigned` emits the latter).
- `internal/facade/server.go` — `WithMgmtPlaneValidator` option and `authenticateRequest` helper. When a validator is configured and admits, `Identity.EndUser` drives the pseudonymised `UserID`, `Identity.Role` drives `UserRoles`, `Identity.Claims["email"]` drives `UserEmail`. When no validator is set or `ErrNoCredential` is returned, the existing Istio-header capture path runs verbatim.
- `charts/omnia/templates/dashboard/signing-keypair.yaml` — auto-generated RSA self-signed keypair Secret, `helm.sh/resource-policy: keep`, `lookup` shortcut so `helm upgrade` never regenerates, BYO override via `dashboard.signingKey.existingSecret`.

## Behaviour preservation

- No validator → no new code path runs (verified in `TestServerAuth_NoValidator_AllowsUpgrade`).
- Validator configured + no `Authorization` header → upgrade still proceeds (`TestServerAuth_ValidatorPresent_NoAuthHeader_AllowsUpgrade`). PR 3 flips this.
- Validator configured + non-`Bearer` scheme → falls through as `ErrNoCredential`, existing behaviour preserved (`TestServerAuth_NonBearerScheme_FallsThrough`).
- Valid mgmt-plane JWT → `Identity` attached, existing propagation fields still populated (`TestServerAuth_ValidToken_AttachesIdentity`).
- Invalid / expired / malformed → 401 before Upgrade (`TestServerAuth_InvalidToken_Rejects`, `_ExpiredToken_Rejects`, `_MalformedToken_Rejects`).

## Test plan

- [x] `internal/facade/auth`: 21 unit tests. Covers valid / expired / wrong iss / wrong aud / wrong origin / bad signature / malformed JWT / missing Authorization / non-Bearer / HMAC signing method / empty bearer / PKCS1 key / x509 certificate format / constructor errors (missing file, bad PEM, non-RSA key, unsupported PEM type) / custom iss-aud overrides.
- [x] `pkg/policy`: 5 new tests — origin/role constants pinned, Identity round-trips through `WithPropagationFields`, nil-Identity no-ops, missing-key returns nil.
- [x] `internal/facade`: 7 WebSocket integration tests via `httptest.Server` — cover the no-validator / no-auth / valid / invalid / expired / malformed / non-Bearer flows end-to-end.
- [x] `charts/omnia/tests/dashboard-signing-keypair_test.yaml`: 5 helm-unittest assertions — Secret type, data keys, `resource-policy: keep` annotation, labels, BYO suppression, `dashboard.enabled: false` suppression.
- [x] Per-file coverage: `pkg/policy/context.go` 100%, `pkg/policy/identity.go` N/A (types only), `internal/facade/auth/mgmt_plane.go` 91.3%, `internal/facade/server.go` 88.5%. All above the 80% gate.
- [x] `gofmt`, `go vet`, `golangci-lint run`, `helm lint`, `helm unittest charts/omnia` green locally.
- [ ] CI quality gate (SonarCloud coverage, cognitive complexity).
- [ ] Arena E2E / core E2E (unaffected — validator not wired in until PR 1b).

## What lands next

- **PR 1b**: Workspace controller mirrors the pubkey as a ConfigMap into each workspace namespace; `deployment_builder.go` adds volume/mount + `OMNIA_MGMT_PLANE_PUBKEY_PATH` env; `cmd/agent/main.go` constructs the validator when the env var points at an existing file.
- **PR 1c**: Dashboard `/api/workspaces/{ws}/agents/{agent}/debug-tokens` POST route, mgmt-plane token minter helper, `live-service.ts` attaches the token on WS upgrade, vitest coverage.