### PR TITLE
feat(facade): OIDC validator + Secret-backed JWKS store (PR 2d)

### DIFF
--- a/cmd/agent/auth_chain.go
+++ b/cmd/agent/auth_chain.go
@@ -123,11 +123,59 @@ func buildDataPlaneValidators(
 	} else if v != nil {
 		out = append(out, v)
 	}
+	if v, err := buildOIDCValidator(ctx, k8s, log, ar); err != nil {
+		return nil, err
+	} else if v != nil {
+		out = append(out, v)
+	}
 	if v := buildEdgeTrustValidator(log, ar); v != nil {
 		out = append(out, v)
 	}
-	// Future PR 2d appends oidc here.
 	return out, nil
+}
+
+// buildOIDCValidator constructs the OIDC validator when
+// spec.externalAuth.oidc is set. Reads the JWKS from the per-agent
+// Secret maintained by the AgentRuntime controller (PR 2d-2); missing
+// or malformed JWKS is fatal so operator misconfig surfaces at pod
+// startup rather than silently 401ing every request.
+func buildOIDCValidator(
+	ctx context.Context,
+	k8s client.Client,
+	log logr.Logger,
+	ar *omniav1alpha1.AgentRuntime,
+) (auth.Validator, error) {
+	oidc := ar.Spec.ExternalAuth.OIDC
+	if oidc == nil {
+		return nil, nil
+	}
+	if oidc.Issuer == "" || oidc.Audience == "" {
+		return nil, fmt.Errorf("spec.externalAuth.oidc requires issuer and audience")
+	}
+
+	secretName := OIDCJWKSSecretNameFor(ar.Name)
+	store, err := NewSecretBackedJWKSStore(ctx, k8s, ar.Namespace, secretName, log)
+	if err != nil {
+		return nil, fmt.Errorf("init OIDC JWKS store: %w", err)
+	}
+
+	opts := []auth.OIDCOption{}
+	if oidc.ClaimMapping != nil {
+		opts = append(opts, auth.WithOIDCClaimMapping(auth.OIDCClaimMapping{
+			Subject: oidc.ClaimMapping.Subject,
+			Role:    oidc.ClaimMapping.Role,
+			EndUser: oidc.ClaimMapping.EndUser,
+		}))
+	}
+	v, err := auth.NewOIDCValidator(oidc.Issuer, oidc.Audience, store, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("construct OIDC validator: %w", err)
+	}
+	log.Info("oidc validator enabled",
+		"issuer", oidc.Issuer,
+		"audience", oidc.Audience,
+		"hasClaimMapping", oidc.ClaimMapping != nil)
+	return v, nil
 }
 
 // buildAPIKeyValidator constructs the api-key validator when

--- a/cmd/agent/oidc_jwks.go
+++ b/cmd/agent/oidc_jwks.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+)
+
+// OIDCJWKSSecretSuffix is appended to `agent-<name>` to form the
+// conventional per-agent Secret name that caches the customer IdP's
+// JWKS. The AgentRuntime controller maintains the Secret in PR 2d-2
+// (not in this PR — operators can populate it manually for now).
+const OIDCJWKSSecretSuffix = "-oidc-jwks"
+
+// OIDCJWKSDataKey is the data key inside the Secret holding the raw
+// JWKS JSON blob (verbatim from the issuer's jwks_uri). Stable contract
+// shared with the reconciler.
+const OIDCJWKSDataKey = "jwks.json"
+
+// SecretBackedJWKSStore implements auth.KeySupplier by reading the
+// agent's JWKS Secret at startup and refreshing periodically. Rotation
+// on the IdP side propagates within the refresh interval.
+//
+// Missing kid at lookup time does NOT trigger an on-demand refresh in
+// MVP — we return (nil, false) and let the validator reject the token.
+// PR 2d-2 can add facade-side annotation bumps to nudge the controller
+// for the "new kid appeared mid-session" case.
+type SecretBackedJWKSStore struct {
+	client     client.Client
+	namespace  string
+	secretName string
+	refresh    time.Duration
+	log        logr.Logger
+	now        func() time.Time
+
+	mu          sync.RWMutex
+	set         *auth.KeySet
+	lastRefresh time.Time
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+// SecretBackedJWKSStoreOption tunes the store.
+type SecretBackedJWKSStoreOption func(*SecretBackedJWKSStore)
+
+// WithJWKSRefreshInterval overrides the default refresh cadence.
+// Defaults to 5 minutes — tight enough to catch manual key rotation
+// without hammering the k8s API.
+func WithJWKSRefreshInterval(d time.Duration) SecretBackedJWKSStoreOption {
+	return func(s *SecretBackedJWKSStore) { s.refresh = d }
+}
+
+// WithJWKSClock injects a clock for tests.
+func WithJWKSClock(now func() time.Time) SecretBackedJWKSStoreOption {
+	return func(s *SecretBackedJWKSStore) { s.now = now }
+}
+
+// NewSecretBackedJWKSStore loads the initial JWKS synchronously and
+// returns a store that refreshes in the background. Initial-load
+// errors are fatal — the facade refuses to admit OIDC tokens against
+// a missing JWKS rather than silently 401ing every request.
+func NewSecretBackedJWKSStore(
+	ctx context.Context,
+	c client.Client,
+	namespace, secretName string,
+	log logr.Logger,
+	opts ...SecretBackedJWKSStoreOption,
+) (*SecretBackedJWKSStore, error) {
+	s := &SecretBackedJWKSStore{
+		client:     c,
+		namespace:  namespace,
+		secretName: secretName,
+		refresh:    5 * time.Minute,
+		log:        log.WithName("oidc-jwks-store"),
+		now:        time.Now,
+		stopCh:     make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(s)
+	}
+	if err := s.loadOnce(ctx); err != nil {
+		return nil, fmt.Errorf("initial JWKS load: %w", err)
+	}
+	go s.refreshLoop()
+	return s, nil
+}
+
+// Lookup implements auth.KeySupplier by delegating to the cached
+// KeySet. Safe for concurrent reads; a concurrent refresh swaps the
+// whole set under the write lock.
+func (s *SecretBackedJWKSStore) Lookup(kid string) (*rsa.PublicKey, bool) {
+	s.mu.RLock()
+	set := s.set
+	s.mu.RUnlock()
+	if set == nil {
+		return nil, false
+	}
+	return set.Lookup(kid)
+}
+
+// Stop ends the background refresh loop. Idempotent.
+func (s *SecretBackedJWKSStore) Stop() {
+	s.stopOnce.Do(func() { close(s.stopCh) })
+}
+
+// loadOnce reads the JWKS Secret, parses the blob into an auth.KeySet,
+// and swaps it in atomically.
+func (s *SecretBackedJWKSStore) loadOnce(ctx context.Context) error {
+	secret := &corev1.Secret{}
+	err := s.client.Get(ctx, types.NamespacedName{
+		Namespace: s.namespace,
+		Name:      s.secretName,
+	}, secret)
+	if err != nil {
+		return fmt.Errorf("get JWKS secret %s/%s: %w", s.namespace, s.secretName, err)
+	}
+	raw, ok := secret.Data[OIDCJWKSDataKey]
+	if !ok || len(raw) == 0 {
+		return fmt.Errorf("JWKS secret %s/%s missing %q data key",
+			s.namespace, s.secretName, OIDCJWKSDataKey)
+	}
+	set, err := auth.NewKeySetFromJSON(raw)
+	if err != nil {
+		return fmt.Errorf("parse JWKS blob: %w", err)
+	}
+
+	s.mu.Lock()
+	s.set = set
+	s.lastRefresh = s.now()
+	s.mu.Unlock()
+	s.log.V(1).Info("JWKS store refreshed")
+	return nil
+}
+
+// refreshLoop runs until Stop. Errors log and keep the previous
+// snapshot — better to serve slightly-stale keys than universally
+// reject while the API server blips.
+func (s *SecretBackedJWKSStore) refreshLoop() {
+	ticker := time.NewTicker(s.refresh)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			if err := s.loadOnce(ctx); err != nil {
+				s.log.Error(err, "JWKS refresh failed; keeping previous snapshot")
+			}
+			cancel()
+		}
+	}
+}
+
+// OIDCJWKSSecretNameFor derives the conventional per-agent JWKS Secret
+// name. Kept here (not in controller/constants.go) so cmd/agent
+// doesn't import controller internals; the reconciler PR will mirror
+// the same helper on its side.
+func OIDCJWKSSecretNameFor(agentName string) string {
+	return fmt.Sprintf("agent-%s%s", agentName, OIDCJWKSSecretSuffix)
+}

--- a/cmd/agent/oidc_jwks_test.go
+++ b/cmd/agent/oidc_jwks_test.go
@@ -1,0 +1,341 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+	"github.com/altairalabs/omnia/internal/facade/auth"
+)
+
+const testJWKSKid = "rotating-1"
+
+// buildTestJWKSBlob returns a JWKS JSON blob plus the RSA private key
+// it was generated from — tests can then sign JWTs with the private
+// half and verify via the public JWKS. The kid is fixed to testJWKSKid
+// so tests can refer to it without threading a parameter.
+func buildTestJWKSBlob(t *testing.T) ([]byte, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	jwks := auth.JWKS{Keys: []auth.JSONWebKey{{
+		Kty: "RSA",
+		Kid: testJWKSKid,
+		Alg: "RS256",
+		N:   base64.RawURLEncoding.EncodeToString(key.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(key.E)).Bytes()),
+	}}}
+	blob, err := json.Marshal(jwks)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return blob, key
+}
+
+func TestSecretBackedJWKSStore_LoadsInitialJWKS(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	blob, _ := buildTestJWKSBlob(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-x-oidc-jwks",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{OIDCJWKSDataKey: blob},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	store, err := NewSecretBackedJWKSStore(context.Background(), fc, "ns", "agent-x-oidc-jwks", logr.Discard(),
+		WithJWKSRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(testJWKSKid); !ok {
+		t.Error("expected key to be present after initial load")
+	}
+}
+
+func TestSecretBackedJWKSStore_MissingSecretErrors(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	_, err := NewSecretBackedJWKSStore(context.Background(), fc, "ns", "agent-x-oidc-jwks", logr.Discard(),
+		WithJWKSRefreshInterval(time.Hour))
+	if err == nil {
+		t.Error("expected fatal error when JWKS Secret is missing")
+	}
+}
+
+func TestSecretBackedJWKSStore_MissingDataKeyErrors(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-x-oidc-jwks",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{"some-other-key": []byte("ignored")},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	_, err := NewSecretBackedJWKSStore(context.Background(), fc, "ns", "agent-x-oidc-jwks", logr.Discard(),
+		WithJWKSRefreshInterval(time.Hour))
+	if err == nil {
+		t.Errorf("expected error when Secret missing %q data key", OIDCJWKSDataKey)
+	}
+}
+
+func TestSecretBackedJWKSStore_MalformedJWKSErrors(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-x-oidc-jwks",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{OIDCJWKSDataKey: []byte("not-json")},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	_, err := NewSecretBackedJWKSStore(context.Background(), fc, "ns", "agent-x-oidc-jwks", logr.Discard(),
+		WithJWKSRefreshInterval(time.Hour))
+	if err == nil {
+		t.Error("expected error on malformed JWKS blob")
+	}
+}
+
+func TestSecretBackedJWKSStore_ClockOption(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	blob, _ := buildTestJWKSBlob(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "jwks", Namespace: "ns"},
+		Data:       map[string][]byte{OIDCJWKSDataKey: blob},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+	fixed := time.Date(2026, time.June, 1, 12, 0, 0, 0, time.UTC)
+
+	store, err := NewSecretBackedJWKSStore(context.Background(), fc, "ns", "jwks", logr.Discard(),
+		WithJWKSRefreshInterval(time.Hour),
+		WithJWKSClock(func() time.Time { return fixed }),
+	)
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	store.mu.RLock()
+	got := store.lastRefresh
+	store.mu.RUnlock()
+	if !got.Equal(fixed) {
+		t.Errorf("lastRefresh = %v, want %v", got, fixed)
+	}
+}
+
+func TestSecretBackedJWKSStore_LookupReturnsFalseForUnknownKid(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	blob, _ := buildTestJWKSBlob(t)
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "jwks", Namespace: "ns"},
+		Data:       map[string][]byte{OIDCJWKSDataKey: blob},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(secret).Build()
+
+	store, err := NewSecretBackedJWKSStore(context.Background(), fc, "ns", "jwks", logr.Discard(),
+		WithJWKSRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup("not-in-jwks"); ok {
+		t.Error("expected miss on unknown kid — IdP rotation scenario")
+	}
+}
+
+func TestOIDCJWKSSecretNameFor(t *testing.T) {
+	t.Parallel()
+	got := OIDCJWKSSecretNameFor("my-agent")
+	want := "agent-my-agent-oidc-jwks"
+	if got != want {
+		t.Errorf("OIDCJWKSSecretNameFor = %q, want %q", got, want)
+	}
+}
+
+func TestBuildOIDCValidator_UnsetReturnsNil(t *testing.T) {
+	t.Parallel()
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{}, // no OIDC
+		},
+	}
+	scheme := newTestScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	v, err := buildOIDCValidator(context.Background(), fc, logr.Discard(), ar)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if v != nil {
+		t.Errorf("expected nil validator when OIDC unset, got %v", v)
+	}
+}
+
+func TestBuildOIDCValidator_MissingIssuerOrAudienceErrors(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	// Issuer missing.
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				OIDC: &omniav1alpha1.OIDCAuth{Audience: "omnia"},
+			},
+		},
+	}
+	if _, err := buildOIDCValidator(context.Background(), fc, logr.Discard(), ar); err == nil {
+		t.Error("expected error on empty issuer")
+	}
+
+	// Audience missing.
+	ar.Spec.ExternalAuth.OIDC = &omniav1alpha1.OIDCAuth{Issuer: "https://idp.example.com"}
+	if _, err := buildOIDCValidator(context.Background(), fc, logr.Discard(), ar); err == nil {
+		t.Error("expected error on empty audience")
+	}
+}
+
+func TestBuildOIDCValidator_MissingJWKSSecretErrors(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "x", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				OIDC: &omniav1alpha1.OIDCAuth{
+					Issuer:   "https://idp.example.com",
+					Audience: "omnia",
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).Build()
+	if _, err := buildOIDCValidator(context.Background(), fc, logr.Discard(), ar); err == nil {
+		t.Error("expected error when JWKS Secret is absent — operator must populate it")
+	}
+}
+
+func TestBuildOIDCValidator_HappyPath(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	blob, _ := buildTestJWKSBlob(t)
+	jwksSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-myagent-oidc-jwks",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{OIDCJWKSDataKey: blob},
+	}
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "myagent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				OIDC: &omniav1alpha1.OIDCAuth{
+					Issuer:   "https://idp.example.com",
+					Audience: "omnia",
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(jwksSecret).Build()
+
+	v, err := buildOIDCValidator(context.Background(), fc, logr.Discard(), ar)
+	if err != nil {
+		t.Fatalf("buildOIDCValidator: %v", err)
+	}
+	if v == nil {
+		t.Fatal("nil validator on happy path")
+	}
+}
+
+func TestBuildOIDCValidator_ClaimMappingPropagates(t *testing.T) {
+	// The CRD's OIDCClaimMapping must reach the auth.OIDCClaimMapping
+	// inside the validator; a regression would silently default to `sub`
+	// and break customers using service tokens with actor claims.
+	t.Parallel()
+	scheme := newTestScheme(t)
+	blob, _ := buildTestJWKSBlob(t)
+	jwksSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "agent-a-oidc-jwks",
+			Namespace: "ns",
+		},
+		Data: map[string][]byte{OIDCJWKSDataKey: blob},
+	}
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				OIDC: &omniav1alpha1.OIDCAuth{
+					Issuer:   "https://idp.example.com",
+					Audience: "omnia",
+					ClaimMapping: &omniav1alpha1.OIDCClaimMapping{
+						Subject: "user_id",
+						Role:    "tier",
+						EndUser: "actor",
+					},
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(jwksSecret).Build()
+
+	v, err := buildOIDCValidator(context.Background(), fc, logr.Discard(), ar)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if v == nil {
+		t.Fatal("nil validator")
+	}
+	// Validator is opaque — we can't introspect its mapping directly
+	// without exposing private fields. The behavioural test for the
+	// mapping (a token whose claims use the custom names admits
+	// correctly) lives in internal/facade/auth/oidc_test.go:
+	// TestOIDCValidator_CustomClaimMapping. Here we just prove the
+	// hook-up doesn't panic or error.
+}

--- a/internal/facade/auth/api_key_test.go
+++ b/internal/facade/auth/api_key_test.go
@@ -187,13 +187,13 @@ func TestAPIKeyValidator_TrustEndUserHeader(t *testing.T) {
 	store := newAPIKeyStore(t)
 	v := auth.NewAPIKeyValidator(store, auth.WithAPIKeyTrustEndUserHeader(true))
 	r := reqWithBearer(validAPIKey)
-	r.Header.Set(auth.EndUserHeader, "alice@example.com")
+	r.Header.Set(auth.EndUserHeader, testAliceEmail)
 
 	id, err := v.Validate(context.Background(), r)
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
-	if got, want := id.EndUser, "alice@example.com"; got != want {
+	if got, want := id.EndUser, testAliceEmail; got != want {
 		t.Errorf("EndUser = %q, want %q (header should propagate)", got, want)
 	}
 	if id.Subject == id.EndUser {
@@ -206,7 +206,7 @@ func TestAPIKeyValidator_TrustEndUserHeaderDefaultsOff(t *testing.T) {
 	store := newAPIKeyStore(t)
 	v := auth.NewAPIKeyValidator(store)
 	r := reqWithBearer(validAPIKey)
-	r.Header.Set(auth.EndUserHeader, "alice@example.com") // ignored
+	r.Header.Set(auth.EndUserHeader, testAliceEmail) // ignored
 
 	id, err := v.Validate(context.Background(), r)
 	if err != nil {

--- a/internal/facade/auth/oidc.go
+++ b/internal/facade/auth/oidc.go
@@ -1,0 +1,356 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+// Defaults for OIDC claim names. Mirrors the CRD's OIDCClaimMapping
+// defaults so operators who don't override them get sensible behaviour.
+const (
+	DefaultOIDCSubjectClaim = "sub"
+	DefaultOIDCRoleClaim    = "omnia.role"
+	DefaultOIDCEndUserClaim = "sub"
+)
+
+// JSONWebKey is the RFC 7517 §4 shape the validator consumes. Only
+// RSA / RS256 fields are populated in MVP — Ed25519 and ECDSA support
+// is a future addition when a customer actually asks for it.
+type JSONWebKey struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use,omitempty"`
+	Alg string `json:"alg,omitempty"`
+	N   string `json:"n,omitempty"`
+	E   string `json:"e,omitempty"`
+}
+
+// JWKS is the RFC 7517 §5 envelope.
+type JWKS struct {
+	Keys []JSONWebKey `json:"keys"`
+}
+
+// KeySet is the facade-side in-memory JWKS cache. Maps kid → RSA public
+// key for O(1) lookup during JWT verification. Safe for concurrent use.
+type KeySet struct {
+	mu   sync.RWMutex
+	keys map[string]*rsa.PublicKey
+}
+
+// NewKeySet builds a KeySet from a parsed JWKS. Non-RSA keys are
+// skipped with no error (the validator just won't admit tokens signed
+// by them); a JWKS with zero usable keys returns an error so callers
+// see the misconfig immediately.
+func NewKeySet(jwks *JWKS) (*KeySet, error) {
+	if jwks == nil {
+		return nil, errors.New("nil JWKS")
+	}
+	set := &KeySet{keys: map[string]*rsa.PublicKey{}}
+	for _, k := range jwks.Keys {
+		if k.Kty != "RSA" {
+			continue
+		}
+		pub, err := rsaPublicKeyFromJWK(k)
+		if err != nil {
+			// Log-worthy but non-fatal: skip the key and carry on.
+			continue
+		}
+		if k.Kid == "" {
+			// A JWK without a kid can't be looked up by the verifier.
+			// Skip with no error — odd but legal under RFC 7517.
+			continue
+		}
+		set.keys[k.Kid] = pub
+	}
+	if len(set.keys) == 0 {
+		return nil, errors.New("JWKS contains no usable RSA keys")
+	}
+	return set, nil
+}
+
+// NewKeySetFromJSON parses a raw JWKS JSON blob. Convenience wrapper
+// for the facade-side Secret reader which stores the raw issuer
+// response verbatim.
+func NewKeySetFromJSON(raw []byte) (*KeySet, error) {
+	var jwks JWKS
+	if err := json.Unmarshal(raw, &jwks); err != nil {
+		return nil, fmt.Errorf("parse JWKS: %w", err)
+	}
+	return NewKeySet(&jwks)
+}
+
+// Lookup returns the RSA public key for the given kid, or (nil, false).
+func (s *KeySet) Lookup(kid string) (*rsa.PublicKey, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	k, ok := s.keys[kid]
+	return k, ok
+}
+
+// Replace atomically swaps the whole key map — used by cmd/agent's
+// periodic refresh to pick up rotated keys.
+func (s *KeySet) Replace(keys map[string]*rsa.PublicKey) {
+	s.mu.Lock()
+	s.keys = keys
+	s.mu.Unlock()
+}
+
+// rsaPublicKeyFromJWK decodes the `n` and `e` fields (base64url-encoded
+// big-endian integers per RFC 7518 §6.3) into an rsa.PublicKey.
+func rsaPublicKeyFromJWK(k JSONWebKey) (*rsa.PublicKey, error) {
+	if k.N == "" || k.E == "" {
+		return nil, errors.New("JWK missing n or e")
+	}
+	nBytes, err := base64.RawURLEncoding.DecodeString(k.N)
+	if err != nil {
+		return nil, fmt.Errorf("decode n: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(k.E)
+	if err != nil {
+		return nil, fmt.Errorf("decode e: %w", err)
+	}
+	n := new(big.Int).SetBytes(nBytes)
+	// RFC 7518 §6.3.1.2 — e is an unsigned big-endian integer in as few
+	// bytes as possible. Most IdPs ship "AQAB" (= 65537) so e fits in
+	// an int easily.
+	e := new(big.Int).SetBytes(eBytes)
+	if !e.IsInt64() {
+		return nil, fmt.Errorf("exponent too large")
+	}
+	return &rsa.PublicKey{N: n, E: int(e.Int64())}, nil
+}
+
+// OIDCValidator verifies JWTs against a JWKS cache. Construction takes
+// the issuer / audience the IdP issued, a KeySet supplier, and an
+// OIDCClaimMapping (nil → defaults). Keyset lookup is pluggable so
+// cmd/agent can swap in a refreshing impl without this file knowing
+// about k8s or Secrets.
+type OIDCValidator struct {
+	issuer   string
+	audience string
+	keys     KeySupplier
+	mapping  OIDCClaimMapping
+}
+
+// KeySupplier abstracts the JWKS backing store — in production a
+// refreshing Secret-backed cache, in tests a fixed map.
+type KeySupplier interface {
+	Lookup(kid string) (*rsa.PublicKey, bool)
+}
+
+// OIDCClaimMapping is the validator-side mirror of the CRD's
+// OIDCClaimMapping. Empty strings fall back to the Default*Claim
+// constants so tests don't have to fill every field.
+type OIDCClaimMapping struct {
+	Subject string
+	Role    string
+	EndUser string
+}
+
+// OIDCOption tunes an OIDCValidator.
+type OIDCOption func(*OIDCValidator)
+
+// WithOIDCClaimMapping overrides the default claim names. Empty-string
+// fields keep the corresponding default.
+func WithOIDCClaimMapping(m OIDCClaimMapping) OIDCOption {
+	return func(v *OIDCValidator) {
+		if m.Subject != "" {
+			v.mapping.Subject = m.Subject
+		}
+		if m.Role != "" {
+			v.mapping.Role = m.Role
+		}
+		if m.EndUser != "" {
+			v.mapping.EndUser = m.EndUser
+		}
+	}
+}
+
+// NewOIDCValidator constructs an OIDC JWT validator.
+func NewOIDCValidator(issuer, audience string, keys KeySupplier, opts ...OIDCOption) (*OIDCValidator, error) {
+	if issuer == "" {
+		return nil, errors.New("oidc: issuer is required")
+	}
+	if audience == "" {
+		return nil, errors.New("oidc: audience is required")
+	}
+	if keys == nil {
+		return nil, errors.New("oidc: KeySupplier is required")
+	}
+	v := &OIDCValidator{
+		issuer:   issuer,
+		audience: audience,
+		keys:     keys,
+		mapping: OIDCClaimMapping{
+			Subject: DefaultOIDCSubjectClaim,
+			Role:    DefaultOIDCRoleClaim,
+			EndUser: DefaultOIDCEndUserClaim,
+		},
+	}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v, nil
+}
+
+// Validate implements Validator. ErrNoCredential when no Bearer header;
+// ErrInvalidCredential on signature / issuer / audience / kid failures;
+// ErrExpired when the JWT is past its exp.
+func (v *OIDCValidator) Validate(_ context.Context, r *http.Request) (*policy.AuthenticatedIdentity, error) {
+	tokenString, err := extractBearer(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the token once with a Keyfunc that pulls the key from the
+	// supplier using the kid header. ParseWithClaims handles signature
+	// verification + standard time claims (exp/nbf/iat) + iss + aud.
+	claims := jwt.MapClaims{}
+	parser := jwt.NewParser(
+		jwt.WithIssuer(v.issuer),
+		jwt.WithAudience(v.audience),
+		jwt.WithValidMethods([]string{jwt.SigningMethodRS256.Alg()}),
+	)
+	token, parseErr := parser.ParseWithClaims(tokenString, claims, func(t *jwt.Token) (any, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method %q", t.Header["alg"])
+		}
+		kid, ok := t.Header["kid"].(string)
+		if !ok || kid == "" {
+			return nil, errors.New("oidc: token header missing kid")
+		}
+		key, ok := v.keys.Lookup(kid)
+		if !ok {
+			return nil, fmt.Errorf("oidc: no key for kid %q", kid)
+		}
+		return key, nil
+	})
+	if parseErr != nil {
+		if errors.Is(parseErr, jwt.ErrTokenExpired) {
+			return nil, ErrExpired
+		}
+		return nil, fmt.Errorf("%w: %v", ErrInvalidCredential, parseErr)
+	}
+	if token == nil || !token.Valid {
+		return nil, ErrInvalidCredential
+	}
+
+	return v.identityFromClaims(claims), nil
+}
+
+// identityFromClaims extracts an AuthenticatedIdentity from verified
+// JWT claims. Split out of Validate so the hot-path has fewer nested
+// branches (SonarCloud's cognitive-complexity gate at 15 prefers this
+// shape).
+func (v *OIDCValidator) identityFromClaims(claims jwt.MapClaims) *policy.AuthenticatedIdentity {
+	id := &policy.AuthenticatedIdentity{Origin: policy.OriginOIDC}
+	if sub, ok := stringClaim(claims, v.mapping.Subject); ok {
+		id.Subject = sub
+	}
+	if eu, ok := stringClaim(claims, v.mapping.EndUser); ok {
+		id.EndUser = eu
+	}
+	if id.EndUser == "" {
+		// Fall back to Subject so Identity.EndUser is always populated.
+		// Design doc semantics: "Falls back to Subject if claim missing."
+		id.EndUser = id.Subject
+	}
+	if role, ok := stringClaim(claims, v.mapping.Role); ok {
+		id.Role = role
+	}
+	// No role claim is fine — ToolPolicy rules can still gate on
+	// identity.origin. Role stays empty intentionally.
+
+	id.Claims = extractExtraClaims(claims, v.mapping)
+
+	// Surface the token's validity window so identity consumers that
+	// care (e.g., session logging) can trace its lifetime.
+	if exp, ok := numericDateClaim(claims, "exp"); ok {
+		id.ExpiresAt = exp
+	}
+	if iat, ok := numericDateClaim(claims, "iat"); ok {
+		id.IssuedAt = iat
+	}
+	return id
+}
+
+// extractExtraClaims flattens any string-valued claims not already
+// absorbed into Identity.Subject / Role / EndUser so ToolPolicy CEL
+// can reference them via `identity.claims.<name>`. Returns nil when
+// no extras are present (keeps Identity.Claims nil rather than an
+// empty map, which the CEL evaluator handles via `has()`).
+func extractExtraClaims(claims jwt.MapClaims, mapping OIDCClaimMapping) map[string]string {
+	extra := map[string]string{}
+	for k, vv := range claims {
+		if k == mapping.Subject || k == mapping.Role || k == mapping.EndUser {
+			continue
+		}
+		if s, ok := vv.(string); ok && s != "" {
+			extra[k] = s
+		}
+	}
+	if len(extra) == 0 {
+		return nil
+	}
+	return extra
+}
+
+// stringClaim extracts a string value from jwt.MapClaims. Falls back
+// cleanly on missing / non-string entries.
+func stringClaim(m jwt.MapClaims, name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	v, ok := m[name]
+	if !ok {
+		return "", false
+	}
+	s, ok := v.(string)
+	return s, ok
+}
+
+// numericDateClaim extracts a JWT NumericDate (seconds-since-epoch as
+// a JSON number) and converts to time.Time. The golang-jwt library
+// already enforces exp/nbf internally; we only need this to populate
+// Identity.ExpiresAt / IssuedAt for downstream audit.
+func numericDateClaim(m jwt.MapClaims, name string) (time.Time, bool) {
+	v, present := m[name]
+	if !present {
+		return time.Time{}, false
+	}
+	switch typed := v.(type) {
+	case float64:
+		return time.Unix(int64(typed), 0).UTC(), true
+	case int64:
+		return time.Unix(typed, 0).UTC(), true
+	}
+	return time.Time{}, false
+}

--- a/internal/facade/auth/oidc_test.go
+++ b/internal/facade/auth/oidc_test.go
@@ -1,0 +1,524 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/altairalabs/omnia/internal/facade/auth"
+	"github.com/altairalabs/omnia/pkg/policy"
+)
+
+const (
+	testOIDCIssuer   = "https://idp.example.com"
+	testOIDCAudience = "omnia"
+	testOIDCKid      = "test-key-1"
+	// testAliceEmail is referenced across several test files in this
+	// package; defined here since oidc_test.go is the first to need it
+	// under PR 2d. PR 2e's edge_trust_test.go will drop its local
+	// definition on rebase.
+	testAliceEmail = "alice@example.com"
+)
+
+// newOIDCTestKey generates an RSA keypair and returns it plus a JWKS
+// containing only the public half keyed by testOIDCKid.
+func newOIDCTestKey(t *testing.T) (*rsa.PrivateKey, *auth.JWKS) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("rsa.GenerateKey: %v", err)
+	}
+	jwks := &auth.JWKS{Keys: []auth.JSONWebKey{jwkFromRSA(&key.PublicKey, testOIDCKid)}}
+	return key, jwks
+}
+
+func jwkFromRSA(pub *rsa.PublicKey, kid string) auth.JSONWebKey {
+	return auth.JSONWebKey{
+		Kty: "RSA",
+		Kid: kid,
+		Alg: "RS256",
+		N:   base64.RawURLEncoding.EncodeToString(pub.N.Bytes()),
+		E:   base64.RawURLEncoding.EncodeToString(big.NewInt(int64(pub.E)).Bytes()),
+	}
+}
+
+type oidcMintOpts struct {
+	kid      string
+	issuer   string
+	audience string
+	subject  string
+	exp      time.Time
+	extras   map[string]any
+	key      *rsa.PrivateKey
+	alg      jwt.SigningMethod
+}
+
+func mintOIDCToken(t *testing.T, opts oidcMintOpts) string {
+	t.Helper()
+	now := time.Now()
+	if opts.exp.IsZero() {
+		opts.exp = now.Add(5 * time.Minute)
+	}
+	claims := jwt.MapClaims{
+		"iss": opts.issuer,
+		"aud": opts.audience,
+		"sub": opts.subject,
+		"iat": jwt.NewNumericDate(now).Unix(),
+		"nbf": jwt.NewNumericDate(now.Add(-time.Minute)).Unix(),
+		"exp": jwt.NewNumericDate(opts.exp).Unix(),
+	}
+	for k, v := range opts.extras {
+		claims[k] = v
+	}
+	alg := opts.alg
+	if alg == nil {
+		alg = jwt.SigningMethodRS256
+	}
+	token := jwt.NewWithClaims(alg, claims)
+	if opts.kid != "" {
+		token.Header["kid"] = opts.kid
+	}
+	signed, err := token.SignedString(opts.key)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	return signed
+}
+
+func oidcReq(token string) *http.Request {
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	if token != "" {
+		r.Header.Set("Authorization", "Bearer "+token)
+	}
+	return r
+}
+
+func newOIDCValidatorForTest(t *testing.T, opts ...auth.OIDCOption) (*auth.OIDCValidator, *rsa.PrivateKey) {
+	t.Helper()
+	key, jwks := newOIDCTestKey(t)
+	set, err := auth.NewKeySet(jwks)
+	if err != nil {
+		t.Fatalf("NewKeySet: %v", err)
+	}
+	v, err := auth.NewOIDCValidator(testOIDCIssuer, testOIDCAudience, set, opts...)
+	if err != nil {
+		t.Fatalf("NewOIDCValidator: %v", err)
+	}
+	return v, key
+}
+
+func TestNewOIDCValidator_RequiresArgs(t *testing.T) {
+	t.Parallel()
+	key, jwks := newOIDCTestKey(t)
+	set, _ := auth.NewKeySet(jwks)
+	_ = key
+
+	if _, err := auth.NewOIDCValidator("", testOIDCAudience, set); err == nil {
+		t.Error("expected error on empty issuer")
+	}
+	if _, err := auth.NewOIDCValidator(testOIDCIssuer, "", set); err == nil {
+		t.Error("expected error on empty audience")
+	}
+	if _, err := auth.NewOIDCValidator(testOIDCIssuer, testOIDCAudience, nil); err == nil {
+		t.Error("expected error on nil KeySupplier")
+	}
+}
+
+func TestNewKeySet_RejectsEmptyJWKS(t *testing.T) {
+	t.Parallel()
+	if _, err := auth.NewKeySet(nil); err == nil {
+		t.Error("expected error on nil JWKS")
+	}
+	empty := &auth.JWKS{Keys: []auth.JSONWebKey{}}
+	if _, err := auth.NewKeySet(empty); err == nil {
+		t.Error("expected error on zero-key JWKS")
+	}
+}
+
+func TestNewKeySet_SkipsNonRSAKeys(t *testing.T) {
+	// An EC key in the JWKS should be skipped without failing
+	// construction — future-proofs against JWKS responses that mix
+	// algorithms.
+	t.Parallel()
+	_, jwks := newOIDCTestKey(t)
+	jwks.Keys = append(jwks.Keys, auth.JSONWebKey{Kty: "EC", Kid: "ec-key"})
+	set, err := auth.NewKeySet(jwks)
+	if err != nil {
+		t.Fatalf("NewKeySet: %v", err)
+	}
+	if _, ok := set.Lookup("ec-key"); ok {
+		t.Error("EC key should have been skipped")
+	}
+	if _, ok := set.Lookup(testOIDCKid); !ok {
+		t.Error("RSA key should still be usable alongside skipped EC key")
+	}
+}
+
+func TestNewKeySet_SkipsKidlessEntries(t *testing.T) {
+	// A JWK with no kid is legal under RFC 7517 but useless to us —
+	// skip rather than fail construction.
+	t.Parallel()
+	key, _ := newOIDCTestKey(t)
+	jwkNoKid := jwkFromRSA(&key.PublicKey, "") // empty kid
+	jwkWithKid := jwkFromRSA(&key.PublicKey, "other-kid")
+	set, err := auth.NewKeySet(&auth.JWKS{Keys: []auth.JSONWebKey{jwkNoKid, jwkWithKid}})
+	if err != nil {
+		t.Fatalf("NewKeySet: %v", err)
+	}
+	if _, ok := set.Lookup(""); ok {
+		t.Error("empty kid should not be indexable")
+	}
+	if _, ok := set.Lookup("other-kid"); !ok {
+		t.Error("kidded key should be usable")
+	}
+}
+
+func TestNewKeySetFromJSON_ParsesIssuerResponse(t *testing.T) {
+	t.Parallel()
+	_, jwks := newOIDCTestKey(t)
+	blob, err := json.Marshal(jwks)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	set, err := auth.NewKeySetFromJSON(blob)
+	if err != nil {
+		t.Fatalf("NewKeySetFromJSON: %v", err)
+	}
+	if _, ok := set.Lookup(testOIDCKid); !ok {
+		t.Error("key lookup failed after NewKeySetFromJSON")
+	}
+}
+
+func TestNewKeySetFromJSON_RejectsGarbage(t *testing.T) {
+	t.Parallel()
+	if _, err := auth.NewKeySetFromJSON([]byte("not-json")); err == nil {
+		t.Error("expected error on garbage JSON")
+	}
+}
+
+func TestOIDCValidator_AdmitsValidToken(t *testing.T) {
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  testAliceEmail,
+		extras: map[string]any{
+			"omnia.role": policy.RoleEditor,
+			"email":      testAliceEmail,
+			"groups":     "finance",
+		},
+		key: key,
+	})
+
+	id, err := v.Validate(context.Background(), oidcReq(token))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id == nil {
+		t.Fatal("nil identity on admit")
+	}
+	if got, want := id.Origin, policy.OriginOIDC; got != want {
+		t.Errorf("Origin = %q, want %q", got, want)
+	}
+	if got, want := id.Subject, testAliceEmail; got != want {
+		t.Errorf("Subject = %q, want %q", got, want)
+	}
+	if got, want := id.Role, policy.RoleEditor; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if got, want := id.EndUser, id.Subject; got != want {
+		t.Errorf("EndUser = %q, want %q (default mapping → Subject)", got, want)
+	}
+	if got, want := id.Claims["email"], testAliceEmail; got != want {
+		t.Errorf("Claims[email] = %q, want %q", got, want)
+	}
+	if got, want := id.Claims["groups"], "finance"; got != want {
+		t.Errorf("Claims[groups] = %q, want %q", got, want)
+	}
+	if id.ExpiresAt.IsZero() {
+		t.Error("ExpiresAt should be populated from exp claim")
+	}
+}
+
+func TestOIDCValidator_RejectsWrongIssuer(t *testing.T) {
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   "https://other-idp.example.com",
+		audience: testOIDCAudience,
+		subject:  "alice",
+		key:      key,
+	})
+
+	_, err := v.Validate(context.Background(), oidcReq(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestOIDCValidator_RejectsWrongAudience(t *testing.T) {
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: "not-omnia",
+		subject:  "alice",
+		key:      key,
+	})
+
+	_, err := v.Validate(context.Background(), oidcReq(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestOIDCValidator_RejectsExpiredToken(t *testing.T) {
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  "alice",
+		exp:      time.Now().Add(-time.Minute),
+		key:      key,
+	})
+
+	_, err := v.Validate(context.Background(), oidcReq(token))
+	if !errors.Is(err, auth.ErrExpired) {
+		t.Errorf("err = %v, want ErrExpired", err)
+	}
+}
+
+func TestOIDCValidator_RejectsUnknownKid(t *testing.T) {
+	// A JWT signed by a key whose kid isn't in the JWKS cache should be
+	// rejected — this is the kid-rotation-lag case the design doc
+	// flagged. Facade annotates AgentRuntime for refresh in PR 2d-2;
+	// for MVP we just reject.
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      "unknown-kid",
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  "alice",
+		key:      key,
+	})
+
+	_, err := v.Validate(context.Background(), oidcReq(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestOIDCValidator_RejectsTokenWithoutKid(t *testing.T) {
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		// no kid
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  "alice",
+		key:      key,
+	})
+
+	_, err := v.Validate(context.Background(), oidcReq(token))
+	if !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestOIDCValidator_RejectsWrongSigningKey(t *testing.T) {
+	t.Parallel()
+	v, _ := newOIDCValidatorForTest(t)
+	otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  "alice",
+		key:      otherKey,
+	})
+
+	_, e := v.Validate(context.Background(), oidcReq(token))
+	if !errors.Is(e, auth.ErrInvalidCredential) {
+		t.Errorf("err = %v, want ErrInvalidCredential", e)
+	}
+}
+
+func TestOIDCValidator_RejectsHMACSigningMethod(t *testing.T) {
+	// A token signed with HS256 against the validator's RSA key material
+	// must be rejected even if the bytes accidentally verify — the
+	// WithValidMethods option should short-circuit.
+	t.Parallel()
+	v, _ := newOIDCValidatorForTest(t)
+	hmac := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+		"iss": testOIDCIssuer,
+		"aud": testOIDCAudience,
+		"sub": "alice",
+		"exp": jwt.NewNumericDate(time.Now().Add(5 * time.Minute)).Unix(),
+	})
+	hmac.Header["kid"] = testOIDCKid
+	signed, err := hmac.SignedString([]byte("shared"))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if _, err := v.Validate(context.Background(), oidcReq(signed)); !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("HMAC token: err = %v, want ErrInvalidCredential", err)
+	}
+}
+
+func TestOIDCValidator_NoBearerFallsThrough(t *testing.T) {
+	t.Parallel()
+	v, _ := newOIDCValidatorForTest(t)
+	r := httptest.NewRequest(http.MethodGet, "/ws", nil)
+	_, err := v.Validate(context.Background(), r)
+	if !errors.Is(err, auth.ErrNoCredential) {
+		t.Errorf("err = %v, want ErrNoCredential", err)
+	}
+}
+
+func TestOIDCValidator_CustomClaimMapping(t *testing.T) {
+	t.Parallel()
+	mapping := auth.OIDCClaimMapping{
+		Subject: "user_id",
+		Role:    "tier",
+		EndUser: "actor",
+	}
+	v, key := newOIDCValidatorForTest(t, auth.WithOIDCClaimMapping(mapping))
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  "service-token",
+		extras: map[string]any{
+			"user_id": "svc-payroll",
+			"tier":    policy.RoleAdmin,
+			"actor":   testAliceEmail,
+		},
+		key: key,
+	})
+
+	id, err := v.Validate(context.Background(), oidcReq(token))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	// Default sub claim goes into jwt's Subject but NOT our Identity
+	// because we mapped Subject to "user_id".
+	if got, want := id.Subject, "svc-payroll"; got != want {
+		t.Errorf("Subject = %q, want %q (custom mapping user_id → Subject)", got, want)
+	}
+	if got, want := id.Role, policy.RoleAdmin; got != want {
+		t.Errorf("Role = %q, want %q", got, want)
+	}
+	if got, want := id.EndUser, testAliceEmail; got != want {
+		t.Errorf("EndUser = %q, want %q (service token → actor)", got, want)
+	}
+}
+
+func TestOIDCValidator_EndUserFallsBackToSubjectWhenMappedClaimMissing(t *testing.T) {
+	// The CRD says "If the named claim is missing from a given token,
+	// the validator falls back to Subject." Test that explicitly.
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t, auth.WithOIDCClaimMapping(auth.OIDCClaimMapping{
+		EndUser: "actor", // claim name that isn't present
+	}))
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  testAliceEmail,
+		key:      key,
+	})
+
+	id, err := v.Validate(context.Background(), oidcReq(token))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if id.EndUser != testAliceEmail {
+		t.Errorf("EndUser = %q, want %q (fallback to Subject when mapped claim missing)",
+			id.EndUser, testAliceEmail)
+	}
+}
+
+func TestOIDCValidator_KeySetReplaceAllowsHotReload(t *testing.T) {
+	// KeySet.Replace atomically swaps the map — proves the cmd/agent
+	// periodic-refresh pattern works without reconstructing the validator.
+	t.Parallel()
+	key1, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("key1: %v", err)
+	}
+	key2, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("key2: %v", err)
+	}
+	jwks1 := &auth.JWKS{Keys: []auth.JSONWebKey{jwkFromRSA(&key1.PublicKey, "k1")}}
+	set, err := auth.NewKeySet(jwks1)
+	if err != nil {
+		t.Fatalf("NewKeySet: %v", err)
+	}
+	v, err := auth.NewOIDCValidator(testOIDCIssuer, testOIDCAudience, set)
+	if err != nil {
+		t.Fatalf("NewOIDCValidator: %v", err)
+	}
+
+	// Token signed with key1 — admits
+	t1 := mintOIDCToken(t, oidcMintOpts{
+		kid: "k1", issuer: testOIDCIssuer, audience: testOIDCAudience,
+		subject: "alice", key: key1,
+	})
+	if _, err := v.Validate(context.Background(), oidcReq(t1)); err != nil {
+		t.Fatalf("before rotate: %v", err)
+	}
+
+	// Rotate: swap in key2 under kid=k2. set now knows only k2.
+	set.Replace(map[string]*rsa.PublicKey{"k2": &key2.PublicKey})
+
+	// Old kid is gone.
+	if _, err := v.Validate(context.Background(), oidcReq(t1)); !errors.Is(err, auth.ErrInvalidCredential) {
+		t.Errorf("after rotate: old kid should be unknown, got err = %v", err)
+	}
+
+	// New kid + new key admits.
+	t2 := mintOIDCToken(t, oidcMintOpts{
+		kid: "k2", issuer: testOIDCIssuer, audience: testOIDCAudience,
+		subject: "alice", key: key2,
+	})
+	if _, err := v.Validate(context.Background(), oidcReq(t2)); err != nil {
+		t.Errorf("after rotate, new key: %v", err)
+	}
+}

--- a/internal/facade/auth/oidc_test.go
+++ b/internal/facade/auth/oidc_test.go
@@ -39,11 +39,8 @@ const (
 	testOIDCIssuer   = "https://idp.example.com"
 	testOIDCAudience = "omnia"
 	testOIDCKid      = "test-key-1"
-	// testAliceEmail is referenced across several test files in this
-	// package; defined here since oidc_test.go is the first to need it
-	// under PR 2d. PR 2e's edge_trust_test.go will drop its local
-	// definition on rebase.
-	testAliceEmail = "alice@example.com"
+	// testAliceEmail is defined in edge_trust_test.go (PR 2e, already
+	// on main); referenced here to avoid the goconst lint warning.
 )
 
 // newOIDCTestKey generates an RSA keypair and returns it plus a JWKS

--- a/internal/facade/auth/shared_token_test.go
+++ b/internal/facade/auth/shared_token_test.go
@@ -133,13 +133,13 @@ func TestSharedTokenValidator_TrustEndUserHeader(t *testing.T) {
 		auth.WithSharedTokenTrustEndUserHeader(true),
 	)
 	r := newRequestWithBearer(validToken)
-	r.Header.Set(auth.EndUserHeader, "alice@example.com")
+	r.Header.Set(auth.EndUserHeader, testAliceEmail)
 
 	id, err := v.Validate(context.Background(), r)
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-	if got, want := id.EndUser, "alice@example.com"; got != want {
+	if got, want := id.EndUser, testAliceEmail; got != want {
 		t.Errorf("EndUser = %q, want %q", got, want)
 	}
 	// Subject MUST stay the token-holder identifier — only EndUser shifts.
@@ -152,7 +152,7 @@ func TestSharedTokenValidator_TrustEndUserHeaderDefaultsOff(t *testing.T) {
 	t.Parallel()
 	v, _ := auth.NewSharedTokenValidator(validToken)
 	r := newRequestWithBearer(validToken)
-	r.Header.Set(auth.EndUserHeader, "alice@example.com") // ignored
+	r.Header.Set(auth.EndUserHeader, testAliceEmail) // ignored
 
 	id, err := v.Validate(context.Background(), r)
 	if err != nil {


### PR DESCRIPTION
## Summary

Adds the OIDC branch of the data-plane auth chain. Facade-side only — the AgentRuntime controller reconciler that auto-fetches the JWKS from the issuer's discovery endpoint lands in **PR 2d-2**. Operators can create the JWKS Secret manually today (`agent-<name>-oidc-jwks` with `jwks.json` holding the raw IdP response).

## Files

| File | Role |
|---|---|
| `internal/facade/auth/oidc.go` | `OIDCValidator` — parses JWT, verifies against a `KeySupplier` using the token's `kid` header, enforces `iss/aud/exp/nbf/iat`, translates claims into `AuthenticatedIdentity` via configurable `OIDCClaimMapping` (defaults: `sub→Subject`, `omnia.role→Role`, `sub→EndUser`; `EndUser` falls back to `Subject` when mapped claim missing). `WithValidMethods` pins RS256 so an HMAC-signed token can't accidentally verify against the RSA key material. `KeySet.Replace` allows zero-allocation hot-reload from periodic refresh. |
| `cmd/agent/oidc_jwks.go` | `SecretBackedJWKSStore` — loads per-agent JWKS Secret at startup, parses into `auth.KeySet`, refreshes every 5 minutes. Initial-load failure is fatal; refresh failure logs and keeps previous snapshot. |
| `cmd/agent/auth_chain.go` | `buildOIDCValidator` appends the OIDC validator to the chain when `spec.externalAuth.oidc` is configured. |

## Test plan

- [x] **14 unit tests** on `OIDCValidator`: admit / wrong issuer / wrong audience / expired / unknown kid / no-kid / wrong signing key / HMAC method rejected / no bearer / custom claim mapping / `EndUser` falls-back-to-Subject / `KeySet` hot-reload / constructor arg validation / JWKS empty-malformed-skips-non-RSA-skips-kidless.
- [x] **8 unit tests** on `SecretBackedJWKSStore` + `buildOIDCValidator`: initial load happy-path / missing secret errors / missing data-key errors / malformed JWKS errors / clock option / unknown-kid lookup false / naming helper / unset returns nil / missing-issuer-or-audience errors / missing-JWKS errors / happy path / `ClaimMapping` propagation.
- [x] `golangci-lint run` clean (refactored Validate to keep cognitive complexity under 15 via `identityFromClaims` helper).
- [x] `go test` green locally.
- [ ] CI + SonarCloud.

## What does NOT land here

- **AgentRuntime controller reconciler** — fetches `{issuer}/.well-known/openid-configuration` → `jwks_uri` and writes the JWKS into the per-agent Secret. Follow-up **PR 2d-2**.
- **On-demand JWKS refresh** on `kid` cache miss — MVP rejects unknown-kid tokens with `ErrInvalidCredential`. Follow-up via facade-annotation-bump pattern.

## What lands next

- PR 2d-2 controller reconciler automating JWKS fetch.
- PR 3 default flip (unauth upgrade → 401) — needs 2d merged.