### PR TITLE
fix(chart): strip spoofable edge-trust headers on SIDECAR_INBOUND (B4)

### DIFF
--- a/charts/omnia/Chart.yaml
+++ b/charts/omnia/Chart.yaml
@@ -5,8 +5,8 @@ type: application
 # version / appVersion track the last git-tagged release. When cutting a
 # new release, bump both in a commit before tagging. The release workflow
 # also rewrites these at package-time as a safety net.
-version: 0.9.0-beta.9
-appVersion: "0.9.0-beta.9"
+version: 0.9.0-beta.10
+appVersion: "0.9.0-beta.10"
 kubeVersion: ">=1.26.0-0"
 home: https://github.com/AltairaLabs/Omnia
 sources:

--- a/charts/omnia/templates/gateway/edge-trust-header-strip.yaml
+++ b/charts/omnia/templates/gateway/edge-trust-header-strip.yaml
@@ -1,0 +1,81 @@
+{{- if and .Values.authentication.enabled .Values.istio.enabled .Values.authentication.edgeTrust.stripInboundClaimHeaders }}
+{{- $fullName := include "omnia.fullname" . }}
+{{- /*
+Deduplicate the strip list from three sources: the default set the facade's
+edgeTrust validator trusts, any header names listed in
+authentication.jwt.outputClaimToHeaders (so the strip stays in sync with what
+the operator ACTUALLY injects), and authentication.edgeTrust.additionalStripHeaders
+for arbitrary custom claim-headers the operator named in an AgentRuntime's
+spec.externalAuth.edgeTrust.claimsFromHeaders.
+*/}}
+{{- $strip := dict }}
+{{- range .Values.authentication.edgeTrust.defaultStripHeaders }}
+{{-   $_ := set $strip (lower .) true }}
+{{- end }}
+{{- range .Values.authentication.jwt.outputClaimToHeaders }}
+{{-   if .header }}
+{{-     $_ := set $strip (lower .header) true }}
+{{-   end }}
+{{- end }}
+{{- range .Values.authentication.edgeTrust.additionalStripHeaders }}
+{{-   $_ := set $strip (lower .) true }}
+{{- end }}
+{{- $headers := keys $strip | sortAlpha }}
+
+# EnvoyFilter strips edge-trust claim headers on inbound requests BEFORE
+# Istio's jwt_authn filter runs. This closes a cross-tenant impersonation
+# primitive where a caller holding any valid JWT could spoof identity by
+# setting x-user-id / x-user-roles / x-user-email themselves — Istio's
+# RequestAuthentication only ADDS verified claims, it does not strip an
+# attacker-supplied copy.
+#
+# The strip list derives from three sources:
+#   1. authentication.edgeTrust.defaultStripHeaders (facade defaults)
+#   2. authentication.jwt.outputClaimToHeaders (what the operator actually injects)
+#   3. authentication.edgeTrust.additionalStripHeaders (custom claims)
+# Deduped and lowercased at render time.
+#
+# See: https://github.com/AltairaLabs/Omnia/issues/964 (B4 finding)
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ $fullName }}-agent-strip-edge-trust-headers
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "omnia.labels" . | nindent 4 }}
+spec:
+  workloadSelector:
+    labels:
+      omnia.altairalabs.ai/component: agent
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: envoy.filters.http.jwt_authn
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.lua
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+            inline_code: |
+              -- Strip spoofable edge-trust claim headers before jwt_authn runs.
+              -- jwt_authn's outputClaimToHeaders (configured on the same agent
+              -- via RequestAuthentication) will then re-add the verified values.
+              function envoy_on_request(request_handle)
+                local headers_to_strip = {
+                {{- range $headers }}
+                  {{ printf "%q" . }},
+                {{- end }}
+                }
+                local headers = request_handle:headers()
+                for _, name in ipairs(headers_to_strip) do
+                  headers:remove(name)
+                end
+              end
+{{- end }}

--- a/charts/omnia/tests/edge-trust-header-strip_test.yaml
+++ b/charts/omnia/tests/edge-trust-header-strip_test.yaml
@@ -1,0 +1,116 @@
+suite: edge-trust header strip EnvoyFilter
+release:
+  name: omnia
+values:
+  - ../values-chart-tests.yaml
+templates:
+  - templates/gateway/edge-trust-header-strip.yaml
+tests:
+  - it: renders an EnvoyFilter when authentication + istio + stripInboundClaimHeaders all on
+    set:
+      authentication.enabled: true
+      authentication.jwt.issuer: https://auth.example.com
+      istio.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: kind
+          value: EnvoyFilter
+      - equal:
+          path: metadata.name
+          value: omnia-agent-strip-edge-trust-headers
+      - equal:
+          path: spec.workloadSelector.labels["omnia.altairalabs.ai/component"]
+          value: agent
+      - equal:
+          path: spec.configPatches[0].applyTo
+          value: HTTP_FILTER
+      - equal:
+          path: spec.configPatches[0].match.context
+          value: SIDECAR_INBOUND
+      - equal:
+          path: spec.configPatches[0].patch.operation
+          value: INSERT_BEFORE
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-user-id"'
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-user-email"'
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-user-roles"'
+
+  - it: is suppressed when istio is disabled
+    set:
+      authentication.enabled: true
+      authentication.jwt.issuer: https://auth.example.com
+      istio.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is suppressed when authentication is disabled
+    set:
+      authentication.enabled: false
+      istio.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: is suppressed when stripInboundClaimHeaders is explicitly false
+    set:
+      authentication.enabled: true
+      authentication.jwt.issuer: https://auth.example.com
+      istio.enabled: true
+      authentication.edgeTrust.stripInboundClaimHeaders: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: merges outputClaimToHeaders into the strip list
+    set:
+      authentication.enabled: true
+      authentication.jwt.issuer: https://auth.example.com
+      istio.enabled: true
+      authentication.jwt.outputClaimToHeaders:
+        - header: X-User-Groups
+          claim: groups
+        - header: X-Org-Id
+          claim: org_id
+    asserts:
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-user-groups"'
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-org-id"'
+
+  - it: appends additionalStripHeaders to the strip list
+    set:
+      authentication.enabled: true
+      authentication.jwt.issuer: https://auth.example.com
+      istio.enabled: true
+      authentication.edgeTrust.additionalStripHeaders:
+        - x-tenant-id
+        - x-session-id
+    asserts:
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-tenant-id"'
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-session-id"'
+
+  - it: lowercases header names so the Lua match is case-insensitive
+    set:
+      authentication.enabled: true
+      authentication.jwt.issuer: https://auth.example.com
+      istio.enabled: true
+      authentication.edgeTrust.additionalStripHeaders:
+        - X-Mixed-Case-Header
+    asserts:
+      - matchRegex:
+          path: spec.configPatches[0].patch.value.typed_config.inline_code
+          pattern: '"x-mixed-case-header"'

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -2088,6 +2088,38 @@ authentication:
       - /healthz
       - /readyz
 
+  # -- Edge-trust header strip.
+  # When an AgentRuntime uses spec.externalAuth.edgeTrust, the facade TRUSTS
+  # claim-headers (x-user-id, x-user-roles, x-user-email, etc.) injected by the
+  # upstream edge without re-verifying the JWT. Istio's RequestAuthentication
+  # only ADDS verified claim headers — it does not strip an attacker-supplied
+  # inbound copy, so a caller holding any valid JWT can spoof identity by
+  # setting these headers directly. The EnvoyFilter below uses a Lua filter to
+  # remove the spoofable headers on SIDECAR_INBOUND before Istio's jwt_authn
+  # filter runs, then the RequestAuthentication re-adds the verified claims.
+  #
+  # Enabled by default when authentication.enabled=true — safe for every
+  # deployment (legitimate clients never send these headers). Set to false
+  # only if you have an upstream that legitimately forwards them.
+  edgeTrust:
+    # -- Strip the spoofable claim-headers on SIDECAR_INBOUND before JWT
+    # validation. Defaults to true. Requires istio.enabled=true and
+    # authentication.enabled=true — no effect otherwise.
+    stripInboundClaimHeaders: true
+    # -- Additional header names to strip. The defaults (below) cover
+    # x-user-id, x-user-roles, x-user-email plus whatever is listed in
+    # authentication.jwt.outputClaimToHeaders. Add names here when an
+    # AgentRuntime's spec.externalAuth.edgeTrust.claimsFromHeaders references
+    # headers the defaults don't cover.
+    additionalStripHeaders: []
+    # -- Default headers the facade's edgeTrust validator trusts (see
+    # internal/facade/auth/edge_trust.go). Rarely overridden — adjust
+    # additionalStripHeaders instead.
+    defaultStripHeaders:
+      - x-user-id
+      - x-user-roles
+      - x-user-email
+
 # ============================================================================
 # KEDA Configuration (Advanced Autoscaling)
 # KEDA enables scale-to-zero, custom metrics scaling, and cron-based scaling


### PR DESCRIPTION
Closes #964.

## Summary
- Istio's RequestAuthentication ADDS verified claim headers but doesn't strip attacker-supplied inbound copies. A caller holding any valid JWT could set \`x-user-id: admin@victim.com\` themselves; the facade's edgeTrust validator admitted as that user.
- New EnvoyFilter installs a tiny Lua filter on SIDECAR_INBOUND that removes the spoofable headers BEFORE \`jwt_authn\` runs — then \`jwt_authn\`'s \`outputClaimToHeaders\` re-populates them from the verified claims.
- Strip list auto-derives from \`authentication.jwt.outputClaimToHeaders\` + facade defaults (\`x-user-id\`, \`x-user-roles\`, \`x-user-email\`) + \`authentication.edgeTrust.additionalStripHeaders\`. Deduped and lowercased at render time so mixed-case / Istio-injected duplicates don't leak.
- Defaults to enabled when \`authentication.enabled=true && istio.enabled=true\`. Safe by default — legitimate clients never send these headers.
- Chart bumped to \`0.9.0-beta.10\` (visible render change for installs with \`authentication.enabled=true\`).

## Test plan
- [x] 7 helm-unittest cases: render-enabled, three suppressed paths (stripInboundClaimHeaders=false, authentication off, istio off), outputClaimToHeaders merge, additionalStripHeaders append, case-insensitive normalization
- [x] \`helm unittest charts/omnia\` — 51 passed (existing suite + new)
- [x] \`bash hack/validate-helm.sh\` — lint + default + enterprise render all clean