### PR TITLE
feat(controller): surface facade auth config as ExternalAuth condition (T11)

### DIFF
--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -408,6 +408,14 @@ func (r *AgentRuntimeReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	SetCondition(&agentRuntime.Status.Conditions, agentRuntime.Generation,
 		privacyCond.Type, privacyCond.Status, privacyCond.Reason, privacyCond.Message)
 
+	// Surface facade auth configuration as a status condition so
+	// operators can see at a glance whether the agent admits traffic.
+	// Catches the Unreachable combo (allowManagementPlane=false + no
+	// data-plane validator) which otherwise 401s silently at runtime.
+	authCond := evaluateExternalAuthCondition(agentRuntime)
+	SetCondition(&agentRuntime.Status.Conditions, agentRuntime.Generation,
+		authCond.Type, authCond.Status, authCond.Reason, authCond.Message)
+
 	// Mirror the OIDC issuer's JWKS into a per-agent Secret (if
 	// spec.externalAuth.oidc is configured). Non-blocking: failures
 	// set the OIDCJWKSReady=False condition and schedule a refresh.

--- a/internal/controller/agentruntime_external_auth_condition.go
+++ b/internal/controller/agentruntime_external_auth_condition.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// evaluateExternalAuthCondition returns the status, reason, and message
+// for ConditionTypeExternalAuth based on spec.externalAuth.
+//
+// Status breakdown:
+//   - True / DashboardOnly        — no externalAuth configured; mgmt-plane is the only admit path
+//   - True / DataPlaneConfigured  — at least one data-plane validator is set
+//   - False / Unreachable         — allowManagementPlane=false AND no data-plane validator — no caller can admit
+//
+// The reconciler sets this condition every pass so operators can
+// `kubectl describe agentruntime` and immediately see whether the
+// configuration they applied actually accepts traffic.
+func evaluateExternalAuthCondition(ar *omniav1alpha1.AgentRuntime) metav1.Condition {
+	ext := ar.Spec.ExternalAuth
+	if ext == nil {
+		return metav1.Condition{
+			Type:    ConditionTypeExternalAuth,
+			Status:  metav1.ConditionTrue,
+			Reason:  "DashboardOnly",
+			Message: "no spec.externalAuth configured; only dashboard-minted management-plane tokens admit",
+		}
+	}
+
+	hasDataPlane := ext.SharedToken != nil ||
+		ext.APIKeys != nil ||
+		ext.OIDC != nil ||
+		ext.EdgeTrust != nil
+
+	// allowManagementPlane defaults to true per the CRD's +kubebuilder:default.
+	// Treat nil as true so users who omit the field get the permissive default.
+	mgmtPlaneAllowed := true
+	if ext.AllowManagementPlane != nil {
+		mgmtPlaneAllowed = *ext.AllowManagementPlane
+	}
+
+	if hasDataPlane {
+		return metav1.Condition{
+			Type:    ConditionTypeExternalAuth,
+			Status:  metav1.ConditionTrue,
+			Reason:  "DataPlaneConfigured",
+			Message: externalAuthConfiguredMessage(ext, mgmtPlaneAllowed),
+		}
+	}
+
+	if !mgmtPlaneAllowed {
+		return metav1.Condition{
+			Type:   ConditionTypeExternalAuth,
+			Status: metav1.ConditionFalse,
+			Reason: "Unreachable",
+			Message: "spec.externalAuth.allowManagementPlane=false but no data-plane validator " +
+				"(sharedToken / apiKeys / oidc / edgeTrust) is configured — the facade will reject every request",
+		}
+	}
+
+	// externalAuth block is set but empty — equivalent to DashboardOnly for
+	// admit purposes but distinct state worth surfacing so operators know
+	// the block exists.
+	return metav1.Condition{
+		Type:    ConditionTypeExternalAuth,
+		Status:  metav1.ConditionTrue,
+		Reason:  "DashboardOnly",
+		Message: "spec.externalAuth is set but has no data-plane validator; only management-plane tokens admit",
+	}
+}
+
+// externalAuthConfiguredMessage summarises which validators are
+// configured. Short and grep-friendly — structured-logging friendly.
+func externalAuthConfiguredMessage(ext *omniav1alpha1.AgentExternalAuth, mgmtPlaneAllowed bool) string {
+	parts := []string{}
+	if ext.SharedToken != nil {
+		parts = append(parts, "sharedToken")
+	}
+	if ext.APIKeys != nil {
+		parts = append(parts, "apiKeys")
+	}
+	if ext.OIDC != nil {
+		parts = append(parts, "oidc")
+	}
+	if ext.EdgeTrust != nil {
+		parts = append(parts, "edgeTrust")
+	}
+	if mgmtPlaneAllowed {
+		parts = append(parts, "managementPlane")
+	}
+	return "facade admits: " + joinWithComma(parts)
+}
+
+// joinWithComma is strings.Join with ", " but avoids pulling in the
+// strings import for a single-purpose helper in a small file.
+func joinWithComma(items []string) string {
+	if len(items) == 0 {
+		return "(none)"
+	}
+	out := items[0]
+	for _, s := range items[1:] {
+		out += ", " + s
+	}
+	return out
+}

--- a/internal/controller/agentruntime_external_auth_condition_test.go
+++ b/internal/controller/agentruntime_external_auth_condition_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+func arWithExternalAuth(ext *omniav1alpha1.AgentExternalAuth) *omniav1alpha1.AgentRuntime {
+	return &omniav1alpha1.AgentRuntime{
+		Spec: omniav1alpha1.AgentRuntimeSpec{ExternalAuth: ext},
+	}
+}
+
+func TestEvaluateExternalAuthCondition_NoExternalAuth(t *testing.T) {
+	t.Parallel()
+	cond := evaluateExternalAuthCondition(arWithExternalAuth(nil))
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("status = %v, want True", cond.Status)
+	}
+	if cond.Reason != "DashboardOnly" {
+		t.Errorf("reason = %q, want DashboardOnly", cond.Reason)
+	}
+}
+
+func TestEvaluateExternalAuthCondition_EmptyExternalAuth(t *testing.T) {
+	// externalAuth block set but no validator populated — still admits
+	// via management-plane, emit DashboardOnly with a hint that the
+	// block is set so operators aren't surprised.
+	t.Parallel()
+	cond := evaluateExternalAuthCondition(arWithExternalAuth(&omniav1alpha1.AgentExternalAuth{}))
+	if cond.Status != metav1.ConditionTrue || cond.Reason != "DashboardOnly" {
+		t.Errorf("status=%v reason=%q, want True/DashboardOnly", cond.Status, cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "no data-plane validator") {
+		t.Errorf("message = %q, want hint about empty block", cond.Message)
+	}
+}
+
+func TestEvaluateExternalAuthCondition_DataPlaneConfigured(t *testing.T) {
+	t.Parallel()
+	cases := map[string]*omniav1alpha1.AgentExternalAuth{
+		"sharedToken": {SharedToken: &omniav1alpha1.SharedTokenAuth{SecretRef: corev1.LocalObjectReference{Name: "t"}}},
+		"apiKeys":     {APIKeys: &omniav1alpha1.APIKeysAuth{}},
+		"oidc":        {OIDC: &omniav1alpha1.OIDCAuth{Issuer: "x", Audience: "y"}},
+		"edgeTrust":   {EdgeTrust: &omniav1alpha1.EdgeTrustAuth{}},
+	}
+	for name, ext := range cases {
+		t.Run(name, func(t *testing.T) {
+			cond := evaluateExternalAuthCondition(arWithExternalAuth(ext))
+			if cond.Status != metav1.ConditionTrue || cond.Reason != "DataPlaneConfigured" {
+				t.Errorf("status=%v reason=%q, want True/DataPlaneConfigured", cond.Status, cond.Reason)
+			}
+			if !strings.Contains(cond.Message, name) {
+				t.Errorf("message = %q should mention %q", cond.Message, name)
+			}
+		})
+	}
+}
+
+// TestEvaluateExternalAuthCondition_Unreachable proves T11 surfaces
+// the "dark agent" foot-gun: allowManagementPlane=false AND no
+// data-plane validator means the facade 401s every request. Operators
+// need to see this as a False condition on kubectl describe.
+func TestEvaluateExternalAuthCondition_Unreachable(t *testing.T) {
+	t.Parallel()
+	ext := &omniav1alpha1.AgentExternalAuth{AllowManagementPlane: ptrBool(false)}
+	cond := evaluateExternalAuthCondition(arWithExternalAuth(ext))
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("status = %v, want False", cond.Status)
+	}
+	if cond.Reason != "Unreachable" {
+		t.Errorf("reason = %q, want Unreachable", cond.Reason)
+	}
+	if !strings.Contains(cond.Message, "reject every request") {
+		t.Errorf("message = %q should call out the effect", cond.Message)
+	}
+}
+
+func TestEvaluateExternalAuthCondition_AllowManagementPlanePointerNil(t *testing.T) {
+	// Pointer nil should be treated as the kubebuilder default (true)
+	// so a block with only oidc set is still True/DataPlaneConfigured.
+	t.Parallel()
+	ext := &omniav1alpha1.AgentExternalAuth{
+		OIDC: &omniav1alpha1.OIDCAuth{Issuer: "x", Audience: "y"},
+	}
+	cond := evaluateExternalAuthCondition(arWithExternalAuth(ext))
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("nil allowManagementPlane should default to true: status=%v", cond.Status)
+	}
+	if !strings.Contains(cond.Message, "managementPlane") {
+		t.Errorf("message should mention managementPlane when default is true: %q", cond.Message)
+	}
+}
+
+func TestEvaluateExternalAuthCondition_AllowManagementPlaneExplicitFalseWithDataPlane(t *testing.T) {
+	// allowManagementPlane=false is fine as long as a data-plane
+	// validator is configured — condition still True, and the message
+	// must NOT include managementPlane since that path is disabled.
+	t.Parallel()
+	ext := &omniav1alpha1.AgentExternalAuth{
+		AllowManagementPlane: ptrBool(false),
+		SharedToken: &omniav1alpha1.SharedTokenAuth{
+			SecretRef: corev1.LocalObjectReference{Name: "t"},
+		},
+	}
+	cond := evaluateExternalAuthCondition(arWithExternalAuth(ext))
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("status = %v, want True", cond.Status)
+	}
+	if strings.Contains(cond.Message, "managementPlane") {
+		t.Errorf("message must not advertise managementPlane when disabled: %q", cond.Message)
+	}
+	if !strings.Contains(cond.Message, "sharedToken") {
+		t.Errorf("message should mention sharedToken: %q", cond.Message)
+	}
+}
+
+func TestJoinWithComma(t *testing.T) {
+	t.Parallel()
+	if got := joinWithComma(nil); got != "(none)" {
+		t.Errorf("nil: got %q, want (none)", got)
+	}
+	if got := joinWithComma([]string{}); got != "(none)" {
+		t.Errorf("empty: got %q, want (none)", got)
+	}
+	if got := joinWithComma([]string{"a"}); got != "a" {
+		t.Errorf("single: got %q, want a", got)
+	}
+	if got := joinWithComma([]string{"a", "b", "c"}); got != "a, b, c" {
+		t.Errorf("multi: got %q, want a, b, c", got)
+	}
+}

--- a/internal/controller/constants.go
+++ b/internal/controller/constants.go
@@ -140,4 +140,12 @@ const (
 	ConditionTypeProviderReady     = "ProviderReady"
 	ConditionTypePackContentValid  = "PackContentValid"
 	ConditionTypeRolloutActive     = "RolloutActive"
+
+	// ConditionTypeExternalAuth surfaces the effective facade auth
+	// configuration. False/Unreachable means the operator explicitly
+	// set spec.externalAuth.allowManagementPlane=false without
+	// configuring any data-plane validator — the agent cannot accept
+	// any callers. Always emitted so operators can assert on it from
+	// kubectl describe / helm unittest.
+	ConditionTypeExternalAuth = "ExternalAuth"
 )


### PR DESCRIPTION
Code-review tightening T11.

## Summary
- Adds a new \`ExternalAuth\` status condition on AgentRuntime so \`kubectl describe\` surfaces whether an agent actually admits traffic.
- Three branches:
  - **True / DashboardOnly** — no \`spec.externalAuth\` (or block empty) → only dashboard-minted management-plane tokens admit
  - **True / DataPlaneConfigured** — at least one validator wired in; message lists admit paths (e.g. "facade admits: sharedToken, oidc, managementPlane")
  - **False / Unreachable** — the foot-gun: \`allowManagementPlane=false\` + zero data-plane validators → facade 401s every request
- Message enumerates effective admit paths so operators can grep and know exactly which credentials the agent accepts.

## Test plan
- [x] 11 unit tests covering every branch + pointer default handling
- [x] \`go test ./internal/controller/... -count=1 -short\` — 589 passed
- [x] Per-file coverage: \`agentruntime_external_auth_condition.go\` 100%, \`agentruntime_controller.go\` 85.1%