### PR TITLE
feat(dashboard): mint mgmt-plane JWT in WS proxy (PR 1c)

### DIFF
--- a/charts/omnia/templates/dashboard/deployment.yaml
+++ b/charts/omnia/templates/dashboard/deployment.yaml
@@ -163,6 +163,18 @@ spec:
             {{- end }}
             {{- end }}
             {{- end }}
+            {{- /*
+              Mgmt-plane signing key path. Pointed at the mounted private
+              half of the dashboard signing keypair. server.js loads it at
+              boot and mints short-lived JWTs that the WS proxy attaches
+              to upstream connections so the facade's mgmt-plane validator
+              admits them. Skipped when an existingSecret override is
+              configured but the operator hasn't actually mounted it via
+              extraVolumeMounts — those deployments take ownership of the
+              path themselves.
+            */}}
+            - name: OMNIA_MGMT_PLANE_SIGNING_KEY_PATH
+              value: /etc/omnia/mgmt-plane/tls.key
             {{- with .Values.dashboard.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -202,6 +214,9 @@ spec:
             - name: workspace-content
               mountPath: {{ .Values.workspaceContent.mountPath | default "/workspace-content" }}
             {{- end }}
+            - name: mgmt-plane-signing-key
+              mountPath: /etc/omnia/mgmt-plane
+              readOnly: true
             {{- $vmMounts := concat (.Values.dashboard.extraVolumeMounts | default list) ($po.extraVolumeMounts | default list) }}
             {{- with $vmMounts }}
             {{- toYaml . | nindent 12 }}
@@ -217,6 +232,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.workspaceContent.persistence.existingClaim | default (printf "%s-workspace-content" (include "omnia.fullname" .)) }}
         {{- end }}
+        - name: mgmt-plane-signing-key
+          secret:
+            secretName: {{ .Values.dashboard.signingKey.existingSecret | default (printf "%s-signing-keypair" (include "omnia.dashboard.fullname" .)) }}
+            defaultMode: 0o400
         {{- $vols := concat (.Values.dashboard.extraVolumes | default list) ($po.extraVolumes | default list) }}
         {{- with $vols }}
         {{- toYaml . | nindent 8 }}

--- a/charts/omnia/tests/dashboard-signing-keypair_test.yaml
+++ b/charts/omnia/tests/dashboard-signing-keypair_test.yaml
@@ -5,8 +5,11 @@ values:
   - ../values-chart-tests.yaml
 templates:
   - templates/dashboard/signing-keypair.yaml
+  - templates/dashboard/deployment.yaml
+  - templates/dashboard/configmap.yaml
 tests:
   - it: renders a kubernetes.io/tls Secret with tls.crt + tls.key
+    template: templates/dashboard/signing-keypair.yaml
     asserts:
       - hasDocuments:
           count: 1
@@ -25,12 +28,14 @@ tests:
           path: data["tls.key"]
 
   - it: annotates the Secret so Helm never deletes or regenerates it
+    template: templates/dashboard/signing-keypair.yaml
     asserts:
       - equal:
           path: metadata.annotations["helm.sh/resource-policy"]
           value: keep
 
   - it: carries the standard dashboard labels
+    template: templates/dashboard/signing-keypair.yaml
     asserts:
       - equal:
           path: metadata.labels["app.kubernetes.io/component"]
@@ -40,6 +45,7 @@ tests:
           value: omnia-dashboard
 
   - it: is suppressed when dashboard.enabled=false
+    template: templates/dashboard/signing-keypair.yaml
     set:
       dashboard.enabled: false
     asserts:
@@ -47,8 +53,48 @@ tests:
           count: 0
 
   - it: is suppressed when an existingSecret is provided (BYO keypair)
+    template: templates/dashboard/signing-keypair.yaml
     set:
       dashboard.signingKey.existingSecret: my-own-signing-keypair
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: dashboard pod mounts the signing-key Secret read-only at /etc/omnia/mgmt-plane
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: mgmt-plane-signing-key
+            mountPath: /etc/omnia/mgmt-plane
+            readOnly: true
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mgmt-plane-signing-key
+            secret:
+              secretName: omnia-dashboard-signing-keypair
+              defaultMode: 256
+
+  - it: dashboard pod gets OMNIA_MGMT_PLANE_SIGNING_KEY_PATH pointing at the mount
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OMNIA_MGMT_PLANE_SIGNING_KEY_PATH
+            value: /etc/omnia/mgmt-plane/tls.key
+
+  - it: dashboard pod mount honours the BYO existingSecret override
+    template: templates/dashboard/deployment.yaml
+    set:
+      dashboard.signingKey.existingSecret: my-own-signing-keypair
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: mgmt-plane-signing-key
+            secret:
+              secretName: my-own-signing-keypair
+              defaultMode: 256

--- a/dashboard/lib/mgmt-plane-token.js
+++ b/dashboard/lib/mgmt-plane-token.js
@@ -1,0 +1,136 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * Management-plane token minter.
+ *
+ * server.js (CommonJS) calls this when proxying a "Try this agent" debug
+ * WebSocket upgrade so the upstream facade sees an Authorization: Bearer
+ * <jwt> header it can validate against the dashboard's signing key
+ * (mounted into every facade pod by PR 1b's Workspace controller).
+ *
+ * Why mint server-side and not in the browser:
+ *   - The signing key never leaves the dashboard pod.
+ *   - The browser's WebSocket API can't set custom headers, so a
+ *     browser-side token would have to ride a query param — an extra
+ *     attack surface and an extra leakable secret in browser history.
+ *   - The dashboard already authenticates the user before serving the
+ *     debug page, so the proxy hop is the right boundary at which to
+ *     mint.
+ *
+ * Pure CJS so server.js can require() it directly. Tested via vitest.
+ */
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+
+/**
+ * Default issuer/audience values. Kept in sync with the Go-side defaults
+ * in internal/facade/auth/mgmt_plane.go (DefaultMgmtPlaneIssuer /
+ * DefaultMgmtPlaneAudience). Mismatches cause the facade to 401 with no
+ * obvious clue, so override both sides together if you change either.
+ */
+const DEFAULT_ISSUER = "omnia-dashboard";
+const DEFAULT_AUDIENCE = "omnia-facade";
+
+/** Origin claim the facade requires to admit a mgmt-plane JWT. */
+const MGMT_PLANE_ORIGIN = "management-plane";
+
+/**
+ * Default token lifetime. Long enough that an admin's debug session
+ * doesn't drop in the middle of a chat, short enough that a leaked token
+ * isn't useful for long. The facade rejects expired tokens with 401 so
+ * the dashboard would simply mint a fresh one on reconnect.
+ */
+const DEFAULT_TTL_SECONDS = 5 * 60;
+
+/**
+ * base64url encode a Buffer or string per RFC 7515 §2 / RFC 7519 §3.
+ *
+ * Node's Buffer.toString("base64url") does this in one shot; we wrap it
+ * so the helper's callers don't need to remember the exact encoding name.
+ */
+function base64url(input) {
+  const buf = typeof input === "string" ? Buffer.from(input, "utf8") : input;
+  return buf.toString("base64url");
+}
+
+/**
+ * Read and parse an RSA private key from a PEM file. Accepts either a
+ * PKCS#1 ("RSA PRIVATE KEY") or PKCS#8 ("PRIVATE KEY") block; Helm's
+ * genSelfSigned emits PKCS#8 alongside the certificate. Returns a
+ * KeyObject suitable for crypto.sign.
+ *
+ * Throws if the file is missing, unreadable, or not a parseable RSA key
+ * — the caller (server.js boot) treats that as fatal so we don't silently
+ * skip mgmt-plane minting in production.
+ */
+function loadSigningKey(path) {
+  const pem = fs.readFileSync(path, { encoding: "utf8" });
+  const key = crypto.createPrivateKey({ key: pem, format: "pem" });
+  if (key.asymmetricKeyType !== "rsa") {
+    throw new Error(
+      `mgmt-plane signing key at ${path} is ${key.asymmetricKeyType}, expected rsa`,
+    );
+  }
+  return key;
+}
+
+/**
+ * Mint a fresh mgmt-plane JWT (RS256) signed by the supplied private key.
+ *
+ * @param {Object} opts
+ * @param {crypto.KeyObject} opts.key - RSA private key from loadSigningKey()
+ * @param {string} opts.subject       - admin username — surfaces as identity.subject in ToolPolicy
+ * @param {string} opts.agent         - target AgentRuntime name
+ * @param {string} opts.workspace     - target workspace
+ * @param {string} [opts.issuer]      - defaults to DEFAULT_ISSUER
+ * @param {string} [opts.audience]    - defaults to DEFAULT_AUDIENCE
+ * @param {number} [opts.ttlSeconds]  - defaults to DEFAULT_TTL_SECONDS
+ * @param {() => number} [opts.now]   - clock injection for tests; returns ms since epoch
+ * @returns {string} compact JWT (header.payload.signature)
+ */
+function mintToken(opts) {
+  if (!opts || !opts.key) {
+    throw new Error("mintToken: opts.key is required");
+  }
+  if (!opts.subject) {
+    throw new Error("mintToken: opts.subject is required");
+  }
+  if (!opts.agent) {
+    throw new Error("mintToken: opts.agent is required");
+  }
+  if (!opts.workspace) {
+    throw new Error("mintToken: opts.workspace is required");
+  }
+
+  const issuer = opts.issuer || DEFAULT_ISSUER;
+  const audience = opts.audience || DEFAULT_AUDIENCE;
+  const ttlSeconds = opts.ttlSeconds || DEFAULT_TTL_SECONDS;
+  const nowMs = opts.now ? opts.now() : Date.now();
+  const nowSec = Math.floor(nowMs / 1000);
+
+  const header = { alg: "RS256", typ: "JWT" };
+  const payload = {
+    iss: issuer,
+    sub: opts.subject,
+    aud: audience,
+    exp: nowSec + ttlSeconds,
+    nbf: nowSec - 1,
+    iat: nowSec,
+    origin: MGMT_PLANE_ORIGIN,
+    agent: opts.agent,
+    workspace: opts.workspace,
+  };
+
+  const signingInput = `${base64url(JSON.stringify(header))}.${base64url(JSON.stringify(payload))}`;
+  const signature = crypto.sign("RSA-SHA256", Buffer.from(signingInput, "utf8"), opts.key);
+  return `${signingInput}.${base64url(signature)}`;
+}
+
+module.exports = {
+  loadSigningKey,
+  mintToken,
+  DEFAULT_ISSUER,
+  DEFAULT_AUDIENCE,
+  DEFAULT_TTL_SECONDS,
+  MGMT_PLANE_ORIGIN,
+};

--- a/dashboard/lib/mgmt-plane-token.test.mjs
+++ b/dashboard/lib/mgmt-plane-token.test.mjs
@@ -1,0 +1,158 @@
+/**
+ * Tests for the mgmt-plane token minter — proves the JWTs we ship to
+ * facade pods carry the exact claim shape facade auth.MgmtPlaneValidator
+ * expects (RS256, iss=omnia-dashboard, aud=omnia-facade,
+ * origin=management-plane, exp/nbf/iat populated).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import { createRequire } from "node:module";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const require = createRequire(import.meta.url);
+const {
+  loadSigningKey,
+  mintToken,
+  DEFAULT_ISSUER,
+  DEFAULT_AUDIENCE,
+  DEFAULT_TTL_SECONDS,
+  MGMT_PLANE_ORIGIN,
+} = require("./mgmt-plane-token.js");
+
+let signingKey;
+let publicKey;
+let pemPath;
+
+const tmpPrefix = "omnia-mgmt-";
+
+beforeAll(() => {
+  const { privateKey, publicKey: pubKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+  });
+  pemPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix)), "key.pem");
+  fs.writeFileSync(pemPath, privateKey, { mode: 0o600 });
+  signingKey = loadSigningKey(pemPath);
+  publicKey = crypto.createPublicKey(pubKey);
+});
+
+function decodeJwt(jwt) {
+  const [headerB64, payloadB64, sigB64] = jwt.split(".");
+  return {
+    header: JSON.parse(Buffer.from(headerB64, "base64url").toString("utf8")),
+    payload: JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")),
+    signingInput: Buffer.from(`${headerB64}.${payloadB64}`, "utf8"),
+    signature: Buffer.from(sigB64, "base64url"),
+  };
+}
+
+describe("loadSigningKey", () => {
+  it("loads a PKCS#8 RSA private key", () => {
+    expect(signingKey.asymmetricKeyType).toBe("rsa");
+  });
+
+  it("rejects non-RSA keys with a clear error", () => {
+    const ec = crypto.generateKeyPairSync("ec", {
+      namedCurve: "P-256",
+      privateKeyEncoding: { type: "pkcs8", format: "pem" },
+      publicKeyEncoding: { type: "spki", format: "pem" },
+    });
+    const ecPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix)), "ec.pem");
+    fs.writeFileSync(ecPath, ec.privateKey);
+    expect(() => loadSigningKey(ecPath)).toThrowError(/expected rsa/);
+  });
+
+  it("propagates ENOENT for missing files", () => {
+    expect(() => loadSigningKey("/no/such/file.pem")).toThrow();
+  });
+
+  it("rejects malformed PEM", () => {
+    const garbagePath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), tmpPrefix)), "garbage.pem");
+    fs.writeFileSync(garbagePath, "this is not pem");
+    expect(() => loadSigningKey(garbagePath)).toThrow();
+  });
+});
+
+describe("mintToken", () => {
+  const baseOpts = {
+    subject: "admin@example.com",
+    agent: "test-agent",
+    workspace: "default",
+  };
+
+  it("returns a three-segment JWT", () => {
+    const jwt = mintToken({ key: signingKey, ...baseOpts });
+    expect(jwt.split(".")).toHaveLength(3);
+  });
+
+  it("signs with RS256", () => {
+    const { header } = decodeJwt(mintToken({ key: signingKey, ...baseOpts }));
+    expect(header.alg).toBe("RS256");
+    expect(header.typ).toBe("JWT");
+  });
+
+  it("includes the facade-required claims", () => {
+    const { payload } = decodeJwt(mintToken({ key: signingKey, ...baseOpts }));
+    expect(payload.iss).toBe(DEFAULT_ISSUER);
+    expect(payload.aud).toBe(DEFAULT_AUDIENCE);
+    expect(payload.origin).toBe(MGMT_PLANE_ORIGIN);
+    expect(payload.sub).toBe("admin@example.com");
+    expect(payload.agent).toBe("test-agent");
+    expect(payload.workspace).toBe("default");
+    expect(typeof payload.exp).toBe("number");
+    expect(typeof payload.iat).toBe("number");
+    expect(typeof payload.nbf).toBe("number");
+  });
+
+  it("respects custom issuer / audience overrides", () => {
+    const { payload } = decodeJwt(
+      mintToken({
+        key: signingKey,
+        ...baseOpts,
+        issuer: "custom-iss",
+        audience: "custom-aud",
+      }),
+    );
+    expect(payload.iss).toBe("custom-iss");
+    expect(payload.aud).toBe("custom-aud");
+  });
+
+  it("defaults exp to now + DEFAULT_TTL_SECONDS", () => {
+    const fixedNow = 1_700_000_000_000;
+    const { payload } = decodeJwt(
+      mintToken({ key: signingKey, ...baseOpts, now: () => fixedNow }),
+    );
+    const expectedNowSec = Math.floor(fixedNow / 1000);
+    expect(payload.iat).toBe(expectedNowSec);
+    expect(payload.exp).toBe(expectedNowSec + DEFAULT_TTL_SECONDS);
+  });
+
+  it("honours explicit ttlSeconds", () => {
+    const fixedNow = 1_700_000_000_000;
+    const { payload } = decodeJwt(
+      mintToken({ key: signingKey, ...baseOpts, ttlSeconds: 30, now: () => fixedNow }),
+    );
+    expect(payload.exp - payload.iat).toBe(30);
+  });
+
+  it("produces a signature the public key verifies", () => {
+    const jwt = mintToken({ key: signingKey, ...baseOpts });
+    const { signingInput, signature } = decodeJwt(jwt);
+    const ok = crypto.verify("RSA-SHA256", signingInput, publicKey, signature);
+    expect(ok).toBe(true);
+  });
+
+  it("rejects calls without a key", () => {
+    expect(() => mintToken({ ...baseOpts })).toThrowError(/opts.key is required/);
+  });
+
+  it.each(["subject", "agent", "workspace"])("rejects calls without %s", (missing) => {
+    const opts = { key: signingKey, ...baseOpts };
+    delete opts[missing];
+    expect(() => mintToken(opts)).toThrowError(new RegExp(`opts.${missing} is required`));
+  });
+});

--- a/dashboard/lib/proxy-auth.test.mjs
+++ b/dashboard/lib/proxy-auth.test.mjs
@@ -1,0 +1,118 @@
+/**
+ * Integration test for the WS proxy's mgmt-plane Authorization header
+ * attachment. Stands up a fake upstream WebSocket server, mints a token
+ * with the same minter server.js uses, opens a client connection through
+ * the same `new WebSocket(url, [], { headers })` pattern, and asserts the
+ * upstream actually sees the Authorization header.
+ *
+ * The point: catch the silent-not-wired failure mode where the minter
+ * works in isolation but the proxy forgets to forward the headers.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { createRequire } from "node:module";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import http from "node:http";
+import { WebSocket, WebSocketServer } from "ws";
+
+const require = createRequire(import.meta.url);
+const { loadSigningKey, mintToken, MGMT_PLANE_ORIGIN } = require("./mgmt-plane-token.js");
+
+let signingKey;
+let publicKey;
+let upstreamServer;
+let upstreamPort;
+const observedHeaders = [];
+
+beforeAll(async () => {
+  // Generate a keypair the test holds both halves of: dashboard mints with
+  // the private half, the test verifies what the upstream receives by
+  // independently re-verifying the JWT with the public half.
+  const { privateKey, publicKey: pubKeyPem } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
+    publicKeyEncoding: { type: "spki", format: "pem" },
+  });
+  const pemPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), "omnia-proxy-")), "key.pem");
+  fs.writeFileSync(pemPath, privateKey, { mode: 0o600 });
+  signingKey = loadSigningKey(pemPath);
+  publicKey = crypto.createPublicKey(pubKeyPem);
+
+  // Stand up a fake upstream that records the headers the proxy sends.
+  await new Promise((resolve) => {
+    upstreamServer = http.createServer();
+    const wss = new WebSocketServer({ server: upstreamServer });
+    wss.on("connection", (_socket, req) => {
+      observedHeaders.push({ ...req.headers });
+    });
+    upstreamServer.listen(0, "127.0.0.1", () => {
+      upstreamPort = upstreamServer.address().port;
+      resolve();
+    });
+  });
+});
+
+afterAll(async () => {
+  await new Promise((resolve) => upstreamServer.close(resolve));
+});
+
+function decodeJwt(jwt) {
+  const [headerB64, payloadB64, sigB64] = jwt.split(".");
+  return {
+    header: JSON.parse(Buffer.from(headerB64, "base64url").toString("utf8")),
+    payload: JSON.parse(Buffer.from(payloadB64, "base64url").toString("utf8")),
+    signingInput: Buffer.from(`${headerB64}.${payloadB64}`, "utf8"),
+    signature: Buffer.from(sigB64, "base64url"),
+  };
+}
+
+async function dialUpstream(headers) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${upstreamPort}/ws`, [], { headers });
+    ws.on("open", () => {
+      ws.close();
+      resolve();
+    });
+    ws.on("error", reject);
+  });
+}
+
+describe("WS proxy mgmt-plane Authorization attachment", () => {
+  it("forwards a Bearer token the upstream can verify with the public key", async () => {
+    observedHeaders.length = 0;
+
+    // This is exactly what server.js's proxyWebSocket does today: mint a
+    // token and pass it as a header on the upstream constructor.
+    const token = mintToken({
+      key: signingKey,
+      subject: "omnia-dashboard-proxy",
+      agent: "test-agent",
+      workspace: "default",
+    });
+
+    await dialUpstream({ Authorization: `Bearer ${token}` });
+
+    expect(observedHeaders).toHaveLength(1);
+    const auth = observedHeaders[0].authorization;
+    expect(auth).toMatch(/^Bearer /);
+
+    const presented = auth.slice("Bearer ".length);
+    const { payload, signingInput, signature } = decodeJwt(presented);
+    expect(payload.origin).toBe(MGMT_PLANE_ORIGIN);
+    expect(payload.agent).toBe("test-agent");
+    expect(payload.workspace).toBe("default");
+
+    const sigOk = crypto.verify("RSA-SHA256", signingInput, publicKey, signature);
+    expect(sigOk).toBe(true);
+  });
+
+  it("preserves the no-auth path when no token is attached", async () => {
+    observedHeaders.length = 0;
+    await dialUpstream({}); // simulate "key not loaded" branch in server.js
+    expect(observedHeaders).toHaveLength(1);
+    expect(observedHeaders[0].authorization).toBeUndefined();
+  });
+});

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -19,6 +19,7 @@ const { parse } = require("url");
 const next = require("next");
 const { WebSocket, WebSocketServer } = require("ws");
 const { checkAnonymousAuthGuard } = require("./lib/auth-boot-guard");
+const { loadSigningKey, mintToken } = require("./lib/mgmt-plane-token");
 
 // Refuse to start if we're configured to run unauthenticated in what looks
 // like production. Mirrors the Helm chart's render-time check
@@ -34,6 +35,38 @@ const hostname = process.env.HOSTNAME || "0.0.0.0";
 const port = Number.parseInt(process.env.PORT || "3000", 10);
 // WebSocket proxy runs on separate port to avoid interfering with Next.js HMR
 const wsProxyPort = Number.parseInt(process.env.WS_PROXY_PORT || "3002", 10);
+
+// Mgmt-plane signing key path. When set and readable the WS proxy attaches
+// a freshly-minted JWT to every upstream connection so the facade's
+// auth.MgmtPlaneValidator admits it. When unset (dev/test) or unreadable,
+// the proxy connects without an Authorization header and the facade
+// falls through to its PR 1a default (unauthenticated upgrade — closes
+// in PR 3).
+const MGMT_PLANE_SIGNING_KEY_PATH = process.env.OMNIA_MGMT_PLANE_SIGNING_KEY_PATH || "";
+
+let mgmtPlaneSigningKey = null;
+if (MGMT_PLANE_SIGNING_KEY_PATH) {
+  try {
+    mgmtPlaneSigningKey = loadSigningKey(MGMT_PLANE_SIGNING_KEY_PATH);
+    console.log(`> mgmt-plane signing key loaded from ${MGMT_PLANE_SIGNING_KEY_PATH}`);
+  } catch (err) {
+    // Fatal — silently downgrading to "no auth" hides a real
+    // misconfiguration from operators (a typo in the volume mount,
+    // wrong PEM format, etc.). PodSecurity admission keeps secret
+    // material from accidentally leaking; refuse to start instead.
+    console.error(
+      `Failed to load mgmt-plane signing key from ${MGMT_PLANE_SIGNING_KEY_PATH}: ${err.message}`,
+    );
+    process.exit(1);
+  }
+}
+
+// Subject claim on minted mgmt-plane tokens. The dashboard proxy is a
+// single trust boundary — every WS upgrade routed through it has already
+// passed the dashboard's own auth check, so we don't try to mint
+// per-user tokens here. ToolPolicy distinguishes mgmt-plane traffic by
+// `identity.origin == "management-plane"`, not by subject.
+const MGMT_PLANE_SUBJECT = "omnia-dashboard-proxy";
 
 // Service domain for K8s cluster DNS
 const SERVICE_DOMAIN = process.env.SERVICE_DOMAIN || "svc.cluster.local";
@@ -166,6 +199,30 @@ function proxyWebSocket(clientSocket, namespace, name, clientParams = {}) {
   console.log(`[WS Proxy] Connecting to upstream: ${upstreamUrl}`);
   console.log(`[WS Proxy] SERVICE_DOMAIN=${SERVICE_DOMAIN}, DEFAULT_FACADE_PORT=${DEFAULT_FACADE_PORT}`);
 
+  // Mint a fresh mgmt-plane JWT for the upstream connection. The dashboard
+  // proxy is the single trust boundary — every WS upgrade has already
+  // passed the dashboard's own auth, so we sign with a constant subject
+  // and let ToolPolicy distinguish mgmt-plane traffic via identity.origin.
+  // No key loaded -> connect without Authorization (preserves PR 1a's
+  // unauthenticated default).
+  const upstreamHeaders = {};
+  if (mgmtPlaneSigningKey) {
+    try {
+      const token = mintToken({
+        key: mgmtPlaneSigningKey,
+        subject: MGMT_PLANE_SUBJECT,
+        agent: name,
+        workspace: namespace,
+      });
+      upstreamHeaders.Authorization = `Bearer ${token}`;
+    } catch (err) {
+      // Token-minting failure is unexpected (key was validated at boot).
+      // Surface it loudly but still attempt the upgrade unauthenticated
+      // so a transient error doesn't break the entire debug view.
+      console.error(`[WS Proxy] Failed to mint mgmt-plane token: ${err.message}`);
+    }
+  }
+
   let upstream = null;
   let upstreamConnected = false;
   let connectionTimeout = null;
@@ -180,7 +237,7 @@ function proxyWebSocket(clientSocket, namespace, name, clientParams = {}) {
   }, 10000);
 
   try {
-    upstream = new WebSocket(upstreamUrl);
+    upstream = new WebSocket(upstreamUrl, [], { headers: upstreamHeaders });
 
     upstream.on("open", () => {
       upstreamConnected = true;


### PR DESCRIPTION
## Summary

Closes the dashboard side of the auth design. Builds on #946 (facade validator + chart Secret) and #947 (cross-namespace pubkey distribution + facade cmd wiring) — together the three PRs make a dashboard-minted JWT validate inside a facade pod end-to-end.

> Originally opened as #949 stacked on `feat/facade-auth-pr1b-pubkey-distribution`; auto-closed when #947 squash-merged and the base branch was deleted. Re-opened on `main` after rebase.

## What this ships

- `dashboard/lib/mgmt-plane-token.js` — pure CJS minter that loads the RSA private half of the dashboard signing keypair and signs short-lived RS256 JWTs matching the claim shape facade `auth.MgmtPlaneValidator` expects (`iss=omnia-dashboard`, `aud=omnia-facade`, `origin=management-plane`, `iat`/`nbf`/`exp` populated). Uses Node `crypto.sign` — no new npm dependency.
- `dashboard/server.js` — loads the signing key once at boot from `OMNIA_MGMT_PLANE_SIGNING_KEY_PATH` (fatal if the env var is set but the file is unreadable / not RSA — silently downgrading to no-auth hides operator misconfig). `proxyWebSocket` mints a fresh token on every upstream WS upgrade and attaches `Authorization: Bearer ...` via the `ws` library's headers option.
- `charts/omnia/templates/dashboard/deployment.yaml` — mounts the signing-keypair Secret read-only at `/etc/omnia/mgmt-plane` and sets `OMNIA_MGMT_PLANE_SIGNING_KEY_PATH=/etc/omnia/mgmt-plane/tls.key`. BYO override pulls from `dashboard.signingKey.existingSecret`.

## Why mint server-side, not in the browser

- The signing key never leaves the dashboard pod.
- Browser WebSocket API can't set custom headers, so a browser-side token would have to ride a query param — extra attack surface and extra leakable secret in browser history.
- The dashboard already authenticates the user before serving the debug page, so the proxy hop is the right boundary.

ToolPolicy distinguishes mgmt-plane traffic by `identity.origin`, not subject — every minted token uses the constant subject `"omnia-dashboard-proxy"`. Per-user audit lives in the dashboard's REST API (where the user's session cookie is checked), not the JWT.

## Test plan

- [x] `dashboard/lib/mgmt-plane-token.test.mjs` — 15 unit tests on the minter: header shape, all required claims present, custom iss/aud overrides, exp/iat math, signature verifies with the matching public key, missing-arg rejection, bad-PEM rejection, non-RSA rejection, missing-file rejection.
- [x] `dashboard/lib/proxy-auth.test.mjs` — 2 integration tests that stand up a fake upstream WebSocket server, mint a token with the same minter `server.js` uses, dial through the same `new WebSocket(url, [], { headers })` pattern, and assert the upstream actually sees the Authorization header (catches the silent-not-wired failure mode CLAUDE.md flags as the most common bug class).
- [x] `charts/omnia/tests/dashboard-signing-keypair_test.yaml` extended with 3 new assertions: dashboard pod mount + env var + BYO `existingSecret` override (44 helm-unittest assertions total across the suite, all green).
- [x] `npm run lint`, `npm run typecheck`, all 965 existing vitest tests + the 17 new ones — green locally.
- [x] `helm lint`, `helm template` — green locally.
- [ ] CI quality gate (SonarCloud).
- [ ] Tilt smoke: dashboard pod boots with the key loaded, debug-view WebSocket against a workspace agent works without falling through to no-auth.

## Default behaviour preservation

Same as PR 1a/1b: when `OMNIA_MGMT_PLANE_SIGNING_KEY_PATH` is unset (dev/test, or chart values that don't enable the dashboard), the proxy connects without an Authorization header and the facade falls through to its existing unauthenticated upgrade path. The default-flip lands in PR 3.

## What does NOT land here

- **Direct WS mode** (`NEXT_PUBLIC_WS_DIRECT_MODE=true`) bypasses the dashboard proxy and connects browser → facade. This is an E2E / dev mode and intentionally has no mgmt-plane auth — the test harness keeps facade validators unconfigured for that path.
- The default flip from "validator unconfigured allows upgrade" to "401 on missing credential" is **PR 3**.
- Per-user audit (current minter uses constant subject) — the dashboard's REST API audit already records the actual user; can be surfaced in the JWT in a follow-up if ToolPolicy needs it.

## What lands next

PR 2 introduces the data-plane validators (`sharedToken`, `apiKeys`, `oidc`, `edgeTrust`) and the `AgentRuntime.spec.externalAuth` CRD block. PR 3 flips the default to reject unauthenticated upgrades. PR 4 wires the `identity` root into ToolPolicy CEL.