### PR TITLE
fix(facade): coerce array / numeric / bool OIDC claims (T4)

### DIFF
--- a/internal/facade/auth/oidc.go
+++ b/internal/facade/auth/oidc.go
@@ -25,6 +25,8 @@ import (
 	"fmt"
 	"math/big"
 	"net/http"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -305,18 +307,31 @@ func (v *OIDCValidator) identityFromClaims(claims jwt.MapClaims) *policy.Authent
 	return id
 }
 
-// extractExtraClaims flattens any string-valued claims not already
-// absorbed into Identity.Subject / Role / EndUser so ToolPolicy CEL
-// can reference them via `identity.claims.<name>`. Returns nil when
-// no extras are present (keeps Identity.Claims nil rather than an
-// empty map, which the CEL evaluator handles via `has()`).
+// extractExtraClaims flattens claims not already absorbed into
+// Identity.Subject / Role / EndUser so ToolPolicy CEL can reference
+// them via `identity.claims.<name>`. Returns nil when no extras are
+// present (keeps Identity.Claims nil rather than an empty map, which
+// the CEL evaluator handles via `has()`).
+//
+// Value coercion rules (T4 — earlier revisions dropped non-string
+// claims silently, which broke array-claim CEL rules):
+//   - string                → verbatim (empty strings dropped)
+//   - []string / []any      → comma-joined ("finance,platform")
+//   - float64 (JSON number) → base-10 formatted ("42", "3.14")
+//   - bool                  → "true" / "false"
+//   - other shapes (nested objects, mixed arrays) → dropped
+//
+// Comma-joined arrays mirror the HTTP multi-value-header convention so
+// ToolPolicy CEL rules can check membership via
+// `identity.claims.groups.contains("finance")` regardless of whether
+// the IdP ships the claim as a string or a list.
 func extractExtraClaims(claims jwt.MapClaims, mapping OIDCClaimMapping) map[string]string {
 	extra := map[string]string{}
 	for k, vv := range claims {
 		if k == mapping.Subject || k == mapping.Role || k == mapping.EndUser {
 			continue
 		}
-		if s, ok := vv.(string); ok && s != "" {
+		if s, ok := claimToString(vv); ok {
 			extra[k] = s
 		}
 	}
@@ -324,6 +339,48 @@ func extractExtraClaims(claims jwt.MapClaims, mapping OIDCClaimMapping) map[stri
 		return nil
 	}
 	return extra
+}
+
+// claimToString coerces a JWT claim value into a string suitable for
+// Identity.Claims. See extractExtraClaims for the full rule set.
+func claimToString(v any) (string, bool) {
+	switch val := v.(type) {
+	case string:
+		if val == "" {
+			return "", false
+		}
+		return val, true
+	case []any:
+		parts := make([]string, 0, len(val))
+		for _, elem := range val {
+			if s, ok := elem.(string); ok && s != "" {
+				parts = append(parts, s)
+			}
+		}
+		if len(parts) == 0 {
+			return "", false
+		}
+		return strings.Join(parts, ","), true
+	case []string:
+		parts := make([]string, 0, len(val))
+		for _, s := range val {
+			if s != "" {
+				parts = append(parts, s)
+			}
+		}
+		if len(parts) == 0 {
+			return "", false
+		}
+		return strings.Join(parts, ","), true
+	case float64:
+		// JSON numbers land as float64; strip trailing zeros for whole
+		// numbers so `level: 5` round-trips as "5", not "5.000000".
+		return strconv.FormatFloat(val, 'f', -1, 64), true
+	case bool:
+		return strconv.FormatBool(val), true
+	default:
+		return "", false
+	}
 }
 
 // stringClaim extracts a string value from jwt.MapClaims. Falls back

--- a/internal/facade/auth/oidc_internal_test.go
+++ b/internal/facade/auth/oidc_internal_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import "testing"
+
+// In-package tests for claimToString. The end-to-end oidc_test.go
+// covers the common paths via real JWT flow, but jwt.MapClaims always
+// marshals arrays as []any — the []string and numericClaim fallback
+// branches only surface when a non-JWT caller uses the coercer
+// directly. Keep those paths green so a future refactor doesn't
+// silently drop them.
+func TestClaimToString_TypedArrays(t *testing.T) {
+	t.Parallel()
+	if got, ok := claimToString([]string{"a", "b"}); !ok || got != "a,b" {
+		t.Errorf("[]string: got (%q,%v), want (a,b, true)", got, ok)
+	}
+	// Empty-after-filtering []string must drop.
+	if _, ok := claimToString([]string{"", ""}); ok {
+		t.Errorf("[]string of empties should drop")
+	}
+	// Mix of empty and non-empty: only non-empty survives.
+	if got, ok := claimToString([]string{"", "x", ""}); !ok || got != "x" {
+		t.Errorf("[]string with blanks: got (%q,%v), want (x, true)", got, ok)
+	}
+}
+
+func TestClaimToString_EmptyInputs(t *testing.T) {
+	t.Parallel()
+	if _, ok := claimToString(""); ok {
+		t.Error("empty string must drop")
+	}
+	if _, ok := claimToString([]any{}); ok {
+		t.Error("empty []any must drop")
+	}
+	if _, ok := claimToString([]string{}); ok {
+		t.Error("empty []string must drop")
+	}
+}
+
+func TestClaimToString_NumericVariants(t *testing.T) {
+	t.Parallel()
+	if got, ok := claimToString(float64(3.14)); !ok || got != "3.14" {
+		t.Errorf("float: got (%q,%v)", got, ok)
+	}
+	if got, ok := claimToString(float64(42)); !ok || got != "42" {
+		t.Errorf("whole-float: got (%q,%v)", got, ok)
+	}
+}
+
+func TestClaimToString_Bools(t *testing.T) {
+	t.Parallel()
+	if got, ok := claimToString(true); !ok || got != "true" {
+		t.Errorf("true: got (%q,%v)", got, ok)
+	}
+	if got, ok := claimToString(false); !ok || got != "false" {
+		t.Errorf("false: got (%q,%v)", got, ok)
+	}
+}
+
+func TestClaimToString_Unsupported(t *testing.T) {
+	t.Parallel()
+	// Nested object / pointer / int — all dropped.
+	if _, ok := claimToString(map[string]string{"a": "b"}); ok {
+		t.Error("map must drop")
+	}
+	if _, ok := claimToString(int(5)); ok {
+		t.Error("plain int must drop (jwt.MapClaims never gives us int)")
+	}
+	if _, ok := claimToString(nil); ok {
+		t.Error("nil must drop")
+	}
+}

--- a/internal/facade/auth/oidc_test.go
+++ b/internal/facade/auth/oidc_test.go
@@ -549,3 +549,87 @@ func TestOIDCValidator_LeewayToleratesSmallDrift(t *testing.T) {
 		t.Errorf("token with iat/nbf=+15s should admit under 30s leeway: %v", err)
 	}
 }
+
+// TestOIDCValidator_ExtractsArrayAndScalarClaims proves T4 is fixed:
+// array-valued claims (common shape for groups/roles/scopes) surface
+// as comma-joined strings on Identity.Claims, numeric claims become
+// base-10 strings, and booleans serialise to "true"/"false". Previous
+// revisions dropped all non-string claims on the floor.
+func TestOIDCValidator_ExtractsArrayAndScalarClaims(t *testing.T) {
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  testAliceEmail,
+		key:      key,
+		extras: map[string]any{
+			"groups":     []any{"finance", "platform"}, // typical IdP group list
+			"scopes":     []string{"read", "write"},    // JWT libs sometimes give []string
+			"level":      float64(5),                   // JSON numbers land as float64
+			"admin":      true,                         // booleans coerced to "true"/"false"
+			"empty_list": []any{},                      // dropped, not stored as empty string
+			"empty":      "",                           // dropped
+		},
+	})
+
+	id, err := v.Validate(context.Background(), oidcReq(token))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	want := map[string]string{
+		"groups": "finance,platform",
+		"scopes": "read,write",
+		"level":  "5",
+		"admin":  "true",
+	}
+	for k, expected := range want {
+		if got := id.Claims[k]; got != expected {
+			t.Errorf("Claims[%q] = %q, want %q", k, got, expected)
+		}
+	}
+	if _, present := id.Claims["empty_list"]; present {
+		t.Error("empty array should be dropped, not stored as empty string")
+	}
+	if _, present := id.Claims["empty"]; present {
+		t.Error("empty string should be dropped")
+	}
+}
+
+// TestOIDCValidator_DropsUnsupportedClaimShapes proves nested objects
+// and mixed-type arrays don't end up in Identity.Claims at all — we
+// would surface garbage to ToolPolicy otherwise.
+func TestOIDCValidator_DropsUnsupportedClaimShapes(t *testing.T) {
+	t.Parallel()
+	v, key := newOIDCValidatorForTest(t)
+	token := mintOIDCToken(t, oidcMintOpts{
+		kid:      testOIDCKid,
+		issuer:   testOIDCIssuer,
+		audience: testOIDCAudience,
+		subject:  testAliceEmail,
+		key:      key,
+		extras: map[string]any{
+			"nested":      map[string]any{"a": "b"}, // unsupported
+			"mixed":       []any{"ok", 5, true},     // non-string elements filtered out
+			"just_number": float64(42),
+		},
+	})
+
+	id, err := v.Validate(context.Background(), oidcReq(token))
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+
+	if _, present := id.Claims["nested"]; present {
+		t.Error("nested object must be dropped, not serialised")
+	}
+	// Mixed arrays keep the string elements only.
+	if got := id.Claims["mixed"]; got != "ok" {
+		t.Errorf("Claims[mixed] = %q, want %q (non-string elements filtered)", got, "ok")
+	}
+	if got := id.Claims["just_number"]; got != "42" {
+		t.Errorf("Claims[just_number] = %q, want %q", got, "42")
+	}
+}


### PR DESCRIPTION
Code-review tightening T4.

## Problem
\`extractExtraClaims\` only accepted string values — so array claims like \`groups\`, \`scopes\`, \`roles\` (the most useful claims for ToolPolicy rules) never reached \`Identity.Claims\`. Numeric / boolean claims hit the same bug.

## Fix
New \`claimToString\` coercer in \`oidc.go\` with explicit rules:
- \`string\` → verbatim
- \`[]string\` / \`[]any\` (strings) → comma-joined (\`"finance,platform"\`)
- \`float64\` (JSON number) → base-10 formatted
- \`bool\` → \`"true"\` / \`"false"\`
- Nested objects, mixed arrays, empty strings/arrays → dropped

ToolPolicy CEL rules like \`identity.claims.groups.contains("finance")\` now work uniformly whether the IdP ships the claim as a string or a list.

## Test plan
- [x] \`TestOIDCValidator_ExtractsArrayAndScalarClaims\` — arrays, []string, float, bool
- [x] \`TestOIDCValidator_DropsUnsupportedClaimShapes\` — nested objects dropped, mixed arrays filtered
- [x] \`go test ./internal/facade/auth/... -count=1\` — 93 passed
- [x] Per-file coverage: oidc.go 86.1%