### PR TITLE
ci(agent-e2e): tolerate transient AgentRuntime phase=Failed

### DIFF
--- a/.github/workflows/test-agent-e2e.yml
+++ b/.github/workflows/test-agent-e2e.yml
@@ -276,8 +276,16 @@ jobs:
           kubectl get pods -n omnia-system -l app.kubernetes.io/name=omnia
           kubectl logs -n omnia-system -l app.kubernetes.io/name=omnia --tail=50 || true
 
-          # Wait for AgentRuntime to be reconciled
+          # Wait for AgentRuntime to be reconciled.
+          # The reconciler sets Phase=Failed transiently when reference
+          # reconciles race (e.g. PromptPack/ToolRegistry not yet
+          # indexed), so we need to see the failure persist before
+          # bailing — otherwise the test flakes on healthy startup.
+          # FAILED_THRESHOLD=3 means we tolerate up to ~30s of Failed
+          # before treating it as terminal.
           echo "Waiting for AgentRuntime to be reconciled..."
+          FAILED_STREAK=0
+          FAILED_THRESHOLD=3
           for i in {1..60}; do
             STATUS=$(kubectl get agentruntime vision-demo -n omnia-demo -o jsonpath='{.status.phase}' 2>/dev/null || echo "NotFound")
             echo "AgentRuntime status: $STATUS ($i/60)"
@@ -286,9 +294,15 @@ jobs:
               break
             fi
             if [ "$STATUS" == "Failed" ]; then
-              echo "AgentRuntime failed!"
-              kubectl describe agentruntime vision-demo -n omnia-demo
-              exit 1
+              FAILED_STREAK=$((FAILED_STREAK + 1))
+              echo "AgentRuntime phase=Failed (streak $FAILED_STREAK/$FAILED_THRESHOLD)"
+              if [ "$FAILED_STREAK" -ge "$FAILED_THRESHOLD" ]; then
+                echo "AgentRuntime failed persistently — bailing"
+                kubectl describe agentruntime vision-demo -n omnia-demo
+                exit 1
+              fi
+            else
+              FAILED_STREAK=0
             fi
             sleep 10
           done

--- a/.github/workflows/test-agent-e2e.yml
+++ b/.github/workflows/test-agent-e2e.yml
@@ -253,6 +253,14 @@ jobs:
               type: websocket
               port: 8080
               handler: demo
+              # The HTTP connectivity probe below curls /ws without a
+              # credential and expects 400 (missing upgrade). The B2
+              # strict default (#967) would return 401 first. Opt into
+              # the dev escape hatch so the connectivity probe keeps
+              # its original semantics.
+              extraEnv:
+                - name: OMNIA_FACADE_ALLOW_UNAUTHENTICATED
+                  value: "true"
           EOF
 
           echo "Demo AgentRuntime created"


### PR DESCRIPTION
Bundled Agent E2E workflow fixes. Both needed to unblock the facade-auth PR series.

## Fix 1: Tolerate transient AgentRuntime phase=Failed
The controller sets Phase=Failed in handleRefError (agentruntime_controller.go:265) whenever a reference fetch misses — including startup races where the PromptPack isn't indexed yet. Require 3 consecutive Failed polls (~30s) before bailing.

## Fix 2: Opt vision-demo AgentRuntime into permissive mode
The HTTP connectivity probe curls /ws without a credential and expects 400 (missing upgrade). After the B2 strict default (#967), the facade 401s first. Opt the test AgentRuntime into the dev escape hatch so the probe keeps its pre-B2 semantics.

## Impact
- **#967 (B2) cannot pass Agent E2E until this lands.**
- Other facade-auth PRs that depend on B2 also blocked.

## Test plan
- [x] Only touches `.github/workflows/test-agent-e2e.yml`
- [ ] After merge, rerun CI on #967 — Agent Flow Tests should pass

Note: workflow file change — needs a reviewer with `workflow` scope to merge.