### PR TITLE
fix(facade): enforce ownerRef on api-key Secrets (T6)

### DIFF
--- a/cmd/agent/api_keys.go
+++ b/cmd/agent/api_keys.go
@@ -92,9 +92,16 @@ type apiKeyScopes struct {
 // agent fan-out (tens of keys at most) that an informer's incremental
 // updates aren't worth the extra plumbing for PR 2c.
 type SecretBackedKeyStore struct {
-	client       client.Client
-	namespace    string
-	agentName    string
+	client    client.Client
+	namespace string
+	agentName string
+	// agentUID is the AgentRuntime CR's UID. When non-empty, loadOnce
+	// requires every candidate Secret's ownerReferences to name this UID
+	// — keys planted by a compromised namespace-admin without going
+	// through the dashboard CRUD path (which sets ownerRef on creation)
+	// are rejected. Empty disables the check, for standalone binaries
+	// that don't hold the CR.
+	agentUID     string
 	refresh      time.Duration
 	log          logr.Logger
 	now          func() time.Time
@@ -120,6 +127,15 @@ func WithKeyStoreRefreshInterval(d time.Duration) SecretBackedKeyStoreOption {
 // WithKeyStoreClock injects a clock for tests.
 func WithKeyStoreClock(now func() time.Time) SecretBackedKeyStoreOption {
 	return func(s *SecretBackedKeyStore) { s.now = now }
+}
+
+// WithKeyStoreAgentUID enables ownerRef verification. Every candidate
+// Secret must carry an ownerReferences entry whose UID matches the
+// passed value; otherwise it is skipped + logged. Defence against a
+// compromised namespace-admin planting a label-matching Secret to gain
+// API-key admission (T6 finding).
+func WithKeyStoreAgentUID(uid string) SecretBackedKeyStoreOption {
+	return func(s *SecretBackedKeyStore) { s.agentUID = uid }
 }
 
 // NewSecretBackedKeyStore loads the initial key set synchronously, then
@@ -185,6 +201,19 @@ func (s *SecretBackedKeyStore) loadOnce(ctx context.Context) error {
 	next := make(map[string]auth.APIKey, len(list.Items))
 	for i := range list.Items {
 		secret := &list.Items[i]
+		// T6 — defence in depth against a namespace-admin planting a
+		// label-matching Secret. When the constructor was handed a UID,
+		// require every candidate Secret to carry an ownerRef naming
+		// that UID. Secrets created through the dashboard CRUD endpoint
+		// (the only sanctioned creation path) always set this; hand-
+		// applied bypasses do not.
+		if s.agentUID != "" && !secretOwnedByAgent(secret, s.agentUID) {
+			s.log.Info("skipping api-key secret — missing matching ownerRef",
+				"secret", secret.Name,
+				"expectedAgentUID", s.agentUID,
+				"hint", "if this is legitimate, have the dashboard CRUD path re-mint the key so ownerRef is set")
+			continue
+		}
 		key, err := parseAPIKeySecret(secret)
 		if err != nil {
 			s.log.V(1).Info("skipping malformed api-key secret",
@@ -229,6 +258,19 @@ func (s *SecretBackedKeyStore) refreshLoop() {
 // parseAPIKeySecret converts a labelled Secret into an APIKey. Returns
 // an error (caller skips + logs) when required fields are missing or
 // malformed — never panics on bad input.
+// secretOwnedByAgent returns true when secret carries an ownerReferences
+// entry whose UID matches the agent's UID. Used by the ownerRef-gated
+// loadOnce path (WithKeyStoreAgentUID) to reject Secrets that didn't go
+// through the dashboard CRUD endpoint.
+func secretOwnedByAgent(secret *corev1.Secret, agentUID string) bool {
+	for _, ref := range secret.OwnerReferences {
+		if string(ref.UID) == agentUID {
+			return true
+		}
+	}
+	return false
+}
+
 func parseAPIKeySecret(secret *corev1.Secret) (auth.APIKey, error) {
 	if len(secret.Data) == 0 {
 		return auth.APIKey{}, fmt.Errorf("empty data")

--- a/cmd/agent/api_keys_test.go
+++ b/cmd/agent/api_keys_test.go
@@ -230,6 +230,81 @@ func TestParseAPIKeySecret_EmptyDataErrors(t *testing.T) {
 	}
 }
 
+// TestSecretBackedKeyStore_RejectsUnownedSecretsWhenUIDSet proves T6:
+// when the store is constructed with an expected agent UID, Secrets
+// whose ownerReferences don't name that UID are skipped even if they
+// carry the right labels. Defence against a compromised namespace-
+// admin planting a label-matching Secret to gain admission without
+// going through the dashboard CRUD path.
+func TestSecretBackedKeyStore_RejectsUnownedSecretsWhenUIDSet(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	hash := sha256Bytes(testRawKey)
+	unowned := newAPIKeySecret("agent-myagent-apikey-planted", "myagent", hash, "admin", "")
+
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unowned).Build()
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour),
+		WithKeyStoreAgentUID("agent-uid-123"))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(auth.HashToken(testRawKey)); ok {
+		t.Error("unowned Secret must not appear in the store when agent UID is set")
+	}
+}
+
+// TestSecretBackedKeyStore_AcceptsCorrectlyOwnedSecret proves the
+// happy path still works: a Secret whose ownerReferences name the
+// expected UID loads normally.
+func TestSecretBackedKeyStore_AcceptsCorrectlyOwnedSecret(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	hash := sha256Bytes(testRawKey)
+	owned := newAPIKeySecret("agent-myagent-apikey-legit", "myagent", hash, "editor", "")
+	owned.OwnerReferences = []metav1.OwnerReference{
+		{APIVersion: "omnia.altairalabs.ai/v1alpha1", Kind: "AgentRuntime",
+			Name: "myagent", UID: "agent-uid-123"},
+	}
+
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(owned).Build()
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour),
+		WithKeyStoreAgentUID("agent-uid-123"))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(auth.HashToken(testRawKey)); !ok {
+		t.Error("ownerRef-matched Secret should admit")
+	}
+}
+
+// TestSecretBackedKeyStore_EmptyUIDDisablesOwnerCheck preserves the
+// standalone-binary path: when no UID is supplied the old label-only
+// filtering is restored.
+func TestSecretBackedKeyStore_EmptyUIDDisablesOwnerCheck(t *testing.T) {
+	t.Parallel()
+	scheme := newTestScheme(t)
+	hash := sha256Bytes(testRawKey)
+	unowned := newAPIKeySecret("agent-myagent-apikey-001", "myagent", hash, "editor", "")
+
+	fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(unowned).Build()
+	store, err := NewSecretBackedKeyStore(context.Background(), fc, "ns", "myagent", logr.Discard(),
+		WithKeyStoreRefreshInterval(time.Hour))
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	defer store.Stop()
+
+	if _, ok := store.Lookup(auth.HashToken(testRawKey)); !ok {
+		t.Error("empty UID should fall back to label-only filtering; Secret should load")
+	}
+}
+
 // TestParseAPIKeySecret_WrongHashLengthRejects proves T5 is fixed:
 // writers that accidentally store a hex-encoded sha256 (64 bytes) or
 // a truncated digest fail loud at load time rather than silently never

--- a/cmd/agent/auth_chain.go
+++ b/cmd/agent/auth_chain.go
@@ -201,7 +201,11 @@ func buildAPIKeyValidator(
 		return nil, nil
 	}
 
-	store, err := NewSecretBackedKeyStore(ctx, k8s, ar.Namespace, ar.Name, log)
+	// Pass the AgentRuntime's UID so the store rejects label-matching
+	// Secrets that weren't created by the dashboard's CRUD path (the
+	// only sanctioned creator sets ownerRef to the AgentRuntime). T6.
+	store, err := NewSecretBackedKeyStore(ctx, k8s, ar.Namespace, ar.Name, log,
+		WithKeyStoreAgentUID(string(ar.UID)))
 	if err != nil {
 		return nil, fmt.Errorf("init api-key store: %w", err)
 	}


### PR DESCRIPTION
Code-review tightening T6.

## Problem
The API-key store trusted \`credential-kind\` + \`agent\` labels alone. Anyone with Secret-create in the namespace could label a Secret for the agent and get it admitted — a privilege escalation vector if the dashboard CRUD endpoint is ever bypassed.

## Fix
- New \`WithKeyStoreAgentUID\` option threads the AgentRuntime's UID into the store.
- \`loadOnce\` skips Secrets whose ownerReferences don't name that UID (with an info-level log).
- \`cmd/agent/auth_chain.go\` passes \`ar.UID\` at build time so production always gets the ownership check.
- Empty UID keeps the old label-only filtering for standalone/dev binaries that don't have an AgentRuntime CR.

## Test plan
- [x] \`TestSecretBackedKeyStore_RejectsUnownedSecretsWhenUIDSet\` — unowned planted Secret is skipped
- [x] \`TestSecretBackedKeyStore_AcceptsCorrectlyOwnedSecret\` — ownerRef-matched admits
- [x] \`TestSecretBackedKeyStore_EmptyUIDDisablesOwnerCheck\` — standalone path preserved
- [x] \`go test ./cmd/agent/ -run 'TestSecretBackedKeyStore|TestParseAPIKeySecret'\` — 18 passed