### PR TITLE
feat(runtime): add identity root to ToolPolicy CEL (PR 4)

### DIFF
--- a/ee/pkg/policy/evaluator.go
+++ b/ee/pkg/policy/evaluator.go
@@ -9,6 +9,7 @@ Functional Source License. See ee/LICENSE for details.
 package policy
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/google/cel-go/ext"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	omniapolicy "github.com/altairalabs/omnia/pkg/policy"
 )
 
 // Header name constants for CEL evaluation context.
@@ -93,10 +95,18 @@ func NewEvaluator() (*Evaluator, error) {
 }
 
 // newCELEnv creates the shared CEL environment with the variables available to rules.
+//
+// The `identity` root is populated from policy.AuthenticatedIdentity (pulled
+// from request context). When no identity is attached to the context, all
+// fields are populated with zero values (empty strings, empty claims map) so
+// rules referencing `identity.*` still evaluate without runtime errors.
+// Rules that need to check whether a claim is present should use
+// `has(identity.claims.<name>)` — the same idiom used for `body.<field>`.
 func newCELEnv() (*cel.Env, error) {
 	return cel.NewEnv(
 		cel.Variable("headers", cel.MapType(cel.StringType, cel.StringType)),
 		cel.Variable("body", cel.MapType(cel.StringType, cel.DynType)),
+		cel.Variable("identity", cel.MapType(cel.StringType, cel.DynType)),
 		ext.Strings(),
 	)
 }
@@ -228,14 +238,33 @@ func (e *Evaluator) RemovePolicy(namespace, name string) {
 // It returns a Decision indicating whether the request should be allowed.
 // In audit mode, the decision will be Allowed=true but DeniedBy will be set
 // to indicate which rule would have denied the request.
+//
+// This form does not consult request context, so the `identity` CEL root is
+// populated with zero values. Callers that want identity-gated rules should
+// use EvaluateWithContext.
 func (e *Evaluator) Evaluate(headers map[string]string, body map[string]interface{}) Decision {
+	return e.EvaluateWithContext(context.Background(), headers, body)
+}
+
+// EvaluateWithContext evaluates all matching policies against the given
+// request context. The context is used to pull an AuthenticatedIdentity (via
+// policy.IdentityFromContext) and expose it to CEL rules as `identity`.
+// When no identity is attached, the identity root is populated with
+// zero-valued strings / empty map so rules do not error on missing data.
+func (e *Evaluator) EvaluateWithContext(
+	ctx context.Context,
+	headers map[string]string,
+	body map[string]interface{},
+) Decision {
 	e.mu.RLock()
 	matching := e.findMatchingPolicies(headers)
 	e.mu.RUnlock()
 
+	identity := identityActivation(ctx)
+
 	var auditDecision *Decision
 	for _, p := range matching {
-		decision := e.evaluatePolicy(p, headers, body)
+		decision := e.evaluatePolicy(p, headers, body, identity)
 		if !decision.Allowed {
 			return decision
 		}
@@ -253,7 +282,21 @@ func (e *Evaluator) Evaluate(headers map[string]string, body map[string]interfac
 
 // EvaluateHeaderInjection evaluates header injection rules for all matching policies.
 // It returns a map of header-name to header-value for all injection rules.
+//
+// This form does not consult request context, so the `identity` CEL root is
+// populated with zero values. Callers that need identity-aware header
+// injection should use EvaluateHeaderInjectionWithContext.
 func (e *Evaluator) EvaluateHeaderInjection(
+	headers map[string]string,
+	body map[string]interface{},
+) (map[string]string, error) {
+	return e.EvaluateHeaderInjectionWithContext(context.Background(), headers, body)
+}
+
+// EvaluateHeaderInjectionWithContext evaluates header injection rules using
+// identity information pulled from the given request context.
+func (e *Evaluator) EvaluateHeaderInjectionWithContext(
+	ctx context.Context,
 	headers map[string]string,
 	body map[string]interface{},
 ) (map[string]string, error) {
@@ -262,7 +305,7 @@ func (e *Evaluator) EvaluateHeaderInjection(
 	e.mu.RUnlock()
 
 	result := make(map[string]string)
-	activation := buildActivation(headers, body)
+	activation := buildActivation(headers, body, identityActivation(ctx))
 
 	for _, p := range matching {
 		if err := evaluatePolicyHeaderInjection(p, activation, result); err != nil {
@@ -341,6 +384,7 @@ func (e *Evaluator) evaluatePolicy(
 	policy *CompiledPolicy,
 	headers map[string]string,
 	body map[string]interface{},
+	identity map[string]interface{},
 ) Decision {
 	// Check required claims first
 	if decision := checkRequiredClaims(policy.RequiredClaims, headers); !decision.Allowed {
@@ -348,7 +392,7 @@ func (e *Evaluator) evaluatePolicy(
 	}
 
 	// Evaluate CEL rules
-	activation := buildActivation(headers, body)
+	activation := buildActivation(headers, body, identity)
 	for _, rule := range policy.Rules {
 		decision := evaluateRule(rule, activation, policy.OnFailure)
 		if !decision.Allowed {
@@ -377,10 +421,18 @@ func checkRequiredClaims(claims []omniav1alpha1.RequiredClaim, headers map[strin
 	return Decision{Allowed: true}
 }
 
-// buildActivation creates the CEL activation map from headers and body.
-func buildActivation(headers map[string]string, body map[string]interface{}) map[string]interface{} {
+// buildActivation creates the CEL activation map from headers, body, and
+// identity. The identity map MUST be pre-populated (empty strings + empty
+// claims map when no identity is attached) so rules referencing
+// `identity.<field>` do not error on missing keys.
+func buildActivation(
+	headers map[string]string,
+	body map[string]interface{},
+	identity map[string]interface{},
+) map[string]interface{} {
 	activation := map[string]interface{}{
-		"headers": headers,
+		"headers":  headers,
+		"identity": identity,
 	}
 	if body != nil {
 		activation["body"] = body
@@ -388,6 +440,38 @@ func buildActivation(headers map[string]string, body map[string]interface{}) map
 		activation["body"] = map[string]interface{}{}
 	}
 	return activation
+}
+
+// identityActivation builds the `identity` CEL activation from the given
+// request context. When no AuthenticatedIdentity is attached, returns a map
+// populated with zero-valued strings and an empty claims map — this matches
+// the defensive default used elsewhere in the evaluator for missing data.
+func identityActivation(ctx context.Context) map[string]interface{} {
+	id := omniapolicy.IdentityFromContext(ctx)
+	if id == nil {
+		return map[string]interface{}{
+			"origin":    "",
+			"subject":   "",
+			"endUser":   "",
+			"workspace": "",
+			"agent":     "",
+			"role":      "",
+			"claims":    map[string]string{},
+		}
+	}
+	claims := id.Claims
+	if claims == nil {
+		claims = map[string]string{}
+	}
+	return map[string]interface{}{
+		"origin":    id.Origin,
+		"subject":   id.Subject,
+		"endUser":   id.EndUser,
+		"workspace": id.Workspace,
+		"agent":     id.Agent,
+		"role":      id.Role,
+		"claims":    claims,
+	}
 }
 
 // evaluateRule evaluates a single CEL rule and returns the decision.

--- a/ee/pkg/policy/evaluator_identity_test.go
+++ b/ee/pkg/policy/evaluator_identity_test.go
@@ -1,0 +1,303 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: FSL-1.1-Apache-2.0
+This file is part of Omnia Enterprise and is subject to the
+Functional Source License. See ee/LICENSE for details.
+*/
+
+package policy
+
+import (
+	"context"
+	"testing"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"
+	omniapolicy "github.com/altairalabs/omnia/pkg/policy"
+)
+
+// newIdentityPolicy builds a single-rule ToolPolicy whose deny expression is
+// provided by the caller. Used by the identity-root tests below.
+func newIdentityPolicy(name, expr string) *omniav1alpha1.ToolPolicy {
+	return newTestPolicy(name, []omniav1alpha1.PolicyRule{
+		{
+			Name: "identity-rule",
+			Deny: omniav1alpha1.PolicyRuleDeny{
+				CEL:     expr,
+				Message: "denied by identity rule",
+			},
+		},
+	})
+}
+
+// evalIdentityRule compiles an identity-root rule into a fresh evaluator and
+// evaluates it against the supplied identity (or no identity if nil).
+func evalIdentityRule(
+	t *testing.T,
+	expr string,
+	identity *omniapolicy.AuthenticatedIdentity,
+) Decision {
+	t.Helper()
+
+	eval, err := NewEvaluator()
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+	policy := newIdentityPolicy("identity-policy", expr)
+	if err := eval.CompilePolicy(policy); err != nil {
+		t.Fatalf("CompilePolicy() error = %v", err)
+	}
+
+	headers := map[string]string{
+		HeaderToolName:     "process_refund",
+		HeaderToolRegistry: "customer-tools",
+	}
+	ctx := context.Background()
+	if identity != nil {
+		ctx = omniapolicy.WithIdentity(ctx, identity)
+	}
+	return eval.EvaluateWithContext(ctx, headers, nil)
+}
+
+// TestEvaluateWithContext_IdentityOrigin_ManagementPlane asserts the
+// `identity.origin == "management-plane"` idiom from the design doc.
+func TestEvaluateWithContext_IdentityOrigin_ManagementPlane(t *testing.T) {
+	identity := &omniapolicy.AuthenticatedIdentity{
+		Origin:  omniapolicy.OriginManagementPlane,
+		Subject: "user-1",
+	}
+
+	decision := evalIdentityRule(t, `identity.origin == "management-plane"`, identity)
+	if decision.Allowed {
+		t.Error("rule should have denied when identity.origin == management-plane")
+	}
+	if decision.DeniedBy != "identity-rule" {
+		t.Errorf("DeniedBy = %q, want identity-rule", decision.DeniedBy)
+	}
+}
+
+// TestEvaluateWithContext_IdentityOrigin_NoIdentity asserts the zero-value
+// default: a context without Identity surfaces identity.origin == "", so a
+// `identity.origin == "management-plane"` rule evaluates to false (no deny).
+func TestEvaluateWithContext_IdentityOrigin_NoIdentity(t *testing.T) {
+	decision := evalIdentityRule(t, `identity.origin == "management-plane"`, nil)
+	if !decision.Allowed {
+		t.Error("rule should be allowed when context carries no identity (zero-value origin)")
+	}
+}
+
+// TestEvaluateWithContext_IdentityRole_Viewer verifies identity.role is
+// usable from CEL.
+func TestEvaluateWithContext_IdentityRole_Viewer(t *testing.T) {
+	identity := &omniapolicy.AuthenticatedIdentity{
+		Origin: omniapolicy.OriginOIDC,
+		Role:   omniapolicy.RoleViewer,
+	}
+
+	decision := evalIdentityRule(t, `identity.role == "viewer"`, identity)
+	if decision.Allowed {
+		t.Error("rule should have denied when identity.role == viewer")
+	}
+}
+
+// TestEvaluateWithContext_IdentitySubject_NotEqualEndUser covers the
+// service-token-spoofing-end-user detection pattern called out in the design
+// doc: rule flags calls where the token holder and the acted-upon user
+// differ.
+func TestEvaluateWithContext_IdentitySubject_NotEqualEndUser(t *testing.T) {
+	identity := &omniapolicy.AuthenticatedIdentity{
+		Origin:  omniapolicy.OriginSharedToken,
+		Subject: "svc-x",
+		EndUser: "alice",
+	}
+
+	decision := evalIdentityRule(t, `identity.subject != identity.endUser`, identity)
+	if decision.Allowed {
+		t.Error("rule should have denied when subject != endUser")
+	}
+}
+
+// TestEvaluateWithContext_IdentityClaim_Present verifies that arbitrary
+// claims are reachable via identity.claims.<name>.
+func TestEvaluateWithContext_IdentityClaim_Present(t *testing.T) {
+	identity := &omniapolicy.AuthenticatedIdentity{
+		Origin: omniapolicy.OriginOIDC,
+		Claims: map[string]string{"groups": "finance"},
+	}
+
+	decision := evalIdentityRule(t, `identity.claims.groups == "finance"`, identity)
+	if decision.Allowed {
+		t.Error("rule should have denied when claims.groups == finance")
+	}
+}
+
+// TestEvaluateWithContext_IdentityClaim_MissingViaHas matches the idiom used
+// elsewhere (`has(body.field)`): rules probe for optional claims with has(),
+// and a missing claim is simply absent from the map.
+func TestEvaluateWithContext_IdentityClaim_MissingViaHas(t *testing.T) {
+	identity := &omniapolicy.AuthenticatedIdentity{
+		Origin: omniapolicy.OriginOIDC,
+		Claims: map[string]string{"groups": "finance"},
+	}
+
+	decision := evalIdentityRule(t, `!has(identity.claims.missing)`, identity)
+	if decision.Allowed {
+		t.Error("rule should have denied when has(identity.claims.missing) is false")
+	}
+}
+
+// TestEvaluateWithContext_IdentityWorkspaceAgent covers the remaining flat
+// identity fields (workspace, agent) in a single rule.
+func TestEvaluateWithContext_IdentityWorkspaceAgent(t *testing.T) {
+	identity := &omniapolicy.AuthenticatedIdentity{
+		Origin:    omniapolicy.OriginAPIKey,
+		Workspace: "ws-finance",
+		Agent:     "support-bot",
+	}
+
+	expr := `identity.workspace == "ws-finance" && identity.agent == "support-bot"`
+	decision := evalIdentityRule(t, expr, identity)
+	if decision.Allowed {
+		t.Error("rule should have denied when workspace/agent both match")
+	}
+}
+
+// TestEvaluateWithContext_NoIdentity_ClaimsEmpty asserts that when no
+// identity is attached, identity.claims is an empty map and `has(...)` on
+// any claim is false.
+func TestEvaluateWithContext_NoIdentity_ClaimsEmpty(t *testing.T) {
+	decision := evalIdentityRule(t, `has(identity.claims.groups)`, nil)
+	if !decision.Allowed {
+		t.Error("rule should be allowed when no identity is attached (claims empty)")
+	}
+}
+
+// TestEvaluateWithContext_NilClaimsMap verifies an identity with nil Claims
+// still yields a non-nil CEL map so `has(...)` works without erroring.
+func TestEvaluateWithContext_NilClaimsMap(t *testing.T) {
+	identity := &omniapolicy.AuthenticatedIdentity{
+		Origin: omniapolicy.OriginAPIKey,
+		// Claims left nil on purpose.
+	}
+
+	decision := evalIdentityRule(t, `has(identity.claims.any)`, identity)
+	if !decision.Allowed {
+		t.Error("rule should be allowed when Claims is nil (treated as empty map)")
+	}
+}
+
+// TestEvaluateHeaderInjectionWithContext_Identity covers the header
+// injection path — identity should be reachable from CEL-valued header
+// injection rules too.
+func TestEvaluateHeaderInjectionWithContext_Identity(t *testing.T) {
+	eval, err := NewEvaluator()
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	policy := newTestPolicy("inject-policy", []omniav1alpha1.PolicyRule{
+		{
+			Name: "never",
+			Deny: omniav1alpha1.PolicyRuleDeny{CEL: "false", Message: "never"},
+		},
+	})
+	policy.Spec.HeaderInjection = []omniav1alpha1.HeaderInjectionRule{
+		{
+			Header: "X-Omnia-Injected-Origin",
+			CEL:    "identity.origin",
+		},
+	}
+	if err := eval.CompilePolicy(policy); err != nil {
+		t.Fatalf("CompilePolicy() error = %v", err)
+	}
+
+	ctx := omniapolicy.WithIdentity(context.Background(), &omniapolicy.AuthenticatedIdentity{
+		Origin: omniapolicy.OriginManagementPlane,
+	})
+	headers := map[string]string{
+		HeaderToolName:     "process_refund",
+		HeaderToolRegistry: "customer-tools",
+	}
+
+	injected, err := eval.EvaluateHeaderInjectionWithContext(ctx, headers, nil)
+	if err != nil {
+		t.Fatalf("EvaluateHeaderInjectionWithContext() error = %v", err)
+	}
+	got := injected["X-Omnia-Injected-Origin"]
+	if got != omniapolicy.OriginManagementPlane {
+		t.Errorf("injected origin = %q, want %q", got, omniapolicy.OriginManagementPlane)
+	}
+}
+
+// TestEvaluate_LegacyAPI_StillWorks confirms the non-context Evaluate entry
+// point keeps working with identity-agnostic rules — a sanity check for
+// back-compat with callers that have not been updated to pass context.
+func TestEvaluate_LegacyAPI_StillWorks(t *testing.T) {
+	eval, err := NewEvaluator()
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	policy := newTestPolicy("legacy", []omniav1alpha1.PolicyRule{
+		{
+			Name: "deny-mgmt-plane",
+			Deny: omniav1alpha1.PolicyRuleDeny{
+				CEL:     `identity.origin == "management-plane"`,
+				Message: "blocked",
+			},
+		},
+	})
+	if err := eval.CompilePolicy(policy); err != nil {
+		t.Fatalf("CompilePolicy() error = %v", err)
+	}
+
+	headers := map[string]string{
+		HeaderToolName:     "process_refund",
+		HeaderToolRegistry: "customer-tools",
+	}
+
+	// Legacy API path → no identity attached → origin defaults to "" → rule
+	// does not match → allowed.
+	decision := eval.Evaluate(headers, nil)
+	if !decision.Allowed {
+		t.Errorf("legacy Evaluate() should allow (origin empty); got denied by %q", decision.DeniedBy)
+	}
+}
+
+// TestEvaluateHeaderInjection_LegacyAPI_StillWorks mirrors the above for the
+// header-injection entry point.
+func TestEvaluateHeaderInjection_LegacyAPI_StillWorks(t *testing.T) {
+	eval, err := NewEvaluator()
+	if err != nil {
+		t.Fatalf("NewEvaluator() error = %v", err)
+	}
+
+	policy := newTestPolicy("legacy-inject", []omniav1alpha1.PolicyRule{
+		{
+			Name: "never",
+			Deny: omniav1alpha1.PolicyRuleDeny{CEL: "false", Message: "never"},
+		},
+	})
+	policy.Spec.HeaderInjection = []omniav1alpha1.HeaderInjectionRule{
+		{
+			Header: "X-Omnia-Injected-Origin",
+			CEL:    "identity.origin",
+		},
+	}
+	if err := eval.CompilePolicy(policy); err != nil {
+		t.Fatalf("CompilePolicy() error = %v", err)
+	}
+
+	headers := map[string]string{
+		HeaderToolName:     "process_refund",
+		HeaderToolRegistry: "customer-tools",
+	}
+
+	injected, err := eval.EvaluateHeaderInjection(headers, nil)
+	if err != nil {
+		t.Fatalf("EvaluateHeaderInjection() error = %v", err)
+	}
+	if got := injected["X-Omnia-Injected-Origin"]; got != "" {
+		t.Errorf("injected origin = %q, want empty string (no identity)", got)
+	}
+}

--- a/ee/pkg/policy/proxy.go
+++ b/ee/pkg/policy/proxy.go
@@ -61,7 +61,7 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	headers := extractHeaders(r)
 	body := parseBody(r, h.logger)
 
-	decision := h.evaluator.Evaluate(headers, body)
+	decision := h.evaluator.EvaluateWithContext(r.Context(), headers, body)
 
 	h.logDecision(r, decision)
 
@@ -77,7 +77,7 @@ func (h *ProxyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // injectHeaders evaluates header injection rules and adds computed headers to the request.
 func (h *ProxyHandler) injectHeaders(r *http.Request, headers map[string]string, body map[string]interface{}) {
-	injected, err := h.evaluator.EvaluateHeaderInjection(headers, body)
+	injected, err := h.evaluator.EvaluateHeaderInjectionWithContext(r.Context(), headers, body)
 	if err != nil {
 		h.logger.Error("header injection evaluation failed", "error", err.Error())
 		return


### PR DESCRIPTION
## Summary

Rules can now reference `identity.origin` / `subject` / `endUser` / `workspace` / `agent` / `role` / `claims.<name>` to gate tool calls on the authenticated caller. Identity comes from `policy.AuthenticatedIdentity` in the request context (attached by `internal/facade/auth`'s middleware in PR 2b/2f). When no identity is attached, the identity root is populated with zero-valued strings and an empty claims map so rules don't panic — the existing `has(identity.claims.<name>)` idiom keeps working.

Independent of PR 2c/2d/2e/2f — only depends on `policy.AuthenticatedIdentity` (on `main` since PR 1a / #946).

## Files

| File | Role |
|---|---|
| `ee/pkg/policy/evaluator.go` | New `cel.Variable("identity", cel.MapType(StringType, DynType))` alongside existing `headers` + `body` roots. `EvaluateWithContext(ctx, headers, body)` + `EvaluateHeaderInjectionWithContext(ctx, headers, body)` pull the identity from context. `Evaluate()` + `EvaluateHeaderInjection()` keep their existing signatures as thin wrappers calling the context-aware variants with `context.Background()` — no caller break. `identityActivation(ctx)` produces the CEL map with safe zero values when no identity is present. |
| `ee/pkg/policy/proxy.go` | Threads `r.Context()` into the new context-aware Evaluate calls so the middleware-attached identity reaches CEL. |

## Test plan

- [x] **12 new tests** in `ee/pkg/policy/evaluator_identity_test.go` covering every design-doc CEL pattern:
  - `identity.origin == "management-plane"` admits
  - `role == "viewer"` gating works
  - `subject != endUser` (service-token spoofing check)
  - `identity.claims.<name>` present
  - `has(identity.claims.<missing>)` returns false
  - workspace + agent fields propagate
  - no-identity defaults (empty strings)
  - nil claims map safe
  - header injection uses identity
  - Legacy `Evaluate()` and `EvaluateHeaderInjection()` signatures still work unchanged
- [x] `go test ./ee/pkg/policy/...` green locally.
- [x] `golangci-lint run`, `go vet`, `gofmt` clean on changed files.
- [x] Coverage: `evaluator.go` 96.5%, `proxy.go` 91.8%.
- [ ] CI quality gate.

## Backwards compatibility

Existing rules that don't reference `identity.*` keep evaluating identically. The `Evaluate()` / `EvaluateHeaderInjection()` signatures don't change.