### PR TITLE
feat(facade): edgeTrust validator (PR 2e)

### DIFF
--- a/cmd/agent/auth_chain.go
+++ b/cmd/agent/auth_chain.go
@@ -123,7 +123,10 @@ func buildDataPlaneValidators(
 	} else if v != nil {
 		out = append(out, v)
 	}
-	// Future PRs append oidc (2d), edgeTrust (2e) here.
+	if v := buildEdgeTrustValidator(log, ar); v != nil {
+		out = append(out, v)
+	}
+	// Future PR 2d appends oidc here.
 	return out, nil
 }
 
@@ -160,6 +163,37 @@ func buildAPIKeyValidator(
 		"defaultRole", ak.DefaultRole,
 		"trustEndUserHeader", ak.TrustEndUserHeader)
 	return v, nil
+}
+
+// buildEdgeTrustValidator constructs the edgeTrust validator when
+// spec.externalAuth.edgeTrust is set. Pure-Go construction — no Secret
+// reads, no API calls — so this can never fail. The validator trusts
+// inbound headers the operator has guaranteed (via Istio
+// AuthorizationPolicy or equivalent) cannot be spoofed by external
+// callers.
+func buildEdgeTrustValidator(log logr.Logger, ar *omniav1alpha1.AgentRuntime) auth.Validator {
+	et := ar.Spec.ExternalAuth.EdgeTrust
+	if et == nil {
+		return nil
+	}
+
+	opts := []auth.EdgeTrustOption{}
+	if et.HeaderMapping != nil {
+		opts = append(opts,
+			auth.WithEdgeTrustSubjectHeader(et.HeaderMapping.Subject),
+			auth.WithEdgeTrustRoleHeader(et.HeaderMapping.Role),
+			auth.WithEdgeTrustEndUserHeader(et.HeaderMapping.EndUser),
+			auth.WithEdgeTrustEmailHeader(et.HeaderMapping.Email),
+		)
+	}
+	if len(et.ClaimsFromHeaders) > 0 {
+		opts = append(opts, auth.WithEdgeTrustExtraClaims(et.ClaimsFromHeaders))
+	}
+	v := auth.NewEdgeTrustValidator(opts...)
+	log.Info("edgeTrust validator enabled",
+		"hasHeaderMapping", et.HeaderMapping != nil,
+		"extraClaims", len(et.ClaimsFromHeaders))
+	return v
 }
 
 // buildSharedTokenValidator resolves spec.externalAuth.sharedToken into

--- a/cmd/agent/auth_chain_test.go
+++ b/cmd/agent/auth_chain_test.go
@@ -224,6 +224,173 @@ func TestBuildAuthChain_TrustEndUserHeaderPropagates(t *testing.T) {
 	}
 }
 
+func TestBuildEdgeTrustValidator_UnsetReturnsNil(t *testing.T) {
+	t.Parallel()
+	ar := &omniav1alpha1.AgentRuntime{
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				// EdgeTrust unset → no validator added
+			},
+		},
+	}
+	if v := buildEdgeTrustValidator(logr.Discard(), ar); v != nil {
+		t.Errorf("expected nil validator when spec.externalAuth.edgeTrust unset, got %v", v)
+	}
+}
+
+func TestBuildEdgeTrustValidator_EmptyConfigUsesDefaults(t *testing.T) {
+	// spec.externalAuth.edgeTrust: {} (no HeaderMapping, no ClaimsFromHeaders)
+	// should still produce a functional validator using the shipped
+	// Istio default mapping.
+	t.Parallel()
+	ar := &omniav1alpha1.AgentRuntime{
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				EdgeTrust: &omniav1alpha1.EdgeTrustAuth{},
+			},
+		},
+	}
+	v := buildEdgeTrustValidator(logr.Discard(), ar)
+	if v == nil {
+		t.Fatal("expected non-nil validator for empty EdgeTrustAuth block")
+	}
+
+	// Prove it uses the default Istio mapping by exercising it.
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set(auth.DefaultEdgeSubjectHeader, "alice")
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got, want := id.Origin, policy.OriginEdgeTrust; got != want {
+		t.Errorf("Origin = %q, want %q", got, want)
+	}
+}
+
+func TestBuildEdgeTrustValidator_HeaderMappingPropagates(t *testing.T) {
+	// Custom HeaderMapping on the CRD should be honoured by the built
+	// validator: a request with the chart's default x-user-id header
+	// should NOT admit, but a request with the custom header should.
+	t.Parallel()
+	ar := &omniav1alpha1.AgentRuntime{
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				EdgeTrust: &omniav1alpha1.EdgeTrustAuth{
+					HeaderMapping: &omniav1alpha1.EdgeTrustHeaderMapping{
+						Subject: "X-Custom-Subject",
+						Role:    "X-Custom-Role",
+						EndUser: "X-Custom-EndUser",
+						Email:   "X-Custom-Email",
+					},
+				},
+			},
+		},
+	}
+	v := buildEdgeTrustValidator(logr.Discard(), ar)
+	if v == nil {
+		t.Fatal("expected non-nil validator")
+	}
+
+	// Default header ignored.
+	r1 := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r1.Header.Set(auth.DefaultEdgeSubjectHeader, "should-not-admit")
+	if _, err := v.Validate(context.Background(), r1); err == nil {
+		t.Error("expected default header to be ignored after override")
+	}
+
+	// Custom header admits.
+	r2 := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r2.Header.Set("X-Custom-Subject", "bob")
+	if _, err := v.Validate(context.Background(), r2); err != nil {
+		t.Errorf("custom header should admit: %v", err)
+	}
+}
+
+func TestBuildEdgeTrustValidator_ClaimsFromHeadersPropagate(t *testing.T) {
+	t.Parallel()
+	ar := &omniav1alpha1.AgentRuntime{
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				EdgeTrust: &omniav1alpha1.EdgeTrustAuth{
+					ClaimsFromHeaders: map[string]string{
+						"X-User-Groups": "groups",
+					},
+				},
+			},
+		},
+	}
+	v := buildEdgeTrustValidator(logr.Discard(), ar)
+	if v == nil {
+		t.Fatal("expected non-nil validator")
+	}
+
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r.Header.Set(auth.DefaultEdgeSubjectHeader, "alice")
+	r.Header.Set("X-User-Groups", "finance,eng")
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got, want := id.Claims["groups"], "finance,eng"; got != want {
+		t.Errorf("Claims[groups] = %q, want %q (CRD-configured ClaimsFromHeaders must plumb through)", got, want)
+	}
+}
+
+func TestBuildAuthChain_EdgeTrustJoinsAfterSharedToken(t *testing.T) {
+	// End-to-end: buildDataPlaneValidators on an AgentRuntime with both
+	// sharedToken AND edgeTrust configured produces a chain where
+	// sharedToken comes first (matching request that presents a Bearer
+	// admits via sharedToken) and edgeTrust is present for requests
+	// carrying only an x-user-id header.
+	t.Parallel()
+	scheme := newTestScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "shared", Namespace: "ns"},
+		Data:       map[string][]byte{"token": []byte("bearer-value")},
+	}
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				SharedToken: &omniav1alpha1.SharedTokenAuth{
+					SecretRef: corev1.LocalObjectReference{Name: "shared"},
+				},
+				EdgeTrust: &omniav1alpha1.EdgeTrustAuth{},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar, secret).Build()
+	chain, err := buildAuthChain(context.Background(), fc, logr.Discard(), "a", "ns", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := len(chain), 2; got != want {
+		t.Fatalf("chain length = %d, want %d (sharedToken + edgeTrust)", got, want)
+	}
+
+	// Request with Bearer admits via sharedToken.
+	r1 := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r1.Header.Set("Authorization", "Bearer bearer-value")
+	id1, err := chain.Run(context.Background(), r1)
+	if err != nil {
+		t.Fatalf("Run (bearer): %v", err)
+	}
+	if got, want := id1.Origin, policy.OriginSharedToken; got != want {
+		t.Errorf("Origin = %q, want %q (Bearer must admit via sharedToken)", got, want)
+	}
+
+	// Request with just x-user-id admits via edgeTrust.
+	r2 := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	r2.Header.Set(auth.DefaultEdgeSubjectHeader, "alice")
+	id2, err := chain.Run(context.Background(), r2)
+	if err != nil {
+		t.Fatalf("Run (edge): %v", err)
+	}
+	if got, want := id2.Origin, policy.OriginEdgeTrust; got != want {
+		t.Errorf("Origin = %q, want %q (edge header must admit via edgeTrust)", got, want)
+	}
+}
+
 // stubMgmtValidator is a minimal Validator for chain-composition tests.
 type stubMgmtValidator struct {
 	id *policy.AuthenticatedIdentity

--- a/internal/facade/auth/edge_trust.go
+++ b/internal/facade/auth/edge_trust.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// EdgeTrust default header mapping. Matches the chart's existing
+// authentication.enabled=true setup
+// (charts/omnia/templates/gateway/authentication.yaml uses Istio's
+// outputClaimToHeaders to emit x-user-id / x-user-roles / x-user-email).
+// Operators running a different edge override these.
+const (
+	DefaultEdgeSubjectHeader = "x-user-id"
+	DefaultEdgeRoleHeader    = "x-user-roles"
+	DefaultEdgeEndUserHeader = "x-user-id"
+	DefaultEdgeEmailHeader   = "x-user-email"
+)
+
+// EdgeTrustValidator admits requests whose Identity has been validated
+// by an upstream JWT/auth filter (Istio RequestAuthentication, an API
+// gateway, etc.). It does NOT re-verify the underlying token — the
+// trust boundary is the operator's responsibility (Istio's
+// AuthorizationPolicy strips inbound claim-headers from untrusted
+// sources on the chart's setup).
+//
+// Admit semantics: a request is admitted iff the Subject header is
+// non-empty. Without a subject we have no stable caller identity to
+// emit, so falling through to the next validator is safer than
+// guessing. Other fields (role, endUser, email, extra claims) are
+// optional and contribute to the Identity when present.
+type EdgeTrustValidator struct {
+	subjectHeader  string
+	roleHeader     string
+	endUserHeader  string
+	emailHeader    string
+	defaultRole    string
+	extraClaims    map[string]string // inboundHeader → claimName
+	defaultSubject string
+}
+
+// EdgeTrustOption tunes an EdgeTrustValidator.
+type EdgeTrustOption func(*EdgeTrustValidator)
+
+// WithEdgeTrustSubjectHeader overrides the inbound header read for
+// Identity.Subject. Defaults to DefaultEdgeSubjectHeader.
+func WithEdgeTrustSubjectHeader(name string) EdgeTrustOption {
+	return func(v *EdgeTrustValidator) {
+		if name != "" {
+			v.subjectHeader = name
+		}
+	}
+}
+
+// WithEdgeTrustRoleHeader overrides the inbound header read for
+// Identity.Role. Defaults to DefaultEdgeRoleHeader.
+func WithEdgeTrustRoleHeader(name string) EdgeTrustOption {
+	return func(v *EdgeTrustValidator) {
+		if name != "" {
+			v.roleHeader = name
+		}
+	}
+}
+
+// WithEdgeTrustEndUserHeader overrides the inbound header read for
+// Identity.EndUser. Defaults to DefaultEdgeEndUserHeader.
+func WithEdgeTrustEndUserHeader(name string) EdgeTrustOption {
+	return func(v *EdgeTrustValidator) {
+		if name != "" {
+			v.endUserHeader = name
+		}
+	}
+}
+
+// WithEdgeTrustEmailHeader overrides the inbound header read for
+// Identity.Claims["email"]. Defaults to DefaultEdgeEmailHeader.
+func WithEdgeTrustEmailHeader(name string) EdgeTrustOption {
+	return func(v *EdgeTrustValidator) {
+		if name != "" {
+			v.emailHeader = name
+		}
+	}
+}
+
+// WithEdgeTrustDefaultRole sets the role applied when the role header
+// is absent. Defaults to policy.RoleViewer.
+func WithEdgeTrustDefaultRole(role string) EdgeTrustOption {
+	return func(v *EdgeTrustValidator) {
+		if role != "" {
+			v.defaultRole = role
+		}
+	}
+}
+
+// WithEdgeTrustExtraClaims wires additional inbound headers into the
+// Identity.Claims map. Keyed by header name (case-insensitive — net/http
+// canonicalises), value is the claim name to emit.
+//
+// Example: {"x-user-groups": "groups"} → identity.claims.groups in
+// ToolPolicy CEL. The header name is sent through http.Header.Get which
+// is case-insensitive; the claim name lands verbatim.
+func WithEdgeTrustExtraClaims(m map[string]string) EdgeTrustOption {
+	return func(v *EdgeTrustValidator) {
+		if v.extraClaims == nil {
+			v.extraClaims = map[string]string{}
+		}
+		for k, name := range m {
+			if k == "" || name == "" {
+				continue
+			}
+			v.extraClaims[k] = name
+		}
+	}
+}
+
+// NewEdgeTrustValidator constructs an edgeTrust validator with the
+// default chart-shipped header mapping. Override any field via the
+// option helpers above.
+func NewEdgeTrustValidator(opts ...EdgeTrustOption) *EdgeTrustValidator {
+	v := &EdgeTrustValidator{
+		subjectHeader:  DefaultEdgeSubjectHeader,
+		roleHeader:     DefaultEdgeRoleHeader,
+		endUserHeader:  DefaultEdgeEndUserHeader,
+		emailHeader:    DefaultEdgeEmailHeader,
+		defaultRole:    policy.RoleViewer,
+		extraClaims:    map[string]string{},
+		defaultSubject: "",
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+// Validate implements Validator. ErrNoCredential when the subject
+// header is absent (chain falls through). The validator never returns
+// ErrInvalidCredential or ErrExpired — the upstream edge has already
+// done the validation, and a missing-but-trusted-edge state is
+// indistinguishable from "no credential".
+func (v *EdgeTrustValidator) Validate(_ context.Context, r *http.Request) (*policy.AuthenticatedIdentity, error) {
+	subject := r.Header.Get(v.subjectHeader)
+	if subject == "" {
+		return nil, ErrNoCredential
+	}
+
+	role := r.Header.Get(v.roleHeader)
+	if role == "" {
+		role = v.defaultRole
+	}
+
+	endUser := r.Header.Get(v.endUserHeader)
+	if endUser == "" {
+		endUser = subject
+	}
+
+	claims := map[string]string{}
+	if email := r.Header.Get(v.emailHeader); email != "" {
+		claims["email"] = email
+	}
+	for header, claimName := range v.extraClaims {
+		if val := r.Header.Get(header); val != "" {
+			claims[claimName] = val
+		}
+	}
+
+	id := &policy.AuthenticatedIdentity{
+		Origin:  policy.OriginEdgeTrust,
+		Subject: subject,
+		EndUser: endUser,
+		Role:    role,
+	}
+	if len(claims) > 0 {
+		id.Claims = claims
+	}
+	return id, nil
+}

--- a/internal/facade/auth/edge_trust_test.go
+++ b/internal/facade/auth/edge_trust_test.go
@@ -1,0 +1,272 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+const testAliceEmail = "alice@example.com"
+
+func reqWithEdgeHeaders(headers map[string]string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	for k, v := range headers {
+		r.Header.Set(k, v)
+	}
+	return r
+}
+
+func TestEdgeTrustValidator_AdmitsWithDefaultIstioHeaders(t *testing.T) {
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator()
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: testAliceEmail,
+		auth.DefaultEdgeRoleHeader:    policy.RoleEditor,
+		auth.DefaultEdgeEmailHeader:   testAliceEmail,
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := id.Origin, policy.OriginEdgeTrust; got != want {
+		t.Errorf("Origin = %q, want %q", got, want)
+	}
+	if got, want := id.Subject, testAliceEmail; got != want {
+		t.Errorf("Subject = %q, want %q", got, want)
+	}
+	if got, want := id.Role, policy.RoleEditor; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if got, want := id.Claims["email"], testAliceEmail; got != want {
+		t.Errorf("Claims[email] = %q, want %q", got, want)
+	}
+	// Default endUserHeader = subjectHeader, so they should match when
+	// only subject is set.
+	if id.EndUser != id.Subject {
+		t.Errorf("EndUser = %q, want %q (default mapping coincides with Subject)", id.EndUser, id.Subject)
+	}
+}
+
+func TestEdgeTrustValidator_FallsThroughWhenSubjectAbsent(t *testing.T) {
+	// No subject header → we have nothing to attribute to. Falling
+	// through is safer than admitting an anonymous request from a
+	// supposedly-trusted edge.
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator()
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeRoleHeader:  "editor", // role without subject
+		auth.DefaultEdgeEmailHeader: "x@example.com",
+	})
+
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestEdgeTrustValidator_DefaultRoleAppliedWhenRoleHeaderAbsent(t *testing.T) {
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator()
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "alice",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := id.Role, policy.RoleViewer; got != want {
+		t.Errorf("Role = %q, want %q (default)", got, want)
+	}
+}
+
+func TestEdgeTrustValidator_DefaultRoleOverride(t *testing.T) {
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator(auth.WithEdgeTrustDefaultRole(policy.RoleAdmin))
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "alice",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := id.Role, policy.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeTrustValidator_CustomHeaderMapping(t *testing.T) {
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator(
+		auth.WithEdgeTrustSubjectHeader("X-Auth-Subject"),
+		auth.WithEdgeTrustRoleHeader("X-Auth-Role"),
+		auth.WithEdgeTrustEndUserHeader("X-Auth-Subject"),
+		auth.WithEdgeTrustEmailHeader("X-Auth-Email"),
+	)
+	r := reqWithEdgeHeaders(map[string]string{
+		"X-Auth-Subject": "bob@example.com",
+		"X-Auth-Role":    policy.RoleAdmin,
+		"X-Auth-Email":   "bob@example.com",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := id.Subject, "bob@example.com"; got != want {
+		t.Errorf("Subject = %q, want %q", got, want)
+	}
+	if got, want := id.Role, policy.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+
+	// Default headers must NOT be read once they're overridden.
+	r2 := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "should-be-ignored",
+	})
+	if _, err := v.Validate(context.Background(), r2); !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("default header should be ignored after override: err = %v", err)
+	}
+}
+
+func TestEdgeTrustValidator_DistinctEndUserHeader(t *testing.T) {
+	// When the edge supplies separate subject/endUser headers (e.g., a
+	// service token acting on behalf of a human), the validator must
+	// surface them distinctly so ToolPolicy CEL can compare them.
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator(
+		auth.WithEdgeTrustSubjectHeader("X-Service-Id"),
+		auth.WithEdgeTrustEndUserHeader("X-On-Behalf-Of"),
+	)
+	r := reqWithEdgeHeaders(map[string]string{
+		"X-Service-Id":   "svc-payroll",
+		"X-On-Behalf-Of": testAliceEmail,
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if id.Subject == id.EndUser {
+		t.Errorf("Subject and EndUser should differ: both = %q", id.Subject)
+	}
+	if got, want := id.Subject, "svc-payroll"; got != want {
+		t.Errorf("Subject = %q, want %q", got, want)
+	}
+	if got, want := id.EndUser, testAliceEmail; got != want {
+		t.Errorf("EndUser = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeTrustValidator_ExtraClaimsPropagate(t *testing.T) {
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator(
+		auth.WithEdgeTrustExtraClaims(map[string]string{
+			"X-User-Groups": "groups",
+			"X-Tenant-Id":   "tenant",
+		}),
+	)
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "alice",
+		"X-User-Groups":               "finance,engineering",
+		"X-Tenant-Id":                 "acme",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := id.Claims["groups"], "finance,engineering"; got != want {
+		t.Errorf("Claims[groups] = %q, want %q", got, want)
+	}
+	if got, want := id.Claims["tenant"], "acme"; got != want {
+		t.Errorf("Claims[tenant] = %q, want %q", got, want)
+	}
+}
+
+func TestEdgeTrustValidator_ExtraClaimsAbsentIsOK(t *testing.T) {
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator(
+		auth.WithEdgeTrustExtraClaims(map[string]string{"X-User-Groups": "groups"}),
+	)
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "alice",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if _, ok := id.Claims["groups"]; ok {
+		t.Error("absent extra-claim header should not produce an empty value in Claims")
+	}
+}
+
+func TestEdgeTrustValidator_EmptyOptionsIgnored(t *testing.T) {
+	// Empty strings passed to the With* options must NOT clear the
+	// default mapping — the chart's CRD allows empty fields and we
+	// don't want to silently disable the defaults.
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator(
+		auth.WithEdgeTrustSubjectHeader(""),
+		auth.WithEdgeTrustRoleHeader(""),
+		auth.WithEdgeTrustEndUserHeader(""),
+		auth.WithEdgeTrustEmailHeader(""),
+		auth.WithEdgeTrustDefaultRole(""),
+	)
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "alice",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if id.Subject != "alice" {
+		t.Errorf("Subject = %q, want %q (default header should still work)", id.Subject, "alice")
+	}
+	if id.Role != policy.RoleViewer {
+		t.Errorf("Role = %q, want %q (default role should still apply)", id.Role, policy.RoleViewer)
+	}
+}
+
+func TestEdgeTrustValidator_NoEmailHeaderOmitsClaim(t *testing.T) {
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator()
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "alice",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if id.Claims != nil {
+		if _, ok := id.Claims["email"]; ok {
+			t.Errorf("Claims[email] = %q, want missing when email header absent", id.Claims["email"])
+		}
+	}
+}

--- a/internal/facade/auth/edge_trust_test.go
+++ b/internal/facade/auth/edge_trust_test.go
@@ -181,6 +181,34 @@ func TestEdgeTrustValidator_DistinctEndUserHeader(t *testing.T) {
 	}
 }
 
+func TestEdgeTrustValidator_ExtraClaimsIgnoresEmptyEntries(t *testing.T) {
+	// A mapping entry with an empty header OR an empty claim name is
+	// garbage — the option should skip it rather than admit junk keys.
+	t.Parallel()
+	v := auth.NewEdgeTrustValidator(
+		auth.WithEdgeTrustExtraClaims(map[string]string{
+			"":              "dropped-missing-header",
+			"X-Header":      "",
+			"X-Real-Header": "real-claim",
+		}),
+	)
+	r := reqWithEdgeHeaders(map[string]string{
+		auth.DefaultEdgeSubjectHeader: "alice",
+		"X-Real-Header":               "value",
+	})
+
+	id, err := v.Validate(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got, want := id.Claims["real-claim"], "value"; got != want {
+		t.Errorf("Claims[real-claim] = %q, want %q", got, want)
+	}
+	if _, ok := id.Claims["dropped-missing-header"]; ok {
+		t.Error("empty-header entry should have been dropped")
+	}
+}
+
 func TestEdgeTrustValidator_ExtraClaimsPropagate(t *testing.T) {
 	t.Parallel()
 	v := auth.NewEdgeTrustValidator(


### PR DESCRIPTION
## Summary

Adds the validator that trusts upstream-injected claim headers from a JWT-validating edge (Istio `RequestAuthentication` + `outputClaimToHeaders`, API gateways, etc.). Admit semantics: `subject` header non-empty → admit with `origin = edge-trust`. Subject absent → `ErrNoCredential` (chain falls through).

**Operator responsibility:** guarantee the configured inbound headers cannot be spoofed by external callers. The chart's existing `authentication.enabled=true` Istio `AuthorizationPolicy` already does this by stripping inbound claim-headers.

## Files

| File | Role |
|---|---|
| `internal/facade/auth/edge_trust.go` | `EdgeTrustValidator` with default mapping matching the chart (`x-user-id` / `x-user-roles` / `x-user-email`). Five `With*` options for per-field overrides plus `WithEdgeTrustExtraClaims` for arbitrary inbound headers exposed as `identity.claims.<name>`. Empty-string options ignored (CRD allows empty fields, defaults must still apply). |
| `cmd/agent/auth_chain.go` | `buildEdgeTrustValidator` — pure-Go (no Secret reads), can never fail. Translates the CRD's `HeaderMapping` + `ClaimsFromHeaders` into the validator's option list. |

## Test plan

- [x] **10 unit tests** covering:
  - Default Istio mapping admits with subject/role/email headers
  - No-subject header → `ErrNoCredential` (chain falls through)
  - Default role (`viewer`) applied when role header absent
  - `WithEdgeTrustDefaultRole` override
  - Custom header mapping (all four slots)
  - Distinct subject vs endUser headers (the "service token on behalf of human" pattern — `identity.subject != identity.endUser` for ToolPolicy CEL)
  - `ClaimsFromHeaders` propagate to `Identity.Claims`
  - Absent extra-claim header doesn't produce empty values
  - Empty-string options ignored (defaults still work)
  - No email header → `Claims["email"]` omitted entirely
- [x] `golangci-lint run` clean on changed packages.
- [x] `go test` green locally.
- [ ] CI quality gate.
- [ ] Tilt smoke: AgentRuntime with `spec.externalAuth.edgeTrust: {}` behind the chart's Istio `authentication.enabled=true` gate → facade admits requests carrying `x-user-id`/`x-user-roles` headers; strips and rejects requests without.

## What does NOT land here

- `oidc` validator + JWKS reconciler (PR 2d).
- A2A handler middleware (PR 2f).
- Default flip (PR 3).
- ToolPolicy CEL `identity` root (PR 4 — in-flight, parallel).