### PR TITLE
fix(facade): PII-safe identity helpers and per-session proxy subject (T3, T10)

### DIFF
--- a/dashboard/server.js
+++ b/dashboard/server.js
@@ -15,6 +15,7 @@
  */
 
 const { createServer } = require("http");
+const crypto = require("node:crypto");
 const { parse } = require("url");
 const next = require("next");
 const { WebSocket, WebSocketServer } = require("ws");
@@ -61,12 +62,45 @@ if (MGMT_PLANE_SIGNING_KEY_PATH) {
   }
 }
 
-// Subject claim on minted mgmt-plane tokens. The dashboard proxy is a
-// single trust boundary — every WS upgrade routed through it has already
-// passed the dashboard's own auth check, so we don't try to mint
-// per-user tokens here. ToolPolicy distinguishes mgmt-plane traffic by
-// `identity.origin == "management-plane"`, not by subject.
-const MGMT_PLANE_SUBJECT = "omnia-dashboard-proxy";
+// Fallback subject claim on minted mgmt-plane tokens. Used when the
+// incoming WS upgrade carries no session cookie (standalone dev /
+// anonymous mode). When a session cookie IS present, we derive a
+// per-session pseudonymous subject from its hash (see
+// mgmtPlaneSubjectForRequest) so audit logs can distinguish admin A
+// from admin B without decrypting iron-session payloads or leaking
+// raw email addresses. ToolPolicy still distinguishes mgmt-plane
+// traffic by `identity.origin == "management-plane"`.
+const MGMT_PLANE_FALLBACK_SUBJECT = "omnia-dashboard-proxy";
+
+// SESSION_COOKIE_NAME names the iron-session cookie we hash into the
+// per-session subject pseudonym. Kept in sync with
+// src/lib/auth/session.ts's default (`omnia_session`); override via env
+// when the chart customises session.cookieName.
+const SESSION_COOKIE_NAME =
+  process.env.OMNIA_SESSION_COOKIE_NAME || "omnia_session";
+
+// mgmtPlaneSubjectForRequest extracts a stable per-session pseudonym
+// from the WS upgrade's Cookie header. Same browser session → same
+// subject; different admins → different subjects. Never surfaces the
+// raw cookie value — we only emit a 16-hex-char prefix of sha256.
+function mgmtPlaneSubjectForRequest(req) {
+  const cookieHeader = req && req.headers ? req.headers.cookie : undefined;
+  if (!cookieHeader) {
+    return MGMT_PLANE_FALLBACK_SUBJECT;
+  }
+  const match = cookieHeader.match(
+    new RegExp(`(?:^|; )${SESSION_COOKIE_NAME}=([^;]+)`),
+  );
+  if (!match) {
+    return MGMT_PLANE_FALLBACK_SUBJECT;
+  }
+  const hash = crypto
+    .createHash("sha256")
+    .update(match[1])
+    .digest("hex")
+    .slice(0, 16);
+  return `omnia-admin-${hash}`;
+}
 
 // OMNIA_MGMT_PLANE_TOKEN_TTL_SECONDS overrides the mgmt-plane JWT TTL
 // (default 5 minutes in lib/mgmt-plane-token.js). Long enough that an
@@ -216,15 +250,16 @@ function sendError(clientSocket, message, code = "CONNECTION_ERROR") {
 /**
  * Proxy a WebSocket connection to an agent's facade.
  */
-function proxyWebSocket(clientSocket, namespace, name, clientParams = {}) {
+function proxyWebSocket(clientSocket, namespace, name, clientParams = {}, req = null) {
   const upstreamUrl = getAgentWsUrl(namespace, name, clientParams);
   console.log(`[WS Proxy] Connecting to upstream: ${upstreamUrl}`);
   console.log(`[WS Proxy] SERVICE_DOMAIN=${SERVICE_DOMAIN}, DEFAULT_FACADE_PORT=${DEFAULT_FACADE_PORT}`);
 
   // Mint a fresh mgmt-plane JWT for the upstream connection. The dashboard
   // proxy is the single trust boundary — every WS upgrade has already
-  // passed the dashboard's own auth, so we sign with a constant subject
-  // and let ToolPolicy distinguish mgmt-plane traffic via identity.origin.
+  // passed the dashboard's own auth. Subject is derived from the session
+  // cookie so audit logs can distinguish individual admins; falls back to
+  // the constant pseudonym when no session cookie is present.
   // No key loaded -> connect without Authorization (preserves PR 1a's
   // unauthenticated default).
   const upstreamHeaders = {};
@@ -232,7 +267,7 @@ function proxyWebSocket(clientSocket, namespace, name, clientParams = {}) {
     try {
       const token = mintToken({
         key: mgmtPlaneSigningKey,
-        subject: MGMT_PLANE_SUBJECT,
+        subject: mgmtPlaneSubjectForRequest(req),
         agent: name,
         workspace: namespace,
         ttlSeconds: MGMT_PLANE_TTL_SECONDS,
@@ -633,7 +668,7 @@ app.prepare().then(() => {
 
     if (agent) {
       const clientParams = parseQueryParams(req.url);
-      proxyWebSocket(ws, agent.namespace, agent.name, clientParams);
+      proxyWebSocket(ws, agent.namespace, agent.name, clientParams, req);
     } else if (isLspPath(pathname)) {
       // Parse query params for LSP context
       const params = parseQueryParams(req.url);

--- a/pkg/policy/identity.go
+++ b/pkg/policy/identity.go
@@ -16,7 +16,11 @@ limitations under the License.
 
 package policy
 
-import "time"
+import (
+	"time"
+
+	"github.com/altairalabs/omnia/pkg/logging"
+)
 
 // Origin strings identify which validator admitted a request. They flow
 // through PropagationFields and surface to ToolPolicy CEL as identity.origin.
@@ -41,18 +45,30 @@ const (
 // Validator. It is the single contract runtime / ToolPolicy see regardless
 // of which credential style the caller presented (shared token, API key,
 // OIDC JWT, edge-injected headers, management-plane JWT).
+//
+// # PII WARNING
+//
+// Subject and EndUser hold RAW user identifiers (email addresses, OIDC
+// subs, device IDs, etc.). They are PII. Never log them directly — use
+// HashedSubject() / HashedEndUser() which emit a stable sha256-prefixed
+// tag suitable for audit trails and log correlation. The flat fields on
+// PropagationFields (UserID) are already pseudonymised via
+// identity.PseudonymizeID; consumers that build their own logs off the
+// Identity struct must do the hashing themselves.
 type AuthenticatedIdentity struct {
 	// Origin names the validator that admitted the request. One of the
 	// Origin* constants above.
 	Origin string
 
 	// Subject is the stable identifier of the token-holder (the app, key,
-	// or user that presented the credential).
+	// or user that presented the credential). RAW — PII. Use
+	// HashedSubject() before logging.
 	Subject string
 
 	// EndUser identifies the human or device on whose behalf the
 	// token-holder is acting. Equals Subject for end-user tokens. For
 	// service tokens carrying an actor claim, EndUser is the actor.
+	// RAW — PII. Use HashedEndUser() before logging.
 	EndUser string
 
 	// Workspace is the workspace the request targets (may be empty for
@@ -75,4 +91,24 @@ type AuthenticatedIdentity struct {
 	// underlying credential exposes them. Zero values when not applicable.
 	IssuedAt  time.Time
 	ExpiresAt time.Time
+}
+
+// HashedSubject returns a log-safe pseudonym for Subject via
+// logging.HashID. Empty Subject returns empty string so callers can
+// build structured-log fields without a nil-check. Use this in every
+// log line that mentions who the admitted caller is.
+func (a *AuthenticatedIdentity) HashedSubject() string {
+	if a == nil || a.Subject == "" {
+		return ""
+	}
+	return logging.HashID(a.Subject)
+}
+
+// HashedEndUser returns a log-safe pseudonym for EndUser via
+// logging.HashID. Same rules as HashedSubject.
+func (a *AuthenticatedIdentity) HashedEndUser() string {
+	if a == nil || a.EndUser == "" {
+		return ""
+	}
+	return logging.HashID(a.EndUser)
 }

--- a/pkg/policy/identity_test.go
+++ b/pkg/policy/identity_test.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package policy
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // These constants are a downstream contract — ToolPolicy rules compare
 // against them and session-logging consumers persist them. Pin the
@@ -51,5 +54,70 @@ func TestRoleConstants(t *testing.T) {
 		if got != expected {
 			t.Errorf("role constant = %q, want %q", got, expected)
 		}
+	}
+}
+
+// T3: HashedSubject / HashedEndUser emit log-safe pseudonyms instead of
+// raw PII. The helpers are nil-safe and empty-string-safe so every
+// logger call site can use them without guards.
+func TestAuthenticatedIdentity_HashedSubject_NilSafe(t *testing.T) {
+	t.Parallel()
+	var id *AuthenticatedIdentity
+	if got := id.HashedSubject(); got != "" {
+		t.Errorf("nil identity: got %q, want empty", got)
+	}
+}
+
+func TestAuthenticatedIdentity_HashedSubject_EmptySubject(t *testing.T) {
+	t.Parallel()
+	id := &AuthenticatedIdentity{Subject: ""}
+	if got := id.HashedSubject(); got != "" {
+		t.Errorf("empty Subject: got %q, want empty", got)
+	}
+}
+
+func TestAuthenticatedIdentity_HashedSubject_RedactsRaw(t *testing.T) {
+	t.Parallel()
+	id := &AuthenticatedIdentity{Subject: "alice@example.com"}
+	got := id.HashedSubject()
+	if got == "alice@example.com" {
+		t.Error("raw subject leaked through HashedSubject")
+	}
+	if !strings.HasPrefix(got, "[hash:") {
+		t.Errorf("HashedSubject = %q, want logging.HashID-style tag", got)
+	}
+}
+
+func TestAuthenticatedIdentity_HashedSubject_Deterministic(t *testing.T) {
+	// Same input → same hash so log-correlation still works across
+	// multiple requests from the same caller.
+	t.Parallel()
+	a := (&AuthenticatedIdentity{Subject: "alice@example.com"}).HashedSubject()
+	b := (&AuthenticatedIdentity{Subject: "alice@example.com"}).HashedSubject()
+	if a != b {
+		t.Errorf("non-deterministic: %q vs %q", a, b)
+	}
+	c := (&AuthenticatedIdentity{Subject: "bob@example.com"}).HashedSubject()
+	if a == c {
+		t.Error("distinct subjects must hash distinctly")
+	}
+}
+
+func TestAuthenticatedIdentity_HashedEndUser_Symmetry(t *testing.T) {
+	t.Parallel()
+	var nilID *AuthenticatedIdentity
+	if got := nilID.HashedEndUser(); got != "" {
+		t.Errorf("nil identity: got %q", got)
+	}
+	if got := (&AuthenticatedIdentity{}).HashedEndUser(); got != "" {
+		t.Errorf("empty EndUser: got %q", got)
+	}
+	id := &AuthenticatedIdentity{EndUser: "carol@example.com"}
+	got := id.HashedEndUser()
+	if got == "carol@example.com" {
+		t.Error("raw end-user leaked through HashedEndUser")
+	}
+	if !strings.HasPrefix(got, "[hash:") {
+		t.Errorf("HashedEndUser = %q, want hash tag", got)
 	}
 }


### PR DESCRIPTION
Bundles T3 and T10 — two small identity-hygiene tightenings.

## T3 — PII warning + HashedSubject/HashedEndUser helpers
\`AuthenticatedIdentity.Subject\` and \`.EndUser\` are raw PII (emails, OIDC subs, device IDs). The struct now carries explicit doc warnings and two nil-safe helpers — \`HashedSubject()\` / \`HashedEndUser()\` — backed by \`logging.HashID\` so call-sites drop in a log-safe pseudonym without guards.

## T10 — Per-session mgmt-plane subject in the dashboard proxy
The dashboard WS proxy used to mint every mgmt-plane JWT with \`sub: "omnia-dashboard-proxy"\`, so audit logs couldn't distinguish admin A from admin B. It now hashes the iron-session cookie value into a 16-hex pseudonym (\`omnia-admin-<hash>\`) per request. Falls back to the old constant when no session cookie is present (standalone dev / anonymous). \`OMNIA_SESSION_COOKIE_NAME\` overrides the default cookie name.

- Never logs or exposes the raw cookie — only the sha256 prefix
- The cookie itself is already iron-encrypted; hashing it gives us a pseudonymous discriminator without server-side decryption
- Same admin → same subject across requests, so log-correlation still works

## Test plan
- [x] \`pkg/policy/identity_test.go\` — 5 new tests covering nil/empty/distinct/deterministic hashing
- [x] \`go test ./... -count=1 -short\` — 6755 passed
- [x] Dashboard typecheck clean
- [x] Per-file coverage: pkg/policy/identity.go 100%