### PR TITLE
fix(dashboard): preserve RFC 9207 iss on OAuth callback (closes #948)

### DIFF
--- a/dashboard/src/app/api/auth/callback/route.test.ts
+++ b/dashboard/src/app/api/auth/callback/route.test.ts
@@ -92,4 +92,37 @@ describe("GET /api/auth/callback", () => {
     const res = await GET(req);
     expect(res.headers.get("location")).toContain("error=no_code");
   });
+
+  // Issue #948: Google advertises RFC 9207 issuer identification via
+  // `authorization_response_iss_parameter_supported: true`. openid-
+  // client v6 then enforces that `iss` is present in the authorization
+  // response — which means the token exchange must receive the REAL
+  // incoming URL (complete with iss), not a rebuilt URL that only
+  // carries code + state. Before the fix, the callback route passed
+  // `(code, pkce)` to exchangeCodeForTokens; it now passes the full
+  // request URL as the third argument. This test pins that contract.
+  it("forwards the full incoming URL to exchangeCodeForTokens (RFC 9207 iss preservation)", async () => {
+    const { exchangeCodeForTokens } = await import("@/lib/auth/oauth");
+    const mockedExchange = vi.mocked(exchangeCodeForTokens);
+    mockedExchange.mockClear();
+
+    // Simulate Google redirecting back with code + state + iss.
+    const url =
+      "https://omnia.example/api/auth/callback?code=code-1" +
+      "&state=state-123&iss=https%3A%2F%2Faccounts.google.com";
+    const req = new NextRequest(url);
+    req.cookies.set("omnia_oauth_state", "state-123");
+
+    const { GET } = await import("./route");
+    await GET(req);
+
+    expect(mockedExchange).toHaveBeenCalledTimes(1);
+    const [passedCode, , passedUrl] = mockedExchange.mock.calls[0];
+    expect(passedCode).toBe("code-1");
+    // Third argument must be the full URL, not undefined — otherwise
+    // openid-client strips iss and Google sign-in 500s.
+    expect(passedUrl).toBeDefined();
+    expect(passedUrl?.searchParams.get("iss")).toBe("https://accounts.google.com");
+    expect(passedUrl?.searchParams.get("code")).toBe("code-1");
+  });
 });

--- a/dashboard/src/app/api/auth/callback/route.ts
+++ b/dashboard/src/app/api/auth/callback/route.ts
@@ -70,7 +70,11 @@ export async function GET(request: NextRequest) {
   if (!code) return loginRedirect("?error=no_code");
 
   try {
-    const tokens = await exchangeCodeForTokens(code, pkce);
+    // Hand the full incoming URL to the token exchange so RFC 9207 iss
+    // (emitted by Google / Google Workspace via
+    // authorization_response_iss_parameter_supported=true) survives
+    // openid-client's strict response validation. Issue #948.
+    const tokens = await exchangeCodeForTokens(code, pkce, request.nextUrl);
 
     let claims = extractClaims(tokens);
     if (!validateClaims(claims) && tokens.access_token) {

--- a/dashboard/src/lib/auth/oauth/client.test.ts
+++ b/dashboard/src/lib/auth/oauth/client.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PKCEData } from "./types";
+
+// Mock the openid-client module so we can observe what URL
+// exchangeCodeForTokens hands to authorizationCodeGrant. The rest of
+// the module (discovery, refresh, userinfo, end-session) sits on the
+// happy-path cache and is exercised by the callback-route integration
+// tests; this file exists specifically to pin the issue-#948 contract.
+vi.mock("openid-client", async () => {
+  const actual = await vi.importActual<typeof import("openid-client")>("openid-client");
+  return {
+    ...actual,
+    discovery: vi.fn(async () => ({
+      serverMetadata: () => ({}),
+    })),
+    authorizationCodeGrant: vi.fn(async () => ({
+      access_token: "at",
+      refresh_token: "rt",
+      id_token: "it",
+      expires_at: 0,
+    })),
+    // PKCE primitives: the real implementations depend on oauth4webapi's
+    // Uint8Array handling that vitest's JSDOM env doesn't reliably
+    // support. Mock to stable strings so generatePKCE round-trips
+    // without touching node:crypto from a browser-like runtime.
+    randomPKCECodeVerifier: () => "test-verifier",
+    calculatePKCECodeChallenge: async () => "test-challenge",
+    randomState: () => "test-state",
+  };
+});
+
+describe("exchangeCodeForTokens (issue #948)", () => {
+  const pkce: PKCEData = {
+    codeVerifier: "v",
+    codeChallenge: "c",
+    state: "state-abc",
+  };
+
+  beforeEach(async () => {
+    process.env.OMNIA_AUTH_MODE = "oauth";
+    process.env.OMNIA_BASE_URL = "https://omnia.example";
+    process.env.OMNIA_OAUTH_PROVIDER = "google";
+    process.env.OMNIA_OAUTH_ISSUER_URL = "https://accounts.google.com";
+    process.env.OMNIA_OAUTH_CLIENT_ID = "client-id";
+    process.env.OMNIA_OAUTH_CLIENT_SECRET = "client-secret";
+    const { clearOAuthCache } = await import("./client");
+    clearOAuthCache();
+  });
+
+  it("uses the incoming URL so RFC 9207 iss survives into validation", async () => {
+    const openid = await import("openid-client");
+    const mocked = vi.mocked(openid.authorizationCodeGrant);
+    mocked.mockClear();
+
+    const { exchangeCodeForTokens } = await import("./client");
+    const incoming = new URL(
+      "https://omnia.example/api/auth/callback?code=c-1&state=state-abc&iss=https%3A%2F%2Faccounts.google.com",
+    );
+
+    await exchangeCodeForTokens("c-1", pkce, incoming);
+
+    const [, passedArg] = mocked.mock.calls[0];
+    const passedUrl = passedArg as URL;
+    // passedUrl retains iss — that's what closes #948 for Google.
+    expect(passedUrl.searchParams.get("iss")).toBe("https://accounts.google.com");
+    // code/state are re-set by the function itself (defensive).
+    expect(passedUrl.searchParams.get("code")).toBe("c-1");
+    expect(passedUrl.searchParams.get("state")).toBe("state-abc");
+  });
+
+  it("falls back to the configured callback URL when incomingUrl is omitted", async () => {
+    // Keeps older test call sites that pass (code, pkce) working
+    // without dragging a URL object through every mock.
+    const openid = await import("openid-client");
+    const mocked = vi.mocked(openid.authorizationCodeGrant);
+    mocked.mockClear();
+
+    const { exchangeCodeForTokens } = await import("./client");
+    await exchangeCodeForTokens("c-2", pkce);
+
+    const [, passedArg] = mocked.mock.calls[0];
+    const passedUrl = passedArg as URL;
+    expect(passedUrl.origin + passedUrl.pathname).toBe(
+      "https://omnia.example/api/auth/callback",
+    );
+    expect(passedUrl.searchParams.get("code")).toBe("c-2");
+    expect(passedUrl.searchParams.get("state")).toBe("state-abc");
+    // No iss on the synthesised URL — that's the bug the fallback path
+    // admits; real callers (the callback route) always pass incomingUrl.
+    expect(passedUrl.searchParams.has("iss")).toBe(false);
+  });
+});
+
+describe("client.ts surface (kept lean)", () => {
+  beforeEach(async () => {
+    process.env.OMNIA_AUTH_MODE = "oauth";
+    process.env.OMNIA_BASE_URL = "https://omnia.example";
+    process.env.OMNIA_OAUTH_PROVIDER = "google";
+    process.env.OMNIA_OAUTH_ISSUER_URL = "https://accounts.google.com";
+    process.env.OMNIA_OAUTH_CLIENT_ID = "client-id";
+    process.env.OMNIA_OAUTH_CLIENT_SECRET = "client-secret";
+    const { clearOAuthCache } = await import("./client");
+    clearOAuthCache();
+  });
+
+  it("generatePKCE emits a verifier + challenge + state and propagates returnTo", async () => {
+    const { generatePKCE } = await import("./client");
+    const pkce = await generatePKCE("/return");
+    expect(pkce.codeVerifier).toBeTruthy();
+    expect(pkce.codeChallenge).toBeTruthy();
+    expect(pkce.state).toBeTruthy();
+    expect(pkce.returnTo).toBe("/return");
+  });
+
+  it("getCallbackUrl uses OMNIA_BASE_URL", async () => {
+    const { getCallbackUrl } = await import("./client");
+    expect(getCallbackUrl()).toBe("https://omnia.example/api/auth/callback");
+  });
+
+  it("buildAuthorizationUrl forwards redirect_uri + scope + state + PKCE", async () => {
+    const openid = await import("openid-client");
+    const spy = vi.spyOn(openid, "buildAuthorizationUrl");
+    spy.mockReturnValue(new URL("https://idp.example/auth?stub=1"));
+
+    const { buildAuthorizationUrl } = await import("./client");
+    const href = await buildAuthorizationUrl({
+      codeVerifier: "v",
+      codeChallenge: "c",
+      state: "s",
+    });
+    expect(href).toBe("https://idp.example/auth?stub=1");
+    const [, paramsArg] = spy.mock.calls[0];
+    const params = paramsArg as Record<string, string>;
+    expect(params.state).toBe("s");
+    expect(params.code_challenge).toBe("c");
+    expect(params.code_challenge_method).toBe("S256");
+    spy.mockRestore();
+  });
+
+  it("refreshAccessToken delegates to openid-client refreshTokenGrant", async () => {
+    const openid = await import("openid-client");
+    const spy = vi.spyOn(openid, "refreshTokenGrant").mockResolvedValue({
+      access_token: "at2",
+    } as never);
+
+    const { refreshAccessToken } = await import("./client");
+    const tokens = await refreshAccessToken("refresh-xyz");
+    expect(tokens.access_token).toBe("at2");
+    const [, refreshArg] = spy.mock.calls[0];
+    expect(refreshArg).toBe("refresh-xyz");
+    spy.mockRestore();
+  });
+
+  it("getUserInfo delegates to openid-client fetchUserInfo", async () => {
+    const openid = await import("openid-client");
+    const spy = vi.spyOn(openid, "fetchUserInfo").mockResolvedValue({
+      sub: "u1",
+    } as never);
+
+    const { getUserInfo } = await import("./client");
+    const info = await getUserInfo("access", "u1");
+    expect(info.sub).toBe("u1");
+    const [, at, sub] = spy.mock.calls[0];
+    expect(at).toBe("access");
+    expect(sub).toBe("u1");
+    spy.mockRestore();
+  });
+
+  it("buildEndSessionUrl returns null when the provider metadata omits end_session_endpoint", async () => {
+    // The mocked discovery returns empty metadata, so buildEndSessionUrl
+    // should return null rather than throw.
+    const { buildEndSessionUrl } = await import("./client");
+    await expect(buildEndSessionUrl("id-token")).resolves.toBeNull();
+  });
+
+  it("buildEndSessionUrl returns a URL when metadata advertises end_session_endpoint", async () => {
+    // Override the discovery mock for this case so the metadata
+    // exposes end_session_endpoint.
+    const openid = await import("openid-client");
+    const discoverySpy = vi.spyOn(openid, "discovery").mockResolvedValue({
+      serverMetadata: () => ({
+        end_session_endpoint: "https://idp.example/logout",
+      }),
+    } as never);
+    const endSessionSpy = vi
+      .spyOn(openid, "buildEndSessionUrl")
+      .mockReturnValue(new URL("https://idp.example/logout?post_logout_redirect_uri=x"));
+
+    const { buildEndSessionUrl, clearOAuthCache } = await import("./client");
+    clearOAuthCache();
+    const url = await buildEndSessionUrl("id-hint");
+    expect(url).toContain("https://idp.example/logout");
+
+    discoverySpy.mockRestore();
+    endSessionSpy.mockRestore();
+  });
+});

--- a/dashboard/src/lib/auth/oauth/client.ts
+++ b/dashboard/src/lib/auth/oauth/client.ts
@@ -106,15 +106,34 @@ export async function buildAuthorizationUrl(pkce: PKCEData): Promise<string> {
 
 /**
  * Exchange authorization code for tokens.
+ *
+ * incomingUrl is the full request URL received on the callback route.
+ * Preserving its query params is load-bearing for providers that
+ * advertise RFC 9207 issuer identification (Google / Google Workspace
+ * set `authorization_response_iss_parameter_supported: true` in their
+ * discovery documents). openid-client v6 refuses the exchange when
+ * `iss` is expected but absent — so stripping query params down to
+ * `code` + `state`, as earlier revisions did, reliably broke Google
+ * sign-in. See issue #948.
+ *
+ * Entra ID and Cognito don't set the flag, which is why the bug was
+ * invisible on omnia-azure / omnia-aws. Falling back to the
+ * configured callback URL keeps the test / non-request call sites
+ * working; real production callers always pass the incoming URL.
  */
 export async function exchangeCodeForTokens(
   code: string,
-  pkce: PKCEData
+  pkce: PKCEData,
+  incomingUrl?: URL
 ): Promise<client.TokenEndpointResponse & client.TokenEndpointResponseHelpers> {
   const oauthConfig = await getOAuthConfig();
 
-  // Build the callback URL with the code and state
-  const callbackUrl = new URL(getCallbackUrl());
+  // Start from the real incoming URL so RFC 9207 iss (and any future
+  // required response params) survive validation. Fall back to the
+  // configured callback URL for call sites without a request in hand.
+  const callbackUrl = incomingUrl
+    ? new URL(incomingUrl.toString())
+    : new URL(getCallbackUrl());
   callbackUrl.searchParams.set("code", code);
   callbackUrl.searchParams.set("state", pkce.state);
 

--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -137,7 +137,11 @@ export default defineConfig({
         "src/lib/auth/api-guard.ts", // API middleware with NextAuth
         "src/lib/auth/proxy.ts", // HTTP proxy utilities
         "src/lib/auth/api-keys/**", // File-based API key stores
-        "src/lib/auth/oauth/**", // OAuth client (requires providers)
+        // OAuth provider configs (issuer URLs and scope defaults) —
+        // data tables, not code paths. client.ts now has direct unit
+        // tests (issue #948); fold it back into the coverage report.
+        "src/lib/auth/oauth/providers/**",
+        "src/lib/auth/oauth/types.ts",
         "src/lib/auth/providers/**", // OAuth provider configs
       ],
       thresholds: {


### PR DESCRIPTION
Closes #948.

## Problem
Dashboard OAuth callback failed with \`response parameter "iss" (issuer) missing\` when the IdP advertises RFC 9207 support. Reproduces with Google; invisible on Entra ID / Cognito because neither sets \`authorization_response_iss_parameter_supported: true\` in their discovery doc.

\`exchangeCodeForTokens\` rebuilt the callback URL from \`getCallbackUrl()\` and only re-attached \`code\` + \`state\`. Any other query param the IdP sent — notably RFC 9207's \`iss\` — was dropped. openid-client v6 then refuses the exchange.

## Fix
Thread the real incoming URL through from the callback route so every response param survives into validation. Fallback to the configured callback URL is kept for non-request call sites.

\`\`\`ts
// dashboard/src/app/api/auth/callback/route.ts
const tokens = await exchangeCodeForTokens(code, pkce, request.nextUrl);
\`\`\`

## Test plan
- [x] New \`client.test.ts\` unit tests — iss preserved when \`incomingUrl\` is supplied; synthesised URL without iss in the fallback path
- [x] New \`route.test.ts\` integration case — callback route forwards \`request.nextUrl\` to \`exchangeCodeForTokens\`
- [x] Verified the route test **fails** without the fix (stashed client.ts → 1 failed)
- [x] \`src/lib/auth/oauth/client.ts\` coverage: 87.8% (vitest.config.ts exclusion narrowed to providers/ + types.ts only)
- [x] All 4184+ dashboard vitest tests still pass