### PR TITLE
fix(facade): propagate Identity.Claims to PropagationFields (B3)

### DIFF
--- a/internal/facade/server.go
+++ b/internal/facade/server.go
@@ -575,6 +575,14 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// too — downstream in-process code can inspect it, but it does not
 	// travel over gRPC (the flat UserID/UserRoles/UserEmail/Claims carry
 	// what runtime needs, via ToOutboundHeaders).
+	//
+	// Also propagate the validator's claim map so downstream HTTP tool
+	// calls see X-Omnia-Claim-<name> headers — ToolPolicy's requiredClaims
+	// contract relies on this regardless of which validator admitted.
+	var validatorClaims map[string]string
+	if authIdentity != nil && len(authIdentity.Claims) > 0 {
+		validatorClaims = authIdentity.Claims
+	}
 	connCtx = policy.WithPropagationFields(connCtx, &policy.PropagationFields{
 		AgentName:     agentName,
 		Namespace:     namespace,
@@ -583,6 +591,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		UserRoles:     userRoles,
 		UserEmail:     userEmail,
 		Authorization: authorization,
+		Claims:        validatorClaims,
 		Identity:      authIdentity,
 	})
 

--- a/internal/facade/server_auth_test.go
+++ b/internal/facade/server_auth_test.go
@@ -309,3 +309,71 @@ func TestServerAuth_SharedTokenChain_RejectsWrongToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode,
 		"sharedToken's ErrInvalidCredential must reject; mgmt-plane must NOT be reached")
 }
+
+// stubClaimValidator is an auth.Validator that admits every request
+// and returns a canned AuthenticatedIdentity with a populated Claims
+// map. Good enough to prove the facade copies the map into
+// PropagationFields regardless of which validator did the admit.
+type stubClaimValidator struct {
+	id *policy.AuthenticatedIdentity
+}
+
+func (s *stubClaimValidator) Validate(_ context.Context, _ *http.Request) (*policy.AuthenticatedIdentity, error) {
+	return s.id, nil
+}
+
+// TestServerAuth_IdentityClaims_PropagatedToHeaders proves B3 is fixed:
+// when a validator admits with non-empty Identity.Claims, those claims
+// must reach PropagationFields.Claims so downstream ToOutboundHeaders
+// emits X-Omnia-Claim-<name> headers regardless of which validator
+// admitted.
+func TestServerAuth_IdentityClaims_PropagatedToHeaders(t *testing.T) {
+	want := &policy.AuthenticatedIdentity{
+		Origin:  policy.OriginOIDC,
+		Subject: "alice@example.com",
+		EndUser: "alice@example.com",
+		Role:    policy.RoleEditor,
+		Claims: map[string]string{
+			"team":   "finance",
+			"region": "us-east",
+			"email":  "alice@example.com",
+		},
+	}
+	chain := auth.Chain{&stubClaimValidator{id: want}}
+
+	observed := make(chan policy.PropagationFields, 1)
+	handler := &mockHandler{
+		handleFunc: func(ctx context.Context, _ string, msg *ClientMessage, w ResponseWriter) error {
+			select {
+			case observed <- policy.ExtractPropagationFields(ctx):
+			default:
+			}
+			return w.WriteDone("echo: " + msg.Content)
+		},
+	}
+	store := session.NewMemoryStore()
+	cfg := DefaultServerConfig()
+	cfg.PingInterval = 100 * time.Millisecond
+	cfg.PongTimeout = 200 * time.Millisecond
+	server := NewServer(cfg, store, handler, logr.Discard(), WithAuthChain(chain))
+	ts := httptest.NewServer(server)
+	t.Cleanup(func() { ts.Close(); _ = store.Close() })
+
+	header := http.Header{"Authorization": []string{"Bearer anything"}}
+	ws, _, err := dialWS(t, ts, header)
+	require.NoError(t, err)
+	defer func() { _ = ws.Close() }()
+	readConnected(t, ws)
+	require.NoError(t, ws.WriteJSON(ClientMessage{Type: "user_message", Content: "hi"}))
+
+	select {
+	case fields := <-observed:
+		require.NotNil(t, fields.Identity, "Identity must still be attached")
+		assert.Equal(t, "finance", fields.Claims["team"],
+			"Identity.Claims must be copied into PropagationFields.Claims (B3)")
+		assert.Equal(t, "us-east", fields.Claims["region"])
+		assert.Equal(t, "alice@example.com", fields.Claims["email"])
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler did not run")
+	}
+}


### PR DESCRIPTION
Closes #963.

## Summary
- Copy \`authIdentity.Claims\` into \`PropagationFields.Claims\` when any validator admits a WebSocket upgrade. Previously the map was dropped, so downstream HTTP tool calls never saw the \`X-Omnia-Claim-<name>\` headers ToolPolicy's \`requiredClaims\` contract relies on.
- Affects every validator that surfaces claims (OIDC, edgeTrust, mgmt-plane).
- The in-process CEL \`identity.claims.X\` path already worked via context; this only fixes the outbound header contract.

## Test plan
- [x] New regression test in \`server_auth_test.go\` admits via a stub validator carrying \`{team, region, email}\` and asserts \`ExtractPropagationFields\` sees them
- [x] Verified the test fails without the fix (stashed server.go, reran — 1 fail)
- [x] \`go test ./internal/facade/... -count=1\` — 225 passed
- [x] Per-file coverage: \`server.go\` 87.2% (up from 85)