### PR TITLE
feat(facade): wrap A2A handler with auth chain middleware (PR 2f)

### DIFF
--- a/cmd/agent/a2a.go
+++ b/cmd/agent/a2a.go
@@ -22,6 +22,7 @@ import (
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	"github.com/altairalabs/omnia/internal/agent"
 	facadea2a "github.com/altairalabs/omnia/internal/facade/a2a"
+	"github.com/altairalabs/omnia/internal/facade/auth"
 	"github.com/altairalabs/omnia/internal/tracing"
 
 	"github.com/AltairaLabs/PromptKit/sdk"
@@ -30,15 +31,18 @@ import (
 
 // buildA2AHandler assembles the HTTP handler chain for an A2A server:
 //
-//	inner handler -> metrics middleware -> OpenTelemetry tracing
+//	auth middleware -> inner handler -> metrics middleware -> OpenTelemetry tracing
 //
-// The tracing wrapper is only applied when tracingProvider is non-nil. This
-// is factored out of runA2AFacade and startA2AServer so both standalone and
+// The tracing wrapper is only applied when tracingProvider is non-nil. The
+// auth middleware is only applied when authChain is non-empty; an empty
+// chain preserves the PR 1 unauthenticated-upgrade default. This is
+// factored out of runA2AFacade and startA2AServer so both standalone and
 // dual-protocol modes share the same middleware stack, and so wiring tests
-// can assert that tracing is wired when the provider is set. A regression
-// that drops the tracing wrapper — or blank-identifies the provider at the
-// call site, like #728 items 3+5 — is caught by
-// TestBuildA2AHandler_WiresTracingProvider.
+// can assert that tracing + auth are wired when configured.
+//
+// Auth wraps OUTERMOST (before metrics/tracing) because rejected requests
+// should be cheap — a caller spamming wrong bearer tokens shouldn't
+// inflate the metrics counters or spawn otel spans for pipeline noise.
 //
 // inner is the handler returned by facadea2a.Server.Handler(). It is taken as
 // an http.Handler (not *facadea2a.Server) so the wiring test can exercise
@@ -47,12 +51,17 @@ func buildA2AHandler(
 	inner http.Handler,
 	metrics *facadea2a.Metrics,
 	tracingProvider *tracing.Provider,
+	authChain auth.Chain,
+	log logr.Logger,
 ) http.Handler {
 	var handler http.Handler = facadea2a.NewMetricsMiddleware(inner, metrics)
 	if tracingProvider != nil {
 		handler = otelhttp.NewHandler(handler, "a2a-facade",
 			otelhttp.WithTracerProvider(tracingProvider.TracerProvider()),
 		)
+	}
+	if len(authChain) > 0 {
+		handler = auth.Middleware(authChain, handler, auth.WithMiddlewareLogger(log))
 	}
 	return handler
 }
@@ -68,11 +77,31 @@ func runA2AFacade(cfg *agent.Config, log logr.Logger, tracingProvider *tracing.P
 		"taskStoreType", cfg.A2ATaskStoreType,
 	)
 
-	// Build authenticator
-	var auth a2aserver.Authenticator
+	// Legacy per-SDK bearer authenticator. Kept for back-compat with
+	// deployments that haven't migrated to spec.externalAuth.sharedToken
+	// yet. Once the projection shim fires (PR 2b), OMNIA_A2A_AUTH_TOKEN
+	// is unset because the shared token reaches the facade via the auth
+	// chain instead — nothing below runs.
+	var a2aAuth a2aserver.Authenticator
 	if cfg.A2AAuthToken != "" {
-		auth = facadea2a.NewBearerAuthenticator(cfg.A2AAuthToken)
-		log.Info("A2A bearer auth enabled")
+		a2aAuth = facadea2a.NewBearerAuthenticator(cfg.A2AAuthToken)
+		log.Info("A2A bearer auth enabled (legacy)")
+	}
+
+	// Build the PR 2b-era auth chain. Reads the agent's own
+	// spec.externalAuth, then combines data-plane validators with the
+	// mgmt-plane validator. Wrapped around buildA2AHandler below so an
+	// A2A caller presenting a valid credential sees the same 200-OK
+	// path as the WS facade.
+	mgmtPlane, err := loadMgmtPlaneValidator(log)
+	if err != nil {
+		log.Error(err, "mgmt-plane validator load failed")
+		os.Exit(1)
+	}
+	chain, err := buildAuthChain(context.Background(), buildK8sClient(), log, cfg.AgentName, cfg.Namespace, mgmtPlane)
+	if err != nil {
+		log.Error(err, "auth chain build failed")
+		os.Exit(1)
 	}
 
 	// Build card provider from CRD config
@@ -105,7 +134,7 @@ func runA2AFacade(cfg *agent.Config, log logr.Logger, tracingProvider *tracing.P
 		TaskTTL:         cfg.A2ATaskTTL,
 		ConversationTTL: cfg.A2AConversationTTL,
 		CardProvider:    cardProvider,
-		Authenticator:   auth,
+		Authenticator:   a2aAuth,
 		TaskStore:       taskStore,
 		SDKOptions:      sdkOptions,
 		Log:             log,
@@ -114,8 +143,8 @@ func runA2AFacade(cfg *agent.Config, log logr.Logger, tracingProvider *tracing.P
 	// Create A2A metrics.
 	a2aMetrics := facadea2a.NewMetrics(cfg.AgentName, cfg.Namespace)
 
-	// Wrap the A2A handler with metrics + (optional) tracing middleware.
-	a2aHandler := buildA2AHandler(a2aSrv.Handler(), a2aMetrics, tracingProvider)
+	// Wrap the A2A handler with auth + metrics + (optional) tracing middleware.
+	a2aHandler := buildA2AHandler(a2aSrv.Handler(), a2aMetrics, tracingProvider, chain, log)
 
 	// Build the mux with metrics endpoint.
 	mux := http.NewServeMux()

--- a/cmd/agent/a2a_wiring_test.go
+++ b/cmd/agent/a2a_wiring_test.go
@@ -16,11 +16,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-logr/logr"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 
 	facadea2a "github.com/altairalabs/omnia/internal/facade/a2a"
+	"github.com/altairalabs/omnia/internal/facade/auth"
 	"github.com/altairalabs/omnia/internal/tracing"
+	"github.com/altairalabs/omnia/pkg/policy"
 )
 
 // TestBuildA2AHandler_WiresTracingProvider verifies the wiring contract for
@@ -50,7 +53,7 @@ func TestBuildA2AHandler_WiresTracingProvider(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	metrics := facadea2a.NewMetrics("probe", "ns")
-	handler := buildA2AHandler(inner, metrics, provider)
+	handler := buildA2AHandler(inner, metrics, provider, nil, logr.Discard())
 
 	req := httptest.NewRequest(http.MethodGet, "/a2a/test", nil)
 	rr := httptest.NewRecorder()
@@ -97,7 +100,7 @@ func TestBuildA2AHandler_NoTracingProviderLeavesHandlerClean(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 	metrics := facadea2a.NewMetrics("probe", "ns")
-	handler := buildA2AHandler(inner, metrics, nil)
+	handler := buildA2AHandler(inner, metrics, nil, nil, logr.Discard())
 
 	req := httptest.NewRequest(http.MethodGet, "/a2a/test", nil)
 	rr := httptest.NewRecorder()
@@ -109,6 +112,109 @@ func TestBuildA2AHandler_NoTracingProviderLeavesHandlerClean(t *testing.T) {
 	if len(exporter.GetSpans()) != 0 {
 		t.Errorf("expected no spans when tracing provider is nil, got %d", len(exporter.GetSpans()))
 	}
+}
+
+// TestBuildA2AHandler_WiresAuthChain verifies the PR 2f wiring: when
+// buildA2AHandler gets a non-empty auth chain, rejected credentials
+// short-circuit before the inner A2A handler runs, and admitted ones
+// propagate identity into the request context so downstream ToolPolicy
+// CEL sees identity.origin. A regression that forgets to wire the
+// chain into buildA2AHandler would let external callers bypass auth on
+// the A2A endpoint even when the WebSocket side is correctly gated.
+func TestBuildA2AHandler_WiresAuthChain(t *testing.T) {
+	freshPromRegistry(t)
+
+	var innerCalled bool
+	var innerSawIdentity *policy.AuthenticatedIdentity
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerCalled = true
+		innerSawIdentity = policy.IdentityFromContext(r.Context())
+		w.WriteHeader(http.StatusOK)
+	})
+
+	metrics := facadea2a.NewMetrics("probe", "ns")
+
+	t.Run("rejects invalid credential with 401", func(t *testing.T) {
+		innerCalled = false
+		innerSawIdentity = nil
+		v := &alwaysRejectValidator{}
+		chain := auth.Chain{v}
+		handler := buildA2AHandler(inner, metrics, nil, chain, logr.Discard())
+
+		req := httptest.NewRequest(http.MethodPost, "/a2a/test", nil)
+		req.Header.Set("Authorization", "Bearer bad")
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("status = %d, want 401 — auth middleware must reject before inner runs", rr.Code)
+		}
+		if innerCalled {
+			t.Error("inner A2A handler must NOT run after auth rejection")
+		}
+	})
+
+	t.Run("admits valid credential and propagates identity", func(t *testing.T) {
+		innerCalled = false
+		innerSawIdentity = nil
+		wantID := &policy.AuthenticatedIdentity{
+			Origin: policy.OriginSharedToken, Subject: "caller",
+		}
+		v := &alwaysAdmitValidator{id: wantID}
+		chain := auth.Chain{v}
+		handler := buildA2AHandler(inner, metrics, nil, chain, logr.Discard())
+
+		req := httptest.NewRequest(http.MethodPost, "/a2a/test", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200", rr.Code)
+		}
+		if !innerCalled {
+			t.Fatal("inner A2A handler must run after admit")
+		}
+		if innerSawIdentity != wantID {
+			t.Errorf("inner saw identity %p, want %p (identity must propagate via request context)",
+				innerSawIdentity, wantID)
+		}
+	})
+
+	t.Run("empty chain preserves unauthenticated default", func(t *testing.T) {
+		innerCalled = false
+		handler := buildA2AHandler(inner, metrics, nil, nil, logr.Discard())
+
+		req := httptest.NewRequest(http.MethodPost, "/a2a/test", nil)
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, req)
+
+		if rr.Code != http.StatusOK {
+			t.Errorf("status = %d, want 200 (empty chain → PR 1 default)", rr.Code)
+		}
+		if !innerCalled {
+			t.Error("inner must run when no auth chain is configured")
+		}
+	})
+}
+
+// alwaysRejectValidator is a Validator that always returns
+// ErrInvalidCredential, simulating a caller presenting a token that
+// doesn't match any configured validator.
+type alwaysRejectValidator struct{}
+
+func (alwaysRejectValidator) Validate(_ context.Context, _ *http.Request) (*policy.AuthenticatedIdentity, error) {
+	return nil, auth.ErrInvalidCredential
+}
+
+// alwaysAdmitValidator is a Validator that always admits, returning
+// the configured identity. Used to prove the admit path propagates
+// identity through to the downstream handler.
+type alwaysAdmitValidator struct {
+	id *policy.AuthenticatedIdentity
+}
+
+func (a alwaysAdmitValidator) Validate(_ context.Context, _ *http.Request) (*policy.AuthenticatedIdentity, error) {
+	return a.id, nil
 }
 
 func spanNames(spans tracetest.SpanStubs) []string {

--- a/cmd/agent/websocket.go
+++ b/cmd/agent/websocket.go
@@ -274,11 +274,29 @@ func startA2AServer(
 		"conversationTTL", cfg.A2AConversationTTL,
 	)
 
-	// Build authenticator
-	var auth a2aserver.Authenticator
+	// Legacy per-SDK bearer authenticator (see a2a.go for rationale).
+	var a2aAuth a2aserver.Authenticator
 	if cfg.A2AAuthToken != "" {
-		auth = facadea2a.NewBearerAuthenticator(cfg.A2AAuthToken)
-		log.Info("A2A bearer auth enabled")
+		a2aAuth = facadea2a.NewBearerAuthenticator(cfg.A2AAuthToken)
+		log.Info("A2A bearer auth enabled (legacy)")
+	}
+
+	// Build the auth chain for this A2A endpoint. In dual-protocol mode
+	// the WebSocket side has already built its chain in
+	// buildWebSocketServer; we rebuild here rather than plumb it across
+	// because the cost is a single AgentRuntime k8s Get at startup and
+	// keeping buildA2AHandler's signature consistent with the standalone
+	// runA2AFacade path is worth more than the saved lookup.
+	mgmtPlane, mgmtErr := loadMgmtPlaneValidator(log)
+	if mgmtErr != nil {
+		log.Error(mgmtErr, "mgmt-plane validator load failed")
+		os.Exit(1)
+	}
+	a2aChain, chainErr := buildAuthChain(
+		context.Background(), buildK8sClient(), log, cfg.AgentName, cfg.Namespace, mgmtPlane)
+	if chainErr != nil {
+		log.Error(chainErr, "auth chain build failed")
+		os.Exit(1)
 	}
 
 	// Build card provider
@@ -304,7 +322,7 @@ func startA2AServer(
 		TaskTTL:         cfg.A2ATaskTTL,
 		ConversationTTL: cfg.A2AConversationTTL,
 		CardProvider:    cardProvider,
-		Authenticator:   auth,
+		Authenticator:   a2aAuth,
 		TaskStore:       taskStore,
 		Log:             log,
 	})
@@ -312,10 +330,11 @@ func startA2AServer(
 	// Create A2A metrics.
 	a2aMetrics := facadea2a.NewMetrics(cfg.AgentName, cfg.Namespace)
 
-	// Wrap with metrics + (optional) tracing middleware. Shared with
-	// standalone mode via buildA2AHandler so both paths get tracing spans
-	// when OMNIA_TRACING_ENABLED=true.
-	a2aHandler := buildA2AHandler(a2aSrv.Handler(), a2aMetrics, tracingProvider)
+	// Wrap with auth + metrics + (optional) tracing middleware. Shared
+	// with standalone mode via buildA2AHandler so both paths get tracing
+	// spans when OMNIA_TRACING_ENABLED=true and the same auth chain as
+	// the WebSocket upgrade path.
+	a2aHandler := buildA2AHandler(a2aSrv.Handler(), a2aMetrics, tracingProvider, a2aChain, log)
 
 	a2aHTTPServer := &http.Server{
 		Addr:    fmt.Sprintf(":%d", cfg.A2APort),

--- a/internal/facade/auth/middleware.go
+++ b/internal/facade/auth/middleware.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// MiddlewareOption tunes Middleware. All optional.
+type MiddlewareOption func(*middlewareConfig)
+
+type middlewareConfig struct {
+	log logr.Logger
+}
+
+// WithMiddlewareLogger binds a logr.Logger for rejection telemetry. The
+// middleware never logs admits — that's expected traffic — only 401s
+// so operators can debug misconfigured validators.
+func WithMiddlewareLogger(log logr.Logger) MiddlewareOption {
+	return func(c *middlewareConfig) { c.log = log }
+}
+
+// Middleware returns an http.Handler wrapper that runs `chain` against
+// each request. On admit it attaches the AuthenticatedIdentity to the
+// request context via policy.WithIdentity and calls next. On
+// ErrNoCredential (or empty chain) it calls next without attaching an
+// identity — the PR 1 unauthenticated-upgrade default stays intact
+// until PR 3 flips it. On any other chain error it returns 401 and
+// short-circuits next.
+//
+// Unlike the WS server's inline authenticateRequest, this wrapper works
+// with any http.Handler — used by the A2A HTTP server which the
+// dashboard proxy doesn't front.
+func Middleware(chain Chain, next http.Handler, opts ...MiddlewareOption) http.Handler {
+	cfg := &middlewareConfig{log: logr.Discard()}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(chain) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+		id, err := chain.Run(r.Context(), r)
+		switch {
+		case err == nil:
+			// Admit: attach identity so downstream handlers (and
+			// ToolPolicy CEL) can reason about the caller.
+			ctx := policy.WithIdentity(r.Context(), id)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		case errors.Is(err, ErrNoCredential):
+			// PR 1 default: no credential → proceed unauthenticated.
+			// PR 3 flips this at the caller layer by configuring a
+			// strict chain that returns ErrInvalidCredential instead.
+			next.ServeHTTP(w, r)
+		default:
+			// ErrInvalidCredential / ErrExpired / anything else →
+			// reject. 401 is the right status per the design doc.
+			cfg.log.V(1).Info("auth middleware rejected request",
+				"reason", err.Error(),
+				"path", r.URL.Path,
+				"method", r.Method)
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		}
+	})
+}

--- a/internal/facade/auth/middleware_test.go
+++ b/internal/facade/auth/middleware_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// observingHandler is an http.Handler that records what it saw — used
+// by the middleware tests to prove next.ServeHTTP was (or wasn't)
+// called, and what identity was attached.
+type observingHandler struct {
+	called  int
+	saw     *policy.AuthenticatedIdentity
+	respond func(w http.ResponseWriter)
+}
+
+func (h *observingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	h.called++
+	h.saw = policy.IdentityFromContext(r.Context())
+	if h.respond != nil {
+		h.respond(w)
+	} else {
+		w.WriteHeader(http.StatusOK)
+	}
+}
+
+// stubMwValidator: programmable Validator for middleware tests. Mirrors
+// chain_test.go's stubValidator but in a form the middleware package
+// can use without re-importing test helpers.
+type stubMwValidator struct {
+	id  *policy.AuthenticatedIdentity
+	err error
+}
+
+func (s *stubMwValidator) Validate(_ context.Context, _ *http.Request) (*policy.AuthenticatedIdentity, error) {
+	return s.id, s.err
+}
+
+func newMwRequest() *http.Request {
+	return httptest.NewRequest(http.MethodGet, "/", nil)
+}
+
+func TestMiddleware_EmptyChainPassesThrough(t *testing.T) {
+	// Empty chain should call next without attaching identity. PR 1
+	// preserves this for back-compat.
+	t.Parallel()
+	next := &observingHandler{}
+	mw := auth.Middleware(auth.Chain{}, next)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, newMwRequest())
+
+	if next.called != 1 {
+		t.Errorf("next called %d times, want 1", next.called)
+	}
+	if next.saw != nil {
+		t.Errorf("expected no identity attached, got %+v", next.saw)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestMiddleware_AdmitAttachesIdentity(t *testing.T) {
+	t.Parallel()
+	want := &policy.AuthenticatedIdentity{
+		Origin:  policy.OriginSharedToken,
+		Subject: "caller-1",
+	}
+	chain := auth.Chain{&stubMwValidator{id: want}}
+	next := &observingHandler{}
+	mw := auth.Middleware(chain, next)
+
+	mw.ServeHTTP(httptest.NewRecorder(), newMwRequest())
+
+	if next.called != 1 {
+		t.Fatalf("next called %d, want 1", next.called)
+	}
+	if next.saw == nil {
+		t.Fatal("expected identity on downstream context")
+	}
+	if next.saw != want {
+		t.Errorf("saw %p, want %p", next.saw, want)
+	}
+}
+
+func TestMiddleware_NoCredentialFallsThrough(t *testing.T) {
+	// ErrNoCredential from all validators → no identity, but next still runs.
+	// This is PR 1a/c's unauthenticated-upgrade default; PR 3 flips it
+	// by configuring a chain that ends with an always-reject validator.
+	t.Parallel()
+	chain := auth.Chain{&stubMwValidator{err: auth.ErrNoCredential}}
+	next := &observingHandler{}
+	mw := auth.Middleware(chain, next)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, newMwRequest())
+
+	if next.called != 1 {
+		t.Errorf("next called %d, want 1 (fall-through)", next.called)
+	}
+	if next.saw != nil {
+		t.Errorf("expected no identity attached, got %+v", next.saw)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestMiddleware_InvalidCredentialReturns401(t *testing.T) {
+	t.Parallel()
+	chain := auth.Chain{&stubMwValidator{err: auth.ErrInvalidCredential}}
+	next := &observingHandler{}
+	mw := auth.Middleware(chain, next)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, newMwRequest())
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if next.called != 0 {
+		t.Errorf("next called %d, want 0 (must short-circuit on reject)", next.called)
+	}
+}
+
+func TestMiddleware_ExpiredReturns401(t *testing.T) {
+	t.Parallel()
+	chain := auth.Chain{&stubMwValidator{err: auth.ErrExpired}}
+	next := &observingHandler{}
+	mw := auth.Middleware(chain, next)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, newMwRequest())
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	if next.called != 0 {
+		t.Error("next must not run after ErrExpired")
+	}
+}
+
+func TestMiddleware_ChainOrderAdmitsFirstMatch(t *testing.T) {
+	// A shared-token chain followed by mgmt-plane: the shared-token
+	// admit should arrive at next.ServeHTTP even if a later validator
+	// would have ALSO admitted.
+	t.Parallel()
+	shared := &policy.AuthenticatedIdentity{Origin: policy.OriginSharedToken}
+	mgmt := &policy.AuthenticatedIdentity{Origin: policy.OriginManagementPlane}
+
+	chain := auth.Chain{
+		&stubMwValidator{id: shared},
+		&stubMwValidator{id: mgmt}, // would also admit, but shouldn't run
+	}
+	next := &observingHandler{}
+	mw := auth.Middleware(chain, next)
+	mw.ServeHTTP(httptest.NewRecorder(), newMwRequest())
+
+	if next.saw != shared {
+		t.Errorf("expected sharedToken identity, got %+v", next.saw)
+	}
+}
+
+func TestMiddleware_FallThroughMultipleValidators(t *testing.T) {
+	// Every validator returns ErrNoCredential; chain ends up returning
+	// ErrNoCredential; middleware falls through to next.
+	t.Parallel()
+	chain := auth.Chain{
+		&stubMwValidator{err: auth.ErrNoCredential},
+		&stubMwValidator{err: auth.ErrNoCredential},
+		&stubMwValidator{err: auth.ErrNoCredential},
+	}
+	next := &observingHandler{}
+	mw := auth.Middleware(chain, next)
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, newMwRequest())
+
+	if next.called != 1 {
+		t.Errorf("next called %d, want 1", next.called)
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}


### PR DESCRIPTION
## Summary

Completes per-agent auth chain coverage: the A2A HTTP server now runs the same validator chain as the WebSocket facade. PR 2b's chain runner is already wired into the WS path via `server.authChain`; this PR adds a generic `http.Handler` middleware and wraps the A2A handler with it.

## Files

| File | Role |
|---|---|
| `internal/facade/auth/middleware.go` | `Middleware(chain, next, opts...)` returns an `http.Handler` wrapper. On admit: attaches Identity via `policy.WithIdentity` and calls next. On `ErrNoCredential` or empty chain: calls next without identity. On any other error: 401. |
| `cmd/agent/a2a.go` + `websocket.go` | `buildA2AHandler` now takes `auth.Chain` + `logr.Logger`. Auth wraps outermost (before metrics/tracing) so rejected callers don't inflate metrics or spawn otel spans for noise. Both callers (standalone `runA2AFacade` and dual-protocol `startA2AServer`) build the chain via `buildAuthChain`. |

Legacy `facadea2a.BearerAuthenticator` (`cfg.A2AAuthToken`) preserved as a fallback for deployments that haven't migrated to `spec.externalAuth.sharedToken`.

## Test plan

- [x] 7 unit tests on `Middleware`: empty chain passes through / admit attaches identity / no-credential falls through / invalid → 401 / expired → 401 / chain order (first admit wins) / fall-through past multiple no-credential validators.
- [x] 3 sub-tests under `TestBuildA2AHandler_WiresAuthChain`: rejected → 401 without inner running; admitted → identity propagates to inner; empty chain → unauthenticated default preserved.
- [x] Existing tracing wiring tests kept working with the new signature.
- [x] `golangci-lint run`, `go test` green locally.
- [ ] CI quality gate.