### PR TITLE
feat(facade): apiKeys validator + Secret-backed key store (PR 2c)

### DIFF
--- a/cmd/agent/api_keys.go
+++ b/cmd/agent/api_keys.go
@@ -1,0 +1,263 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+)
+
+// Secret labels + data keys for agent-scoped API keys. Mirrored on the
+// dashboard side when the CRUD UI lands; defined here so cmd/agent can
+// list-by-label without importing the controller package.
+const (
+	// LabelCredentialKind tags every agent-scoped credential Secret. Same
+	// label is used for sharedToken / oidc-jwks Secrets so a single
+	// list-by-label can find them all if needed later; we filter further
+	// by LabelCredentialKindValue.
+	LabelCredentialKind = "omnia.altairalabs.ai/credential-kind"
+	// LabelCredentialKindAgentAPIKey identifies the api-keys flavour.
+	LabelCredentialKindAgentAPIKey = "agent-api-key"
+	// LabelAgent narrows the list to keys for THIS agent only — many
+	// agents may share a namespace, but each pod must only see its own
+	// keys.
+	LabelAgent = "omnia.altairalabs.ai/agent"
+
+	// Data keys inside the API-key Secret. The hash and scope formats
+	// are stable contracts shared between the dashboard CRUD endpoint
+	// and the facade KeyStore.
+	APIKeyDataKeyHash      = "keyHash"
+	APIKeyDataKeyScopes    = "scopes"
+	APIKeyDataKeyExpiresAt = "expiresAt"
+)
+
+// apiKeySecretSuffix is the prefix the dashboard CRUD endpoint uses when
+// minting a new key Secret (`agent-<agent>-apikey-<id>`). The KeyStore
+// derives APIKey.ID from the suffix after the second `-apikey-`. Stable
+// and parsed by both sides, so the dashboard can list-by-label and link
+// the rendered key list back to the Secret.
+const apiKeySecretPrefix = "-apikey-"
+
+// apiKeyScopes is the JSON shape stored under data.scopes. Kept tight —
+// per-tool scopes land in a future iteration of the design.
+type apiKeyScopes struct {
+	Role string `json:"role,omitempty"`
+}
+
+// SecretBackedKeyStore is the cmd/agent implementation of
+// auth.KeyStore. It maintains an atomically-swapped map keyed by
+// hex(sha256(rawKey)) → APIKey, refreshed from the labelled Secrets in
+// the agent's namespace on a configurable interval.
+//
+// Refresh strategy: list-by-label (Get by selector), parse each Secret,
+// build a fresh map, swap atomically. Cheap enough at the expected per-
+// agent fan-out (tens of keys at most) that an informer's incremental
+// updates aren't worth the extra plumbing for PR 2c.
+type SecretBackedKeyStore struct {
+	client       client.Client
+	namespace    string
+	agentName    string
+	refresh      time.Duration
+	log          logr.Logger
+	now          func() time.Time
+	mu           sync.RWMutex
+	keys         map[string]auth.APIKey
+	stopCh       chan struct{}
+	stopOnce     sync.Once
+	lastRefresh  time.Time
+	refreshError error
+}
+
+// SecretBackedKeyStoreOption tunes the store. All optional.
+type SecretBackedKeyStoreOption func(*SecretBackedKeyStore)
+
+// WithKeyStoreRefreshInterval sets how often the store re-lists matching
+// Secrets. Defaults to 30 seconds — fast enough to feel responsive when
+// an admin revokes a key in the dashboard, slow enough to keep API
+// pressure low at scale.
+func WithKeyStoreRefreshInterval(d time.Duration) SecretBackedKeyStoreOption {
+	return func(s *SecretBackedKeyStore) { s.refresh = d }
+}
+
+// WithKeyStoreClock injects a clock for tests.
+func WithKeyStoreClock(now func() time.Time) SecretBackedKeyStoreOption {
+	return func(s *SecretBackedKeyStore) { s.now = now }
+}
+
+// NewSecretBackedKeyStore loads the initial key set synchronously, then
+// returns a store that periodically re-lists in the background. Returns
+// an error on the initial load failure (operator misconfig surfaces at
+// pod startup); a periodic refresh failure later only logs and keeps
+// the previous snapshot.
+func NewSecretBackedKeyStore(
+	ctx context.Context,
+	c client.Client,
+	namespace, agentName string,
+	log logr.Logger,
+	opts ...SecretBackedKeyStoreOption,
+) (*SecretBackedKeyStore, error) {
+	s := &SecretBackedKeyStore{
+		client:    c,
+		namespace: namespace,
+		agentName: agentName,
+		refresh:   30 * time.Second,
+		log:       log.WithName("apikey-store"),
+		now:       time.Now,
+		stopCh:    make(chan struct{}),
+		keys:      map[string]auth.APIKey{},
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if err := s.loadOnce(ctx); err != nil {
+		return nil, fmt.Errorf("initial api-key load: %w", err)
+	}
+	go s.refreshLoop()
+	return s, nil
+}
+
+// Lookup implements auth.KeyStore.
+func (s *SecretBackedKeyStore) Lookup(hashHex string) (auth.APIKey, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	k, ok := s.keys[hashHex]
+	return k, ok
+}
+
+// Stop ends the background refresh loop. Safe to call more than once.
+func (s *SecretBackedKeyStore) Stop() {
+	s.stopOnce.Do(func() { close(s.stopCh) })
+}
+
+// loadOnce performs a single list-and-parse cycle, atomically replacing
+// the in-memory key set on success. Surface-area inputs for the tests.
+func (s *SecretBackedKeyStore) loadOnce(ctx context.Context) error {
+	list := &corev1.SecretList{}
+	err := s.client.List(ctx, list,
+		client.InNamespace(s.namespace),
+		client.MatchingLabels{
+			LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+			LabelAgent:          s.agentName,
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("list api-key secrets: %w", err)
+	}
+
+	next := make(map[string]auth.APIKey, len(list.Items))
+	for i := range list.Items {
+		secret := &list.Items[i]
+		key, err := parseAPIKeySecret(secret)
+		if err != nil {
+			s.log.V(1).Info("skipping malformed api-key secret",
+				"secret", secret.Name, "reason", err.Error())
+			continue
+		}
+		next[key.HashHex] = key
+	}
+
+	s.mu.Lock()
+	s.keys = next
+	s.lastRefresh = s.now()
+	s.refreshError = nil
+	s.mu.Unlock()
+	s.log.V(1).Info("api-key store refreshed", "count", len(next))
+	return nil
+}
+
+// refreshLoop runs until Stop. Refresh failures log and keep the
+// previous snapshot — better to serve a slightly-stale key set than
+// reject every request because the API server hiccupped.
+func (s *SecretBackedKeyStore) refreshLoop() {
+	ticker := time.NewTicker(s.refresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := s.loadOnce(ctx); err != nil {
+				s.mu.Lock()
+				s.refreshError = err
+				s.mu.Unlock()
+				s.log.Error(err, "api-key refresh failed; keeping previous snapshot")
+			}
+			cancel()
+		}
+	}
+}
+
+// parseAPIKeySecret converts a labelled Secret into an APIKey. Returns
+// an error (caller skips + logs) when required fields are missing or
+// malformed — never panics on bad input.
+func parseAPIKeySecret(secret *corev1.Secret) (auth.APIKey, error) {
+	if len(secret.Data) == 0 {
+		return auth.APIKey{}, fmt.Errorf("empty data")
+	}
+
+	hashRaw, ok := secret.Data[APIKeyDataKeyHash]
+	if !ok || len(hashRaw) == 0 {
+		return auth.APIKey{}, fmt.Errorf("missing %q data key", APIKeyDataKeyHash)
+	}
+	// The dashboard endpoint stores the binary sha256; we keep the in-
+	// memory representation as lowercase hex so APIKeyValidator's
+	// constant-time compare aligns with HashToken's output.
+	hashHex := hex.EncodeToString(hashRaw)
+
+	id := strings.TrimPrefix(secret.Name, fmt.Sprintf("agent-%s%s",
+		secret.Labels[LabelAgent], apiKeySecretPrefix))
+	if id == secret.Name {
+		// Name didn't match the expected pattern — fall back to the full
+		// Secret name as a last resort. ToolPolicy can still distinguish
+		// callers by Identity.Subject.
+		id = secret.Name
+	}
+
+	key := auth.APIKey{
+		ID:      id,
+		HashHex: hashHex,
+	}
+
+	if scopesRaw, ok := secret.Data[APIKeyDataKeyScopes]; ok && len(scopesRaw) > 0 {
+		var scopes apiKeyScopes
+		if err := json.Unmarshal(scopesRaw, &scopes); err != nil {
+			return auth.APIKey{}, fmt.Errorf("parse scopes: %w", err)
+		}
+		key.Role = scopes.Role
+	}
+
+	if expRaw, ok := secret.Data[APIKeyDataKeyExpiresAt]; ok && len(expRaw) > 0 {
+		t, err := time.Parse(time.RFC3339, string(expRaw))
+		if err != nil {
+			return auth.APIKey{}, fmt.Errorf("parse expiresAt: %w", err)
+		}
+		key.ExpiresAt = t
+	}
+	return key, nil
+}

--- a/cmd/agent/api_keys_test.go
+++ b/cmd/agent/api_keys_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+)
+
+const testRawKey = "omk_some_random_value"
+
+func sha256Bytes(s string) []byte {
+	sum := sha256.Sum256([]byte(s))
+	return sum[:]
+}
+
+func newAPIKeySecret(name, agent string, hash []byte, role string, expiresAt string) *corev1.Secret {
+	data := map[string][]byte{
+		APIKeyDataKeyHash: hash,
+	}
+	if role != "" {
+		data[APIKeyDataKeyScopes] = []byte(`{"role":"` + role + `"}`)
+	}
+	if expiresAt != "" {
+		data[APIKeyDataKeyExpiresAt] = []byte(expiresAt)
+	}
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "ns",
+			Labels: map[string]string{
+				LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+				LabelAgent:          agent,
+			},
+		},
+		Data: data,
+	}
+}
+
+func TestSecretBackedKeyStore_LoadsMatchingSecrets(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	hash := sha256Bytes(testRawKey)
+	secret := newAPIKeySecret("agent-myagent-apikey-001", "myagent", hash, "editor", "")
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	hashHex := auth.HashToken(testRawKey)
+	key, ok := store.Lookup(hashHex)
+	if !ok {
+		t.Fatalf("expected key in store, available hashes were not exposed")
+	}
+	if got, want := key.ID, "001"; got != want {
+		t.Errorf("ID = %q, want %q", got, want)
+	}
+	if got, want := key.Role, "editor"; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+}
+
+func TestSecretBackedKeyStore_FiltersOtherAgents(t *testing.T) {
+	// A Secret with the right credential-kind label but a DIFFERENT
+	// agent label must not appear in this agent's store — the per-agent
+	// isolation is the whole point of the label scheme.
+	t.Parallel()
+	scheme := newTestScheme(t)
+	hash := sha256Bytes(testRawKey)
+	other := newAPIKeySecret("agent-other-apikey-001", "other-agent", hash, "editor", "")
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(other).Build()
+
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(auth.HashToken(testRawKey)); ok {
+		t.Error("expected miss — Secret belongs to a different agent")
+	}
+}
+
+func TestSecretBackedKeyStore_FiltersOtherCredentialKinds(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	hash := sha256Bytes(testRawKey)
+	wrong := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-myagent-apikey-001",
+			Namespace: "ns",
+			Labels: map[string]string{
+				LabelCredentialKind: "agent-shared-token", // wrong kind
+				LabelAgent:          "myagent",
+			},
+		},
+		Data: map[string][]byte{APIKeyDataKeyHash: hash},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(wrong).Build()
+
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(auth.HashToken(testRawKey)); ok {
+		t.Error("expected miss — Secret has wrong credential-kind")
+	}
+}
+
+func TestSecretBackedKeyStore_ParsesExpiry(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	hash := sha256Bytes(testRawKey)
+	expires := "2030-12-31T23:59:59Z"
+	secret := newAPIKeySecret("agent-myagent-apikey-x", "myagent", hash, "viewer", expires)
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	key, ok := store.Lookup(auth.HashToken(testRawKey))
+	if !ok {
+		t.Fatal("expected key present")
+	}
+	want := time.Date(2030, time.December, 31, 23, 59, 59, 0, time.UTC)
+	if !key.ExpiresAt.Equal(want) {
+		t.Errorf("ExpiresAt = %v, want %v", key.ExpiresAt, want)
+	}
+}
+
+func TestSecretBackedKeyStore_SkipsMalformedSecrets(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	good := newAPIKeySecret("agent-myagent-apikey-good", "myagent", sha256Bytes("good-key"), "editor", "")
+	missingHash := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-myagent-apikey-bad",
+			Namespace: "ns",
+			Labels: map[string]string{
+				LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+				LabelAgent:          "myagent",
+			},
+		},
+		Data: map[string][]byte{}, // missing keyHash
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(good, missingHash).Build()
+
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(auth.HashToken("good-key")); !ok {
+		t.Error("good key should still load alongside the malformed sibling")
+	}
+}
+
+func TestSecretBackedKeyStore_NoMatchingSecretsIsValid(t *testing.T) {
+	// An agent with apiKeys configured but no Secrets yet should still
+	// init successfully — operators may enable the feature before
+	// minting any keys via the dashboard.
+	t.Parallel()
+	scheme := newTestScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(auth.HashToken(testRawKey)); ok {
+		t.Error("empty store should miss every lookup")
+	}
+}
+
+func TestParseAPIKeySecret_MalformedScopesErrors(t *testing.T) {
+	t.Parallel()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agent-x-apikey-y",
+			Labels: map[string]string{
+				LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+				LabelAgent:          "x",
+			},
+		},
+		Data: map[string][]byte{
+			APIKeyDataKeyHash:   sha256Bytes("k"),
+			APIKeyDataKeyScopes: []byte("not-json"),
+		},
+	}
+	if _, err := parseAPIKeySecret(secret); err == nil {
+		t.Error("expected error on malformed scopes JSON")
+	}
+}
+
+func TestParseAPIKeySecret_MalformedExpiresAtErrors(t *testing.T) {
+	t.Parallel()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agent-x-apikey-y",
+			Labels: map[string]string{
+				LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+				LabelAgent:          "x",
+			},
+		},
+		Data: map[string][]byte{
+			APIKeyDataKeyHash:      sha256Bytes("k"),
+			APIKeyDataKeyExpiresAt: []byte("yesterday"),
+		},
+	}
+	if _, err := parseAPIKeySecret(secret); err == nil {
+		t.Error("expected error on malformed expiresAt")
+	}
+}

--- a/cmd/agent/api_keys_test.go
+++ b/cmd/agent/api_keys_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/altairalabs/omnia/internal/facade/auth"
@@ -209,6 +210,88 @@ func TestSecretBackedKeyStore_NoMatchingSecretsIsValid(t *testing.T) {
 
 	if _, ok := store.Lookup(auth.HashToken(testRawKey)); ok {
 		t.Error("empty store should miss every lookup")
+	}
+}
+
+func TestParseAPIKeySecret_EmptyDataErrors(t *testing.T) {
+	t.Parallel()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "agent-x-apikey-y",
+			Labels: map[string]string{
+				LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+				LabelAgent:          "x",
+			},
+		},
+		// No Data at all — should reject rather than panic.
+	}
+	if _, err := parseAPIKeySecret(secret); err == nil {
+		t.Error("expected error on empty secret data")
+	}
+}
+
+func TestParseAPIKeySecret_NameNotMatchingPatternFallsBackToFullName(t *testing.T) {
+	// A hand-edited Secret without the expected `agent-<agent>-apikey-<id>`
+	// prefix should still load — its ID falls back to the full Secret name
+	// so ToolPolicy can still distinguish callers by identity.subject.
+	t.Parallel()
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "custom-key-naming",
+			Labels: map[string]string{
+				LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+				LabelAgent:          "x",
+			},
+		},
+		Data: map[string][]byte{APIKeyDataKeyHash: sha256Bytes("k")},
+	}
+	key, err := parseAPIKeySecret(secret)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if got, want := key.ID, "custom-key-naming"; got != want {
+		t.Errorf("ID = %q, want %q (fallback to full Secret name)", got, want)
+	}
+}
+
+func TestNewSecretBackedKeyStore_InitialLoadListErrorPropagates(t *testing.T) {
+	// Construct a client without Secret kind registered so List errors.
+	// The initial-load failure should propagate as a fatal error, not
+	// silently fall through.
+	t.Parallel()
+	emptyScheme := runtime.NewScheme()
+	fc := fake.NewClientBuilder().WithScheme(emptyScheme).Build()
+
+	_, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "a", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err == nil {
+		t.Error("expected error when the scheme lacks Secret kind")
+	}
+}
+
+func TestSecretBackedKeyStore_ClockOption(t *testing.T) {
+	// WithKeyStoreClock is plumbed through NewSecretBackedKeyStore; the
+	// test asserts the option takes effect by observing the recorded
+	// lastRefresh timestamp after loadOnce completes.
+	t.Parallel()
+	scheme := newTestScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	fixed := time.Date(2026, time.May, 1, 12, 0, 0, 0, time.UTC)
+
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "a", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour),
+		WithKeyStoreClock(func() time.Time { return fixed }),
+	)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	store.mu.RLock()
+	got := store.lastRefresh
+	store.mu.RUnlock()
+	if !got.Equal(fixed) {
+		t.Errorf("lastRefresh = %v, want %v (clock injection should drive the timestamp)", got, fixed)
 	}
 }
 

--- a/cmd/agent/auth_chain.go
+++ b/cmd/agent/auth_chain.go
@@ -118,8 +118,48 @@ func buildDataPlaneValidators(
 	} else if v != nil {
 		out = append(out, v)
 	}
-	// Future PRs append apiKeys (2c), oidc (2d), edgeTrust (2e) here.
+	if v, err := buildAPIKeyValidator(ctx, k8s, log, ar); err != nil {
+		return nil, err
+	} else if v != nil {
+		out = append(out, v)
+	}
+	// Future PRs append oidc (2d), edgeTrust (2e) here.
 	return out, nil
+}
+
+// buildAPIKeyValidator constructs the api-key validator when
+// spec.externalAuth.apiKeys is set. Returns nil when not configured.
+// The KeyStore lifetime is tied to the validator's — it leaks for the
+// life of the process; that's fine because the facade only constructs
+// the chain once at startup.
+func buildAPIKeyValidator(
+	ctx context.Context,
+	k8s client.Client,
+	log logr.Logger,
+	ar *omniav1alpha1.AgentRuntime,
+) (auth.Validator, error) {
+	ak := ar.Spec.ExternalAuth.APIKeys
+	if ak == nil {
+		return nil, nil
+	}
+
+	store, err := NewSecretBackedKeyStore(ctx, k8s, ar.Namespace, ar.Name, log)
+	if err != nil {
+		return nil, fmt.Errorf("init api-key store: %w", err)
+	}
+
+	opts := []auth.APIKeyOption{}
+	if ak.DefaultRole != "" {
+		opts = append(opts, auth.WithAPIKeyDefaultRole(ak.DefaultRole))
+	}
+	if ak.TrustEndUserHeader {
+		opts = append(opts, auth.WithAPIKeyTrustEndUserHeader(true))
+	}
+	v := auth.NewAPIKeyValidator(store, opts...)
+	log.Info("api-key validator enabled",
+		"defaultRole", ak.DefaultRole,
+		"trustEndUserHeader", ak.TrustEndUserHeader)
+	return v, nil
 }
 
 // buildSharedTokenValidator resolves spec.externalAuth.sharedToken into

--- a/internal/facade/auth/api_key.go
+++ b/internal/facade/auth/api_key.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"net/http"
+	"time"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// APIKey is the in-memory representation of a single agent API key. The
+// value is a sha256 hash of the raw bearer token; the validator never
+// stores the raw value. Built by cmd/agent's KeyStore from the labelled
+// Secret data; defined here so the validator can be unit-tested against
+// a synthetic []APIKey slice.
+type APIKey struct {
+	// ID is a stable identifier for the key (the Secret name's suffix
+	// after `agent-<agent>-apikey-`). Surfaces as Identity.Subject so
+	// audit and ToolPolicy rules can distinguish callers.
+	ID string
+
+	// HashHex is the lowercase-hex sha256 of the raw token bytes. The
+	// validator compares the hex representation of the incoming token's
+	// hash against this with a constant-time compare.
+	HashHex string
+
+	// Role is the caller's role for this key. One of policy.RoleAdmin /
+	// policy.RoleEditor / policy.RoleViewer. Falls back to APIKeysAuth's
+	// defaultRole at the cmd/agent layer if unset on the Secret.
+	Role string
+
+	// ExpiresAt is the absolute time after which the key is no longer
+	// valid. Zero value means "no expiry" — the operator opts in by
+	// setting an expiresAt field on the Secret.
+	ExpiresAt time.Time
+}
+
+// KeyStore is the lookup interface APIKeyValidator depends on. cmd/agent
+// supplies a Secret-backed implementation; tests can swap in a
+// hand-built map. Lookup by hex sha256 is O(1) — the common case after
+// a token presents.
+type KeyStore interface {
+	// Lookup returns the APIKey matching the supplied hex sha256, or
+	// (zero, false) if none. Implementations are expected to be safe
+	// for concurrent use.
+	Lookup(hashHex string) (APIKey, bool)
+}
+
+// APIKeyValidator implements Validator for the per-caller API key
+// pattern: each key is a Secret in the agent's namespace; the facade
+// hashes the incoming bearer and looks the hash up in a KeyStore. Hash
+// comparison is constant-time even though we're comparing hex strings —
+// timing attacks against hex compares are practical.
+type APIKeyValidator struct {
+	store              KeyStore
+	defaultRole        string
+	trustEndUserHeader bool
+	now                func() time.Time // injectable for tests; defaults to time.Now
+}
+
+// APIKeyOption tunes an APIKeyValidator.
+type APIKeyOption func(*APIKeyValidator)
+
+// WithAPIKeyDefaultRole sets the role applied to keys whose Secret data
+// does not carry one. Mirrors the CRD's APIKeysAuth.defaultRole field.
+func WithAPIKeyDefaultRole(role string) APIKeyOption {
+	return func(v *APIKeyValidator) { v.defaultRole = role }
+}
+
+// WithAPIKeyTrustEndUserHeader honours X-End-User-Id when populating
+// Identity.EndUser. Same security trade-off as sharedToken — see the
+// design doc.
+func WithAPIKeyTrustEndUserHeader(trust bool) APIKeyOption {
+	return func(v *APIKeyValidator) { v.trustEndUserHeader = trust }
+}
+
+// WithAPIKeyClock injects a clock for expiry tests.
+func WithAPIKeyClock(now func() time.Time) APIKeyOption {
+	return func(v *APIKeyValidator) { v.now = now }
+}
+
+// NewAPIKeyValidator constructs a validator backed by the supplied
+// KeyStore.
+func NewAPIKeyValidator(store KeyStore, opts ...APIKeyOption) *APIKeyValidator {
+	v := &APIKeyValidator{
+		store:       store,
+		defaultRole: policy.RoleViewer,
+		now:         time.Now,
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+// HashToken returns the lowercase-hex sha256 of a raw token. Exposed so
+// cmd/agent's KeyStore implementation can populate the cache from
+// Secret data using the same hash function the validator uses on the
+// inbound side.
+func HashToken(raw string) string {
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// Validate implements Validator. ErrNoCredential when no Bearer header;
+// ErrInvalidCredential when the hash isn't in the store; ErrExpired
+// when a matching key has lapsed.
+func (v *APIKeyValidator) Validate(_ context.Context, r *http.Request) (*policy.AuthenticatedIdentity, error) {
+	tokenString, err := extractBearer(r)
+	if err != nil {
+		return nil, err
+	}
+
+	candidate := HashToken(tokenString)
+	key, found := v.store.Lookup(candidate)
+	if !found {
+		return nil, ErrInvalidCredential
+	}
+	// Hash collisions on sha256 are not a thing in practice; the
+	// constant-time compare is defence-in-depth against any future
+	// store implementation that does prefix-matching or similar.
+	if subtle.ConstantTimeCompare([]byte(candidate), []byte(key.HashHex)) != 1 {
+		return nil, ErrInvalidCredential
+	}
+	if !key.ExpiresAt.IsZero() && !v.now().Before(key.ExpiresAt) {
+		return nil, ErrExpired
+	}
+
+	role := key.Role
+	if role == "" {
+		role = v.defaultRole
+	}
+
+	subject := key.ID
+	endUser := subject
+	if v.trustEndUserHeader {
+		if h := r.Header.Get(EndUserHeader); h != "" {
+			endUser = h
+		}
+	}
+
+	return &policy.AuthenticatedIdentity{
+		Origin:    policy.OriginAPIKey,
+		Subject:   subject,
+		EndUser:   endUser,
+		Role:      role,
+		ExpiresAt: key.ExpiresAt,
+	}, nil
+}
+
+// StaticKeyStore is the in-memory KeyStore — what cmd/agent constructs
+// after listing the agent's labelled Secrets, and what tests use
+// directly. Maps hex sha256 → APIKey; safe for concurrent reads (no
+// per-request mutation), but writers must replace the whole map atomically.
+type StaticKeyStore struct {
+	keys map[string]APIKey
+}
+
+// NewStaticKeyStore returns a KeyStore backed by the supplied map. The
+// caller passes ownership of the map — callers must not mutate it after
+// construction (use Replace on a future hot-reload-friendly impl).
+func NewStaticKeyStore(keys map[string]APIKey) *StaticKeyStore {
+	if keys == nil {
+		keys = map[string]APIKey{}
+	}
+	return &StaticKeyStore{keys: keys}
+}
+
+// Lookup implements KeyStore.
+func (s *StaticKeyStore) Lookup(hashHex string) (APIKey, bool) {
+	k, ok := s.keys[hashHex]
+	return k, ok
+}

--- a/internal/facade/auth/api_key_test.go
+++ b/internal/facade/auth/api_key_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+const validAPIKey = "omk_test_raw_value_for_unit_tests"
+
+func newAPIKeyStore(t *testing.T, opts ...func(*auth.APIKey)) *auth.StaticKeyStore {
+	t.Helper()
+	hashHex := auth.HashToken(validAPIKey)
+	k := auth.APIKey{
+		ID:      "key-001",
+		HashHex: hashHex,
+		Role:    policy.RoleEditor,
+	}
+	for _, opt := range opts {
+		opt(&k)
+	}
+	return auth.NewStaticKeyStore(map[string]auth.APIKey{hashHex: k})
+}
+
+func reqWithBearer(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+func TestHashToken_StableAndDeterministic(t *testing.T) {
+	t.Parallel()
+	a := auth.HashToken("alpha")
+	b := auth.HashToken("alpha")
+	c := auth.HashToken("alpha-different")
+	if a != b {
+		t.Errorf("HashToken not deterministic: %q vs %q", a, b)
+	}
+	if a == c {
+		t.Error("HashToken collision on different inputs")
+	}
+	// sha256 hex is 64 chars.
+	if len(a) != 64 {
+		t.Errorf("HashToken length = %d, want 64 (hex sha256)", len(a))
+	}
+}
+
+func TestAPIKeyValidator_AdmitsKnownKey(t *testing.T) {
+	t.Parallel()
+	store := newAPIKeyStore(t)
+	v := auth.NewAPIKeyValidator(store)
+
+	id, err := v.Validate(context.Background(), reqWithBearer(validAPIKey))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if id == nil {
+		t.Fatal("nil identity on admit")
+	}
+	if got, want := id.Origin, policy.OriginAPIKey; got != want {
+		t.Errorf("Origin = %q, want %q", got, want)
+	}
+	if got, want := id.Subject, "key-001"; got != want {
+		t.Errorf("Subject = %q, want %q (key ID)", got, want)
+	}
+	if got, want := id.Role, policy.RoleEditor; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if id.EndUser != id.Subject {
+		t.Errorf("EndUser = %q, want %q (no trustEndUserHeader)", id.EndUser, id.Subject)
+	}
+}
+
+func TestAPIKeyValidator_RejectsUnknownKey(t *testing.T) {
+	t.Parallel()
+	store := newAPIKeyStore(t)
+	v := auth.NewAPIKeyValidator(store)
+	_, err := v.Validate(context.Background(), reqWithBearer("unknown-key-value"))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestAPIKeyValidator_NoBearerFallsThrough(t *testing.T) {
+	t.Parallel()
+	store := newAPIKeyStore(t)
+	v := auth.NewAPIKeyValidator(store)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestAPIKeyValidator_NonBearerFallsThrough(t *testing.T) {
+	t.Parallel()
+	store := newAPIKeyStore(t)
+	v := auth.NewAPIKeyValidator(store)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set("Authorization", "Basic xxx")
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestAPIKeyValidator_ExpiredKeyReturnsErrExpired(t *testing.T) {
+	t.Parallel()
+	past := time.Date(2020, time.January, 1, 0, 0, 0, 0, time.UTC)
+	store := newAPIKeyStore(t, func(k *auth.APIKey) { k.ExpiresAt = past })
+	v := auth.NewAPIKeyValidator(store, auth.WithAPIKeyClock(func() time.Time {
+		return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}))
+	_, err := v.Validate(context.Background(), reqWithBearer(validAPIKey))
+	if !errors.Is(err, auth.ErrExpired) {
+		t.Errorf("err = %v, want ErrExpired", err)
+	}
+}
+
+func TestAPIKeyValidator_NotYetExpiredAdmits(t *testing.T) {
+	t.Parallel()
+	future := time.Date(2030, time.January, 1, 0, 0, 0, 0, time.UTC)
+	store := newAPIKeyStore(t, func(k *auth.APIKey) { k.ExpiresAt = future })
+	v := auth.NewAPIKeyValidator(store, auth.WithAPIKeyClock(func() time.Time {
+		return time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}))
+	id, err := v.Validate(context.Background(), reqWithBearer(validAPIKey))
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if !id.ExpiresAt.Equal(future) {
+		t.Errorf("Identity.ExpiresAt = %v, want %v", id.ExpiresAt, future)
+	}
+}
+
+func TestAPIKeyValidator_NoExpiryNeverExpires(t *testing.T) {
+	t.Parallel()
+	// Zero ExpiresAt means "no expiry" — admit indefinitely.
+	store := newAPIKeyStore(t)
+	v := auth.NewAPIKeyValidator(store, auth.WithAPIKeyClock(func() time.Time {
+		return time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC)
+	}))
+	if _, err := v.Validate(context.Background(), reqWithBearer(validAPIKey)); err != nil {
+		t.Errorf("err = %v, want nil for no-expiry key", err)
+	}
+}
+
+func TestAPIKeyValidator_DefaultRoleAppliedWhenSecretMissingRole(t *testing.T) {
+	t.Parallel()
+	store := newAPIKeyStore(t, func(k *auth.APIKey) { k.Role = "" })
+	v := auth.NewAPIKeyValidator(store, auth.WithAPIKeyDefaultRole(policy.RoleViewer))
+	id, err := v.Validate(context.Background(), reqWithBearer(validAPIKey))
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := id.Role, policy.RoleViewer; got != want {
+		t.Errorf("Role = %q, want %q (default applied)", got, want)
+	}
+}
+
+func TestAPIKeyValidator_TrustEndUserHeader(t *testing.T) {
+	t.Parallel()
+	store := newAPIKeyStore(t)
+	v := auth.NewAPIKeyValidator(store, auth.WithAPIKeyTrustEndUserHeader(true))
+	r := reqWithBearer(validAPIKey)
+	r.Header.Set(auth.EndUserHeader, "alice@example.com")
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := id.EndUser, "alice@example.com"; got != want {
+		t.Errorf("EndUser = %q, want %q (header should propagate)", got, want)
+	}
+	if id.Subject == id.EndUser {
+		t.Error("Subject should remain the key ID, not equal EndUser")
+	}
+}
+
+func TestAPIKeyValidator_TrustEndUserHeaderDefaultsOff(t *testing.T) {
+	t.Parallel()
+	store := newAPIKeyStore(t)
+	v := auth.NewAPIKeyValidator(store)
+	r := reqWithBearer(validAPIKey)
+	r.Header.Set(auth.EndUserHeader, "alice@example.com") // ignored
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if id.EndUser != id.Subject {
+		t.Errorf("EndUser = %q, want %q (header ignored when flag off)", id.EndUser, id.Subject)
+	}
+}
+
+func TestStaticKeyStore_NilMapIsSafe(t *testing.T) {
+	t.Parallel()
+	s := auth.NewStaticKeyStore(nil)
+	if _, ok := s.Lookup("anything"); ok {
+		t.Error("expected miss on empty store")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the per-caller API key validator and the cmd/agent KeyStore that materialises the in-memory `hash → APIKey` lookup table from labelled Secrets in the agent's namespace. Validator enables when `spec.externalAuth.apiKeys` is set on the AgentRuntime; everything else stays on PR 1's behaviour-preserving default.

No dashboard CRUD UI in this PR — it lands in a small follow-up so the Go side can ship/review independently. Operators can mint keys out-of-band today (kubectl + a hand-built Secret matching the documented label scheme below).

## What this ships

| File | Role |
|---|---|
| `internal/facade/auth/api_key.go` | `APIKey`, `KeyStore`, `StaticKeyStore`, `APIKeyValidator`, `HashToken` (lowercase hex sha256 — shared with cmd/agent loader). Validator does `subtle.ConstantTimeCompare` on the hex hash → expiry check → returns `Identity{Origin: api-key, Subject: keyID, Role: scopes.role-or-default, EndUser: subject (or X-End-User-Id when trustEndUserHeader)}`. |
| `cmd/agent/api_keys.go` | `SecretBackedKeyStore` lists Secrets matching `credential-kind=agent-api-key` + `agent=<this-agent>` in the agent's namespace, parses each into an `APIKey`, atomically swaps the in-memory map. Periodic refresh (default 30s) keeps rotation/revocation within the design's "few seconds" window. Initial-load failures are fatal (operator misconfig surfaces at pod startup); periodic-refresh failures log and keep the previous snapshot. |
| `cmd/agent/auth_chain.go` | `buildDataPlaneValidators` now appends api-key after sharedToken. Order matters: `ErrInvalidCredential` from api-key short-circuits the chain so a wrong token can't accidentally admit via mgmt-plane. |

## Stable Secret contract

```yaml
metadata:
  labels:
    omnia.altairalabs.ai/credential-kind: agent-api-key
    omnia.altairalabs.ai/agent: <agent-name>
data:
  keyHash:    <binary sha256 of raw token, base64-encoded by k8s>
  scopes:     <JSON: {"role": "viewer|editor|admin"}>
  expiresAt:  <RFC3339, optional>
```

The dashboard CRUD endpoint follow-up will create Secrets in this exact shape, and the secret naming convention is `agent-<agent>-apikey-<id>` so the KeyStore can derive a stable `Identity.Subject` from the suffix.

## Test plan

- [x] `internal/facade/auth/api_key_test.go` — **9 unit tests** on `APIKeyValidator`: admit / unknown-key / no-bearer / non-Bearer / expired (`ErrExpired`) / not-yet-expired / no-expiry-never-expires / default-role-applied / `trustEndUserHeader` on+off. Plus `TestHashToken_StableAndDeterministic` (1) and `TestStaticKeyStore_NilMapIsSafe` (1).
- [x] `cmd/agent/api_keys_test.go` — **6 unit tests** on `SecretBackedKeyStore`: load happy-path / other-agent filtering / other-credential-kind filtering / expiry parsing / skip-malformed-and-keep-going / no-secrets-yet startup. Plus 2 unit tests on `parseAPIKeySecret` for malformed scopes JSON / malformed expiresAt.
- [x] `golangci-lint run` clean on changed packages.
- [x] `go test ./cmd/agent/... ./internal/facade/auth/...` green locally.
- [ ] CI quality gate (SonarCloud).
- [ ] Tilt smoke: AgentRuntime with `spec.externalAuth.apiKeys: {}` + a labelled Secret → facade pod admits the matching Bearer; rotation visible within 30s of editing the Secret; mgmt-plane debug view still works.

## Default behaviour preservation

- `spec.externalAuth.apiKeys` unset → no validator added → chain unchanged.
- `spec.externalAuth.apiKeys: {}` set + no Secrets minted yet → validator runs but always misses → 401 on any presented bearer (correct) → mgmt-plane debug view still admits via the chain (mgmt-plane stays after data-plane validators).

## What does NOT land here

- Dashboard CRUD UI for API keys — small follow-up so the Go side reviews cleanly.
- `oidc` validator + JWKS reconciler (PR 2d).
- `edgeTrust` validator (PR 2e).
- A2A handler middleware (PR 2f).
- Default flip from "unauth upgrade allowed" to "401" (PR 3).
- ToolPolicy CEL `identity` root (PR 4 — in-flight in a parallel agent).