### PR TITLE
feat(facade): reject unauthenticated upgrade by default — closes C-3 (PR 3)

### DIFF
--- a/internal/facade/auth/middleware.go
+++ b/internal/facade/auth/middleware.go
@@ -17,7 +17,6 @@ limitations under the License.
 package auth
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -29,7 +28,8 @@ import (
 type MiddlewareOption func(*middlewareConfig)
 
 type middlewareConfig struct {
-	log logr.Logger
+	log                  logr.Logger
+	allowUnauthenticated bool
 }
 
 // WithMiddlewareLogger binds a logr.Logger for rejection telemetry. The
@@ -39,47 +39,69 @@ func WithMiddlewareLogger(log logr.Logger) MiddlewareOption {
 	return func(c *middlewareConfig) { c.log = log }
 }
 
+// WithMiddlewareAllowUnauthenticated controls the empty-chain fallback.
+// Defaults to true so dev/test handlers without a chain configured keep
+// working. Set false to reject every unauthenticated request including
+// the empty-chain case.
+//
+// When the chain is non-empty, ErrNoCredential from all validators
+// always 401s regardless of this flag — that's the PR 3 default-flip
+// semantic. Production deployments run a non-empty chain (mgmt-plane
+// at minimum) so this flag is a no-op for them.
+func WithMiddlewareAllowUnauthenticated(allow bool) MiddlewareOption {
+	return func(c *middlewareConfig) { c.allowUnauthenticated = allow }
+}
+
 // Middleware returns an http.Handler wrapper that runs `chain` against
 // each request. On admit it attaches the AuthenticatedIdentity to the
-// request context via policy.WithIdentity and calls next. On
-// ErrNoCredential (or empty chain) it calls next without attaching an
-// identity — the PR 1 unauthenticated-upgrade default stays intact
-// until PR 3 flips it. On any other chain error it returns 401 and
-// short-circuits next.
+// request context via policy.WithIdentity and calls next.
+//
+// PR 3 flipped the ErrNoCredential path: when a non-empty chain is
+// configured and no validator admits, the middleware returns 401
+// instead of falling through to next. Empty chain (no validators
+// configured) still falls through when allowUnauthenticated is true
+// (the default) so dev/test handlers work — production always runs a
+// non-empty chain with mgmt-plane at minimum.
 //
 // Unlike the WS server's inline authenticateRequest, this wrapper works
 // with any http.Handler — used by the A2A HTTP server which the
 // dashboard proxy doesn't front.
 func Middleware(chain Chain, next http.Handler, opts ...MiddlewareOption) http.Handler {
-	cfg := &middlewareConfig{log: logr.Discard()}
+	cfg := &middlewareConfig{
+		log:                  logr.Discard(),
+		allowUnauthenticated: true,
+	}
 	for _, opt := range opts {
 		opt(cfg)
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if len(chain) == 0 {
-			next.ServeHTTP(w, r)
+			if cfg.allowUnauthenticated {
+				next.ServeHTTP(w, r)
+				return
+			}
+			reject401(w, r, cfg.log, "empty chain with allowUnauthenticated=false")
 			return
 		}
 		id, err := chain.Run(r.Context(), r)
-		switch {
-		case err == nil:
-			// Admit: attach identity so downstream handlers (and
-			// ToolPolicy CEL) can reason about the caller.
-			ctx := policy.WithIdentity(r.Context(), id)
-			next.ServeHTTP(w, r.WithContext(ctx))
-		case errors.Is(err, ErrNoCredential):
-			// PR 1 default: no credential → proceed unauthenticated.
-			// PR 3 flips this at the caller layer by configuring a
-			// strict chain that returns ErrInvalidCredential instead.
-			next.ServeHTTP(w, r)
-		default:
-			// ErrInvalidCredential / ErrExpired / anything else →
-			// reject. 401 is the right status per the design doc.
-			cfg.log.V(1).Info("auth middleware rejected request",
-				"reason", err.Error(),
-				"path", r.URL.Path,
-				"method", r.Method)
-			http.Error(w, "unauthorized", http.StatusUnauthorized)
+		if err != nil {
+			// ErrNoCredential / ErrInvalidCredential / ErrExpired /
+			// anything else → reject. PR 3 flipped the ErrNoCredential
+			// branch from "pass through" to 401 to close pen-test C-3.
+			reject401(w, r, cfg.log, err.Error())
+			return
 		}
+		// Admit: attach identity so downstream handlers (and
+		// ToolPolicy CEL) can reason about the caller.
+		ctx := policy.WithIdentity(r.Context(), id)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func reject401(w http.ResponseWriter, r *http.Request, log logr.Logger, reason string) {
+	log.V(1).Info("auth middleware rejected request",
+		"reason", reason,
+		"path", r.URL.Path,
+		"method", r.Method)
+	http.Error(w, "unauthorized", http.StatusUnauthorized)
 }

--- a/internal/facade/auth/middleware_test.go
+++ b/internal/facade/auth/middleware_test.go
@@ -104,10 +104,10 @@ func TestMiddleware_AdmitAttachesIdentity(t *testing.T) {
 	}
 }
 
-func TestMiddleware_NoCredentialFallsThrough(t *testing.T) {
-	// ErrNoCredential from all validators → no identity, but next still runs.
-	// This is PR 1a/c's unauthenticated-upgrade default; PR 3 flips it
-	// by configuring a chain that ends with an always-reject validator.
+func TestMiddleware_NoCredentialRejects401(t *testing.T) {
+	// PR 3: ErrNoCredential from every validator in a non-empty chain
+	// now 401s instead of falling through. Non-empty chain = "operator
+	// configured auth", so not presenting a credential is a hard fail.
 	t.Parallel()
 	chain := auth.Chain{&stubMwValidator{err: auth.ErrNoCredential}}
 	next := &observingHandler{}
@@ -115,14 +115,11 @@ func TestMiddleware_NoCredentialFallsThrough(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mw.ServeHTTP(rec, newMwRequest())
 
-	if next.called != 1 {
-		t.Errorf("next called %d, want 1 (fall-through)", next.called)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (PR 3: no credential with chain configured must reject)", rec.Code)
 	}
-	if next.saw != nil {
-		t.Errorf("expected no identity attached, got %+v", next.saw)
-	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", rec.Code)
+	if next.called != 0 {
+		t.Errorf("next called %d, want 0 (must short-circuit)", next.called)
 	}
 }
 
@@ -179,9 +176,10 @@ func TestMiddleware_ChainOrderAdmitsFirstMatch(t *testing.T) {
 	}
 }
 
-func TestMiddleware_FallThroughMultipleValidators(t *testing.T) {
-	// Every validator returns ErrNoCredential; chain ends up returning
-	// ErrNoCredential; middleware falls through to next.
+func TestMiddleware_AllFallThroughRejects401(t *testing.T) {
+	// PR 3: when every validator in a non-empty chain returns
+	// ErrNoCredential, the middleware rejects with 401 regardless of
+	// how many validators are in the chain.
 	t.Parallel()
 	chain := auth.Chain{
 		&stubMwValidator{err: auth.ErrNoCredential},
@@ -193,10 +191,29 @@ func TestMiddleware_FallThroughMultipleValidators(t *testing.T) {
 	rec := httptest.NewRecorder()
 	mw.ServeHTTP(rec, newMwRequest())
 
-	if next.called != 1 {
-		t.Errorf("next called %d, want 1", next.called)
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
 	}
-	if rec.Code != http.StatusOK {
-		t.Errorf("status = %d, want 200", rec.Code)
+	if next.called != 0 {
+		t.Error("next must not run when chain rejects every request")
+	}
+}
+
+func TestMiddleware_EmptyChainStrictModeRejects401(t *testing.T) {
+	// PR 3 escape hatch: set WithMiddlewareAllowUnauthenticated(false)
+	// to reject empty-chain requests too. Used by integration tests
+	// that want to prove the strict default without configuring a
+	// chain.
+	t.Parallel()
+	next := &observingHandler{}
+	mw := auth.Middleware(auth.Chain{}, next, auth.WithMiddlewareAllowUnauthenticated(false))
+	rec := httptest.NewRecorder()
+	mw.ServeHTTP(rec, newMwRequest())
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 with strict empty-chain mode", rec.Code)
+	}
+	if next.called != 0 {
+		t.Error("next must not run in strict mode with empty chain")
 	}
 }

--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -159,15 +159,23 @@ type Server struct {
 	// authChain, when non-empty, runs every configured Validator against
 	// the upgrade request in order and admits on the first match. On
 	// admit the identity flows into PropagationFields.Identity and the
-	// flat UserID / UserRoles / UserEmail fields. Empty chain (or
-	// chain-wide ErrNoCredential) preserves the PR 1 unauthenticated
-	// upgrade default; invalid/expired credentials always 401.
+	// flat UserID / UserRoles / UserEmail fields.
 	//
-	// PR 1a/c shipped a single mgmtPlaneValidator field; PR 2b promotes
-	// it to a chain so the data-plane validators (sharedToken, apiKeys,
-	// oidc, edgeTrust) can stack with mgmt-plane behind them.
+	// PR 3 flipped the chain-wide ErrNoCredential behaviour from
+	// "proceed unauthenticated" (PR 1 default) to "return 401 before
+	// Upgrade", closing pen-test finding C-3.
+	//
+	// Empty chain still proceeds when allowUnauthenticated is true (the
+	// default) so dev/test binaries without any validator configured
+	// keep working; set WithAllowUnauthenticated(false) to reject those
+	// as well.
 	authChain auth.Chain
-	log       logr.Logger
+	// allowUnauthenticated controls the empty-chain fallback. Default
+	// true for back-compat with dev/test; production always has at
+	// least the mgmt-plane validator in the chain, so this flag is a
+	// no-op in deployed setups.
+	allowUnauthenticated bool
+	log                  logr.Logger
 
 	mu           sync.RWMutex
 	connections  map[*websocket.Conn]*Connection
@@ -241,17 +249,40 @@ func WithMgmtPlaneValidator(v auth.Validator) ServerOption {
 
 // WithAuthChain configures the server to run the supplied auth chain on
 // every upgrade. Admit attaches the resulting identity to the
-// connection's PropagationFields. ErrNoCredential (or empty chain)
-// preserves the PR 1 unauthenticated upgrade default; any other error
-// returns 401 before Upgrade.
+// connection's PropagationFields. ErrNoCredential (no validator admits)
+// now returns 401 before Upgrade — PR 3 flipped this from the
+// behaviour-preserving default of proceeding unauthenticated, closing
+// pen-test finding C-3.
 //
 // Validator order matters — the first validator that admits wins, so
 // list the most specific credential style first. The conventional order
 // shipped by cmd/agent is sharedToken → apiKeys → oidc → edgeTrust →
 // mgmt-plane.
+//
+// Empty chain still proceeds unauthenticated to keep the dev/test path
+// working when no validator can be constructed (no mgmt-plane key, no
+// externalAuth CRD). Set WithAllowUnauthenticated(false) at the server
+// to also reject those requests.
 func WithAuthChain(chain auth.Chain) ServerOption {
 	return func(s *Server) {
 		s.authChain = chain
+	}
+}
+
+// WithAllowUnauthenticated controls the fallback behaviour when the
+// auth chain is empty (no validators configured). Defaults to true so
+// standalone dev/test binaries without a k8s client or mgmt-plane key
+// still accept WebSocket upgrades. Production deployments going through
+// cmd/agent always have at least the mgmt-plane validator in the chain,
+// so this flag does not affect them — they 401 on missing credentials
+// regardless.
+//
+// Set to false to reject every unauthenticated upgrade including the
+// empty-chain case. Useful for integration tests that want to prove the
+// strict default.
+func WithAllowUnauthenticated(allow bool) ServerOption {
+	return func(s *Server) {
+		s.allowUnauthenticated = allow
 	}
 }
 
@@ -264,6 +295,12 @@ func NewServer(cfg ServerConfig, store session.Store, handler MessageHandler, lo
 		metrics:      &NoOpMetrics{}, // Default to no-op
 		log:          log.WithName("websocket-server"),
 		connections:  make(map[*websocket.Conn]*Connection),
+		// Default true so dev/test binaries keep working without an
+		// auth chain configured. Production deployments always have
+		// at least mgmt-plane in the chain so this flag is a no-op
+		// for them — the PR 3 flip applies via the chain's 401 on
+		// ErrNoCredential regardless of this bool.
+		allowUnauthenticated: true,
 	}
 
 	// Apply options first so allowedOrigins is set before building the upgrader
@@ -369,21 +406,32 @@ func ParseAllowedOrigins(raw string) []string {
 }
 
 // authenticateRequest runs the configured auth chain against the request.
-// Returns the admitted identity (or nil when no chain is configured / no
-// credential was presented), or an error when a credential was presented
-// but rejected. A nil error with a nil identity means "fall through to
-// the existing unauthenticated upgrade path" — PR 1 preserves this for
-// back-compat; PR 3 will flip the default at this layer.
+// Returns the admitted identity, or an error when no validator admits.
+//
+// PR 3 flipped the ErrNoCredential branch from "proceed unauthenticated"
+// to "return 401". Empty chain still proceeds iff allowUnauthenticated
+// is true (default); production deployments always have at least the
+// mgmt-plane validator in the chain so the empty-chain path is a
+// dev/test escape hatch.
+//
+// Returning (nil, nil) means "proceed without identity" — callers
+// should treat this as the unauthenticated-but-allowed path. Returning
+// a non-nil error means "reject" — callers translate to 401.
 func (s *Server) authenticateRequest(r *http.Request) (*policy.AuthenticatedIdentity, error) {
 	if len(s.authChain) == 0 {
-		return nil, nil
+		if s.allowUnauthenticated {
+			return nil, nil
+		}
+		return nil, auth.ErrNoCredential
 	}
 	id, err := s.authChain.Run(r.Context(), r)
 	switch {
 	case err == nil:
 		return id, nil
 	case errors.Is(err, auth.ErrNoCredential):
-		return nil, nil
+		// PR 3: no validator admitted. Production = 401. The PR 1
+		// back-compat pass-through is gone.
+		return nil, err
 	default:
 		// ErrInvalidCredential / ErrExpired / anything else — surface as
 		// a rejection so the caller returns 401.

--- a/internal/facade/server_auth_test.go
+++ b/internal/facade/server_auth_test.go
@@ -128,9 +128,11 @@ func dialWS(t *testing.T, ts *httptest.Server, header http.Header) (*websocket.C
 	return websocket.DefaultDialer.Dial(wsURL(ts.URL)+"?agent=test-agent", header)
 }
 
-func TestServerAuth_NoValidator_AllowsUpgrade(t *testing.T) {
-	// Behaviour-preserving default: with no validator configured, upgrade
-	// proceeds even without Authorization header.
+func TestServerAuth_NoValidator_DevModeAllowsUpgrade(t *testing.T) {
+	// Empty chain is the dev/test escape hatch — allowUnauthenticated
+	// defaults to true at the Server layer so a bare NewServer call
+	// (no WithAuthChain) keeps working for standalone binaries that
+	// have no k8s client or mgmt-plane key.
 	_, ts := newTestServer(t, nil)
 	ws, _, err := dialWS(t, ts, nil)
 	require.NoError(t, err)
@@ -138,26 +140,19 @@ func TestServerAuth_NoValidator_AllowsUpgrade(t *testing.T) {
 	readConnected(t, ws)
 }
 
-func TestServerAuth_ValidatorPresent_NoAuthHeader_AllowsUpgrade(t *testing.T) {
-	// PR 1 preserves the unauthenticated upgrade path even when a validator
-	// is configured. PR 3 flips this default.
+func TestServerAuth_ValidatorPresent_NoAuthHeader_Rejects401(t *testing.T) {
+	// PR 3: with a chain configured, a request carrying no credential
+	// must 401 before Upgrade. This is the default-flip that closes
+	// pen-test C-3 — a customer app reaching the facade without
+	// authentication must not get a WebSocket session.
 	v, _ := newAuthTestValidator(t)
-	ts, observed := newAuthTestServer(t, v)
+	ts, _ := newAuthTestServer(t, v)
 
-	ws, _, err := dialWS(t, ts, nil)
-	require.NoError(t, err)
-	defer func() { _ = ws.Close() }()
-	readConnected(t, ws)
-
-	// Send a message so the handler captures propagation fields.
-	require.NoError(t, ws.WriteJSON(ClientMessage{Type: "user_message", Content: "hi"}))
-
-	select {
-	case fields := <-observed:
-		assert.Nil(t, fields.Identity, "no credential presented → no Identity attached")
-	case <-time.After(2 * time.Second):
-		t.Fatal("handler did not run")
-	}
+	_, resp, err := dialWS(t, ts, nil)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"PR 3: missing credential with chain configured must 401")
 }
 
 func TestServerAuth_ValidToken_AttachesIdentity(t *testing.T) {
@@ -228,18 +223,21 @@ func TestServerAuth_MalformedToken_Rejects(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }
 
-func TestServerAuth_NonBearerScheme_FallsThrough(t *testing.T) {
-	// Non-Bearer Authorization header (Basic, Negotiate, etc.) is not a
-	// mgmt-plane credential — the chain falls through and the upgrade
-	// proceeds unauthenticated (PR 1 behaviour).
+func TestServerAuth_NonBearerScheme_Rejects401(t *testing.T) {
+	// PR 3: a non-Bearer Authorization header (Basic, Negotiate, etc.)
+	// is no credential any configured validator recognises. Under PR 3
+	// the chain-wide ErrNoCredential result 401s instead of falling
+	// through to the unauthenticated upgrade path. This closes the
+	// "attacker sends Basic auth and gets a WS session" bypass.
 	v, _ := newAuthTestValidator(t)
 	ts, _ := newAuthTestServer(t, v)
 
 	header := http.Header{"Authorization": []string{"Basic dXNlcjpwYXNz"}}
-	ws, _, err := dialWS(t, ts, header)
-	require.NoError(t, err)
-	defer func() { _ = ws.Close() }()
-	readConnected(t, ws)
+	_, resp, err := dialWS(t, ts, header)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
+		"non-Bearer Authorization with chain configured must 401")
 }
 
 // TestServerAuth_SharedTokenChain_AdmitsBeforeMgmtPlane proves that PR


### PR DESCRIPTION
## Summary

The default-flip that closes pen-test finding **C-3** — "unauthenticated Upgrade on any facade type." When the auth chain is non-empty and every validator returns `ErrNoCredential`, the facade now returns 401 before the WebSocket upgrade / A2A handler runs. The PR 1a/c pass-through semantic is gone.

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| Chain configured + valid credential | admit + identity | admit + identity *(unchanged)* |
| Chain configured + invalid / expired credential | 401 | 401 *(unchanged)* |
| **Chain configured + no credential presented** | **proceed unauth** | **401** |
| **Chain configured + non-Bearer Authorization** (Basic, Negotiate) | **proceed unauth** | **401** |
| Empty chain (dev/test, no validators configured) | proceed unauth | proceed unauth *(via `WithAllowUnauthenticated(true)`, default)* |
| Empty chain + `WithAllowUnauthenticated(false)` | n/a | 401 *(new opt-in)* |

## Files

| File | Role |
|---|---|
| `internal/facade/server.go` | `authenticateRequest` — `ErrNoCredential` now returns err (401) instead of `(nil, nil)`. Added `allowUnauthenticated` field + `WithAllowUnauthenticated(bool)` option (default true for empty-chain dev mode). |
| `internal/facade/auth/middleware.go` | `Middleware` — any non-nil error from `chain.Run` 401s. Empty-chain mode controlled by `WithMiddlewareAllowUnauthenticated(bool)` (default true). |

## Operator upgrade notes

- **AgentRuntime with `spec.externalAuth` UNSET** → facade runs mgmt-plane-only. Any request without a dashboard-minted Bearer (external customer apps, curl without auth) now 401s where it previously succeeded. Operators must either:
  - configure `spec.externalAuth` on every agent serving external traffic, OR
  - move to the chart's Istio gate (`authentication.enabled: true`) which propagates trusted headers consumed by the `edgeTrust` validator.
- **Dashboard debug view** ("Try this agent") stays working — the WS proxy attaches a mgmt-plane JWT (PR 1c, already shipped).
- **Legacy `spec.a2a.authentication.secretRef`** still works — PR 2a's projection shim folds it into `spec.externalAuth.sharedToken` at reconcile time.

## Test plan

- [x] 9 WebSocket integration tests in `internal/facade/server_auth_test.go` updated/added:
  - `TestServerAuth_NoValidator_DevModeAllowsUpgrade` — empty chain still proceeds (dev).
  - `TestServerAuth_ValidatorPresent_NoAuthHeader_Rejects401` — the default-flip.
  - `TestServerAuth_NonBearerScheme_Rejects401` — closes the Basic-auth bypass.
  - `TestServerAuth_InvalidToken_Rejects`, `_ExpiredToken_Rejects`, `_MalformedToken_Rejects` — unchanged.
  - `TestServerAuth_ValidToken_AttachesIdentity`, `_SharedTokenChain_AdmitsBeforeMgmtPlane`, `_RejectsWrongToken` — unchanged.
- [x] 8 middleware tests in `internal/facade/auth/middleware_test.go`:
  - `TestMiddleware_NoCredentialRejects401` — default-flip.
  - `TestMiddleware_AllFallThroughRejects401` — multi-validator chain, every one returns `ErrNoCredential`.
  - `TestMiddleware_EmptyChainStrictModeRejects401` — new opt-in test.
  - Admit path, invalid, expired, chain order, empty-chain-default unchanged.
- [x] 3 sub-tests under `TestBuildA2AHandler_WiresAuthChain` unchanged — A2A handler empty-chain preserves unauth by design (`allowUnauthenticated` default).
- [x] `golangci-lint run` clean.
- [x] `go test ./internal/facade/... ./cmd/agent/...` green locally.
- [ ] CI quality gate.
- [ ] E2E (Core + Arena) — may need `WithAllowUnauthenticated(true)` in the test harness if any existing test leaves the chain empty and relies on pass-through.

## What lands next

- **PR 2d-2** — AgentRuntime controller reconciler that auto-fetches `{issuer}/.well-known/openid-configuration` + JWKS into the per-agent Secret. Operators populate the Secret manually today.
- Docs rewrite of `docs/src/content/docs/how-to/configure-authentication.md` with Istio-free and Istio-gated recipes — small follow-up.

## Ships the design-doc feature

This PR makes the whole series end-to-end functional: a customer app reaching the facade without a valid credential gets a 401 — the original goal of the redesign.