### PR TITLE
feat(facade): sharedToken validator + auth chain runner (PR 2b)

### DIFF
--- a/cmd/agent/auth_chain.go
+++ b/cmd/agent/auth_chain.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+	"github.com/altairalabs/omnia/internal/facade/auth"
+)
+
+// sharedTokenSecretKey is the data key the chart-managed Secret holds
+// the bearer value under. Matches the existing OMNIA_A2A_AUTH_TOKEN
+// pattern (and the documented A2A integration).
+const sharedTokenSecretKey = "token"
+
+// buildAuthChain assembles the facade's per-agent auth chain. Order:
+//
+//	sharedToken → mgmt-plane
+//
+// (apiKeys, oidc, edgeTrust slot in here in PRs 2c/2d/2e — they are
+// no-ops here when their CRD field is unset.)
+//
+// Inputs:
+//
+//   - k8s: client for reading the AgentRuntime CR + the referenced
+//     SharedToken Secret. Pass nil when the agent is running outside a
+//     cluster (dev/test); the chain falls back to mgmt-plane only.
+//   - mgmtPlane: the mgmt-plane validator built earlier in startup
+//     (loadMgmtPlaneValidator). Pass nil to omit it from the chain.
+//
+// Returns nil if the chain ends up empty — the facade then runs in the
+// PR 1a/c default unauthenticated-upgrade mode.
+func buildAuthChain(
+	ctx context.Context,
+	k8s client.Client,
+	log logr.Logger,
+	agentName, namespace string,
+	mgmtPlane auth.Validator,
+) (auth.Chain, error) {
+	chain := auth.Chain{}
+
+	if k8s != nil && agentName != "" && namespace != "" {
+		ar := &omniav1alpha1.AgentRuntime{}
+		err := k8s.Get(ctx, types.NamespacedName{Name: agentName, Namespace: namespace}, ar)
+		switch {
+		case apierrors.IsNotFound(err):
+			// Agent is being created or deleted out-of-band — fall back
+			// to mgmt-plane only and let the controller catch up.
+			log.V(1).Info("agent runtime not found at startup, skipping data-plane validators",
+				"agent", agentName, "namespace", namespace)
+		case err != nil:
+			return nil, fmt.Errorf("get AgentRuntime %s/%s: %w", namespace, agentName, err)
+		default:
+			validators, err := buildDataPlaneValidators(ctx, k8s, log, ar)
+			if err != nil {
+				return nil, err
+			}
+			chain = append(chain, validators...)
+		}
+	} else {
+		log.V(1).Info("data-plane chain build skipped",
+			"reason", "no k8s client or identity",
+			"hasK8sClient", k8s != nil,
+			"hasAgentName", agentName != "",
+			"hasNamespace", namespace != "")
+	}
+
+	if mgmtPlane != nil {
+		chain = append(chain, mgmtPlane)
+	}
+
+	if len(chain) == 0 {
+		return nil, nil
+	}
+	return chain, nil
+}
+
+// buildDataPlaneValidators reads the AgentRuntime's spec.externalAuth
+// and constructs the matching validators. Each sub-block is independent;
+// missing blocks contribute zero validators (the chain just walks the
+// remaining ones in order).
+func buildDataPlaneValidators(
+	ctx context.Context,
+	k8s client.Client,
+	log logr.Logger,
+	ar *omniav1alpha1.AgentRuntime,
+) ([]auth.Validator, error) {
+	if ar.Spec.ExternalAuth == nil {
+		return nil, nil
+	}
+
+	var out []auth.Validator
+	if v, err := buildSharedTokenValidator(ctx, k8s, log, ar); err != nil {
+		return nil, err
+	} else if v != nil {
+		out = append(out, v)
+	}
+	// Future PRs append apiKeys (2c), oidc (2d), edgeTrust (2e) here.
+	return out, nil
+}
+
+// buildSharedTokenValidator resolves spec.externalAuth.sharedToken into
+// a *SharedTokenValidator by reading the referenced Secret. Returns nil
+// (no validator) when the field is unset; returns an error when the
+// Secret can't be read or is missing the "token" key — operators expect
+// loud failure on misconfig rather than silent skip.
+func buildSharedTokenValidator(
+	ctx context.Context,
+	k8s client.Client,
+	log logr.Logger,
+	ar *omniav1alpha1.AgentRuntime,
+) (auth.Validator, error) {
+	st := ar.Spec.ExternalAuth.SharedToken
+	if st == nil {
+		return nil, nil
+	}
+	if st.SecretRef.Name == "" {
+		return nil, errors.New("spec.externalAuth.sharedToken.secretRef.name is empty")
+	}
+
+	secret := &corev1.Secret{}
+	err := k8s.Get(ctx, types.NamespacedName{Name: st.SecretRef.Name, Namespace: ar.Namespace}, secret)
+	if err != nil {
+		return nil, fmt.Errorf("get sharedToken secret %s/%s: %w", ar.Namespace, st.SecretRef.Name, err)
+	}
+	tokenBytes, ok := secret.Data[sharedTokenSecretKey]
+	if !ok || len(tokenBytes) == 0 {
+		return nil, fmt.Errorf("sharedToken secret %s/%s missing %q data key",
+			ar.Namespace, st.SecretRef.Name, sharedTokenSecretKey)
+	}
+
+	opts := []auth.SharedTokenOption{}
+	if st.TrustEndUserHeader {
+		opts = append(opts, auth.WithSharedTokenTrustEndUserHeader(true))
+	}
+	v, err := auth.NewSharedTokenValidator(string(tokenBytes), opts...)
+	if err != nil {
+		return nil, fmt.Errorf("construct sharedToken validator: %w", err)
+	}
+	log.Info("sharedToken validator enabled",
+		"secret", st.SecretRef.Name,
+		"trustEndUserHeader", st.TrustEndUserHeader)
+	return v, nil
+}

--- a/cmd/agent/auth_chain_test.go
+++ b/cmd/agent/auth_chain_test.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		t.Fatalf("add core scheme: %v", err)
+	}
+	if err := omniav1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add omnia scheme: %v", err)
+	}
+	return scheme
+}
+
+func TestBuildAuthChain_NoK8sClientReturnsMgmtOnly(t *testing.T) {
+	t.Parallel()
+	mgmt := &stubMgmtValidator{id: &policy.AuthenticatedIdentity{Origin: policy.OriginManagementPlane}}
+	chain, err := buildAuthChain(context.Background(), nil, logr.Discard(), "agent", "ns", mgmt)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := len(chain), 1; got != want {
+		t.Fatalf("chain length = %d, want %d", got, want)
+	}
+}
+
+func TestBuildAuthChain_NoK8sClientNoMgmtReturnsNil(t *testing.T) {
+	t.Parallel()
+	chain, err := buildAuthChain(context.Background(), nil, logr.Discard(), "agent", "ns", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if chain != nil {
+		t.Errorf("chain = %v, want nil when no validators", chain)
+	}
+}
+
+func TestBuildAuthChain_AgentNotFoundFallsBackToMgmt(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	mgmt := &stubMgmtValidator{}
+	chain, err := buildAuthChain(context.Background(), fc, logr.Discard(), "missing-agent", "ns", mgmt)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (NotFound is expected during pod startup)", err)
+	}
+	if got, want := len(chain), 1; got != want {
+		t.Errorf("chain length = %d, want %d (mgmt-plane only)", got, want)
+	}
+}
+
+func TestBuildAuthChain_ExternalAuthUnsetReturnsMgmtOnly(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		// No ExternalAuth — preserves PR 1c default of mgmt-plane only.
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar).Build()
+	mgmt := &stubMgmtValidator{}
+	chain, err := buildAuthChain(context.Background(), fc, logr.Discard(), "agent", "ns", mgmt)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := len(chain), 1; got != want {
+		t.Errorf("chain length = %d, want %d", got, want)
+	}
+}
+
+func TestBuildAuthChain_SharedTokenAddsValidatorBeforeMgmt(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared-token", Namespace: "ns"},
+		Data:       map[string][]byte{"token": []byte("opaque-bearer")},
+	}
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				SharedToken: &omniav1alpha1.SharedTokenAuth{
+					SecretRef: corev1.LocalObjectReference{Name: "shared-token"},
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar, secret).Build()
+	mgmt := &stubMgmtValidator{}
+
+	chain, err := buildAuthChain(context.Background(), fc, logr.Discard(), "agent", "ns", mgmt)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := len(chain), 2; got != want {
+		t.Fatalf("chain length = %d, want %d (sharedToken + mgmt)", got, want)
+	}
+
+	// Prove sharedToken really is wired by exercising the chain end-to-end:
+	// a request with the right Bearer should admit via shared-token, NOT
+	// via mgmt-plane (mgmt-plane would also admit because the stub admits
+	// everything; we want to prove order).
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("Authorization", "Bearer opaque-bearer")
+	id, err := chain.Run(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := id.Origin, policy.OriginSharedToken; got != want {
+		t.Errorf("Origin = %q, want %q (sharedToken should win first)", got, want)
+	}
+}
+
+func TestBuildAuthChain_SharedTokenSecretMissingErrors(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				SharedToken: &omniav1alpha1.SharedTokenAuth{
+					SecretRef: corev1.LocalObjectReference{Name: "absent"},
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar).Build()
+
+	if _, err := buildAuthChain(context.Background(), fc, logr.Discard(), "agent", "ns", nil); err == nil {
+		t.Error("expected error when sharedToken secret is missing")
+	}
+}
+
+func TestBuildAuthChain_SharedTokenSecretMissingTokenKeyErrors(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	badSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "wrong-keys", Namespace: "ns"},
+		Data:       map[string][]byte{"value": []byte("xx")},
+	}
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				SharedToken: &omniav1alpha1.SharedTokenAuth{
+					SecretRef: corev1.LocalObjectReference{Name: "wrong-keys"},
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar, badSecret).Build()
+	if _, err := buildAuthChain(context.Background(), fc, logr.Discard(), "agent", "ns", nil); err == nil {
+		t.Error("expected error when sharedToken secret missing the 'token' data key")
+	}
+}
+
+func TestBuildAuthChain_TrustEndUserHeaderPropagates(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "ns"},
+		Data:       map[string][]byte{"token": []byte("tok")},
+	}
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				SharedToken: &omniav1alpha1.SharedTokenAuth{
+					SecretRef:          corev1.LocalObjectReference{Name: "shared"},
+					TrustEndUserHeader: true,
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar, secret).Build()
+	chain, err := buildAuthChain(context.Background(), fc, logr.Discard(), "agent", "ns", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("Authorization", "Bearer tok")
+	r.Header.Set(auth.EndUserHeader, "alice@example.com")
+	id, err := chain.Run(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := id.EndUser, "alice@example.com"; got != want {
+		t.Errorf("EndUser = %q, want %q (trustEndUserHeader=true should propagate)", got, want)
+	}
+}
+
+// stubMgmtValidator is a minimal Validator for chain-composition tests.
+type stubMgmtValidator struct {
+	id *policy.AuthenticatedIdentity
+}
+
+func (s *stubMgmtValidator) Validate(_ context.Context, _ *http.Request) (*policy.AuthenticatedIdentity, error) {
+	if s.id != nil {
+		return s.id, nil
+	}
+	return &policy.AuthenticatedIdentity{Origin: policy.OriginManagementPlane}, nil
+}

--- a/cmd/agent/websocket.go
+++ b/cmd/agent/websocket.go
@@ -126,15 +126,23 @@ func buildWebSocketServer(
 	if pf, ok := store.(facade.PolicyFetcher); ok {
 		serverOpts = append(serverOpts, facade.WithPolicyFetcher(pf))
 	}
-	// Load the mgmt-plane validator when the operator has pointed us at a
-	// mounted dashboard public key. A loading failure (malformed PEM,
-	// non-RSA key) is fatal — silently downgrading to "no auth" would
-	// mask a real misconfiguration.
-	if v, err := loadMgmtPlaneValidator(log); err != nil {
+	// Build the auth chain: data-plane validators (sharedToken in PR 2b;
+	// apiKeys/oidc/edgeTrust in PRs 2c–2e) followed by the mgmt-plane
+	// validator. Loading failures (malformed PEM, missing Secret data
+	// key, empty shared token) are fatal — silent downgrade to no-auth
+	// would mask real operator misconfig.
+	mgmtPlane, err := loadMgmtPlaneValidator(log)
+	if err != nil {
 		log.Error(err, "mgmt-plane validator load failed")
 		os.Exit(1)
-	} else if v != nil {
-		serverOpts = append(serverOpts, facade.WithMgmtPlaneValidator(v))
+	}
+	chain, err := buildAuthChain(context.Background(), buildK8sClient(), log, cfg.AgentName, cfg.Namespace, mgmtPlane)
+	if err != nil {
+		log.Error(err, "auth chain build failed")
+		os.Exit(1)
+	}
+	if len(chain) > 0 {
+		serverOpts = append(serverOpts, facade.WithAuthChain(chain))
 	}
 	wsServer := facade.NewServer(wsConfig, store, handler, log, serverOpts...)
 

--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -339,6 +339,13 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{RequeueAfter: time.Millisecond}, nil
 	}
 
+	// Project the deprecated spec.a2a.authentication.secretRef into
+	// spec.externalAuth.sharedToken so downstream code (cmd/agent's
+	// chain builder, the dashboard UI, etc.) only has to look at one
+	// field. In-memory only — never persisted. PR 2a added the helper;
+	// PR 2b wires it.
+	projectLegacyA2AAuth(agentRuntime)
+
 	// Initialize status if needed
 	if agentRuntime.Status.Phase == "" {
 		agentRuntime.Status.Phase = omniav1alpha1.AgentRuntimePhasePending

--- a/internal/facade/auth/chain.go
+++ b/internal/facade/auth/chain.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// Chain runs an ordered slice of Validators against each request and
+// returns the first one that admits.
+//
+// Order matters because the data-plane validators each look at the
+// Authorization header in slightly different ways and a token meant for
+// one validator can syntactically resemble another (e.g., a JWT also
+// looks like an opaque bearer to sharedToken). The conventional order
+// shipped by cmd/agent is:
+//
+//	sharedToken → apiKeys → oidc → edgeTrust → mgmtPlane
+//
+// — narrowest match first, broadest last. ErrInvalidCredential from any
+// validator short-circuits the chain (a credential of that style was
+// presented and rejected; we don't fall through to a different style),
+// while ErrNoCredential moves to the next validator.
+//
+// An empty chain admits nothing — Run returns ErrNoCredential so the
+// caller can decide whether that means "fall through to no-auth path"
+// (PR 1a/c default) or "401" (PR 3 default).
+type Chain []Validator
+
+// Run walks the chain in order. The semantic contract:
+//
+//   - First validator returning a non-nil identity wins. Identity is returned.
+//   - ErrNoCredential continues to the next validator.
+//   - Any other error short-circuits — no later validator runs, the error
+//     is returned to the caller (which translates to 401 at the HTTP layer).
+//   - Empty chain or all-fall-through returns ErrNoCredential.
+//
+// The runner does not log — that is the caller's job, where the request
+// scope lives and the structured logger is bound. Returning typed
+// sentinels lets the caller decide whether to surface the underlying
+// reason or aggregate.
+func (c Chain) Run(ctx context.Context, r *http.Request) (*policy.AuthenticatedIdentity, error) {
+	for _, v := range c {
+		id, err := v.Validate(ctx, r)
+		switch {
+		case err == nil && id != nil:
+			return id, nil
+		case errors.Is(err, ErrNoCredential):
+			continue
+		case err != nil:
+			// Either ErrInvalidCredential, ErrExpired, or an unexpected
+			// runtime error from the validator. Any of those means a
+			// credential of *some* style was presented and we've decided
+			// to reject it — short-circuit so a different validator
+			// can't accidentally admit the same request.
+			return nil, err
+		default:
+			// nil identity + nil error is a buggy validator. Treat it
+			// as "no credential here" rather than panicking — log-and-
+			// continue is more defensible than crashing on a bad plug-in.
+			continue
+		}
+	}
+	return nil, ErrNoCredential
+}

--- a/internal/facade/auth/chain_test.go
+++ b/internal/facade/auth/chain_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// stubValidator is a programmable Validator for chain tests. Each test
+// composes a chain by listing what each step should return.
+type stubValidator struct {
+	id   *policy.AuthenticatedIdentity
+	err  error
+	name string
+	// called records how many times Validate was invoked — lets us prove
+	// short-circuit semantics (no validator runs after a non-fall-through
+	// result).
+	called int
+}
+
+func (s *stubValidator) Validate(_ context.Context, _ *http.Request) (*policy.AuthenticatedIdentity, error) {
+	s.called++
+	return s.id, s.err
+}
+
+func newReq() *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/ws", nil)
+}
+
+func TestChainRun_EmptyChainReturnsErrNoCredential(t *testing.T) {
+	t.Parallel()
+	chain := auth.Chain{}
+	_, err := chain.Run(context.Background(), newReq())
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestChainRun_FirstValidatorAdmits(t *testing.T) {
+	t.Parallel()
+	wantID := &policy.AuthenticatedIdentity{Origin: policy.OriginSharedToken}
+	first := &stubValidator{name: "shared", id: wantID}
+	second := &stubValidator{name: "mgmt", err: auth.ErrNoCredential}
+
+	chain := auth.Chain{first, second}
+	id, err := chain.Run(context.Background(), newReq())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if id != wantID {
+		t.Errorf("identity pointer mismatch: got %p, want %p", id, wantID)
+	}
+	if second.called != 0 {
+		t.Errorf("second validator should not run after first admits, called=%d", second.called)
+	}
+}
+
+func TestChainRun_FallsThroughOnNoCredential(t *testing.T) {
+	t.Parallel()
+	wantID := &policy.AuthenticatedIdentity{Origin: policy.OriginManagementPlane}
+	first := &stubValidator{name: "shared", err: auth.ErrNoCredential}
+	second := &stubValidator{name: "mgmt", id: wantID}
+
+	chain := auth.Chain{first, second}
+	id, err := chain.Run(context.Background(), newReq())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if id != wantID {
+		t.Errorf("expected fall-through to second validator, got %v", id)
+	}
+	if first.called != 1 || second.called != 1 {
+		t.Errorf("call counts: first=%d second=%d, want 1 1", first.called, second.called)
+	}
+}
+
+func TestChainRun_AllFallThroughReturnsErrNoCredential(t *testing.T) {
+	t.Parallel()
+	first := &stubValidator{err: auth.ErrNoCredential}
+	second := &stubValidator{err: auth.ErrNoCredential}
+
+	chain := auth.Chain{first, second}
+	_, err := chain.Run(context.Background(), newReq())
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestChainRun_InvalidCredentialShortCircuits(t *testing.T) {
+	// A validator returning ErrInvalidCredential means "I recognise this
+	// credential style and reject it" — falling through to a downstream
+	// validator that might admit the same request would be a security
+	// hole (an OIDC token rejected for wrong issuer can't suddenly admit
+	// via shared-token comparison).
+	t.Parallel()
+	first := &stubValidator{err: auth.ErrInvalidCredential}
+	second := &stubValidator{id: &policy.AuthenticatedIdentity{Origin: "would-admit-incorrectly"}}
+
+	chain := auth.Chain{first, second}
+	_, err := chain.Run(context.Background(), newReq())
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+	if second.called != 0 {
+		t.Error("second validator must not run after ErrInvalidCredential")
+	}
+}
+
+func TestChainRun_ExpiredShortCircuits(t *testing.T) {
+	t.Parallel()
+	first := &stubValidator{err: auth.ErrExpired}
+	second := &stubValidator{id: &policy.AuthenticatedIdentity{Origin: "later-validator"}}
+
+	chain := auth.Chain{first, second}
+	_, err := chain.Run(context.Background(), newReq())
+	if !errors.Is(err, auth.ErrExpired) {
+		t.Errorf("err = %v, want ErrExpired", err)
+	}
+	if second.called != 0 {
+		t.Error("second validator must not run after ErrExpired")
+	}
+}
+
+func TestChainRun_UnknownErrorShortCircuits(t *testing.T) {
+	// An unexpected runtime error (e.g., k8s informer not yet primed)
+	// shouldn't accidentally admit via a downstream validator either.
+	t.Parallel()
+	custom := errors.New("informer not synced yet")
+	first := &stubValidator{err: custom}
+	second := &stubValidator{id: &policy.AuthenticatedIdentity{Origin: "later-validator"}}
+
+	chain := auth.Chain{first, second}
+	_, err := chain.Run(context.Background(), newReq())
+	if !errors.Is(err, custom) {
+		t.Errorf("err = %v, want %v", err, custom)
+	}
+	if second.called != 0 {
+		t.Error("second validator must not run after unknown error")
+	}
+}
+
+func TestChainRun_NilIdentityNilErrTreatedAsNoCredential(t *testing.T) {
+	// Defensive: a buggy validator returning (nil, nil) should not crash
+	// or short-circuit — log-and-continue is the safer default.
+	t.Parallel()
+	wantID := &policy.AuthenticatedIdentity{Origin: policy.OriginSharedToken}
+	first := &stubValidator{} // nil id, nil err
+	second := &stubValidator{id: wantID}
+
+	chain := auth.Chain{first, second}
+	id, err := chain.Run(context.Background(), newReq())
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if id != wantID {
+		t.Errorf("expected fall-through past buggy validator")
+	}
+}

--- a/internal/facade/auth/shared_token.go
+++ b/internal/facade/auth/shared_token.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"net/http"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// EndUserHeader is the inbound HTTP header callers MAY set to identify the
+// end-user on whose behalf they're acting. Honoured by the sharedToken /
+// apiKeys validators only when their `trustEndUserHeader` flag is true on
+// the AgentRuntime CRD; the default is to ignore it (Identity.EndUser
+// equals Identity.Subject in that case). Documented in
+// docs/local-backlog/2026-04-21-agent-facade-auth-design.md.
+const EndUserHeader = "X-End-User-Id"
+
+// DefaultSharedTokenSubject is the Subject claim emitted on Identity when
+// no override is configured. Single-bearer tokens have no built-in caller
+// identity — the placeholder here flags that fact to ToolPolicy and
+// audit consumers that compare on `identity.subject`.
+const DefaultSharedTokenSubject = "shared-token-holder"
+
+// SharedTokenValidator implements Validator for the simplest data-plane
+// auth pattern: a single bearer token shared across every caller of an
+// agent. The token is loaded once at facade startup from the Secret
+// referenced by spec.externalAuth.sharedToken.secretRef and constant-time
+// compared against the bearer payload on each request.
+type SharedTokenValidator struct {
+	tokenHash          []byte
+	subject            string
+	role               string
+	trustEndUserHeader bool
+}
+
+// SharedTokenOption tunes a SharedTokenValidator. All optional.
+type SharedTokenOption func(*SharedTokenValidator)
+
+// WithSharedTokenSubject overrides the Identity.Subject value the
+// validator emits on admit. Defaults to DefaultSharedTokenSubject.
+func WithSharedTokenSubject(sub string) SharedTokenOption {
+	return func(v *SharedTokenValidator) { v.subject = sub }
+}
+
+// WithSharedTokenRole overrides the Identity.Role value. Defaults to
+// policy.RoleEditor (a sensible middle-ground — sharedToken can't tell
+// callers apart, so admin would be too permissive and viewer too narrow).
+func WithSharedTokenRole(role string) SharedTokenOption {
+	return func(v *SharedTokenValidator) { v.role = role }
+}
+
+// WithSharedTokenTrustEndUserHeader makes the validator honour
+// X-End-User-Id from the inbound request when populating Identity.EndUser.
+// Off by default — when off, EndUser == Subject. Turning this on is a
+// trust statement: the calling app can spoof arbitrary end-users with a
+// valid token, so ToolPolicy rules gating on identity.endUser must be
+// paired with an app-level trust assessment (per the design doc).
+func WithSharedTokenTrustEndUserHeader(trust bool) SharedTokenOption {
+	return func(v *SharedTokenValidator) { v.trustEndUserHeader = trust }
+}
+
+// NewSharedTokenValidator constructs a validator that admits requests
+// presenting the supplied bearer value. Returns an error if the token
+// is empty — empty-string credentials are silently always-pass with
+// constant-time compare semantics, which would be a catastrophic
+// misconfig. We refuse to construct rather than ship that.
+func NewSharedTokenValidator(token string, opts ...SharedTokenOption) (*SharedTokenValidator, error) {
+	if token == "" {
+		return nil, errors.New("auth: sharedToken value is empty — refusing to construct an always-admit validator")
+	}
+	v := &SharedTokenValidator{
+		// Materialised as a byte slice so we can pass directly to
+		// subtle.ConstantTimeCompare without per-request allocation.
+		tokenHash: []byte(token),
+		subject:   DefaultSharedTokenSubject,
+		role:      policy.RoleEditor,
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v, nil
+}
+
+// Validate implements Validator. It returns ErrNoCredential when no
+// Bearer header is present so the chain can fall through; ErrInvalidCredential
+// when a Bearer header is present but the token does not match.
+func (v *SharedTokenValidator) Validate(_ context.Context, r *http.Request) (*policy.AuthenticatedIdentity, error) {
+	tokenString, err := extractBearer(r)
+	if err != nil {
+		return nil, err
+	}
+	// Length-mismatch short-circuit can leak length in microbenchmarks.
+	// subtle.ConstantTimeCompare already returns 0 when lengths differ
+	// without revealing which one is longer — let it handle the check.
+	if subtle.ConstantTimeCompare([]byte(tokenString), v.tokenHash) != 1 {
+		return nil, ErrInvalidCredential
+	}
+
+	endUser := v.subject
+	if v.trustEndUserHeader {
+		if h := r.Header.Get(EndUserHeader); h != "" {
+			endUser = h
+		}
+	}
+
+	return &policy.AuthenticatedIdentity{
+		Origin:  policy.OriginSharedToken,
+		Subject: v.subject,
+		EndUser: endUser,
+		Role:    v.role,
+	}, nil
+}

--- a/internal/facade/auth/shared_token_test.go
+++ b/internal/facade/auth/shared_token_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+const validToken = "supersecret-bearer-token"
+
+func newRequestWithBearer(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+func TestNewSharedTokenValidator_RejectsEmptyToken(t *testing.T) {
+	t.Parallel()
+	// An empty configured token would constant-time-equal an empty bearer
+	// presented by an attacker, silently always-admitting. Refuse to
+	// construct rather than allow this footgun.
+	if _, err := auth.NewSharedTokenValidator(""); err == nil {
+		t.Error("expected error from NewSharedTokenValidator(\"\")")
+	}
+}
+
+func TestSharedTokenValidator_AdmitsCorrectToken(t *testing.T) {
+	t.Parallel()
+	v, err := auth.NewSharedTokenValidator(validToken)
+	if err != nil {
+		t.Fatalf("construct: %v", err)
+	}
+	id, err := v.Validate(context.Background(), newRequestWithBearer(validToken))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id == nil {
+		t.Fatal("nil identity on admit")
+	}
+	if got, want := id.Origin, policy.OriginSharedToken; got != want {
+		t.Errorf("Origin = %q, want %q", got, want)
+	}
+	if got, want := id.Role, policy.RoleEditor; got != want {
+		t.Errorf("Role = %q, want %q (default)", got, want)
+	}
+	if got, want := id.Subject, auth.DefaultSharedTokenSubject; got != want {
+		t.Errorf("Subject = %q, want %q (default)", got, want)
+	}
+	if got, want := id.EndUser, id.Subject; got != want {
+		t.Errorf("EndUser = %q, want %q (no trustEndUserHeader → equals Subject)", got, want)
+	}
+}
+
+func TestSharedTokenValidator_RejectsWrongToken(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(validToken)
+	_, err := v.Validate(context.Background(), newRequestWithBearer("other-token"))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestSharedTokenValidator_RejectsLengthMismatch(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(validToken)
+	// Different length should also be rejected without leaking which
+	// candidate is longer.
+	_, err := v.Validate(context.Background(), newRequestWithBearer("short"))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestSharedTokenValidator_NoBearerHeaderFallsThrough(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(validToken)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil) // no Authorization
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential (chain must fall through)", err)
+	}
+}
+
+func TestSharedTokenValidator_NonBearerSchemeFallsThrough(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(validToken)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("Authorization", "Basic dXNlcjpwYXNz")
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("non-Bearer scheme: err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestSharedTokenValidator_EmptyBearerRejected(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(validToken)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("Authorization", "Bearer ")
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("empty bearer: err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestSharedTokenValidator_TrustEndUserHeader(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(
+		validToken,
+		auth.WithSharedTokenTrustEndUserHeader(true),
+	)
+	r := newRequestWithBearer(validToken)
+	r.Header.Set(auth.EndUserHeader, "alice@example.com")
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got, want := id.EndUser, "alice@example.com"; got != want {
+		t.Errorf("EndUser = %q, want %q", got, want)
+	}
+	// Subject MUST stay the token-holder identifier — only EndUser shifts.
+	if id.Subject == id.EndUser {
+		t.Error("Subject should remain the token-holder when trustEndUserHeader is on, not equal EndUser")
+	}
+}
+
+func TestSharedTokenValidator_TrustEndUserHeaderDefaultsOff(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(validToken)
+	r := newRequestWithBearer(validToken)
+	r.Header.Set(auth.EndUserHeader, "alice@example.com") // ignored
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got, want := id.EndUser, id.Subject; got != want {
+		t.Errorf("EndUser = %q, want %q (header ignored when trust flag off)", got, want)
+	}
+}
+
+func TestSharedTokenValidator_OptionOverrides(t *testing.T) {
+	t.Parallel()
+	v, _ := auth.NewSharedTokenValidator(
+		validToken,
+		auth.WithSharedTokenSubject("custom-sub"),
+		auth.WithSharedTokenRole(policy.RoleAdmin),
+	)
+	id, err := v.Validate(context.Background(), newRequestWithBearer(validToken))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got, want := id.Subject, "custom-sub"; got != want {
+		t.Errorf("Subject override: got %q, want %q", got, want)
+	}
+	if got, want := id.Role, policy.RoleAdmin; got != want {
+		t.Errorf("Role override: got %q, want %q", got, want)
+	}
+}

--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -156,15 +156,18 @@ type Server struct {
 	recordingPool   *RecordingPool
 	allowedOrigins  []string
 	policyFetcher   PolicyFetcher
-	// mgmtPlaneValidator, when set, validates dashboard-minted
-	// management-plane JWTs on each upgrade request. On admit, the
-	// resulting identity flows into PropagationFields.Identity and the
-	// flat UserID/UserRoles/UserEmail fields. Nil means no mgmt-plane
-	// auth — the upgrade path is unauthenticated (the PR 1 default,
-	// preserving behaviour). Invalid/expired tokens always 401 regardless
-	// of this toggle.
-	mgmtPlaneValidator auth.Validator
-	log                logr.Logger
+	// authChain, when non-empty, runs every configured Validator against
+	// the upgrade request in order and admits on the first match. On
+	// admit the identity flows into PropagationFields.Identity and the
+	// flat UserID / UserRoles / UserEmail fields. Empty chain (or
+	// chain-wide ErrNoCredential) preserves the PR 1 unauthenticated
+	// upgrade default; invalid/expired credentials always 401.
+	//
+	// PR 1a/c shipped a single mgmtPlaneValidator field; PR 2b promotes
+	// it to a chain so the data-plane validators (sharedToken, apiKeys,
+	// oidc, edgeTrust) can stack with mgmt-plane behind them.
+	authChain auth.Chain
+	log       logr.Logger
 
 	mu           sync.RWMutex
 	connections  map[*websocket.Conn]*Connection
@@ -223,15 +226,32 @@ func WithPolicyFetcher(f PolicyFetcher) ServerOption {
 	}
 }
 
-// WithMgmtPlaneValidator configures the server to run the given auth
-// Validator for management-plane JWTs on every upgrade. Admit attaches the
-// validated identity to the connection's PropagationFields. Presentation of
-// an invalid/expired token is rejected with 401. Absence of any Authorization
-// header falls through to the existing unauthenticated upgrade path (PR 1
-// preserves behaviour — PR 3 flips this default to reject).
+// WithMgmtPlaneValidator configures the server to run a single mgmt-plane
+// Validator. Convenience wrapper around WithAuthChain — exists to keep
+// the PR 1a/c API stable while the wider chain machinery (PR 2b+) lands.
+//
+// Identical semantics to WithAuthChain(auth.Chain{v}): the validator
+// runs first; ErrNoCredential falls through to the unauthenticated
+// upgrade path (PR 1 default); invalid/expired returns 401. Combine with
+// WithAuthChain instead of this option once data-plane validators are in
+// the mix.
 func WithMgmtPlaneValidator(v auth.Validator) ServerOption {
+	return WithAuthChain(auth.Chain{v})
+}
+
+// WithAuthChain configures the server to run the supplied auth chain on
+// every upgrade. Admit attaches the resulting identity to the
+// connection's PropagationFields. ErrNoCredential (or empty chain)
+// preserves the PR 1 unauthenticated upgrade default; any other error
+// returns 401 before Upgrade.
+//
+// Validator order matters — the first validator that admits wins, so
+// list the most specific credential style first. The conventional order
+// shipped by cmd/agent is sharedToken → apiKeys → oidc → edgeTrust →
+// mgmt-plane.
+func WithAuthChain(chain auth.Chain) ServerOption {
 	return func(s *Server) {
-		s.mgmtPlaneValidator = v
+		s.authChain = chain
 	}
 }
 
@@ -349,15 +369,16 @@ func ParseAllowedOrigins(raw string) []string {
 }
 
 // authenticateRequest runs the configured auth chain against the request.
-// Returns the admitted identity (or nil when no validator is configured /
-// no credential was presented), or an error when a credential was presented
-// but rejected. A nil error with a nil identity means "fall through to the
-// existing unauthenticated upgrade path" — PR 1 preserves this for back-compat.
+// Returns the admitted identity (or nil when no chain is configured / no
+// credential was presented), or an error when a credential was presented
+// but rejected. A nil error with a nil identity means "fall through to
+// the existing unauthenticated upgrade path" — PR 1 preserves this for
+// back-compat; PR 3 will flip the default at this layer.
 func (s *Server) authenticateRequest(r *http.Request) (*policy.AuthenticatedIdentity, error) {
-	if s.mgmtPlaneValidator == nil {
+	if len(s.authChain) == 0 {
 		return nil, nil
 	}
-	id, err := s.mgmtPlaneValidator.Validate(r.Context(), r)
+	id, err := s.authChain.Run(r.Context(), r)
 	switch {
 	case err == nil:
 		return id, nil

--- a/internal/facade/server_auth_test.go
+++ b/internal/facade/server_auth_test.go
@@ -241,3 +241,73 @@ func TestServerAuth_NonBearerScheme_FallsThrough(t *testing.T) {
 	defer func() { _ = ws.Close() }()
 	readConnected(t, ws)
 }
+
+// TestServerAuth_SharedTokenChain_AdmitsBeforeMgmtPlane proves that PR
+// 2b's chain wiring works end-to-end through the facade — a sharedToken
+// validator placed before the mgmt-plane validator admits a presented-
+// bearer request and tags the identity with origin=shared-token.
+func TestServerAuth_SharedTokenChain_AdmitsBeforeMgmtPlane(t *testing.T) {
+	mgmt, _ := newAuthTestValidator(t)
+	const sharedToken = "shared-bearer-value"
+	stv, err := auth.NewSharedTokenValidator(sharedToken)
+	require.NoError(t, err)
+	chain := auth.Chain{stv, mgmt}
+
+	observed := make(chan policy.PropagationFields, 1)
+	handler := &mockHandler{
+		handleFunc: func(ctx context.Context, _ string, msg *ClientMessage, w ResponseWriter) error {
+			select {
+			case observed <- policy.ExtractPropagationFields(ctx):
+			default:
+			}
+			return w.WriteDone("echo: " + msg.Content)
+		},
+	}
+	store := session.NewMemoryStore()
+	cfg := DefaultServerConfig()
+	cfg.PingInterval = 100 * time.Millisecond
+	cfg.PongTimeout = 200 * time.Millisecond
+	server := NewServer(cfg, store, handler, logr.Discard(), WithAuthChain(chain))
+	ts := httptest.NewServer(server)
+	t.Cleanup(func() { ts.Close(); _ = store.Close() })
+
+	header := http.Header{"Authorization": []string{"Bearer " + sharedToken}}
+	ws, _, err := dialWS(t, ts, header)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close() }()
+	readConnected(t, ws)
+	require.NoError(t, ws.WriteJSON(ClientMessage{Type: "user_message", Content: "hi"}))
+
+	select {
+	case fields := <-observed:
+		require.NotNil(t, fields.Identity)
+		assert.Equal(t, policy.OriginSharedToken, fields.Identity.Origin,
+			"sharedToken must win over mgmt-plane when both could admit")
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not run")
+	}
+}
+
+// TestServerAuth_SharedTokenChain_RejectsWrongToken proves that a
+// presented bearer that fails the sharedToken compare short-circuits
+// the chain — we must NOT fall through to mgmt-plane and accidentally
+// admit a data-plane token via a different validator.
+func TestServerAuth_SharedTokenChain_RejectsWrongToken(t *testing.T) {
+	mgmt, _ := newAuthTestValidator(t)
+	stv, err := auth.NewSharedTokenValidator("expected-token")
+	require.NoError(t, err)
+	chain := auth.Chain{stv, mgmt}
+
+	cfg := DefaultServerConfig()
+	store := session.NewMemoryStore()
+	server := NewServer(cfg, store, &mockHandler{}, logr.Discard(), WithAuthChain(chain))
+	ts := httptest.NewServer(server)
+	t.Cleanup(func() { ts.Close(); _ = store.Close() })
+
+	header := http.Header{"Authorization": []string{"Bearer wrong-token"}}
+	_, resp, err := dialWS(t, ts, header)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"sharedToken's ErrInvalidCredential must reject; mgmt-plane must NOT be reached")
+}


### PR DESCRIPTION
## Summary

Wires up the first data-plane validator and the chain machinery the rest of the PR 2 series will plug into. After this PR an admin can drop a `spec.externalAuth.sharedToken.secretRef` on an AgentRuntime, the facade reads the referenced Secret at startup, and external callers presenting that token get admitted with `identity.origin == "shared-token"` ahead of the mgmt-plane validator.

Behaviour-preserving for any operator who hasn't set `spec.externalAuth` — the chain stays empty and the unauthenticated upgrade path runs as before. PR 3 flips that default.

## What this ships

| File | Role |
|---|---|
| `internal/facade/auth/chain.go` | `Chain []Validator` with `Run(ctx, r)` — first non-nil identity wins; `ErrNoCredential` continues; any other error short-circuits so a downstream validator can't accidentally admit a rejected credential. Empty chain → `ErrNoCredential`. |
| `internal/facade/auth/shared_token.go` | Constant-time bearer compare via `crypto/subtle`. Refuses to construct from an empty string (would silently always-admit). Subject/role configurable; `trustEndUserHeader` opt-in. |
| `internal/facade/server.go` | Replaces the single-validator field with `authChain auth.Chain`. `WithMgmtPlaneValidator` stays as a back-compat wrapper around `WithAuthChain(Chain{v})` — PR 1c integration tests still pass unchanged. |
| `internal/controller/agentruntime_controller.go` | Calls `projectLegacyA2AAuth(ar)` early in Reconcile so the deprecated `spec.a2a.authentication.secretRef` shape is treated by downstream code as if the operator had configured `spec.externalAuth.sharedToken` directly. |
| `cmd/agent/auth_chain.go` | `buildAuthChain` reads the AgentRuntime CR + the referenced Secret at facade startup and returns `Chain{sharedToken (if configured), mgmt-plane (if loaded)}`. Loading errors are fatal — silent downgrade to no-auth would mask operator misconfig. |
| `cmd/agent/websocket.go` | Replaces the inline mgmt-plane wiring with `buildAuthChain` + the new `WithAuthChain` server option. |

## Test plan

- [x] `internal/facade/auth/shared_token_test.go` — **10 unit tests**: admit / wrong-token / length-mismatch / no-bearer / non-Bearer / empty-bearer / `trustEndUserHeader` on+off / subject+role overrides / empty-token constructor refusal.
- [x] `internal/facade/auth/chain_test.go` — **8 unit tests**: empty / first-admits / fall-through / all-fall-through / `ErrInvalidCredential` short-circuit / `ErrExpired` short-circuit / unknown-error short-circuit / nil-id-nil-err defensive fall-through.
- [x] `cmd/agent/auth_chain_test.go` — **7 unit tests**: nil k8s client / not-found agent fallback / unset `externalAuth` / sharedToken happy-path / missing Secret / missing token data key / `trustEndUserHeader` propagation.
- [x] `internal/facade/server_auth_test.go` — **2 end-to-end integration tests** wiring the chain through `facade.Server`: sharedToken admits before mgmt-plane (origin tag is correct), wrong-token short-circuits without falling through to mgmt-plane.
- [x] `golangci-lint run` clean on all changed packages.
- [x] Full `go test ./internal/controller/... ./internal/facade/... ./cmd/agent/... ./api/v1alpha1/... ./pkg/policy/...` green locally (envtest passes).
- [ ] CI quality gate (SonarCloud).
- [ ] Tilt smoke: AgentRuntime with `spec.externalAuth.sharedToken.secretRef` → facade pod accepts the matching Bearer; rejects wrong tokens; mgmt-plane debug view still works.

## Behaviour preservation

- `spec.externalAuth` unset → chain empty → unauth upgrade still proceeds (PR 1 default unchanged).
- `spec.externalAuth.sharedToken` set + valid Bearer → admits, `identity.origin = "shared-token"`.
- `spec.externalAuth.sharedToken` set + wrong Bearer → 401 (does not fall through to mgmt-plane).
- `spec.a2a.authentication.secretRef` (legacy) set, `spec.externalAuth` unset → projection shim folds the legacy SecretRef into `spec.externalAuth.sharedToken`; existing A2A configs migrate automatically with no operator action.
- Mgmt-plane validator stays in the chain after sharedToken when both are configured — dashboard "Try this agent" debug flow keeps working.

## What does NOT land here

- `apiKeys`, `oidc`, `edgeTrust` validators (PRs 2c–2e).
- A2A handler middleware (PR 2f).
- Default flip from "unauth upgrade allowed" to "401" (PR 3).
- ToolPolicy CEL `identity` root (PR 4 — independent of 2*).