### PR TITLE
fix(facade): project legacy A2A secretRef in cmd/agent chain builder (B1)

### DIFF
--- a/api/v1alpha1/agentruntime_external_auth_projection.go
+++ b/api/v1alpha1/agentruntime_external_auth_projection.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+// ProjectLegacyA2AAuth folds the deprecated spec.a2a.authentication.secretRef
+// into spec.externalAuth.sharedToken so the new validator chain can treat
+// both shapes uniformly.
+//
+// Precedence rules:
+//   - If spec.externalAuth.sharedToken is already set, do nothing — the
+//     operator has explicitly chosen the new shape and we don't want to
+//     surprise them by overwriting.
+//   - If spec.a2a.authentication.secretRef is unset, do nothing — there's
+//     no legacy state to project.
+//   - Otherwise, ensure spec.externalAuth exists and copy the SecretRef
+//     into spec.externalAuth.sharedToken.
+//
+// Mutates ar in place. Idempotent: subsequent calls with the same input
+// are no-ops once the projection has happened.
+//
+// Why this lives in api/v1alpha1 rather than internal/controller: both
+// the controller's Reconcile and cmd/agent's startup chain builder need
+// to apply the same projection (otherwise legacy CRs that haven't been
+// migrated see an empty data-plane chain at the facade and every request
+// 401s). Keeping it on the type package means both callers share one
+// definition without a reverse dependency.
+//
+// The function does not modify the legacy field. We leave it visible on
+// the spec so operators see exactly what they configured; the controller
+// emits a deprecation warning condition when the old field is still
+// populated.
+func ProjectLegacyA2AAuth(ar *AgentRuntime) {
+	if ar == nil || ar.Spec.A2A == nil {
+		return
+	}
+	// The whole point of this helper is to migrate the deprecated
+	// authentication shape into the new one, so reading the old field is
+	// the intended behaviour — silence staticcheck's deprecated check.
+	legacy := ar.Spec.A2A.Authentication //nolint:staticcheck // SA1019: intentional read of deprecated field for projection
+	if legacy == nil || legacy.SecretRef == nil {
+		return
+	}
+	if ar.Spec.ExternalAuth == nil {
+		ar.Spec.ExternalAuth = &AgentExternalAuth{}
+	}
+	if ar.Spec.ExternalAuth.SharedToken != nil {
+		// Operator explicitly set the new shape — respect it.
+		return
+	}
+	ar.Spec.ExternalAuth.SharedToken = &SharedTokenAuth{
+		SecretRef: *legacy.SecretRef,
+	}
+}

--- a/api/v1alpha1/agentruntime_external_auth_projection_test.go
+++ b/api/v1alpha1/agentruntime_external_auth_projection_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestProjectLegacyA2AAuth_NilAgent(t *testing.T) {
+	t.Parallel()
+	// Should not panic on a nil pointer.
+	ProjectLegacyA2AAuth(nil)
+}
+
+func TestProjectLegacyA2AAuth_NoA2AConfig(t *testing.T) {
+	t.Parallel()
+	ar := &AgentRuntime{}
+	ProjectLegacyA2AAuth(ar)
+	if ar.Spec.ExternalAuth != nil {
+		t.Errorf("ExternalAuth = %+v, want nil when no A2A config to project", ar.Spec.ExternalAuth)
+	}
+}
+
+func TestProjectLegacyA2AAuth_NoLegacyAuth(t *testing.T) {
+	t.Parallel()
+	ar := &AgentRuntime{
+		Spec: AgentRuntimeSpec{
+			A2A: &A2AConfig{},
+		},
+	}
+	ProjectLegacyA2AAuth(ar)
+	if ar.Spec.ExternalAuth != nil {
+		t.Errorf("ExternalAuth = %+v, want nil when legacy auth absent", ar.Spec.ExternalAuth)
+	}
+}
+
+func TestProjectLegacyA2AAuth_ProjectsToNewShape(t *testing.T) {
+	t.Parallel()
+	ar := &AgentRuntime{
+		Spec: AgentRuntimeSpec{
+			A2A: &A2AConfig{
+				Authentication: &A2AAuthConfig{
+					SecretRef: &corev1.LocalObjectReference{Name: "legacy-token"},
+				},
+			},
+		},
+	}
+	ProjectLegacyA2AAuth(ar)
+	if ar.Spec.ExternalAuth == nil {
+		t.Fatal("ExternalAuth not created")
+	}
+	if ar.Spec.ExternalAuth.SharedToken == nil {
+		t.Fatal("ExternalAuth.SharedToken not populated")
+	}
+	if got := ar.Spec.ExternalAuth.SharedToken.SecretRef.Name; got != "legacy-token" {
+		t.Errorf("SecretRef.Name = %q, want %q", got, "legacy-token")
+	}
+}
+
+func TestProjectLegacyA2AAuth_PreservesExistingExternalAuth(t *testing.T) {
+	// When externalAuth.sharedToken is already set, the projection must
+	// not overwrite — operators who deliberately moved to the new shape
+	// shouldn't have legacy state silently take precedence.
+	t.Parallel()
+	ar := &AgentRuntime{
+		Spec: AgentRuntimeSpec{
+			A2A: &A2AConfig{
+				Authentication: &A2AAuthConfig{
+					SecretRef: &corev1.LocalObjectReference{Name: "legacy-token"},
+				},
+			},
+			ExternalAuth: &AgentExternalAuth{
+				SharedToken: &SharedTokenAuth{
+					SecretRef: corev1.LocalObjectReference{Name: "operator-chosen-token"},
+				},
+			},
+		},
+	}
+	ProjectLegacyA2AAuth(ar)
+	if got := ar.Spec.ExternalAuth.SharedToken.SecretRef.Name; got != "operator-chosen-token" {
+		t.Errorf("SecretRef.Name = %q, want %q (legacy must NOT overwrite)", got, "operator-chosen-token")
+	}
+}
+
+func TestProjectLegacyA2AAuth_AppendsAlongsideOtherValidators(t *testing.T) {
+	// When externalAuth is set with non-sharedToken validators, projection
+	// should populate sharedToken alongside them.
+	t.Parallel()
+	ar := &AgentRuntime{
+		Spec: AgentRuntimeSpec{
+			A2A: &A2AConfig{
+				Authentication: &A2AAuthConfig{
+					SecretRef: &corev1.LocalObjectReference{Name: "legacy-token"},
+				},
+			},
+			ExternalAuth: &AgentExternalAuth{
+				OIDC: &OIDCAuth{
+					Issuer:   "https://idp.example.com",
+					Audience: "omnia",
+				},
+			},
+		},
+	}
+	ProjectLegacyA2AAuth(ar)
+	if ar.Spec.ExternalAuth.OIDC == nil {
+		t.Error("existing OIDC config dropped by projection")
+	}
+	if ar.Spec.ExternalAuth.SharedToken == nil {
+		t.Error("legacy A2A auth was not projected alongside OIDC")
+	}
+}
+
+func TestProjectLegacyA2AAuth_Idempotent(t *testing.T) {
+	t.Parallel()
+	ar := &AgentRuntime{
+		Spec: AgentRuntimeSpec{
+			A2A: &A2AConfig{
+				Authentication: &A2AAuthConfig{
+					SecretRef: &corev1.LocalObjectReference{Name: "legacy"},
+				},
+			},
+		},
+	}
+	ProjectLegacyA2AAuth(ar)
+	first := ar.Spec.ExternalAuth.SharedToken.SecretRef.Name
+	ProjectLegacyA2AAuth(ar)
+	second := ar.Spec.ExternalAuth.SharedToken.SecretRef.Name
+	if first != second {
+		t.Errorf("non-idempotent: %q vs %q", first, second)
+	}
+}

--- a/cmd/agent/auth_chain.go
+++ b/cmd/agent/auth_chain.go
@@ -74,6 +74,13 @@ func buildAuthChain(
 		case err != nil:
 			return nil, fmt.Errorf("get AgentRuntime %s/%s: %w", namespace, agentName, err)
 		default:
+			// Fold the deprecated spec.a2a.authentication.secretRef into
+			// spec.externalAuth.sharedToken. The reconciler does the same
+			// on its in-memory copy, but that copy is never persisted, so
+			// this side needs to re-run the projection — otherwise legacy
+			// CRs without spec.externalAuth produce an empty data-plane
+			// chain and every A2A request 401s after PR 3's default flip.
+			omniav1alpha1.ProjectLegacyA2AAuth(ar)
 			validators, err := buildDataPlaneValidators(ctx, k8s, log, ar)
 			if err != nil {
 				return nil, err

--- a/cmd/agent/auth_chain_test.go
+++ b/cmd/agent/auth_chain_test.go
@@ -145,6 +145,106 @@ func TestBuildAuthChain_SharedTokenAddsValidatorBeforeMgmt(t *testing.T) {
 	}
 }
 
+// TestBuildAuthChain_LegacyA2AAuthenticationProjects proves B1 is fixed:
+// an AgentRuntime that uses only the deprecated
+// spec.a2a.authentication.secretRef (with no spec.externalAuth) must
+// produce a data-plane chain containing the sharedToken validator. The
+// reconciler runs the projection on an in-memory copy that never gets
+// persisted, so cmd/agent has to re-run it at startup or the customer's
+// A2A traffic 401s after PR 3's default flip.
+func TestBuildAuthChain_LegacyA2AAuthenticationProjects(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "legacy-token", Namespace: "ns"},
+		Data:       map[string][]byte{"token": []byte("legacy-bearer")},
+	}
+	// Only the deprecated shape is set — the new spec.externalAuth field
+	// is deliberately nil to mirror a CR written before the redesign.
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			A2A: &omniav1alpha1.A2AConfig{
+				Authentication: &omniav1alpha1.A2AAuthConfig{
+					SecretRef: &corev1.LocalObjectReference{Name: "legacy-token"},
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar, secret).Build()
+
+	chain, err := buildAuthChain(context.Background(), fc, logr.Discard(), "agent", "ns", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := len(chain), 1; got != want {
+		t.Fatalf("chain length = %d, want %d (sharedToken projected from legacy a2a)", got, want)
+	}
+
+	// Exercise the chain end-to-end: a request with the legacy bearer
+	// must admit via sharedToken and come out tagged as such.
+	r := httptest.NewRequest(http.MethodGet, "/a2a", nil)
+	r.Header.Set("Authorization", "Bearer legacy-bearer")
+	id, err := chain.Run(context.Background(), r)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := id.Origin, policy.OriginSharedToken; got != want {
+		t.Errorf("Origin = %q, want %q", got, want)
+	}
+}
+
+// TestBuildAuthChain_ExternalAuthWinsOverLegacy proves the precedence
+// rule in ProjectLegacyA2AAuth: when both shapes are set, the new
+// externalAuth.sharedToken stays untouched (operators who migrated
+// deliberately must not get silently overwritten).
+func TestBuildAuthChain_ExternalAuthWinsOverLegacy(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	newSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "new-token", Namespace: "ns"},
+		Data:       map[string][]byte{"token": []byte("new-bearer")},
+	}
+	ar := &omniav1alpha1.AgentRuntime{
+		ObjectMeta: metav1.ObjectMeta{Name: "agent", Namespace: "ns"},
+		Spec: omniav1alpha1.AgentRuntimeSpec{
+			A2A: &omniav1alpha1.A2AConfig{
+				Authentication: &omniav1alpha1.A2AAuthConfig{
+					SecretRef: &corev1.LocalObjectReference{Name: "legacy-token"},
+				},
+			},
+			ExternalAuth: &omniav1alpha1.AgentExternalAuth{
+				SharedToken: &omniav1alpha1.SharedTokenAuth{
+					SecretRef: corev1.LocalObjectReference{Name: "new-token"},
+				},
+			},
+		},
+	}
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ar, newSecret).Build()
+
+	chain, err := buildAuthChain(context.Background(), fc, logr.Discard(), "agent", "ns", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if got, want := len(chain), 1; got != want {
+		t.Fatalf("chain length = %d, want %d", got, want)
+	}
+
+	// Only the new bearer admits — confirms the legacy secret was NOT
+	// projected on top of the already-set externalAuth.
+	r := httptest.NewRequest(http.MethodGet, "/a2a", nil)
+	r.Header.Set("Authorization", "Bearer new-bearer")
+	if _, err := chain.Run(context.Background(), r); err != nil {
+		t.Errorf("new bearer should admit: %v", err)
+	}
+	r2 := httptest.NewRequest(http.MethodGet, "/a2a", nil)
+	r2.Header.Set("Authorization", "Bearer legacy-bearer")
+	if _, err := chain.Run(context.Background(), r2); err == nil {
+		t.Error("legacy bearer must NOT admit when externalAuth.sharedToken is explicitly set")
+	}
+}
+
 func TestBuildAuthChain_SharedTokenSecretMissingErrors(t *testing.T) {
 	t.Parallel()
 	scheme := newTestScheme(t)

--- a/internal/controller/agentruntime_external_auth_projection.go
+++ b/internal/controller/agentruntime_external_auth_projection.go
@@ -20,46 +20,11 @@ import (
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 )
 
-// projectLegacyA2AAuth folds the deprecated spec.a2a.authentication.secretRef
-// into spec.externalAuth.sharedToken so that the new validator chain can
-// treat both shapes uniformly.
-//
-// Precedence rules:
-//   - If spec.externalAuth.sharedToken is already set, do nothing — the
-//     operator has explicitly chosen the new shape and we don't want to
-//     surprise them by overwriting.
-//   - If spec.a2a.authentication.secretRef is unset, do nothing — there's
-//     no legacy state to project.
-//   - Otherwise, ensure spec.externalAuth exists and copy the SecretRef
-//     into spec.externalAuth.sharedToken.
-//
-// Mutates ar in place. Idempotent: subsequent calls with the same input
-// are no-ops once the projection has happened. PR 2a ships this helper
-// behind no callers — the chain runner in PR 2b is what invokes it.
-//
-// The function does not modify the legacy field. We leave it visible on
-// the spec so operators see exactly what they configured; status emits
-// a deprecation warning condition (added in PR 2b) when the old field is
-// still populated.
+// projectLegacyA2AAuth is a thin wrapper around v1alpha1.ProjectLegacyA2AAuth.
+// The canonical implementation now lives in api/v1alpha1 so cmd/agent's
+// startup chain builder can share the same logic (otherwise legacy CRs
+// without spec.externalAuth would silently 401 at the facade). See the
+// shared helper for precedence rules and rationale.
 func projectLegacyA2AAuth(ar *omniav1alpha1.AgentRuntime) {
-	if ar == nil || ar.Spec.A2A == nil {
-		return
-	}
-	// The whole point of this helper is to migrate the deprecated
-	// authentication shape into the new one, so reading the old field is
-	// the intended behaviour — silence staticcheck's deprecated check.
-	legacy := ar.Spec.A2A.Authentication //nolint:staticcheck // SA1019: intentional read of deprecated field for projection
-	if legacy == nil || legacy.SecretRef == nil {
-		return
-	}
-	if ar.Spec.ExternalAuth == nil {
-		ar.Spec.ExternalAuth = &omniav1alpha1.AgentExternalAuth{}
-	}
-	if ar.Spec.ExternalAuth.SharedToken != nil {
-		// Operator explicitly set the new shape — respect it.
-		return
-	}
-	ar.Spec.ExternalAuth.SharedToken = &omniav1alpha1.SharedTokenAuth{
-		SecretRef: *legacy.SecretRef,
-	}
+	omniav1alpha1.ProjectLegacyA2AAuth(ar)
 }


### PR DESCRIPTION
Closes #961.

## Summary
- Legacy \`spec.a2a.authentication.secretRef\` was only being projected onto \`spec.externalAuth.sharedToken\` in the reconciler's in-memory copy — never persisted. At facade startup, \`cmd/agent\` re-read the CR via \`k8s.Get\` and saw no \`externalAuth\`, so \`buildDataPlaneValidators\` returned nothing. After PR 3's default-flip, legacy CRs 401'd every A2A request.
- Moved the projection helper from \`internal/controller\` to \`api/v1alpha1.ProjectLegacyA2AAuth\` so the controller and the facade startup path share one definition. Called from \`cmd/agent/auth_chain.go\` immediately after the \`k8s.Get\`.
- Controller-side helper becomes a thin wrapper so existing tests keep passing without churn.

## Test plan
- [x] New regression test \`TestBuildAuthChain_LegacyA2AAuthenticationProjects\` in \`cmd/agent/auth_chain_test.go\`: legacy-only CR → chain contains one sharedToken validator, Bearer admits with Origin=sharedToken.
- [x] New precedence test \`TestBuildAuthChain_ExternalAuthWinsOverLegacy\`: when both shapes set, externalAuth wins (legacy bearer must NOT admit).
- [x] Ported unit tests for \`ProjectLegacyA2AAuth\` into \`api/v1alpha1\` so the helper's home package owns coverage.
- [x] Verified the regression test fails without the \`ProjectLegacyA2AAuth\` call in \`buildAuthChain\`.
- [x] \`go test ./... -count=1 -short\` — 6725 passed.
- [x] Per-file coverage: both projection files at 100%.