### PR TITLE
feat(controller): distribute mgmt-plane pubkey to facade pods (PR 1b)

### DIFF
--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -72,6 +72,18 @@ spec:
             - --memory-api-image={{ include "omnia.memoryApi.image" . }}
             - --memory-api-image-pull-policy={{ .Values.workspaceServices.memoryApi.image.pullPolicy }}
             - --agent-workspace-reader-clusterrole={{ include "omnia.fullname" . }}-agent-workspace-reader
+            {{- if .Values.dashboard.enabled }}
+            {{- /*
+              Tell the Workspace controller which Secret holds the dashboard
+              mgmt-plane signing keypair. The controller mirrors the public
+              cert (tls.crt) into a per-workspace ConfigMap so facade pods
+              can validate dashboard-minted debug tokens. When dashboard.enabled
+              is false the flag is omitted -> mirror disabled -> facade keeps
+              its mgmt-plane-unaware default. BYO override pulls from
+              dashboard.signingKey.existingSecret when set.
+            */}}
+            - --mgmt-plane-signing-secret={{ .Values.dashboard.signingKey.existingSecret | default (printf "%s-signing-keypair" (include "omnia.dashboard.fullname" .)) }}
+            {{- end }}
             {{- if and .Values.tracing.enabled $resolvedTracingEndpoint }}
             - --tracing-enabled=true
             - --tracing-endpoint={{ $resolvedTracingEndpoint }}

--- a/cmd/agent/mgmt_plane.go
+++ b/cmd/agent/mgmt_plane.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"errors"
+	"os"
+
+	"github.com/go-logr/logr"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+)
+
+// envMgmtPlanePubkeyPath is the env var the operator sets on the facade
+// container pointing at the mounted dashboard mgmt-plane public key. Kept
+// in sync with internal/controller/constants.go:EnvMgmtPlanePubkeyPath.
+// Duplicated as a literal here to avoid importing the controller package
+// into the facade binary.
+const envMgmtPlanePubkeyPath = "OMNIA_MGMT_PLANE_PUBKEY_PATH"
+
+// loadMgmtPlaneValidator constructs an auth.MgmtPlaneValidator when the
+// env var points at an existing, readable PEM file. Returns (nil, nil)
+// when the var is unset, the file is absent (the ConfigMap mirror hasn't
+// landed yet, or the dashboard isn't deployed), or the file is empty —
+// in every case the caller runs without mgmt-plane validation, which is
+// PR 1a's default.
+//
+// Any other error (malformed PEM, non-RSA key) is surfaced so the facade
+// startup fails loudly rather than silently running without auth — an
+// actively-broken keypair shouldn't downgrade to "no mgmt plane".
+func loadMgmtPlaneValidator(log logr.Logger) (auth.Validator, error) {
+	path := os.Getenv(envMgmtPlanePubkeyPath)
+	if path == "" {
+		log.V(1).Info("mgmt-plane validator skipped",
+			"reason", "env var unset",
+			"envVar", envMgmtPlanePubkeyPath)
+		return nil, nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.V(1).Info("mgmt-plane validator skipped",
+				"reason", "pubkey file missing",
+				"path", path)
+			return nil, nil
+		}
+		return nil, err
+	}
+	if info.Size() == 0 {
+		log.V(1).Info("mgmt-plane validator skipped",
+			"reason", "pubkey file empty",
+			"path", path)
+		return nil, nil
+	}
+
+	v, err := auth.NewMgmtPlaneValidator(path)
+	if err != nil {
+		return nil, err
+	}
+	log.Info("mgmt-plane validator enabled", "pubkeyPath", path)
+	return v, nil
+}

--- a/cmd/agent/mgmt_plane_test.go
+++ b/cmd/agent/mgmt_plane_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func writeTestPubKey(t *testing.T) string {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "pub.pem")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create pem file: %v", err)
+	}
+	defer func() { _ = f.Close() }()
+	if err := pem.Encode(f, &pem.Block{Type: "PUBLIC KEY", Bytes: der}); err != nil {
+		t.Fatalf("encode pem: %v", err)
+	}
+	return path
+}
+
+func TestLoadMgmtPlaneValidator_EnvUnset(t *testing.T) {
+	t.Setenv(envMgmtPlanePubkeyPath, "")
+	v, err := loadMgmtPlaneValidator(logr.Discard())
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if v != nil {
+		t.Errorf("validator = %v, want nil when env unset", v)
+	}
+}
+
+func TestLoadMgmtPlaneValidator_FileMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.pem")
+	t.Setenv(envMgmtPlanePubkeyPath, missing)
+	v, err := loadMgmtPlaneValidator(logr.Discard())
+	if err != nil {
+		t.Fatalf("err = %v, want nil (missing file is not fatal)", err)
+	}
+	if v != nil {
+		t.Errorf("validator = %v, want nil when file missing", v)
+	}
+}
+
+func TestLoadMgmtPlaneValidator_FileEmpty(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "empty.pem")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatalf("write empty file: %v", err)
+	}
+	t.Setenv(envMgmtPlanePubkeyPath, path)
+
+	v, err := loadMgmtPlaneValidator(logr.Discard())
+	if err != nil {
+		t.Fatalf("err = %v, want nil (empty file treated as absent)", err)
+	}
+	if v != nil {
+		t.Errorf("validator = %v, want nil when file empty", v)
+	}
+}
+
+func TestLoadMgmtPlaneValidator_ValidPubkey(t *testing.T) {
+	path := writeTestPubKey(t)
+	t.Setenv(envMgmtPlanePubkeyPath, path)
+
+	v, err := loadMgmtPlaneValidator(logr.Discard())
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected non-nil validator for valid pub key")
+	}
+}
+
+func TestLoadMgmtPlaneValidator_MalformedPEM_Errors(t *testing.T) {
+	// Malformed PEM must surface as a startup error, not a silent
+	// downgrade to no-auth — otherwise an operator misconfiguration
+	// looks identical to "mgmt-plane not configured".
+	path := filepath.Join(t.TempDir(), "garbage.pem")
+	if err := os.WriteFile(path, []byte("this is not pem"), 0o600); err != nil {
+		t.Fatalf("write garbage pem: %v", err)
+	}
+	t.Setenv(envMgmtPlanePubkeyPath, path)
+
+	v, err := loadMgmtPlaneValidator(logr.Discard())
+	if err == nil {
+		t.Errorf("err = nil, want non-nil for malformed PEM (got validator %v)", v)
+	}
+}

--- a/cmd/agent/websocket.go
+++ b/cmd/agent/websocket.go
@@ -126,6 +126,16 @@ func buildWebSocketServer(
 	if pf, ok := store.(facade.PolicyFetcher); ok {
 		serverOpts = append(serverOpts, facade.WithPolicyFetcher(pf))
 	}
+	// Load the mgmt-plane validator when the operator has pointed us at a
+	// mounted dashboard public key. A loading failure (malformed PEM,
+	// non-RSA key) is fatal — silently downgrading to "no auth" would
+	// mask a real misconfiguration.
+	if v, err := loadMgmtPlaneValidator(log); err != nil {
+		log.Error(err, "mgmt-plane validator load failed")
+		os.Exit(1)
+	} else if v != nil {
+		serverOpts = append(serverOpts, facade.WithMgmtPlaneValidator(v))
+	}
 	wsServer := facade.NewServer(wsConfig, store, handler, log, serverOpts...)
 
 	mux := http.NewServeMux()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,6 +91,7 @@ func main() {
 	var enterpriseEnabled bool
 	var licenseServerURL string
 	var clusterName string
+	var mgmtPlaneSigningSecret string
 	var tlsOpts []func(*tls.Config)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
@@ -150,6 +151,12 @@ func main() {
 		"URL of the license activation server for enterprise features")
 	flag.StringVar(&clusterName, "cluster-name", "",
 		"Human-readable name for this cluster in license records")
+	flag.StringVar(&mgmtPlaneSigningSecret, "mgmt-plane-signing-secret", "",
+		"Name of the Secret in POD_NAMESPACE holding the dashboard's mgmt-plane "+
+			"JWT signing keypair (type kubernetes.io/tls). The Workspace controller "+
+			"mirrors the public cert into a ConfigMap per workspace namespace so "+
+			"facade pods can validate dashboard-minted debug tokens. Empty disables "+
+			"the mirror — facade stays mgmt-plane-unaware.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -278,6 +285,7 @@ func main() {
 		},
 		AgentWorkspaceReaderClusterRole: agentWorkspaceReaderClusterRole,
 		OperatorNamespace:               os.Getenv("POD_NAMESPACE"),
+		MgmtPlaneSigningSecret:          mgmtPlaneSigningSecret,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, errUnableToCreateController, logKeyController, "Workspace")
 		os.Exit(1)

--- a/internal/controller/agentruntime_controller_test.go
+++ b/internal/controller/agentruntime_controller_test.go
@@ -1417,10 +1417,17 @@ var _ = Describe("AgentRuntime Controller", func() {
 			Expect(runtimeContainer.VolumeMounts[0].MountPath).To(Equal(PromptPackMountPath))
 			Expect(runtimeContainer.VolumeMounts[0].ReadOnly).To(BeTrue())
 
-			// Check volumes
-			Expect(deployment.Spec.Template.Spec.Volumes).To(HaveLen(1))
-			Expect(deployment.Spec.Template.Spec.Volumes[0].Name).To(Equal("promptpack-config"))
-			Expect(deployment.Spec.Template.Spec.Volumes[0].ConfigMap.Name).To(Equal("prompts-config"))
+			// Check volumes — promptpack-config plus the unconditional
+			// mgmt-plane pubkey mirror added in PR 1b.
+			var promptVol *corev1.Volume
+			for i := range deployment.Spec.Template.Spec.Volumes {
+				if deployment.Spec.Template.Spec.Volumes[i].Name == "promptpack-config" {
+					promptVol = &deployment.Spec.Template.Spec.Volumes[i]
+					break
+				}
+			}
+			Expect(promptVol).NotTo(BeNil(), "promptpack-config volume must be present")
+			Expect(promptVol.ConfigMap.Name).To(Equal("prompts-config"))
 		})
 
 		It("should handle ToolRegistry in different namespace", func() {

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -86,6 +86,25 @@ const (
 	promptpackConfigVolumeName = "promptpack-config"
 	// toolsConfigVolumeName is the name of the tools config volume.
 	toolsConfigVolumeName = "tools-config"
+	// MgmtPlanePubkeyConfigMapName is the ConfigMap name the Workspace
+	// controller creates in every workspace namespace. It mirrors the
+	// public half of the dashboard's mgmt-plane signing keypair
+	// (Secret lives in the operator namespace; pods cannot cross-mount
+	// other namespaces' secrets).
+	MgmtPlanePubkeyConfigMapName = "omnia-dashboard-mgmt-plane-pubkey"
+	// MgmtPlanePubkeyDataKey is the key inside the mirror ConfigMap's
+	// data map that holds the PEM-encoded public cert.
+	MgmtPlanePubkeyDataKey = "pubkey.pem"
+	// mgmtPlanePubkeyVolumeName is the volume name in the facade pod.
+	mgmtPlanePubkeyVolumeName = "mgmt-plane-pubkey"
+	// MgmtPlanePubkeyMountDir is the directory the facade mounts the
+	// pubkey ConfigMap into. The file path the facade reads is
+	// MgmtPlanePubkeyMountDir + "/" + MgmtPlanePubkeyDataKey.
+	MgmtPlanePubkeyMountDir = "/etc/omnia/mgmt-plane"
+	// EnvMgmtPlanePubkeyPath is the env var the operator sets on the
+	// facade container pointing at the mounted pubkey file. cmd/agent
+	// reads this and, when present, constructs a mgmt-plane validator.
+	EnvMgmtPlanePubkeyPath = "OMNIA_MGMT_PLANE_PUBKEY_PATH"
 )
 
 // Eval-related constants.

--- a/internal/controller/deployment_builder.go
+++ b/internal/controller/deployment_builder.go
@@ -881,6 +881,15 @@ func (r *AgentRuntimeReconciler) buildFacadeEnvVars(
 		)
 	}
 
+	// Point the facade at the mgmt-plane pubkey file mounted from the
+	// workspace-namespace ConfigMap mirror (Workspace controller's
+	// responsibility). cmd/agent treats a missing file as "no validator"
+	// and the facade runs unauthenticated — PR 1a's default.
+	envVars = append(envVars, corev1.EnvVar{
+		Name:  EnvMgmtPlanePubkeyPath,
+		Value: fmt.Sprintf("%s/%s", MgmtPlanePubkeyMountDir, MgmtPlanePubkeyDataKey),
+	})
+
 	// Add extra env vars from CRD
 	if agentRuntime.Spec.Facade.ExtraEnv != nil {
 		envVars = append(envVars, agentRuntime.Spec.Facade.ExtraEnv...)

--- a/internal/controller/deployment_builder_test.go
+++ b/internal/controller/deployment_builder_test.go
@@ -825,7 +825,9 @@ func TestResolveSessionURLForWorkspace(t *testing.T) {
 }
 
 // TestBuildFacadeVolumeMounts_WithConfigMap verifies that a PromptPack backed by a
-// ConfigMap produces a single promptpack-config volume mount.
+// ConfigMap produces a promptpack-config volume mount. The mgmt-plane pubkey
+// mount is always present and validated separately in
+// mgmt_plane_pubkey_wiring_test.go.
 func TestBuildFacadeVolumeMounts_WithConfigMap(t *testing.T) {
 	r := &AgentRuntimeReconciler{}
 	pp := &omniav1alpha1.PromptPack{}
@@ -834,37 +836,36 @@ func TestBuildFacadeVolumeMounts_WithConfigMap(t *testing.T) {
 
 	mounts := r.buildFacadeVolumeMounts(pp)
 
-	if len(mounts) != 1 {
-		t.Fatalf("expected 1 volume mount, got %d", len(mounts))
+	mount := findMount(mounts, "promptpack-config")
+	if mount == nil {
+		t.Fatalf("expected promptpack-config mount, got %+v", mounts)
 	}
-	if mounts[0].Name != "promptpack-config" {
-		t.Errorf("mount name = %q, want %q", mounts[0].Name, "promptpack-config")
+	if mount.MountPath != PromptPackMountPath {
+		t.Errorf("mount path = %q, want %q", mount.MountPath, PromptPackMountPath)
 	}
-	if mounts[0].MountPath != PromptPackMountPath {
-		t.Errorf("mount path = %q, want %q", mounts[0].MountPath, PromptPackMountPath)
-	}
-	if !mounts[0].ReadOnly {
+	if !mount.ReadOnly {
 		t.Error("expected mount to be read-only")
 	}
 }
 
 // TestBuildFacadeVolumeMounts_NoConfigMapRef verifies that a PromptPack without a
-// ConfigMapRef produces no volume mounts.
+// ConfigMapRef produces no promptpack-config mount (the mgmt-plane mount is
+// unconditional and covered by its own test).
 func TestBuildFacadeVolumeMounts_NoConfigMapRef(t *testing.T) {
 	r := &AgentRuntimeReconciler{}
 	pp := &omniav1alpha1.PromptPack{}
 	pp.Spec.Source.Type = omniav1alpha1.PromptPackSourceTypeConfigMap
-	pp.Spec.Source.ConfigMapRef = nil // no ref → nothing to mount
+	pp.Spec.Source.ConfigMapRef = nil // no ref → no promptpack-config mount
 
 	mounts := r.buildFacadeVolumeMounts(pp)
 
-	if len(mounts) != 0 {
-		t.Errorf("expected 0 volume mounts, got %d", len(mounts))
+	if m := findMount(mounts, "promptpack-config"); m != nil {
+		t.Errorf("did not expect promptpack-config mount, got %+v", m)
 	}
 }
 
 // TestBuildFacadeVolumeMounts_NonConfigMapSource verifies that a PromptPack with a
-// non-ConfigMap source type produces no volume mounts.
+// non-ConfigMap source type produces no promptpack-config mount.
 func TestBuildFacadeVolumeMounts_NonConfigMapSource(t *testing.T) {
 	r := &AgentRuntimeReconciler{}
 	pp := &omniav1alpha1.PromptPack{}
@@ -873,13 +874,13 @@ func TestBuildFacadeVolumeMounts_NonConfigMapSource(t *testing.T) {
 
 	mounts := r.buildFacadeVolumeMounts(pp)
 
-	if len(mounts) != 0 {
-		t.Errorf("expected 0 volume mounts for non-configmap source, got %d", len(mounts))
+	if m := findMount(mounts, "promptpack-config"); m != nil {
+		t.Errorf("did not expect promptpack-config mount for non-configmap source, got %+v", m)
 	}
 }
 
 // TestBuildFacadeContainer_VolumeMounts verifies that buildFacadeContainer sets
-// VolumeMounts when the PromptPack source is a ConfigMap.
+// the promptpack-config VolumeMount when the PromptPack source is a ConfigMap.
 func TestBuildFacadeContainer_VolumeMounts(t *testing.T) {
 	r := &AgentRuntimeReconciler{}
 	ar := &omniav1alpha1.AgentRuntime{}
@@ -892,19 +893,18 @@ func TestBuildFacadeContainer_VolumeMounts(t *testing.T) {
 
 	container := r.buildFacadeContainer(ar, pp, 8080)
 
-	if len(container.VolumeMounts) != 1 {
-		t.Fatalf("expected 1 volume mount on facade container, got %d", len(container.VolumeMounts))
+	mount := findMount(container.VolumeMounts, "promptpack-config")
+	if mount == nil {
+		t.Fatalf("expected promptpack-config on facade container, got %+v", container.VolumeMounts)
 	}
-	if container.VolumeMounts[0].Name != "promptpack-config" {
-		t.Errorf("mount name = %q, want %q", container.VolumeMounts[0].Name, "promptpack-config")
-	}
-	if container.VolumeMounts[0].MountPath != PromptPackMountPath {
-		t.Errorf("mount path = %q, want %q", container.VolumeMounts[0].MountPath, PromptPackMountPath)
+	if mount.MountPath != PromptPackMountPath {
+		t.Errorf("mount path = %q, want %q", mount.MountPath, PromptPackMountPath)
 	}
 }
 
-// TestBuildFacadeContainer_NoVolumeMounts verifies that buildFacadeContainer has no
-// VolumeMounts when the PromptPack does not reference a ConfigMap.
+// TestBuildFacadeContainer_NoVolumeMounts verifies that buildFacadeContainer has
+// no promptpack-config VolumeMount when the PromptPack does not reference a
+// ConfigMap. Other unconditional mounts (mgmt-plane pubkey) may still be present.
 func TestBuildFacadeContainer_NoVolumeMounts(t *testing.T) {
 	r := &AgentRuntimeReconciler{}
 	ar := &omniav1alpha1.AgentRuntime{}
@@ -916,8 +916,8 @@ func TestBuildFacadeContainer_NoVolumeMounts(t *testing.T) {
 
 	container := r.buildFacadeContainer(ar, pp, 8080)
 
-	if len(container.VolumeMounts) != 0 {
-		t.Errorf("expected 0 volume mounts on facade container, got %d", len(container.VolumeMounts))
+	if m := findMount(container.VolumeMounts, "promptpack-config"); m != nil {
+		t.Errorf("did not expect promptpack-config mount, got %+v", m)
 	}
 }
 

--- a/internal/controller/mgmt_plane_pubkey_wiring_test.go
+++ b/internal/controller/mgmt_plane_pubkey_wiring_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// These tests assert that every facade pod produced by the AgentRuntime
+// deployment builder carries the plumbing PR 1b needs to load the
+// mgmt-plane validator: a ConfigMap-backed volume (optional), a mount on
+// the facade container, and the env var pointing at the file. Without
+// all three wired together, cmd/agent silently skips validator
+// construction and the dashboard debug view can't authenticate — exactly
+// the "exists but not wired" failure mode CLAUDE.md flags in its
+// "Wiring tests" section.
+
+func findVolume(pod []corev1.Volume, name string) *corev1.Volume {
+	for i := range pod {
+		if pod[i].Name == name {
+			return &pod[i]
+		}
+	}
+	return nil
+}
+
+func findMount(mounts []corev1.VolumeMount, name string) *corev1.VolumeMount {
+	for i := range mounts {
+		if mounts[i].Name == name {
+			return &mounts[i]
+		}
+	}
+	return nil
+}
+
+func findEnv(envs []corev1.EnvVar, name string) *corev1.EnvVar {
+	for i := range envs {
+		if envs[i].Name == name {
+			return &envs[i]
+		}
+	}
+	return nil
+}
+
+func TestBuildVolumes_IncludesMgmtPlanePubkey(t *testing.T) {
+	r := &AgentRuntimeReconciler{}
+	ar := &omniav1alpha1.AgentRuntime{}
+	ar.Name = "test-agent"
+	ar.Namespace = "workspace-a"
+
+	volumes := r.buildVolumes(ar, newTestPromptPack(), nil)
+
+	v := findVolume(volumes, mgmtPlanePubkeyVolumeName)
+	if v == nil {
+		t.Fatalf("expected volume %q on pod, got %+v", mgmtPlanePubkeyVolumeName, volumes)
+	}
+	if v.ConfigMap == nil {
+		t.Fatal("volume must be ConfigMap-backed")
+	}
+	if v.ConfigMap.Name != MgmtPlanePubkeyConfigMapName {
+		t.Errorf("ConfigMap name = %q, want %q", v.ConfigMap.Name, MgmtPlanePubkeyConfigMapName)
+	}
+	if v.ConfigMap.Optional == nil || !*v.ConfigMap.Optional {
+		t.Error("ConfigMap must be optional — missing mirror shouldn't crashloop the pod")
+	}
+}
+
+func TestBuildFacadeVolumeMounts_IncludesMgmtPlanePubkey(t *testing.T) {
+	r := &AgentRuntimeReconciler{}
+	mounts := r.buildFacadeVolumeMounts(newTestPromptPack())
+
+	m := findMount(mounts, mgmtPlanePubkeyVolumeName)
+	if m == nil {
+		t.Fatalf("expected mount %q on facade container, got %+v", mgmtPlanePubkeyVolumeName, mounts)
+	}
+	if m.MountPath != MgmtPlanePubkeyMountDir {
+		t.Errorf("mount path = %q, want %q", m.MountPath, MgmtPlanePubkeyMountDir)
+	}
+	if !m.ReadOnly {
+		t.Error("mount must be read-only (public key material)")
+	}
+}
+
+func TestBuildFacadeEnvVars_SetsMgmtPlanePubkeyPath(t *testing.T) {
+	r := &AgentRuntimeReconciler{}
+	ar := &omniav1alpha1.AgentRuntime{}
+	ar.Name = "test-agent"
+
+	envs := r.buildFacadeEnvVars(ar)
+
+	e := findEnv(envs, EnvMgmtPlanePubkeyPath)
+	if e == nil {
+		t.Fatalf("expected env var %q on facade container", EnvMgmtPlanePubkeyPath)
+	}
+	wantVal := fmt.Sprintf("%s/%s", MgmtPlanePubkeyMountDir, MgmtPlanePubkeyDataKey)
+	if e.Value != wantVal {
+		t.Errorf("env value = %q, want %q", e.Value, wantVal)
+	}
+}

--- a/internal/controller/volumes.go
+++ b/internal/controller/volumes.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 )
@@ -89,6 +90,25 @@ func (r *AgentRuntimeReconciler) buildVolumes(
 		})
 	}
 
+	// Mount the mgmt-plane pubkey ConfigMap the Workspace controller
+	// mirrors into every workspace namespace. Marked optional so the
+	// facade pod still starts when the ConfigMap is absent (e.g., before
+	// the Workspace controller has reconciled it, or when the dashboard
+	// is not deployed at all). cmd/agent/main.go treats a missing file
+	// as "no mgmt-plane validator" and runs unauthenticated — matching
+	// the PR 1a default.
+	volumes = append(volumes, corev1.Volume{
+		Name: mgmtPlanePubkeyVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: MgmtPlanePubkeyConfigMapName,
+				},
+				Optional: ptr.To(true),
+			},
+		},
+	})
+
 	// Add user-specified volumes for media files, mock configs, etc.
 	if agentRuntime.Spec.Runtime != nil && len(agentRuntime.Spec.Runtime.Volumes) > 0 {
 		volumes = append(volumes, agentRuntime.Spec.Runtime.Volumes...)
@@ -113,6 +133,16 @@ func (r *AgentRuntimeReconciler) buildFacadeVolumeMounts(
 			ReadOnly:  true,
 		})
 	}
+
+	// Mount the optional mgmt-plane pubkey ConfigMap. When the ConfigMap
+	// exists the file at <MgmtPlanePubkeyMountDir>/<MgmtPlanePubkeyDataKey>
+	// is the PEM the facade validator loads; when it doesn't, kubelet
+	// projects an empty directory and cmd/agent skips validator wiring.
+	volumeMounts = append(volumeMounts, corev1.VolumeMount{
+		Name:      mgmtPlanePubkeyVolumeName,
+		MountPath: MgmtPlanePubkeyMountDir,
+		ReadOnly:  true,
+	})
 
 	return volumeMounts
 }

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -105,6 +105,16 @@ type WorkspaceReconciler struct {
 	// POD_NAMESPACE at operator startup; empty string disables the auto-
 	// allow (useful in tests).
 	OperatorNamespace string
+
+	// MgmtPlaneSigningSecret is the name of the Secret in OperatorNamespace
+	// holding the dashboard's mgmt-plane JWT signing keypair
+	// (type kubernetes.io/tls, tls.crt + tls.key). The reconciler mirrors
+	// the public half (tls.crt) into a ConfigMap in every workspace
+	// namespace so facade pods can validate dashboard-minted debug tokens
+	// without cross-namespace Secret reads. Empty string disables the
+	// mirror — the facade stays mgmt-plane-unaware, matching PR 1a's
+	// behaviour-preserving default.
+	MgmtPlaneSigningSecret string
 }
 
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=workspaces,verbs=get;list;watch;create;update;patch;delete
@@ -122,6 +132,7 @@ type WorkspaceReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods;pods/log,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=agentpolicies;agentruntimes;promptpacks;toolpolicies;toolregistries;providers;arenasources;arenajobs;arenatemplatesources;arenadevsessions,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=agentpolicies/status;arenasources/status;arenajobs/status;arenatemplatesources/status;arenadevsessions/status;toolpolicies/status,verbs=get
@@ -252,6 +263,17 @@ func (r *WorkspaceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return r.setReconcileError(ctx, workspace, ConditionTypeServicesReady, "ServicesFailed", err, log)
 	}
 	setServicesReadyCondition(&workspace.Status.Conditions, workspace.Generation, workspace.Status.Services)
+
+	// Mirror the dashboard's mgmt-plane public key into this workspace
+	// namespace so facade pods can validate dashboard-minted debug tokens
+	// without cross-namespace Secret reads. Failures here are non-fatal
+	// (logged as warnings) — the facade gracefully runs without mgmt-plane
+	// auth if the ConfigMap is missing, matching PR 1a's default.
+	if err := r.reconcileMgmtPlanePubkey(ctx, workspace); err != nil {
+		log.Error(err, "mgmt-plane pubkey mirror failed",
+			"operatorNamespace", r.OperatorNamespace,
+			"signingSecret", r.MgmtPlaneSigningSecret)
+	}
 
 	// Update member count
 	r.updateMemberCount(workspace)

--- a/internal/controller/workspace_mgmt_plane_pubkey.go
+++ b/internal/controller/workspace_mgmt_plane_pubkey.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// tlsCertSecretKey is the data key inside a kubernetes.io/tls Secret that
+// holds the PEM-encoded X.509 certificate. Matches the Helm chart's
+// signing-keypair template and k8s TLS secret conventions.
+const tlsCertSecretKey = "tls.crt"
+
+// reconcileMgmtPlanePubkey mirrors the public half of the dashboard's
+// mgmt-plane signing keypair into a ConfigMap in the workspace namespace.
+//
+// Why: facade pods live in workspace namespaces and cannot cross-mount
+// secrets from the operator namespace. The chart keeps the keypair in
+// the operator namespace (a Secret) so the dashboard can sign with the
+// private half; the reconciler copies just the public cert into a
+// namespace-local ConfigMap that every facade pod in this workspace
+// mounts read-only.
+//
+// Semantics:
+//   - r.OperatorNamespace == "" OR r.MgmtPlaneSigningSecret == ""  → skip
+//     (leaves any existing mirror in place; cleanup lives with ns delete).
+//   - source Secret not found  → delete the mirror if present (chart was
+//     uninstalled or dashboard.enabled flipped to false). Non-fatal.
+//   - source Secret found but missing tls.crt  → return an error so the
+//     Workspace status surfaces the misconfiguration.
+//   - source present and valid  → upsert the ConfigMap so data["pubkey.pem"]
+//     matches the source's tls.crt.
+func (r *WorkspaceReconciler) reconcileMgmtPlanePubkey(ctx context.Context, workspace *omniav1alpha1.Workspace) error {
+	log := logf.FromContext(ctx)
+
+	if r.OperatorNamespace == "" || r.MgmtPlaneSigningSecret == "" {
+		log.V(1).Info("mgmt-plane pubkey mirror skipped",
+			"reason", "not configured",
+			"operatorNamespace", r.OperatorNamespace,
+			"signingSecret", r.MgmtPlaneSigningSecret)
+		return nil
+	}
+
+	namespaceName := workspace.Spec.Namespace.Name
+
+	source := &corev1.Secret{}
+	err := r.Get(ctx, types.NamespacedName{Namespace: r.OperatorNamespace, Name: r.MgmtPlaneSigningSecret}, source)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			// Source missing — drop any stale mirror. Idempotent.
+			return r.deleteMgmtPlanePubkeyMirror(ctx, namespaceName)
+		}
+		return fmt.Errorf("get signing secret %s/%s: %w", r.OperatorNamespace, r.MgmtPlaneSigningSecret, err)
+	}
+
+	certBytes, ok := source.Data[tlsCertSecretKey]
+	if !ok || len(certBytes) == 0 {
+		return fmt.Errorf("signing secret %s/%s missing %q data key",
+			r.OperatorNamespace, r.MgmtPlaneSigningSecret, tlsCertSecretKey)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MgmtPlanePubkeyConfigMapName,
+			Namespace: namespaceName,
+		},
+	}
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, cm, func() error {
+		if cm.Labels == nil {
+			cm.Labels = map[string]string{}
+		}
+		cm.Labels[labelWorkspace] = workspace.Name
+		cm.Labels[labelWorkspaceManaged] = labelValueTrue
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		cm.Data[MgmtPlanePubkeyDataKey] = string(certBytes)
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("upsert mgmt-plane pubkey configmap %s/%s: %w",
+			namespaceName, MgmtPlanePubkeyConfigMapName, err)
+	}
+	if op != controllerutil.OperationResultNone {
+		log.Info("mgmt-plane pubkey mirror reconciled",
+			"namespace", namespaceName,
+			"configMap", MgmtPlanePubkeyConfigMapName,
+			"operation", op)
+	}
+	return nil
+}
+
+// deleteMgmtPlanePubkeyMirror removes the mirror ConfigMap. Used when the
+// source Secret no longer exists (dashboard turned off, chart uninstalled).
+// NotFound errors are swallowed — cleanup is idempotent.
+func (r *WorkspaceReconciler) deleteMgmtPlanePubkeyMirror(ctx context.Context, namespace string) error {
+	log := logf.FromContext(ctx)
+
+	cm := &corev1.ConfigMap{}
+	err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: MgmtPlanePubkeyConfigMapName}, cm)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("get mgmt-plane pubkey configmap %s/%s for cleanup: %w",
+			namespace, MgmtPlanePubkeyConfigMapName, err)
+	}
+	if err := r.Delete(ctx, cm, &client.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("delete mgmt-plane pubkey configmap %s/%s: %w",
+			namespace, MgmtPlanePubkeyConfigMapName, err)
+	}
+	log.Info("mgmt-plane pubkey mirror removed",
+		"reason", "source signing secret absent",
+		"namespace", namespace)
+	return nil
+}

--- a/internal/controller/workspace_mgmt_plane_pubkey_test.go
+++ b/internal/controller/workspace_mgmt_plane_pubkey_test.go
@@ -1,0 +1,289 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := omniav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add omnia scheme: %v", err)
+	}
+	return scheme
+}
+
+func newSigningSecret(name, namespace, cert string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Type:       corev1.SecretTypeTLS,
+		Data: map[string][]byte{
+			tlsCertSecretKey: []byte(cert),
+			"tls.key":        []byte("---fake-private-key---"),
+		},
+	}
+}
+
+func newWorkspace(name, namespace string) *omniav1alpha1.Workspace {
+	return &omniav1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: omniav1alpha1.WorkspaceSpec{
+			Namespace: omniav1alpha1.NamespaceConfig{
+				Name:   namespace,
+				Create: true,
+			},
+		},
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_NotConfigured(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &WorkspaceReconciler{Client: fc, Scheme: scheme}
+	ws := newWorkspace("ws", "ws-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("err = %v, want nil when not configured", err)
+	}
+	cm := &corev1.ConfigMap{}
+	err := fc.Get(context.Background(),
+		types.NamespacedName{Namespace: "ws-ns", Name: MgmtPlanePubkeyConfigMapName}, cm)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected ConfigMap absent when not configured, got err=%v", err)
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_OperatorNamespaceEmpty(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		MgmtPlaneSigningSecret: "some-secret", // configured but no operator ns
+	}
+	ws := newWorkspace("ws", "ws-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_SourceMissing(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		OperatorNamespace:      "omnia-system",
+		MgmtPlaneSigningSecret: "absent",
+	}
+	ws := newWorkspace("ws", "ws-ns")
+
+	// Source Secret doesn't exist — reconciler should not error.
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("err = %v, want nil when source absent", err)
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_SourceMissingTLSCert(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	badSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "broken", Namespace: "omnia-system"},
+		Type:       corev1.SecretTypeTLS,
+		Data:       map[string][]byte{"tls.key": []byte("only-private")},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(badSecret).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		OperatorNamespace:      "omnia-system",
+		MgmtPlaneSigningSecret: "broken",
+	}
+	ws := newWorkspace("ws", "ws-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err == nil {
+		t.Error("expected error when source secret missing tls.crt")
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_CreatesMirror(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	source := newSigningSecret("dashboard-keys", "omnia-system", "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n")
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(source).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		OperatorNamespace:      "omnia-system",
+		MgmtPlaneSigningSecret: "dashboard-keys",
+	}
+	ws := newWorkspace("ws-alpha", "ws-alpha-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("reconcileMgmtPlanePubkey: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := fc.Get(context.Background(),
+		types.NamespacedName{Namespace: "ws-alpha-ns", Name: MgmtPlanePubkeyConfigMapName}, cm)
+	if err != nil {
+		t.Fatalf("expected ConfigMap to be created: %v", err)
+	}
+	if got := cm.Data[MgmtPlanePubkeyDataKey]; got != string(source.Data[tlsCertSecretKey]) {
+		t.Errorf("ConfigMap data[%q] = %q, want %q", MgmtPlanePubkeyDataKey, got, string(source.Data[tlsCertSecretKey]))
+	}
+	if got := cm.Labels[labelWorkspace]; got != "ws-alpha" {
+		t.Errorf("workspace label = %q, want %q", got, "ws-alpha")
+	}
+	if got := cm.Labels[labelWorkspaceManaged]; got != labelValueTrue {
+		t.Errorf("managed label = %q, want %q", got, labelValueTrue)
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_UpdatesMirrorOnSourceChange(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	source := newSigningSecret("dashboard-keys", "omnia-system", "ORIGINAL")
+	stale := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MgmtPlanePubkeyConfigMapName,
+			Namespace: "ws-ns",
+		},
+		Data: map[string]string{MgmtPlanePubkeyDataKey: "STALE"},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(source, stale).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		OperatorNamespace:      "omnia-system",
+		MgmtPlaneSigningSecret: "dashboard-keys",
+	}
+	ws := newWorkspace("ws", "ws-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := fc.Get(context.Background(),
+		types.NamespacedName{Namespace: "ws-ns", Name: MgmtPlanePubkeyConfigMapName}, cm); err != nil {
+		t.Fatalf("get configmap: %v", err)
+	}
+	if got := cm.Data[MgmtPlanePubkeyDataKey]; got != "ORIGINAL" {
+		t.Errorf("ConfigMap data not updated: got %q, want %q", got, "ORIGINAL")
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_DeletesMirrorWhenSourceVanishes(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	// Mirror exists but source is missing — simulates dashboard.enabled
+	// flipped to false after a previous reconcile.
+	stale := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      MgmtPlanePubkeyConfigMapName,
+			Namespace: "ws-ns",
+		},
+		Data: map[string]string{MgmtPlanePubkeyDataKey: "OLD"},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(stale).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		OperatorNamespace:      "omnia-system",
+		MgmtPlaneSigningSecret: "dashboard-keys",
+	}
+	ws := newWorkspace("ws", "ws-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	err := fc.Get(context.Background(),
+		types.NamespacedName{Namespace: "ws-ns", Name: MgmtPlanePubkeyConfigMapName}, cm)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected ConfigMap deleted when source vanishes, got err=%v", err)
+	}
+}
+
+func TestReconcileMgmtPlanePubkey_DeleteIsIdempotent(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	// Source absent and mirror also absent — should not error.
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		OperatorNamespace:      "omnia-system",
+		MgmtPlaneSigningSecret: "dashboard-keys",
+	}
+	ws := newWorkspace("ws", "ws-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+}
+
+// Sanity: prove the workspace namespace lookup uses the spec value, not
+// the workspace's metadata namespace (Workspace is cluster-scoped — its
+// metadata.namespace is always empty).
+func TestReconcileMgmtPlanePubkey_UsesSpecNamespaceNotMetaNamespace(t *testing.T) {
+	t.Parallel()
+	scheme := newScheme(t)
+	source := newSigningSecret("dashboard-keys", "omnia-system", "CERT")
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(source).Build()
+	r := &WorkspaceReconciler{
+		Client:                 fc,
+		Scheme:                 scheme,
+		OperatorNamespace:      "omnia-system",
+		MgmtPlaneSigningSecret: "dashboard-keys",
+	}
+	ws := newWorkspace("ws", "spec-defined-ns")
+
+	if err := r.reconcileMgmtPlanePubkey(context.Background(), ws); err != nil {
+		t.Fatalf("reconcile: %v", err)
+	}
+
+	// ConfigMap must end up in spec.namespace.name, not metadata.namespace.
+	if err := fc.Get(context.Background(),
+		client.ObjectKey{Namespace: "spec-defined-ns", Name: MgmtPlanePubkeyConfigMapName},
+		&corev1.ConfigMap{}); err != nil {
+		t.Errorf("ConfigMap not in spec namespace: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Builds on #946. Closes the loop so a dashboard-minted JWT actually validates inside a facade pod running in a workspace namespace — without touching cross-namespace Secret access (which Kubernetes does not allow for pod volumes).

The Workspace controller now mirrors the public half of the dashboard's mgmt-plane signing keypair into a per-namespace ConfigMap (`omnia-dashboard-mgmt-plane-pubkey`, `data["pubkey.pem"]`). The mirror is keyed off two operator-startup inputs: `POD_NAMESPACE` (where the source Secret lives) and the new `--mgmt-plane-signing-secret` flag (which Secret to read). Either empty disables the mirror — facade stays mgmt-plane-unaware, matching #946's behaviour-preserving default.

The AgentRuntime deployment builder mounts the ConfigMap at `/etc/omnia/mgmt-plane` (`Optional: true` so a missing mirror leaves an empty dir rather than crash-looping the pod) and sets `OMNIA_MGMT_PLANE_PUBKEY_PATH` on the facade container. `cmd/agent`'s `loadMgmtPlaneValidator` reads the env var, checks the file exists and is non-empty, and constructs an `auth.MgmtPlaneValidator` — graceful degrade when the file is absent, fast-fail on malformed PEM.

The Helm chart wires `--mgmt-plane-signing-secret` only when `dashboard.enabled=true`; BYO override pulls from `dashboard.signingKey.existingSecret`.

The dashboard side (signing-key mount on the dashboard pod, mgmt-plane token minter, live-service WS attach) lands in PR 1c — coming next.

## Source-state semantics

| State | Result |
|---|---|
| `MgmtPlaneSigningSecret` empty (or `OperatorNamespace` empty) | reconciler no-op |
| Source Secret present + `tls.crt` set | upsert mirror |
| Source Secret missing | delete any stale mirror (idempotent) |
| Source Secret present but missing `tls.crt` | error → workspace status surfaces misconfig |

Cmd/agent semantics:

| State | Result |
|---|---|
| `OMNIA_MGMT_PLANE_PUBKEY_PATH` unset | no validator (PR 1a default) |
| Path set, file missing | no validator (graceful degrade) |
| Path set, file empty | no validator (graceful degrade) |
| Path set, file valid | validator wired |
| Path set, malformed PEM / non-RSA key | startup fails (refuse silent downgrade) |

## Test plan

- [x] `internal/controller`: 9 unit tests on `reconcileMgmtPlanePubkey` covering not-configured, source-missing, source-malformed, create, update, delete-on-source-vanish, idempotent-delete, spec-namespace-not-meta-namespace.
- [x] `internal/controller`: 3 wiring tests in `mgmt_plane_pubkey_wiring_test.go` asserting the volume + facade mount + env var are present (per CLAUDE.md "wiring tests" pattern — catches the silent-not-wired failure mode).
- [x] `cmd/agent`: 5 unit tests on `loadMgmtPlaneValidator` covering env unset, file missing, file empty, valid pubkey, malformed-PEM-errors.
- [x] Existing `TestBuildFacadeVolumeMounts_*` and `TestBuildFacadeContainer_*` refactored to look up the `promptpack-config` mount by name (not exact-count) so future unconditional mounts don't break them.
- [x] The "should mount ConfigMap volume for PromptPack" envtest looks up the `promptpack-config` volume by name instead of asserting exactly one volume.
- [x] Per-file coverage: `internal/controller/workspace_mgmt_plane_pubkey.go` 90.0%. Other touched files keep their existing coverage.
- [x] `gofmt`, `go vet`, `golangci-lint run`, `helm lint`, `helm unittest charts/omnia` (5 suites, 41 assertions) green locally.
- [x] Full `go test ./internal/controller/...` envtest run green.
- [ ] CI quality gate (SonarCloud).
- [ ] Arena E2E / core E2E (would benefit from a smoke test that the mirror actually lands — current envtests use a fake client; `test/e2e/` Tilt smoke can validate end-to-end after this lands).

## What lands next

- **PR 1c**: Helm chart mounts the private signing key into the dashboard pod; `dashboard/lib/mgmt-plane-token.js` mints short-lived debug tokens; `dashboard/server.js` WebSocket proxy attaches `Authorization: Bearer <jwt>` on the upstream connection so dashboard "Try this agent" flows authenticate against the facade. No browser-visible token endpoint needed since the proxy mints server-side.