### PR TITLE
fix(facade): T2 + T5 + T9 tightenings

### DIFF
--- a/cmd/agent/api_keys.go
+++ b/cmd/agent/api_keys.go
@@ -51,9 +51,22 @@ const (
 	// Data keys inside the API-key Secret. The hash and scope formats
 	// are stable contracts shared between the dashboard CRUD endpoint
 	// and the facade KeyStore.
+	//
+	// APIKeyDataKeyHash stores the raw 32-byte sha256 digest of the
+	// caller-facing bearer value — NOT hex-encoded. k8s Secret data is
+	// transported as base64 in YAML but resolves to raw bytes in Go, so
+	// writers (dashboard, seed jobs) must pass the 32-byte digest
+	// directly. parseAPIKeySecret re-encodes it as lowercase hex for the
+	// in-memory lookup map.
 	APIKeyDataKeyHash      = "keyHash"
 	APIKeyDataKeyScopes    = "scopes"
 	APIKeyDataKeyExpiresAt = "expiresAt"
+
+	// apiKeyHashLen is the expected sha256 digest length in bytes.
+	// parseAPIKeySecret rejects Secrets with a non-matching length so
+	// accidental hex-encoded payloads (which would be 64 bytes) fail
+	// loud at load time rather than silently never matching at lookup.
+	apiKeyHashLen = 32
 )
 
 // apiKeySecretSuffix is the prefix the dashboard CRUD endpoint uses when
@@ -224,6 +237,16 @@ func parseAPIKeySecret(secret *corev1.Secret) (auth.APIKey, error) {
 	hashRaw, ok := secret.Data[APIKeyDataKeyHash]
 	if !ok || len(hashRaw) == 0 {
 		return auth.APIKey{}, fmt.Errorf("missing %q data key", APIKeyDataKeyHash)
+	}
+	// Guard against the most common writer mistake: storing a 64-byte
+	// hex-encoded digest instead of the raw 32-byte digest. Either would
+	// "work" as bytes but only the raw form round-trips to
+	// HashToken(plaintext). Fail loud on the wrong length so the
+	// misconfig surfaces at load time, not at auth time.
+	if len(hashRaw) != apiKeyHashLen {
+		return auth.APIKey{}, fmt.Errorf("%q data key must be %d raw bytes (got %d) — "+
+			"writers must pass the raw sha256 digest, not a hex-encoded string",
+			APIKeyDataKeyHash, apiKeyHashLen, len(hashRaw))
 	}
 	// The dashboard endpoint stores the binary sha256; we keep the in-
 	// memory representation as lowercase hex so APIKeyValidator's

--- a/cmd/agent/api_keys_test.go
+++ b/cmd/agent/api_keys_test.go
@@ -230,6 +230,37 @@ func TestParseAPIKeySecret_EmptyDataErrors(t *testing.T) {
 	}
 }
 
+// TestParseAPIKeySecret_WrongHashLengthRejects proves T5 is fixed:
+// writers that accidentally store a hex-encoded sha256 (64 bytes) or
+// a truncated digest fail loud at load time rather than silently never
+// matching at auth time. The hash must be exactly 32 raw bytes.
+func TestParseAPIKeySecret_WrongHashLengthRejects(t *testing.T) {
+	t.Parallel()
+	cases := map[string][]byte{
+		"too-short (16 bytes)":               make([]byte, 16),
+		"hex-encoded mistake (64 bytes)":     make([]byte, 64),
+		"empty after length check (garbage)": make([]byte, 1),
+	}
+	for name, hash := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "agent-x-apikey-y",
+					Labels: map[string]string{
+						LabelCredentialKind: LabelCredentialKindAgentAPIKey,
+						LabelAgent:          "x",
+					},
+				},
+				Data: map[string][]byte{APIKeyDataKeyHash: hash},
+			}
+			if _, err := parseAPIKeySecret(secret); err == nil {
+				t.Errorf("expected length-check failure for %s", name)
+			}
+		})
+	}
+}
+
 func TestParseAPIKeySecret_NameNotMatchingPatternFallsBackToFullName(t *testing.T) {
 	// A hand-edited Secret without the expected `agent-<agent>-apikey-<id>`
 	// prefix should still load — its ID falls back to the full Secret name

--- a/cmd/agent/mgmt_plane.go
+++ b/cmd/agent/mgmt_plane.go
@@ -53,16 +53,24 @@ func loadMgmtPlaneValidator(log logr.Logger) (auth.Validator, error) {
 	info, err := os.Stat(path)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			log.V(1).Info("mgmt-plane validator skipped",
-				"reason", "pubkey file missing",
-				"path", path)
+			// Log at info level (not V(1)): the env var was SET, which
+			// means the operator wired a pubkey path, but the file is
+			// missing. Most likely the Workspace controller has not yet
+			// reconciled the mirror ConfigMap — a genuine race at pod
+			// startup. Either way this is operationally interesting
+			// enough that operators should see it at the default log
+			// verbosity; a silent skip was the T2 finding.
+			log.Info("mgmt-plane validator skipped — pubkey file missing",
+				"path", path,
+				"hint", "usually resolves after the Workspace controller reconciles "+
+					"the pubkey ConfigMap; if it persists, verify dashboard.enabled "+
+					"and the workspace's namespace label")
 			return nil, nil
 		}
 		return nil, err
 	}
 	if info.Size() == 0 {
-		log.V(1).Info("mgmt-plane validator skipped",
-			"reason", "pubkey file empty",
+		log.Info("mgmt-plane validator skipped — pubkey file is empty",
 			"path", path)
 		return nil, nil
 	}

--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -68,6 +68,28 @@ if (MGMT_PLANE_SIGNING_KEY_PATH) {
 // `identity.origin == "management-plane"`, not by subject.
 const MGMT_PLANE_SUBJECT = "omnia-dashboard-proxy";
 
+// OMNIA_MGMT_PLANE_TOKEN_TTL_SECONDS overrides the mgmt-plane JWT TTL
+// (default 5 minutes in lib/mgmt-plane-token.js). Long enough that an
+// admin's debug session doesn't drop mid-chat, short enough that a
+// leaked token isn't useful for long. Operators on slow IdP-redirect
+// chains or high-latency networks can tune up; everyone else should
+// leave it alone. Parsed at boot; unparseable / non-positive values
+// fall back to the library default.
+const MGMT_PLANE_TTL_SECONDS = (() => {
+  const raw = process.env.OMNIA_MGMT_PLANE_TOKEN_TTL_SECONDS;
+  if (!raw) {
+    return undefined;
+  }
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) {
+    console.error(
+      `[WS Proxy] OMNIA_MGMT_PLANE_TOKEN_TTL_SECONDS=${raw} is not a positive integer — falling back to default`,
+    );
+    return undefined;
+  }
+  return n;
+})();
+
 // Service domain for K8s cluster DNS
 const SERVICE_DOMAIN = process.env.SERVICE_DOMAIN || "svc.cluster.local";
 // Default facade port
@@ -213,6 +235,7 @@ function proxyWebSocket(clientSocket, namespace, name, clientParams = {}) {
         subject: MGMT_PLANE_SUBJECT,
         agent: name,
         workspace: namespace,
+        ttlSeconds: MGMT_PLANE_TTL_SECONDS,
       });
       upstreamHeaders.Authorization = `Bearer ${token}`;
     } catch (err) {


### PR DESCRIPTION
Code-review tightenings T2, T5, T9 — three small, independent fixes bundled together.

## T2 — mgmt-plane pubkey "file missing" no longer silent
\`cmd/agent/mgmt_plane.go\` now logs at info level with a troubleshooting hint when \`OMNIA_MGMT_PLANE_PUBKEY_PATH\` is set but the file is missing. A set env var with a missing file is an operationally interesting state (usually a boot race with the Workspace controller's ConfigMap mirror) — operators should see it at default verbosity.

## T5 — API-key hash length guard
\`cmd/agent/api_keys.go\` documents that \`APIKeyDataKeyHash\` stores the raw 32-byte sha256 digest (NOT hex). \`parseAPIKeySecret\` now rejects wrong-length payloads so writers that accidentally store a hex string (64 bytes) or a truncated digest fail loud at load time rather than silently never matching at auth time.

## T9 — Configurable mgmt-plane JWT TTL
\`OMNIA_MGMT_PLANE_TOKEN_TTL_SECONDS\` overrides the 5-minute default on dashboard-minted tokens. Unparseable / non-positive values fall back to the library default with an error log. Operators on slow IdP-redirect chains can tune up without touching the library code.

## Test plan
- [x] 3 wrong-length fixtures in \`TestParseAPIKeySecret_WrongHashLengthRejects\`
- [x] \`go test ./... -count=1 -short\` — 6748 passed
- [x] Dashboard: \`npx vitest run lib/mgmt-plane-token\` still passes; \`npm run typecheck\` clean