### PR TITLE
feat(controller): auto-fetch OIDC JWKS for agent runtimes (PR 2d-2)

### DIFF
--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -112,6 +113,11 @@ type AgentRuntimeReconciler struct {
 	// RolloutMetrics holds Prometheus metrics for rollout observability.
 	// Nil in tests that don't need metrics.
 	RolloutMetrics *RolloutMetrics
+	// OIDCHTTPClient is the HTTP client used to fetch the OIDC
+	// discovery document and JWKS when spec.externalAuth.oidc is set.
+	// Nil uses a default client with a bounded timeout — tests inject
+	// an httptest.Server-backed client here.
+	OIDCHTTPClient *http.Client
 }
 
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=agentruntimes,verbs=get;list;watch;create;update;patch;delete
@@ -402,6 +408,14 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	SetCondition(&agentRuntime.Status.Conditions, agentRuntime.Generation,
 		privacyCond.Type, privacyCond.Status, privacyCond.Reason, privacyCond.Message)
 
+	// Mirror the OIDC issuer's JWKS into a per-agent Secret (if
+	// spec.externalAuth.oidc is configured). Non-blocking: failures
+	// set the OIDCJWKSReady=False condition and schedule a refresh.
+	jwksNext, err := r.reconcileOIDCJWKS(ctx, agentRuntime)
+	if err != nil {
+		log.Error(err, "OIDC JWKS reconciliation failed")
+	}
+
 	// Set overall Ready condition
 	if agentRuntime.Status.Replicas != nil && agentRuntime.Status.Replicas.Ready > 0 {
 		agentRuntime.Status.Phase = omniav1alpha1.AgentRuntimePhaseRunning
@@ -418,7 +432,7 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{}, nil
+	return scheduleOIDCJWKSRefresh(jwksNext), nil
 }
 
 func (r *AgentRuntimeReconciler) reconcileDelete(ctx context.Context, agentRuntime *omniav1alpha1.AgentRuntime) (ctrl.Result, error) {

--- a/internal/controller/agentruntime_oidc_jwks.go
+++ b/internal/controller/agentruntime_oidc_jwks.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// OIDC JWKS mirror constants. Match the facade side in
+// cmd/agent/oidc_jwks.go so admins can rely on a stable Secret shape.
+const (
+	// OIDCJWKSSecretSuffix is appended to `agent-<name>` to form the
+	// conventional per-agent JWKS Secret name.
+	OIDCJWKSSecretSuffix = "-oidc-jwks"
+
+	// OIDCJWKSDataKey is the key inside the Secret that holds the raw
+	// JWKS JSON blob (verbatim from the issuer's jwks_uri).
+	OIDCJWKSDataKey = "jwks.json"
+
+	// labelCredentialKind tags per-agent credential Secrets so the
+	// dashboard's credential-listing endpoints can enumerate them
+	// without a kind-specific label per Secret type.
+	labelCredentialKind = "omnia.altairalabs.ai/credential-kind"
+
+	// LabelCredentialKindAgentOIDCJWKS is the value stamped onto
+	// labelCredentialKind for the mirror Secret.
+	LabelCredentialKindAgentOIDCJWKS = "agent-oidc-jwks"
+
+	// OIDCJWKSRefreshInterval is how often the reconciler re-fetches
+	// the JWKS from the issuer. The design doc sets 6h; IdPs that
+	// rotate faster than this need the on-demand stale-signal path
+	// (deferred to a future PR).
+	OIDCJWKSRefreshInterval = 6 * time.Hour
+
+	// OIDCDiscoveryPath is the well-known endpoint per RFC 8414.
+	OIDCDiscoveryPath = "/.well-known/openid-configuration"
+
+	// OIDCJWKSHTTPTimeout bounds the issuer round-trip. Generous so
+	// slow IdPs don't churn the reconcile loop, but short enough that
+	// a wedged issuer doesn't hold up other AgentRuntime work.
+	OIDCJWKSHTTPTimeout = 15 * time.Second
+)
+
+// ConditionTypeOIDCJWKSReady is the status condition surfacing the
+// reconciler's last fetch outcome. Set True on successful upsert,
+// False with a Reason of DiscoveryFailed / JWKSFetchFailed /
+// JWKSInvalid so operators can see why their agent refuses external
+// callers.
+const ConditionTypeOIDCJWKSReady = "OIDCJWKSReady"
+
+// oidcDiscovery is the subset of the OIDC provider configuration we
+// care about (RFC 8414). We only need jwks_uri; other fields are
+// ignored so a surprise IdP can still produce a parseable response.
+type oidcDiscovery struct {
+	JWKSURI string `json:"jwks_uri"`
+}
+
+// reconcileOIDCJWKS fetches the issuer's JWKS and mirrors it into
+// `agent-<name>-oidc-jwks`. Returns the requeue duration for the next
+// scheduled refresh (0 when OIDC isn't configured — nothing to
+// refresh).
+//
+// The AgentRuntime controller calls this after the deployment + other
+// resources are reconciled; failures here don't block agent bring-up
+// (the facade's empty JWKS store just 401s OIDC tokens until the next
+// reconcile succeeds).
+func (r *AgentRuntimeReconciler) reconcileOIDCJWKS(
+	ctx context.Context,
+	ar *omniav1alpha1.AgentRuntime,
+) (time.Duration, error) {
+	log := logf.FromContext(ctx).WithValues("oidc-jwks", ar.Name)
+
+	if ar.Spec.ExternalAuth == nil || ar.Spec.ExternalAuth.OIDC == nil {
+		// OIDC not configured — drop any stale Secret so a flip from
+		// enabled-to-disabled doesn't leave dead JWKS lying around.
+		if err := r.deleteOIDCJWKSSecretIfPresent(ctx, ar); err != nil {
+			return 0, fmt.Errorf("clean up stale jwks secret: %w", err)
+		}
+		return 0, nil
+	}
+
+	oidc := ar.Spec.ExternalAuth.OIDC
+	if oidc.Issuer == "" {
+		r.setOIDCJWKSCondition(ar, metav1.ConditionFalse, "MissingIssuer",
+			"spec.externalAuth.oidc.issuer is empty")
+		return 0, fmt.Errorf("oidc issuer is empty")
+	}
+
+	jwks, err := r.fetchOIDCJWKS(ctx, oidc.Issuer)
+	if err != nil {
+		r.setOIDCJWKSCondition(ar, metav1.ConditionFalse, "DiscoveryFailed", err.Error())
+		// Don't return the error — let the reconciler continue so
+		// other agents aren't held up. Next RequeueAfter retries.
+		log.Error(err, "OIDC JWKS fetch failed; will retry")
+		return OIDCJWKSRefreshInterval, nil
+	}
+
+	if err := r.upsertOIDCJWKSSecret(ctx, ar, jwks); err != nil {
+		r.setOIDCJWKSCondition(ar, metav1.ConditionFalse, "SecretWriteFailed", err.Error())
+		return OIDCJWKSRefreshInterval, fmt.Errorf("upsert jwks secret: %w", err)
+	}
+
+	r.setOIDCJWKSCondition(ar, metav1.ConditionTrue, "JWKSUpdated",
+		fmt.Sprintf("JWKS mirrored from %s", oidc.Issuer))
+	return OIDCJWKSRefreshInterval, nil
+}
+
+// fetchOIDCJWKS fetches {issuer}/.well-known/openid-configuration,
+// follows jwks_uri, and returns the raw JWKS JSON blob. The caller
+// stores it verbatim so the facade sees exactly what the IdP published
+// — no round-trip through an intermediate struct that might drop
+// fields the IdP cares about (x5c, key_ops, etc.).
+func (r *AgentRuntimeReconciler) fetchOIDCJWKS(ctx context.Context, issuer string) ([]byte, error) {
+	client := r.oidcHTTPClient()
+	discoveryURL := strings.TrimRight(issuer, "/") + OIDCDiscoveryPath
+
+	disc, err := fetchOIDCDiscovery(ctx, client, discoveryURL)
+	if err != nil {
+		return nil, err
+	}
+	if disc.JWKSURI == "" {
+		return nil, fmt.Errorf("discovery document missing jwks_uri")
+	}
+
+	blob, err := fetchOIDCBlob(ctx, client, disc.JWKSURI)
+	if err != nil {
+		return nil, fmt.Errorf("fetch jwks: %w", err)
+	}
+
+	// Minimal sanity: must be valid JSON with a `keys` array. Full
+	// parse lives on the facade side so a malformed IdP response
+	// still reaches operators via the Secret for diagnosis rather
+	// than getting dropped here.
+	var probe struct {
+		Keys []json.RawMessage `json:"keys"`
+	}
+	if err := json.Unmarshal(blob, &probe); err != nil {
+		return nil, fmt.Errorf("jwks is not valid JSON: %w", err)
+	}
+	if len(probe.Keys) == 0 {
+		return nil, fmt.Errorf("jwks has no keys")
+	}
+	return blob, nil
+}
+
+// oidcHTTPClient returns the HTTP client used for issuer round-trips.
+// Injected via the reconciler's OIDCHTTPClient field so tests can swap
+// in an httptest.Server-backed client; falls back to a reasonable
+// default otherwise.
+func (r *AgentRuntimeReconciler) oidcHTTPClient() *http.Client {
+	if r.OIDCHTTPClient != nil {
+		return r.OIDCHTTPClient
+	}
+	return &http.Client{Timeout: OIDCJWKSHTTPTimeout}
+}
+
+// fetchOIDCDiscovery GETs the well-known discovery document.
+func fetchOIDCDiscovery(ctx context.Context, client *http.Client, url string) (oidcDiscovery, error) {
+	blob, err := fetchOIDCBlob(ctx, client, url)
+	if err != nil {
+		return oidcDiscovery{}, fmt.Errorf("fetch discovery: %w", err)
+	}
+	var disc oidcDiscovery
+	if err := json.Unmarshal(blob, &disc); err != nil {
+		return oidcDiscovery{}, fmt.Errorf("parse discovery: %w", err)
+	}
+	return disc, nil
+}
+
+// fetchOIDCBlob is a tiny GET helper shared by the discovery + JWKS
+// paths. Pulled out so both can surface the same error shape.
+func fetchOIDCBlob(ctx context.Context, client *http.Client, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("new request %s: %w", url, err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: status %d", url, resp.StatusCode)
+	}
+	// Reasonable cap — JWKS payloads should be well under 64 KB.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+	return body, nil
+}
+
+// upsertOIDCJWKSSecret writes the JWKS into the per-agent Secret. Sets
+// controller-reference so the Secret is GC'd when the AgentRuntime is
+// deleted; if that fails (rare — cross-namespace, etc.) we still
+// upsert the content so the facade isn't broken by an ownership edge
+// case.
+func (r *AgentRuntimeReconciler) upsertOIDCJWKSSecret(
+	ctx context.Context,
+	ar *omniav1alpha1.AgentRuntime,
+	jwks []byte,
+) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oidcJWKSSecretName(ar.Name),
+			Namespace: ar.Namespace,
+		},
+	}
+	op, err := controllerutil.CreateOrUpdate(ctx, r.Client, secret, func() error {
+		if err := controllerutil.SetControllerReference(ar, secret, r.Scheme); err != nil {
+			return err
+		}
+		if secret.Labels == nil {
+			secret.Labels = map[string]string{}
+		}
+		secret.Labels[labelCredentialKind] = LabelCredentialKindAgentOIDCJWKS
+		secret.Labels[labelAppInstance] = ar.Name
+		secret.Labels[labelAppManagedBy] = labelValueOmniaOperator
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
+		}
+		secret.Data[OIDCJWKSDataKey] = jwks
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	logf.FromContext(ctx).V(1).Info("oidc jwks secret reconciled",
+		"operation", op,
+		"secret", secret.Name)
+	return nil
+}
+
+// deleteOIDCJWKSSecretIfPresent removes the per-agent JWKS Secret.
+// Called when spec.externalAuth.oidc is turned off; NotFound is
+// swallowed so the reconciler stays idempotent.
+func (r *AgentRuntimeReconciler) deleteOIDCJWKSSecretIfPresent(
+	ctx context.Context,
+	ar *omniav1alpha1.AgentRuntime,
+) error {
+	secret := &corev1.Secret{}
+	key := types.NamespacedName{Name: oidcJWKSSecretName(ar.Name), Namespace: ar.Namespace}
+	err := r.Get(ctx, key, secret)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if err := r.Delete(ctx, secret); err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	return nil
+}
+
+// oidcJWKSSecretName derives the per-agent Secret name. Kept package-
+// local so callers don't cross-import cmd/agent.
+func oidcJWKSSecretName(agentName string) string {
+	return "agent-" + agentName + OIDCJWKSSecretSuffix
+}
+
+// setOIDCJWKSCondition updates the OIDCJWKSReady status condition in-
+// memory on the AgentRuntime. The caller's status update pushes it to
+// the API server.
+func (r *AgentRuntimeReconciler) setOIDCJWKSCondition(
+	ar *omniav1alpha1.AgentRuntime,
+	status metav1.ConditionStatus,
+	reason, message string,
+) {
+	SetCondition(&ar.Status.Conditions, ar.Generation,
+		ConditionTypeOIDCJWKSReady, status, reason, message)
+}
+
+// scheduleOIDCJWKSRefresh returns a ctrl.Result with RequeueAfter set
+// to the next scheduled JWKS refresh, or a zero Result when OIDC is
+// not configured.
+func scheduleOIDCJWKSRefresh(next time.Duration) ctrl.Result {
+	if next == 0 {
+		return ctrl.Result{}
+	}
+	return ctrl.Result{RequeueAfter: next}
+}

--- a/internal/controller/agentruntime_oidc_jwks_test.go
+++ b/internal/controller/agentruntime_oidc_jwks_test.go
@@ -1,0 +1,429 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// fakeJWKSBlob returns a minimal JWKS JSON blob with a single RSA key
+// stub. Good enough to satisfy the reconciler's sanity probe without
+// needing real cryptographic material.
+func fakeJWKSBlob() string {
+	return `{"keys":[{"kty":"RSA","kid":"k1","use":"sig","n":"stub","e":"AQAB"}]}`
+}
+
+// oidcTestServer spins up an httptest.Server that serves an RFC-8414
+// discovery document pointing at its own /jwks endpoint. The returned
+// close function MUST be called by the test.
+func oidcTestServer(t *testing.T, jwks string) (*httptest.Server, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc(OIDCDiscoveryPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":   serverURL,
+			"jwks_uri": serverURL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(jwks))
+	})
+	srv := httptest.NewServer(mux)
+	serverURL = srv.URL
+	return srv, srv.Close
+}
+
+// testAgentName / testAgentNamespace are the conventional identifiers
+// used across the reconciler tests — picked once so assertions can
+// hard-code derived Secret/label values without drifting as new test
+// cases are added.
+const (
+	testAgentName      = "alpha"
+	testAgentNamespace = "ws-ns"
+)
+
+func newAgentRuntimeWithOIDC(issuer string) *omniav1alpha1.AgentRuntime {
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       testAgentName,
+			Namespace:  testAgentNamespace,
+			UID:        types.UID("uid-" + testAgentName),
+			Generation: 1,
+		},
+	}
+	if issuer != "" {
+		ar.Spec.ExternalAuth = &omniav1alpha1.AgentExternalAuth{
+			OIDC: &omniav1alpha1.OIDCAuth{
+				Issuer:   issuer,
+				Audience: "audience-x",
+			},
+		}
+	}
+	return ar
+}
+
+func newOIDCReconciler(t *testing.T, objs ...client.Object) *AgentRuntimeReconciler {
+	t.Helper()
+	scheme := newScheme(t)
+	fc := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&omniav1alpha1.AgentRuntime{}).
+		WithObjects(objs...).
+		Build()
+	return &AgentRuntimeReconciler{Client: fc, Scheme: scheme}
+}
+
+func TestReconcileOIDCJWKS_NotConfigured(t *testing.T) {
+	t.Parallel()
+	ar := newAgentRuntimeWithOIDC("")
+	r := newOIDCReconciler(t, ar)
+
+	next, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err != nil {
+		t.Fatalf("err = %v, want nil when OIDC absent", err)
+	}
+	if next != 0 {
+		t.Errorf("next = %v, want 0 (no refresh when not configured)", next)
+	}
+}
+
+func TestReconcileOIDCJWKS_DisabledDeletesStaleSecret(t *testing.T) {
+	t.Parallel()
+	ar := newAgentRuntimeWithOIDC("")
+	stale := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      oidcJWKSSecretName("alpha"),
+			Namespace: testAgentNamespace,
+		},
+		Data: map[string][]byte{OIDCJWKSDataKey: []byte("{}")},
+	}
+	r := newOIDCReconciler(t, ar, stale)
+
+	if _, err := r.reconcileOIDCJWKS(context.Background(), ar); err != nil {
+		t.Fatalf("err = %v", err)
+	}
+
+	got := &corev1.Secret{}
+	err := r.Get(context.Background(),
+		types.NamespacedName{Namespace: testAgentNamespace, Name: oidcJWKSSecretName("alpha")},
+		got)
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("stale Secret still present (err=%v); expected NotFound", err)
+	}
+}
+
+func TestReconcileOIDCJWKS_EmptyIssuerErrors(t *testing.T) {
+	t.Parallel()
+	ar := newAgentRuntimeWithOIDC("https://issuer.example")
+	ar.Spec.ExternalAuth.OIDC.Issuer = "" // force empty post-construction
+	r := newOIDCReconciler(t, ar)
+
+	_, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err == nil {
+		t.Fatal("expected error on empty issuer")
+	}
+	// Condition is set to False/MissingIssuer — verify via in-memory AR.
+	cond := findCondition(ar.Status.Conditions, ConditionTypeOIDCJWKSReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "MissingIssuer" {
+		t.Errorf("OIDCJWKSReady condition = %+v, want False/MissingIssuer", cond)
+	}
+}
+
+func TestReconcileOIDCJWKS_HappyPathUpsertsSecret(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := oidcTestServer(t, fakeJWKSBlob())
+	defer cleanup()
+
+	ar := newAgentRuntimeWithOIDC(srv.URL)
+	r := newOIDCReconciler(t, ar)
+	r.OIDCHTTPClient = srv.Client()
+
+	next, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err != nil {
+		t.Fatalf("err = %v, want nil on happy path", err)
+	}
+	if next != OIDCJWKSRefreshInterval {
+		t.Errorf("next = %v, want %v", next, OIDCJWKSRefreshInterval)
+	}
+
+	got := &corev1.Secret{}
+	if err := r.Get(context.Background(),
+		types.NamespacedName{Namespace: testAgentNamespace, Name: oidcJWKSSecretName("alpha")},
+		got); err != nil {
+		t.Fatalf("secret get: %v", err)
+	}
+	if blob := string(got.Data[OIDCJWKSDataKey]); blob != fakeJWKSBlob() {
+		t.Errorf("secret[%s] = %q, want verbatim issuer JWKS", OIDCJWKSDataKey, blob)
+	}
+	if got.Labels[labelCredentialKind] != LabelCredentialKindAgentOIDCJWKS {
+		t.Errorf("labelCredentialKind = %q, want %q",
+			got.Labels[labelCredentialKind], LabelCredentialKindAgentOIDCJWKS)
+	}
+	if got.Labels[labelAppInstance] != "alpha" {
+		t.Errorf("labelAppInstance = %q, want %q", got.Labels[labelAppInstance], "alpha")
+	}
+	if got.Labels[labelAppManagedBy] != labelValueOmniaOperator {
+		t.Errorf("labelAppManagedBy = %q, want %q",
+			got.Labels[labelAppManagedBy], labelValueOmniaOperator)
+	}
+	if len(got.OwnerReferences) != 1 || got.OwnerReferences[0].UID != ar.UID {
+		t.Errorf("ownerReferences = %+v, want exactly one pointing at AgentRuntime",
+			got.OwnerReferences)
+	}
+	cond := findCondition(ar.Status.Conditions, ConditionTypeOIDCJWKSReady)
+	if cond == nil || cond.Status != metav1.ConditionTrue || cond.Reason != "JWKSUpdated" {
+		t.Errorf("OIDCJWKSReady condition = %+v, want True/JWKSUpdated", cond)
+	}
+}
+
+func TestReconcileOIDCJWKS_DiscoveryFailureSetsCondition(t *testing.T) {
+	t.Parallel()
+	// Point the issuer at a dead URL so discovery fails.
+	ar := newAgentRuntimeWithOIDC("http://127.0.0.1:1") // :1 is blackholed
+	r := newOIDCReconciler(t, ar)
+	r.OIDCHTTPClient = &http.Client{Timeout: 200 * 1e6} // 200ms — short
+
+	next, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err != nil {
+		t.Fatalf("reconcileOIDCJWKS returned hard error: %v (should be swallowed)", err)
+	}
+	if next != OIDCJWKSRefreshInterval {
+		t.Errorf("next = %v, want %v (retry schedule)", next, OIDCJWKSRefreshInterval)
+	}
+	cond := findCondition(ar.Status.Conditions, ConditionTypeOIDCJWKSReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse || cond.Reason != "DiscoveryFailed" {
+		t.Errorf("OIDCJWKSReady condition = %+v, want False/DiscoveryFailed", cond)
+	}
+}
+
+func TestReconcileOIDCJWKS_DiscoveryMissingJWKSURI(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	mux.HandleFunc(OIDCDiscoveryPath, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Issuer returns a discovery doc with no jwks_uri field.
+		_, _ = w.Write([]byte(`{"issuer":"x"}`))
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	ar := newAgentRuntimeWithOIDC(srv.URL)
+	r := newOIDCReconciler(t, ar)
+	r.OIDCHTTPClient = srv.Client()
+
+	next, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err != nil {
+		t.Fatalf("reconcileOIDCJWKS returned hard error: %v", err)
+	}
+	if next != OIDCJWKSRefreshInterval {
+		t.Errorf("next = %v, want retry schedule", next)
+	}
+	cond := findCondition(ar.Status.Conditions, ConditionTypeOIDCJWKSReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("OIDCJWKSReady condition = %+v, want False", cond)
+	}
+	if !strings.Contains(cond.Message, "jwks_uri") {
+		t.Errorf("condition message = %q, want mention of jwks_uri", cond.Message)
+	}
+}
+
+func TestReconcileOIDCJWKS_InvalidJWKSJSONFails(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := oidcTestServer(t, "not json at all")
+	defer cleanup()
+
+	ar := newAgentRuntimeWithOIDC(srv.URL)
+	r := newOIDCReconciler(t, ar)
+	r.OIDCHTTPClient = srv.Client()
+
+	next, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err != nil {
+		t.Fatalf("hard error: %v", err)
+	}
+	if next != OIDCJWKSRefreshInterval {
+		t.Errorf("next = %v, want retry schedule", next)
+	}
+	cond := findCondition(ar.Status.Conditions, ConditionTypeOIDCJWKSReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Fatalf("condition = %+v, want False", cond)
+	}
+}
+
+func TestReconcileOIDCJWKS_ZeroKeysFails(t *testing.T) {
+	t.Parallel()
+	srv, cleanup := oidcTestServer(t, `{"keys":[]}`)
+	defer cleanup()
+
+	ar := newAgentRuntimeWithOIDC(srv.URL)
+	r := newOIDCReconciler(t, ar)
+	r.OIDCHTTPClient = srv.Client()
+
+	next, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err != nil {
+		t.Fatalf("hard error: %v", err)
+	}
+	if next != OIDCJWKSRefreshInterval {
+		t.Errorf("next = %v, want retry schedule", next)
+	}
+	cond := findCondition(ar.Status.Conditions, ConditionTypeOIDCJWKSReady)
+	if cond == nil || !strings.Contains(cond.Message, "no keys") {
+		t.Errorf("condition = %+v, want message mentioning 'no keys'", cond)
+	}
+}
+
+func TestReconcileOIDCJWKS_JWKSFetchNon200(t *testing.T) {
+	t.Parallel()
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc(OIDCDiscoveryPath, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":   serverURL,
+			"jwks_uri": serverURL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	})
+	srv := httptest.NewServer(mux)
+	serverURL = srv.URL
+	defer srv.Close()
+
+	ar := newAgentRuntimeWithOIDC(srv.URL)
+	r := newOIDCReconciler(t, ar)
+	r.OIDCHTTPClient = srv.Client()
+
+	next, err := r.reconcileOIDCJWKS(context.Background(), ar)
+	if err != nil {
+		t.Fatalf("hard error: %v", err)
+	}
+	if next != OIDCJWKSRefreshInterval {
+		t.Errorf("next = %v, want retry schedule", next)
+	}
+	cond := findCondition(ar.Status.Conditions, ConditionTypeOIDCJWKSReady)
+	if cond == nil || cond.Status != metav1.ConditionFalse {
+		t.Errorf("condition = %+v, want False", cond)
+	}
+}
+
+func TestReconcileOIDCJWKS_UpsertIsIdempotent(t *testing.T) {
+	t.Parallel()
+	// First reconcile upserts; second reconcile with a different JWKS
+	// body overwrites without error.
+	first := fakeJWKSBlob()
+	second := `{"keys":[{"kty":"RSA","kid":"k2","use":"sig","n":"other","e":"AQAB"}]}`
+	var active = first
+	mux := http.NewServeMux()
+	var serverURL string
+	mux.HandleFunc(OIDCDiscoveryPath, func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"issuer":   serverURL,
+			"jwks_uri": serverURL + "/jwks",
+		})
+	})
+	mux.HandleFunc("/jwks", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, active)
+	})
+	srv := httptest.NewServer(mux)
+	serverURL = srv.URL
+	defer srv.Close()
+
+	ar := newAgentRuntimeWithOIDC(srv.URL)
+	r := newOIDCReconciler(t, ar)
+	r.OIDCHTTPClient = srv.Client()
+
+	if _, err := r.reconcileOIDCJWKS(context.Background(), ar); err != nil {
+		t.Fatalf("first reconcile: %v", err)
+	}
+	active = second
+	if _, err := r.reconcileOIDCJWKS(context.Background(), ar); err != nil {
+		t.Fatalf("second reconcile: %v", err)
+	}
+
+	got := &corev1.Secret{}
+	if err := r.Get(context.Background(),
+		types.NamespacedName{Namespace: testAgentNamespace, Name: oidcJWKSSecretName("alpha")},
+		got); err != nil {
+		t.Fatalf("get secret: %v", err)
+	}
+	if string(got.Data[OIDCJWKSDataKey]) != second {
+		t.Errorf("second reconcile did not overwrite: got %q want %q",
+			got.Data[OIDCJWKSDataKey], second)
+	}
+}
+
+func TestReconcileOIDCJWKS_DeleteMissingSecretIsNoop(t *testing.T) {
+	t.Parallel()
+	// OIDC disabled and no stale Secret to clean up — must not error.
+	ar := newAgentRuntimeWithOIDC("")
+	r := newOIDCReconciler(t, ar)
+
+	if err := r.deleteOIDCJWKSSecretIfPresent(context.Background(), ar); err != nil {
+		t.Fatalf("delete when absent should be noop, got err=%v", err)
+	}
+}
+
+func TestOIDCJWKSSecretName(t *testing.T) {
+	t.Parallel()
+	got := oidcJWKSSecretName("myagent")
+	want := "agent-myagent-oidc-jwks"
+	if got != want {
+		t.Errorf("oidcJWKSSecretName = %q, want %q", got, want)
+	}
+}
+
+func TestScheduleOIDCJWKSRefresh(t *testing.T) {
+	t.Parallel()
+	if res := scheduleOIDCJWKSRefresh(0); res.RequeueAfter != 0 {
+		t.Errorf("zero input: got RequeueAfter=%v, want 0", res.RequeueAfter)
+	}
+	if res := scheduleOIDCJWKSRefresh(OIDCJWKSRefreshInterval); res.RequeueAfter != OIDCJWKSRefreshInterval {
+		t.Errorf("non-zero input: got RequeueAfter=%v, want %v",
+			res.RequeueAfter, OIDCJWKSRefreshInterval)
+	}
+}
+
+func TestOIDCHTTPClient_FallsBackToDefault(t *testing.T) {
+	t.Parallel()
+	r := &AgentRuntimeReconciler{}
+	c := r.oidcHTTPClient()
+	if c == nil {
+		t.Fatal("expected non-nil default client")
+	}
+	if c.Timeout != OIDCJWKSHTTPTimeout {
+		t.Errorf("default timeout = %v, want %v", c.Timeout, OIDCJWKSHTTPTimeout)
+	}
+}
+
+// findCondition is shared across controller tests (see promptpack_skills_test.go).


### PR DESCRIPTION
## Summary
- AgentRuntime controller reconciles a per-agent \`agent-<name>-oidc-jwks\` Secret when \`spec.externalAuth.oidc\` is configured
- Fetches \`{issuer}/.well-known/openid-configuration\` → \`jwks_uri\`, mirrors raw JWKS JSON verbatim
- 6h refresh cadence via \`RequeueAfter\`; disabling OIDC cleans up the Secret; failures surface through a new \`OIDCJWKSReady\` status condition

Facade's \`SecretBackedJWKSStore\` (landed in PR 2d) already consumes this Secret — no facade changes needed. Closes the last gap in the PR 2d OIDC path: operators can now set \`issuer\` + \`audience\` on the CRD and the controller handles key distribution.

## Test plan
- [x] \`go test ./internal/controller/... -count=1\` (578 tests pass)
- [x] \`golangci-lint run ./internal/controller/...\` (clean)
- [x] Per-file coverage: \`agentruntime_oidc_jwks.go\` 89.0%, \`agentruntime_controller.go\` 85.0%
- [x] Unit tests cover: not-configured, disabled-cleans-up, missing-issuer, happy-path upsert, discovery-failure, missing-jwks_uri, invalid JSON, zero-keys, non-200 JWKS, idempotent re-upsert, delete-when-absent, secret-name derivation, requeue scheduling, default HTTP client