### PR TITLE
ci(docs): bump docs build to Node 22 to unblock Astro

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          # Astro 5+ requires Node >= 22.12 (blocks dependabot PR #945).
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: docs/package-lock.json
 


### PR DESCRIPTION
Unblocks dependabot #945 (@astrojs/starlight → Astro 5 bump).

Astro 5+ requires Node >= 22.12. The docs build pinned Node 20, so #945's \`astro build\` step was failing with:
\`\`\`
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
\`\`\`

## Test plan
- [x] Only touches \`.github/workflows/docs.yml\`
- [ ] After merge, rerun CI on #945 — the \`build\` job should pass

Note: needs a reviewer with \`workflow\` scope to merge.