### PR TITLE
feat(memory): multi-tier retrieval phase 1 — endpoint + ranking + agent scope

### DIFF
--- a/cmd/memory-api/wiring_test.go
+++ b/cmd/memory-api/wiring_test.go
@@ -56,6 +56,9 @@ func (fakeMemoryStore) ExportAll(_ context.Context, _ map[string]string) ([]*mem
 func (fakeMemoryStore) BatchDelete(_ context.Context, _ map[string]string, _ int) (int, error) {
 	return 0, nil
 }
+func (fakeMemoryStore) RetrieveMultiTier(_ context.Context, _ memory.MultiTierRequest) (*memory.MultiTierResult, error) {
+	return &memory.MultiTierResult{Memories: []*memory.MultiTierMemory{}, Total: 0}, nil
+}
 
 // TestBuildAPIMux_POSTMemoryWithoutUserIDReturns400 verifies the wiring
 // contract that the POST /api/v1/memories route is registered and reaches the

--- a/cmd/runtime/main.go
+++ b/cmd/runtime/main.go
@@ -428,6 +428,7 @@ func configDerivedServerOpts(cfg *pkruntime.Config) []pkruntime.ServerOption {
 		pkruntime.WithPackPath(cfg.PromptPackPath),
 		pkruntime.WithPromptName(cfg.PromptName),
 		pkruntime.WithAgentIdentity(cfg.AgentName, cfg.Namespace),
+		pkruntime.WithAgentUID(cfg.AgentUID),
 		pkruntime.WithPromptPackName(cfg.PromptPackName),
 		pkruntime.WithModel(cfg.Model),
 		pkruntime.WithMockProvider(cfg.MockProvider),

--- a/cmd/runtime/wiring_test.go
+++ b/cmd/runtime/wiring_test.go
@@ -200,3 +200,25 @@ func TestConfigDerivedServerOpts_EmptyMediaBasePathLeavesResolverNil(t *testing.
 			"MediaBasePath is empty — WithMediaBasePath semantics changed")
 	}
 }
+
+// TestConfigDerivedServerOpts_WiresAgentUID asserts that cfg.AgentUID is
+// applied on the resulting Server via WithAgentUID. Without this option the
+// runtime's memory scope never carries agent_id, which silently disables the
+// multi-tier retrieval routing in the httpclient — callers get only the flat
+// user-scoped search endpoint.
+func TestConfigDerivedServerOpts_WiresAgentUID(t *testing.T) {
+	const wantUID = "44444444-4444-4444-4444-444444444444"
+	cfg := &pkruntime.Config{
+		AgentName: "wiring-test",
+		AgentUID:  wantUID,
+		Namespace: "wiring",
+	}
+	opts := configDerivedServerOpts(cfg)
+
+	srv := pkruntime.NewServer(opts...)
+	t.Cleanup(func() { _ = srv.Close() })
+
+	if got := pkruntime.ServerAgentUID(srv); got != wantUID {
+		t.Errorf("AgentUID not propagated: got %q, want %q", got, wantUID)
+	}
+}

--- a/internal/memory/api/event_publisher_test.go
+++ b/internal/memory/api/event_publisher_test.go
@@ -77,6 +77,10 @@ func (m *mockMemoryStore) ExportAll(_ context.Context, _ map[string]string) ([]*
 	return nil, nil
 }
 
+func (m *mockMemoryStore) RetrieveMultiTier(_ context.Context, _ memory.MultiTierRequest) (*memory.MultiTierResult, error) {
+	return &memory.MultiTierResult{Memories: []*memory.MultiTierMemory{}, Total: 0}, nil
+}
+
 func (m *mockMemoryStore) BatchDelete(_ context.Context, _ map[string]string, _ int) (int, error) {
 	return 0, nil
 }

--- a/internal/memory/api/handler.go
+++ b/internal/memory/api/handler.go
@@ -109,6 +109,7 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/v1/memories/{id}", h.handleDeleteMemory)
 	mux.HandleFunc("DELETE /api/v1/memories/batch", h.handleBatchDeleteMemories)
 	mux.HandleFunc("DELETE /api/v1/memories", h.handleDeleteAllMemories)
+	mux.HandleFunc("POST /api/v1/memories/retrieve", h.handleRetrieveMultiTier)
 
 	h.registerDocsRoutes(mux)
 }

--- a/internal/memory/api/handler_retrieve.go
+++ b/internal/memory/api/handler_retrieve.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// Retrieve endpoint limits.
+const (
+	defaultRetrieveLimit = 15
+	maxRetrieveLimit     = 100
+)
+
+// RetrieveMultiTierRequest is the JSON body for POST /api/v1/memories/retrieve.
+type RetrieveMultiTierRequest struct {
+	WorkspaceID   string   `json:"workspace_id"`
+	UserID        string   `json:"user_id,omitempty"`
+	AgentID       string   `json:"agent_id,omitempty"`
+	Query         string   `json:"query,omitempty"`
+	Types         []string `json:"types,omitempty"`
+	MinConfidence float64  `json:"min_confidence,omitempty"`
+	Limit         int      `json:"limit,omitempty"`
+}
+
+// RetrieveMultiTierResponse is the JSON response for the endpoint.
+type RetrieveMultiTierResponse struct {
+	Memories []*memory.MultiTierMemory `json:"memories"`
+	Total    int                       `json:"total"`
+}
+
+// handleRetrieveMultiTier handles POST /api/v1/memories/retrieve.
+// Body-based so query + types don't inflate URLs and so the scope map
+// carrying user_id/agent_id isn't exposed in request logs.
+func (h *Handler) handleRetrieveMultiTier(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, h.maxBodySize)
+
+	var req RetrieveMultiTierRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if isMaxBytesError(err) {
+			writeError(w, ErrBodyTooLarge)
+			return
+		}
+		writeError(w, ErrMissingBody)
+		return
+	}
+
+	if req.WorkspaceID == "" {
+		writeError(w, ErrMissingWorkspace)
+		return
+	}
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultRetrieveLimit
+	}
+	if limit > maxRetrieveLimit {
+		limit = maxRetrieveLimit
+	}
+
+	storeReq := memory.MultiTierRequest{
+		WorkspaceID:   req.WorkspaceID,
+		UserID:        req.UserID,
+		AgentID:       req.AgentID,
+		Query:         req.Query,
+		Types:         req.Types,
+		MinConfidence: req.MinConfidence,
+		Limit:         limit,
+	}
+
+	result, err := h.service.RetrieveMultiTier(r.Context(), storeReq)
+	if err != nil {
+		h.log.Error(err, "RetrieveMultiTier failed", "workspace", req.WorkspaceID)
+		writeError(w, err)
+		return
+	}
+
+	writeJSON(w, RetrieveMultiTierResponse{
+		Memories: result.Memories,
+		Total:    result.Total,
+	})
+}

--- a/internal/memory/api/handler_retrieve_test.go
+++ b/internal/memory/api/handler_retrieve_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+func newRetrieveTestHandler(t *testing.T, store memory.Store) *Handler {
+	t.Helper()
+	svc := NewMemoryService(store, nil, MemoryServiceConfig{}, logr.Discard())
+	return NewHandler(svc, logr.Discard())
+}
+
+func TestHandleRetrieveMultiTier_HappyPath(t *testing.T) {
+	store := &multiTierStoreStub{
+		mtResult: &memory.MultiTierResult{
+			Memories: []*memory.MultiTierMemory{
+				{Memory: &memory.Memory{ID: "m-1", Content: "inst"}, Tier: memory.TierInstitutional, Score: 0.9},
+				{Memory: &memory.Memory{ID: "m-2", Content: "user"}, Tier: memory.TierUser, Score: 0.7},
+			},
+			Total: 2,
+		},
+	}
+	h := newRetrieveTestHandler(t, store)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"workspace_id":"ws-1","user_id":"u-1","agent_id":"a-1","query":"dark","limit":5}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/memories/retrieve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code, rec.Body.String())
+	var out RetrieveMultiTierResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	assert.Equal(t, 2, out.Total)
+	require.Len(t, out.Memories, 2)
+	assert.Equal(t, memory.TierInstitutional, out.Memories[0].Tier)
+
+	store.mu.Lock()
+	require.Len(t, store.mtCalls, 1)
+	call := store.mtCalls[0]
+	store.mu.Unlock()
+	assert.Equal(t, "ws-1", call.WorkspaceID)
+	assert.Equal(t, "u-1", call.UserID)
+	assert.Equal(t, "a-1", call.AgentID)
+	assert.Equal(t, "dark", call.Query)
+	assert.Equal(t, 5, call.Limit)
+}
+
+func TestHandleRetrieveMultiTier_RejectsMissingWorkspace(t *testing.T) {
+	store := &multiTierStoreStub{}
+	h := newRetrieveTestHandler(t, store)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/memories/retrieve", strings.NewReader(`{"user_id":"u-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	store.mu.Lock()
+	assert.Empty(t, store.mtCalls)
+	store.mu.Unlock()
+}
+
+func TestHandleRetrieveMultiTier_RejectsBadJSON(t *testing.T) {
+	store := &multiTierStoreStub{}
+	h := newRetrieveTestHandler(t, store)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/memories/retrieve", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleRetrieveMultiTier_CapsLimit(t *testing.T) {
+	store := &multiTierStoreStub{
+		mtResult: &memory.MultiTierResult{Memories: []*memory.MultiTierMemory{}, Total: 0},
+	}
+	h := newRetrieveTestHandler(t, store)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"workspace_id":"ws","limit":9999}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/memories/retrieve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.mtCalls, 1)
+	assert.Equal(t, maxRetrieveLimit, store.mtCalls[0].Limit)
+}
+
+func TestHandleRetrieveMultiTier_ReturnsServiceError(t *testing.T) {
+	store := &multiTierStoreStub{mtErr: assertErr{msg: "db exploded"}}
+	h := newRetrieveTestHandler(t, store)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"workspace_id":"ws-1"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/memories/retrieve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	// writeError maps unknown errors to 500.
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandleRetrieveMultiTier_BodyTooLarge(t *testing.T) {
+	store := &multiTierStoreStub{}
+	svc := NewMemoryService(store, nil, MemoryServiceConfig{}, logr.Discard())
+	h := NewHandler(svc, logr.Discard())
+	h.maxBodySize = 16 // force a too-large error on any non-trivial body.
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"workspace_id":"ws-with-a-reasonably-long-id-that-exceeds-the-limit"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/memories/retrieve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+// assertErr is a local error type for service-error tests. Separate from the
+// standard errors sentinel so writeError takes the default 500 branch.
+type assertErr struct{ msg string }
+
+func (a assertErr) Error() string { return a.msg }
+
+func TestHandleRetrieveMultiTier_DefaultLimitApplied(t *testing.T) {
+	store := &multiTierStoreStub{
+		mtResult: &memory.MultiTierResult{Memories: []*memory.MultiTierMemory{}, Total: 0},
+	}
+	h := newRetrieveTestHandler(t, store)
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"workspace_id":"ws"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/memories/retrieve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	store.mu.Lock()
+	defer store.mu.Unlock()
+	require.Len(t, store.mtCalls, 1)
+	assert.Equal(t, defaultRetrieveLimit, store.mtCalls[0].Limit)
+}

--- a/internal/memory/api/handler_test.go
+++ b/internal/memory/api/handler_test.go
@@ -110,6 +110,30 @@ func setupMux(h *Handler) *http.ServeMux {
 	return mux
 }
 
+// TestHandler_RegisterRoutes_IncludesRetrieveMultiTier pins the multi-tier
+// retrieval route to the mux. A regression that drops the route (e.g. stale
+// merge or accidental deletion) shows up here as a 404 — every other status
+// proves the route is registered, even if the handler rejects the body.
+func TestHandler_RegisterRoutes_IncludesRetrieveMultiTier(t *testing.T) {
+	store := &mockStore{}
+	h := newTestHandler(store)
+	mux := setupMux(h)
+
+	req := httptest.NewRequest(
+		http.MethodPost,
+		"/api/v1/memories/retrieve",
+		strings.NewReader(`{"workspace_id":"ws"}`),
+	)
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("POST /api/v1/memories/retrieve returned 404 — route not registered")
+	}
+}
+
 // --- List memories tests ---
 
 func TestHandleListMemories_Success(t *testing.T) {

--- a/internal/memory/api/handler_test.go
+++ b/internal/memory/api/handler_test.go
@@ -73,6 +73,10 @@ func (m *mockStore) List(_ context.Context, _ map[string]string, _ memory.ListOp
 	return m.memories, nil
 }
 
+func (m *mockStore) RetrieveMultiTier(_ context.Context, _ memory.MultiTierRequest) (*memory.MultiTierResult, error) {
+	return &memory.MultiTierResult{Memories: []*memory.MultiTierMemory{}, Total: 0}, nil
+}
+
 func (m *mockStore) Delete(_ context.Context, _ map[string]string, _ string) error {
 	return m.delErr
 }

--- a/internal/memory/api/service_retrieve.go
+++ b/internal/memory/api/service_retrieve.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// retrieveOperationTag is the metadata tag emitted on multi-tier retrieval
+// audit events. Kept as a constant so tests and grep lookups share a single
+// source of truth.
+const retrieveOperationTag = "retrieve_multi_tier"
+
+// RetrieveMultiTier runs a multi-tier retrieval and emits one memory_accessed
+// audit event. The store result is returned unchanged so the handler can
+// forward tier annotations and scores to the client. Audit runs only on
+// success so failed queries are not recorded as accesses.
+func (s *MemoryService) RetrieveMultiTier(ctx context.Context, req memory.MultiTierRequest) (*memory.MultiTierResult, error) {
+	result, err := s.store.RetrieveMultiTier(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   auditEventMemoryAccessed,
+		WorkspaceID: req.WorkspaceID,
+		UserID:      req.UserID,
+		Metadata: map[string]string{
+			"operation": retrieveOperationTag,
+		},
+	})
+	return result, nil
+}

--- a/internal/memory/api/service_retrieve_test.go
+++ b/internal/memory/api/service_retrieve_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// multiTierStoreStub extends mockMemoryStore-like behavior with configurable
+// multi-tier responses. Inline to avoid leaking test-only state into the
+// shared mockMemoryStore type.
+type multiTierStoreStub struct {
+	mockMemoryStore
+	mu       sync.Mutex
+	mtCalls  []memory.MultiTierRequest
+	mtResult *memory.MultiTierResult
+	mtErr    error
+}
+
+func (m *multiTierStoreStub) RetrieveMultiTier(_ context.Context, req memory.MultiTierRequest) (*memory.MultiTierResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mtCalls = append(m.mtCalls, req)
+	if m.mtErr != nil {
+		return nil, m.mtErr
+	}
+	return m.mtResult, nil
+}
+
+func TestRetrieveMultiTier_PassesThroughAndEmitsAudit(t *testing.T) {
+	store := &multiTierStoreStub{
+		mtResult: &memory.MultiTierResult{
+			Memories: []*memory.MultiTierMemory{
+				{Memory: &memory.Memory{ID: "m-1"}, Tier: memory.TierUser},
+			},
+			Total: 1,
+		},
+	}
+	audit := newMockAuditLogger()
+	svc := NewMemoryService(store, nil, MemoryServiceConfig{}, logr.Discard())
+	svc.SetAuditLogger(audit)
+
+	got, err := svc.RetrieveMultiTier(context.Background(), memory.MultiTierRequest{
+		WorkspaceID: "ws-1",
+		UserID:      "u-1",
+		AgentID:     "a-1",
+		Query:       "dark",
+		Limit:       10,
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, got.Total)
+	assert.Equal(t, "m-1", got.Memories[0].ID)
+
+	store.mu.Lock()
+	require.Len(t, store.mtCalls, 1)
+	call := store.mtCalls[0]
+	store.mu.Unlock()
+	assert.Equal(t, "ws-1", call.WorkspaceID)
+	assert.Equal(t, "a-1", call.AgentID)
+
+	entry := audit.receiveEntry(t)
+	assert.Equal(t, auditEventMemoryAccessed, entry.EventType)
+	assert.Equal(t, "retrieve_multi_tier", entry.Metadata["operation"])
+	assert.Equal(t, "ws-1", entry.WorkspaceID)
+	assert.Equal(t, "u-1", entry.UserID)
+}
+
+func TestRetrieveMultiTier_PropagatesStoreError(t *testing.T) {
+	store := &multiTierStoreStub{mtErr: errors.New("boom")}
+	audit := newMockAuditLogger()
+	svc := NewMemoryService(store, nil, MemoryServiceConfig{}, logr.Discard())
+	svc.SetAuditLogger(audit)
+
+	_, err := svc.RetrieveMultiTier(context.Background(), memory.MultiTierRequest{WorkspaceID: "ws-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+
+	// No audit on failure.
+	select {
+	case e := <-audit.entries:
+		t.Fatalf("unexpected audit entry on store error: %+v", e)
+	case <-time.After(50 * time.Millisecond):
+		// expected — no event
+	}
+}

--- a/internal/memory/cache.go
+++ b/internal/memory/cache.go
@@ -95,6 +95,14 @@ func (c *CachedStore) Retrieve(ctx context.Context, scope map[string]string, que
 	return mems, nil
 }
 
+// RetrieveMultiTier delegates to the inner store without caching. The
+// multi-tier result shape carries per-row tier tags and scores that are cheap
+// to recompute; adding a cache layer here would complicate invalidation for
+// modest savings. Revisit if retrieval becomes hot.
+func (c *CachedStore) RetrieveMultiTier(ctx context.Context, req MultiTierRequest) (*MultiTierResult, error) {
+	return c.inner.RetrieveMultiTier(ctx, req)
+}
+
 // List returns cached results when available, falling back to the inner store on miss or Redis error.
 func (c *CachedStore) List(ctx context.Context, scope map[string]string, opts ListOptions) ([]*Memory, error) {
 	key := c.listKey(ctx, scope, opts)

--- a/internal/memory/cache_test.go
+++ b/internal/memory/cache_test.go
@@ -69,6 +69,10 @@ func (m *cacheTestStore) Retrieve(_ context.Context, _ map[string]string, _ stri
 	return m.memories, nil
 }
 
+func (m *cacheTestStore) RetrieveMultiTier(_ context.Context, _ MultiTierRequest) (*MultiTierResult, error) {
+	return &MultiTierResult{Memories: []*MultiTierMemory{}, Total: 0}, nil
+}
+
 func (m *cacheTestStore) List(_ context.Context, _ map[string]string, _ ListOptions) ([]*Memory, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -57,6 +57,10 @@ func (m *mockStore) List(_ context.Context, _ map[string]string, _ ListOptions) 
 	return nil, nil
 }
 
+func (m *mockStore) RetrieveMultiTier(_ context.Context, _ MultiTierRequest) (*MultiTierResult, error) {
+	return &MultiTierResult{Memories: []*MultiTierMemory{}, Total: 0}, nil
+}
+
 func (m *mockStore) Delete(_ context.Context, _ map[string]string, _ string) error {
 	return nil
 }

--- a/internal/memory/httpclient/retrieve_multi_tier.go
+++ b/internal/memory/httpclient/retrieve_multi_tier.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package httpclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+)
+
+// multiTierPath is the memory-api endpoint for multi-tier retrieval.
+const multiTierPath = "/api/v1/memories/retrieve"
+
+// MultiTierRequest is the client-side body for POST /api/v1/memories/retrieve.
+// Mirrors memory/api.RetrieveMultiTierRequest — redeclared here to preserve
+// dependency direction (httpclient must not import the api package).
+type MultiTierRequest struct {
+	WorkspaceID   string   `json:"workspace_id"`
+	UserID        string   `json:"user_id,omitempty"`
+	AgentID       string   `json:"agent_id,omitempty"`
+	Query         string   `json:"query,omitempty"`
+	Types         []string `json:"types,omitempty"`
+	MinConfidence float64  `json:"min_confidence,omitempty"`
+	Limit         int      `json:"limit,omitempty"`
+}
+
+// MultiTierMemory is a decoded response entry with tier annotation and score.
+type MultiTierMemory struct {
+	*pkmemory.Memory
+	Tier        string  `json:"tier"`
+	AccessCount int     `json:"access_count"`
+	Score       float64 `json:"score"`
+}
+
+// MultiTierResult is the decoded response.
+type MultiTierResult struct {
+	Memories []*MultiTierMemory `json:"memories"`
+	Total    int                `json:"total"`
+}
+
+// RetrieveMultiTier calls POST /api/v1/memories/retrieve and decodes the
+// tier-annotated response. Callers that need only flat memories should use
+// Retrieve, which dispatches to this method when the scope has agent_id.
+func (s *Store) RetrieveMultiTier(ctx context.Context, req MultiTierRequest) (*MultiTierResult, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("memory httpclient: retrieve_multi_tier: encode: %w", err)
+	}
+
+	resp, err := s.doRequest(ctx, http.MethodPost, multiTierPath, body)
+	if err != nil {
+		return nil, fmt.Errorf("memory httpclient: retrieve_multi_tier: %w", err)
+	}
+	defer drainAndClose(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, s.readError("retrieve_multi_tier", resp)
+	}
+
+	var out MultiTierResult
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("memory httpclient: retrieve_multi_tier: decode: %w", err)
+	}
+	if out.Memories == nil {
+		out.Memories = []*MultiTierMemory{}
+	}
+	return &out, nil
+}
+
+// retrieveMultiTierToMemories calls RetrieveMultiTier and discards tier
+// metadata to satisfy the pkmemory.Store.Retrieve signature.
+func (s *Store) retrieveMultiTierToMemories(ctx context.Context, scope map[string]string, query string, opts pkmemory.RetrieveOptions) ([]*pkmemory.Memory, error) {
+	res, err := s.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID:   scope["workspace_id"],
+		UserID:        scope["user_id"],
+		AgentID:       scope["agent_id"],
+		Query:         query,
+		Types:         opts.Types,
+		MinConfidence: opts.MinConfidence,
+		Limit:         opts.Limit,
+	})
+	if err != nil {
+		return nil, err
+	}
+	mems := make([]*pkmemory.Memory, 0, len(res.Memories))
+	for _, m := range res.Memories {
+		if m.Memory != nil {
+			mems = append(mems, m.Memory)
+		}
+	}
+	return mems, nil
+}

--- a/internal/memory/httpclient/retrieve_multi_tier_test.go
+++ b/internal/memory/httpclient/retrieve_multi_tier_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package httpclient
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetrieve_RoutesToMultiTierWhenAgentIDPresent(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		require.Equal(t, http.MethodPost, r.Method)
+		b, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(b, &gotBody))
+		_, _ = w.Write([]byte(`{"memories":[{"id":"m-1","tier":"user","content":"c"}],"total":1}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	scope := map[string]string{
+		"workspace_id": "ws-1",
+		"user_id":      "u-1",
+		"agent_id":     "a-1",
+	}
+
+	mems, err := store.Retrieve(context.Background(), scope, "dark mode", pkmemory.RetrieveOptions{Limit: 5})
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/v1/memories/retrieve", gotPath)
+	assert.Equal(t, "ws-1", gotBody["workspace_id"])
+	assert.Equal(t, "a-1", gotBody["agent_id"])
+	assert.Equal(t, "dark mode", gotBody["query"])
+	require.Len(t, mems, 1)
+	assert.Equal(t, "m-1", mems[0].ID)
+}
+
+func TestRetrieve_FallsBackToSearchWhenNoAgentID(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_, _ = w.Write([]byte(`{"memories":[],"total":0}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	scope := map[string]string{"workspace_id": "ws-1", "user_id": "u-1"}
+
+	_, err := store.Retrieve(context.Background(), scope, "q", pkmemory.RetrieveOptions{})
+	require.NoError(t, err)
+	assert.True(t, strings.HasPrefix(gotPath, "/api/v1/memories/search"), "expected search fallback, got %s", gotPath)
+}
+
+func TestRetrieveMultiTier_Direct(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"memories":[{"id":"m-1","tier":"institutional","content":"c","score":0.87}],"total":1}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	res, err := store.RetrieveMultiTier(context.Background(), MultiTierRequest{
+		WorkspaceID: "ws-1",
+		UserID:      "u-1",
+		AgentID:     "a-1",
+		Limit:       5,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, 1, res.Total)
+	require.Len(t, res.Memories, 1)
+	assert.Equal(t, "institutional", res.Memories[0].Tier)
+	assert.Equal(t, 0.87, res.Memories[0].Score)
+}
+
+func TestRetrieveMultiTier_ErrorStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":"db down"}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	_, err := store.RetrieveMultiTier(context.Background(), MultiTierRequest{WorkspaceID: "ws-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db down")
+}
+
+func TestRetrieveMultiTier_DecodeError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("not json"))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	_, err := store.RetrieveMultiTier(context.Background(), MultiTierRequest{WorkspaceID: "ws-1"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "decode")
+}
+
+func TestRetrieveMultiTier_NormalizesNilMemories(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"total":0}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	res, err := store.RetrieveMultiTier(context.Background(), MultiTierRequest{WorkspaceID: "ws-1"})
+	require.NoError(t, err)
+	assert.NotNil(t, res.Memories)
+	assert.Empty(t, res.Memories)
+}
+
+func TestRetrieveMultiTier_NetworkError(t *testing.T) {
+	store := NewStore("http://127.0.0.1:1", logr.Discard())
+	_, err := store.RetrieveMultiTier(context.Background(), MultiTierRequest{WorkspaceID: "ws-1"})
+	require.Error(t, err)
+}

--- a/internal/memory/httpclient/store.go
+++ b/internal/memory/httpclient/store.go
@@ -117,8 +117,15 @@ func (s *Store) Save(ctx context.Context, mem *pkmemory.Memory) error {
 	return nil
 }
 
-// Retrieve searches memories via GET /api/v1/memories/search.
+// Retrieve searches memories. When the scope carries agent_id we route to
+// the multi-tier endpoint (POST /api/v1/memories/retrieve) so institutional
+// and agent tiers are merged into the results. Otherwise we fall back to the
+// flat GET /api/v1/memories/search path.
 func (s *Store) Retrieve(ctx context.Context, scope map[string]string, query string, opts pkmemory.RetrieveOptions) ([]*pkmemory.Memory, error) {
+	if scope["agent_id"] != "" {
+		return s.retrieveMultiTierToMemories(ctx, scope, query, opts)
+	}
+
 	params := scopeParams(scope)
 	params.Set("q", query)
 	if opts.Limit > 0 {

--- a/internal/memory/retrieve_multi_tier.go
+++ b/internal/memory/retrieve_multi_tier.go
@@ -1,0 +1,337 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// Tier identifies which scope layer a memory belongs to in a multi-tier
+// retrieval. The value is always one of the four named constants.
+type Tier string
+
+// Tier variants covered by RetrieveMultiTier.
+const (
+	TierInstitutional Tier = "institutional"
+	TierAgent         Tier = "agent"
+	TierUser          Tier = "user"
+	TierUserForAgent  Tier = "user_for_agent"
+)
+
+// MultiTierRequest describes a single multi-tier retrieval query.
+// WorkspaceID is required; all other fields are optional filters.
+type MultiTierRequest struct {
+	WorkspaceID   string
+	UserID        string
+	AgentID       string
+	Query         string
+	Types         []string
+	MinConfidence float64
+	Limit         int
+	Now           time.Time
+}
+
+// MultiTierMemory augments a Memory with the tier it was retrieved from,
+// the observation access count (used for frequency scoring), and the final
+// ranking score computed by rankResults.
+type MultiTierMemory struct {
+	*Memory
+	Tier        Tier
+	AccessCount int
+	Score       float64
+}
+
+// MultiTierResult is the top-level response returned by RetrieveMultiTier.
+type MultiTierResult struct {
+	Memories []*MultiTierMemory
+	Total    int
+}
+
+// multiTierCandidatePool is the SQL-level candidate cap applied before
+// Go-side ranking. It is intentionally larger than any client Limit so the
+// ranker sees enough rows to sort meaningfully.
+const multiTierCandidatePool = 200
+
+// defaultMultiTierLimit is the caller-visible default Limit when the
+// request does not specify one.
+const defaultMultiTierLimit = 15
+
+// ranking weight/normalisation constants.
+const (
+	weightConfidence = 0.5
+	weightFrequency  = 0.3
+	weightRecency    = 0.2
+	freqLogCeiling   = 100.0
+	recencyTauHours  = 168.0
+)
+
+// RetrieveMultiTier runs a single multi-tier SQL query covering institutional,
+// agent, user, and user-for-agent scope variants, then ranks and truncates
+// the results Go-side.
+func (s *PostgresMemoryStore) RetrieveMultiTier(ctx context.Context, req MultiTierRequest) (*MultiTierResult, error) {
+	sql, args, err := buildMultiTierQuery(req)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := s.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("memory: multi-tier query: %w", err)
+	}
+	defer rows.Close()
+
+	memories, err := scanMultiTierRows(rows, req.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := req.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	rankResults(memories, now)
+
+	limit := req.Limit
+	if limit <= 0 {
+		limit = defaultMultiTierLimit
+	}
+	if len(memories) > limit {
+		memories = memories[:limit]
+	}
+
+	return &MultiTierResult{Memories: memories, Total: len(memories)}, nil
+}
+
+// buildMultiTierQuery constructs the SQL and positional arguments for a
+// multi-tier retrieval. It returns an error when WorkspaceID is empty; the
+// candidate LIMIT is a constant (multiTierCandidatePool) independent of the
+// caller's Limit.
+func buildMultiTierQuery(req MultiTierRequest) (string, []any, error) {
+	if req.WorkspaceID == "" {
+		return "", nil, errors.New(errWorkspaceRequired)
+	}
+
+	args := make([]any, 0, 6)
+	args = append(args, req.WorkspaceID)
+	clauses := []string{
+		"e.workspace_id=$" + strconv.Itoa(len(args)),
+		colEntityForgot,
+	}
+
+	clauses = append(clauses, userTierClause(req.UserID, &args))
+	clauses = append(clauses, agentTierClause(req.AgentID, &args))
+
+	if len(req.Types) == 1 {
+		args = append(args, req.Types[0])
+		clauses = append(clauses, "e.kind=$"+strconv.Itoa(len(args)))
+	} else if len(req.Types) > 1 {
+		args = append(args, req.Types)
+		clauses = append(clauses, "e.kind = ANY($"+strconv.Itoa(len(args))+")")
+	}
+
+	if req.MinConfidence > 0 {
+		args = append(args, req.MinConfidence)
+		clauses = append(clauses, "o.confidence >= $"+strconv.Itoa(len(args)))
+	}
+
+	if req.Query != "" {
+		args = append(args, "%"+req.Query+"%")
+		clauses = append(clauses, "o.content ILIKE $"+strconv.Itoa(len(args)))
+	}
+
+	sql := fmt.Sprintf(`SELECT DISTINCT ON (e.id) e.id, e.kind, e.metadata, e.created_at, e.expires_at, e.virtual_user_id, e.agent_id, o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at, o.access_count FROM memory_entities e JOIN memory_observations o ON o.entity_id = e.id WHERE %s ORDER BY e.id, o.observed_at DESC LIMIT %d`,
+		joinAnd(clauses), multiTierCandidatePool)
+
+	return sql, args, nil
+}
+
+// userTierClause returns the user-scope predicate for the multi-tier query.
+// When userID is empty the predicate anchors to NULL so institutional-only
+// retrievals do not bleed through other users' memories. The column is
+// unqualified because memory_observations does not share it, avoiding an
+// alias prefix keeps the emitted SQL aligned with the agreed contract.
+func userTierClause(userID string, args *[]any) string {
+	if userID == "" {
+		return "virtual_user_id IS NULL"
+	}
+	*args = append(*args, userID)
+	return "(virtual_user_id IS NULL OR virtual_user_id=$" + strconv.Itoa(len(*args)) + ")"
+}
+
+// agentTierClause returns the agent-scope predicate. Same NULL-anchoring
+// behaviour as userTierClause.
+func agentTierClause(agentID string, args *[]any) string {
+	if agentID == "" {
+		return "agent_id IS NULL"
+	}
+	*args = append(*args, agentID)
+	return "(agent_id IS NULL OR agent_id=$" + strconv.Itoa(len(*args)) + ")"
+}
+
+// joinAnd is a tiny helper so callers do not need to import strings for one use.
+func joinAnd(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += " AND "
+		}
+		out += p
+	}
+	return out
+}
+
+// scanMultiTierRows reads multi-tier query rows into MultiTierMemory values.
+// workspaceID seeds the memory Scope so downstream consumers see the same
+// scope keys Retrieve/List populate.
+func scanMultiTierRows(rows pgx.Rows, workspaceID string) ([]*MultiTierMemory, error) {
+	var results []*MultiTierMemory
+	for rows.Next() {
+		mem, err := scanMultiTierRow(rows, workspaceID)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, mem)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory: multi-tier rows iteration: %w", err)
+	}
+	if results == nil {
+		results = []*MultiTierMemory{}
+	}
+	return results, nil
+}
+
+// scanMultiTierRow scans a single row from the multi-tier query.
+func scanMultiTierRow(row pgx.Rows, workspaceID string) (*MultiTierMemory, error) {
+	var (
+		mem          Memory
+		metadataJSON []byte
+		expiresAt    *time.Time
+		userID       *string
+		agentID      *string
+		sessionID    *string
+		turnRange    []int
+		observedAt   *time.Time
+		accessedAt   *time.Time
+		accessCount  int
+	)
+
+	err := row.Scan(
+		&mem.ID, &mem.Type, &metadataJSON, &mem.CreatedAt, &expiresAt,
+		&userID, &agentID,
+		&mem.Content, &mem.Confidence, &sessionID, &turnRange, &observedAt, &accessedAt, &accessCount,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("memory: scan multi-tier row: %w", err)
+	}
+
+	mem.Scope = buildScope(workspaceID, userID, agentID)
+	mem.ExpiresAt = expiresAt
+	if sessionID != nil {
+		mem.SessionID = *sessionID
+	}
+	if len(turnRange) == 2 {
+		mem.TurnRange = [2]int{turnRange[0], turnRange[1]}
+	}
+	if accessedAt != nil {
+		mem.AccessedAt = *accessedAt
+	}
+	if len(metadataJSON) > 0 {
+		_ = json.Unmarshal(metadataJSON, &mem.Metadata)
+	}
+
+	return &MultiTierMemory{
+		Memory:      &mem,
+		Tier:        classifyTier(userID, agentID),
+		AccessCount: accessCount,
+	}, nil
+}
+
+// buildScope assembles the Memory.Scope map from the non-nullable workspace
+// plus any nullable tier identifiers present on the row.
+func buildScope(workspaceID string, userID, agentID *string) map[string]string {
+	scope := map[string]string{ScopeWorkspaceID: workspaceID}
+	if userID != nil && *userID != "" {
+		scope[ScopeUserID] = *userID
+	}
+	if agentID != nil && *agentID != "" {
+		scope[ScopeAgentID] = *agentID
+	}
+	return scope
+}
+
+// classifyTier maps the nullable user/agent identifiers from a row to the
+// corresponding Tier constant.
+func classifyTier(userID, agentID *string) Tier {
+	hasUser := userID != nil
+	hasAgent := agentID != nil
+	switch {
+	case hasUser && hasAgent:
+		return TierUserForAgent
+	case hasUser:
+		return TierUser
+	case hasAgent:
+		return TierAgent
+	default:
+		return TierInstitutional
+	}
+}
+
+// rankResults assigns a Score to each MultiTierMemory and sorts the slice in
+// descending score order. The formula mixes confidence, access-count
+// frequency (log-normalised), and recency (exponential decay).
+func rankResults(results []*MultiTierMemory, now time.Time) {
+	for _, r := range results {
+		r.Score = computeScore(r, now)
+	}
+	sort.SliceStable(results, func(i, j int) bool {
+		return results[i].Score > results[j].Score
+	})
+}
+
+// computeScore returns the ranking score for a single memory.
+func computeScore(r *MultiTierMemory, now time.Time) float64 {
+	confidence := r.Confidence
+	freq := math.Log1p(float64(r.AccessCount)) / math.Log1p(freqLogCeiling)
+	if freq < 0 {
+		freq = 0
+	}
+	if freq > 1 {
+		freq = 1
+	}
+	ref := r.AccessedAt
+	if ref.IsZero() {
+		ref = r.CreatedAt
+	}
+	ageHours := now.Sub(ref).Hours()
+	if ageHours < 0 {
+		ageHours = 0
+	}
+	recency := math.Exp(-ageHours / recencyTauHours)
+	return weightConfidence*confidence + weightFrequency*freq + weightRecency*recency
+}

--- a/internal/memory/retrieve_multi_tier.go
+++ b/internal/memory/retrieve_multi_tier.go
@@ -26,6 +26,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -193,16 +194,9 @@ func agentTierClause(agentID string, args *[]any) string {
 	return "(agent_id IS NULL OR agent_id=$" + strconv.Itoa(len(*args)) + ")"
 }
 
-// joinAnd is a tiny helper so callers do not need to import strings for one use.
+// joinAnd joins SQL WHERE fragments with " AND ".
 func joinAnd(parts []string) string {
-	out := ""
-	for i, p := range parts {
-		if i > 0 {
-			out += " AND "
-		}
-		out += p
-	}
-	return out
+	return strings.Join(parts, " AND ")
 }
 
 // scanMultiTierRows reads multi-tier query rows into MultiTierMemory values.

--- a/internal/memory/retrieve_multi_tier_test.go
+++ b/internal/memory/retrieve_multi_tier_test.go
@@ -1,0 +1,314 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildMultiTierQuery_RequiresWorkspace(t *testing.T) {
+	_, _, err := buildMultiTierQuery(MultiTierRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing workspace_id")
+	}
+}
+
+func TestBuildMultiTierQuery_InstitutionalOnly(t *testing.T) {
+	sql, args, err := buildMultiTierQuery(MultiTierRequest{
+		WorkspaceID: "ws-1",
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "workspace_id=$1") {
+		t.Errorf("workspace filter missing: %s", sql)
+	}
+	// With no user, predicate must anchor to NULL user_id (no bleed-through).
+	if !strings.Contains(sql, "virtual_user_id IS NULL") {
+		t.Errorf("user NULL anchor missing: %s", sql)
+	}
+	if !strings.Contains(sql, "agent_id IS NULL") {
+		t.Errorf("agent NULL anchor missing: %s", sql)
+	}
+	if len(args) != 1 || args[0] != "ws-1" {
+		t.Errorf("unexpected args: %v", args)
+	}
+}
+
+func TestBuildMultiTierQuery_UserAndAgent(t *testing.T) {
+	sql, args, err := buildMultiTierQuery(MultiTierRequest{
+		WorkspaceID: "ws-1",
+		UserID:      "u-1",
+		AgentID:     "a-1",
+		Limit:       25,
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "virtual_user_id IS NULL OR virtual_user_id=$2") {
+		t.Errorf("user tier predicate missing: %s", sql)
+	}
+	if !strings.Contains(sql, "agent_id IS NULL OR agent_id=$3") {
+		t.Errorf("agent tier predicate missing: %s", sql)
+	}
+	if len(args) != 3 {
+		t.Fatalf("expected 3 args, got %d: %v", len(args), args)
+	}
+}
+
+func TestBuildMultiTierQuery_QueryAddsILIKE(t *testing.T) {
+	sql, args, err := buildMultiTierQuery(MultiTierRequest{
+		WorkspaceID: "ws-1",
+		UserID:      "u-1",
+		Query:       "dark mode",
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(sql, "o.content ILIKE") {
+		t.Errorf("ILIKE filter missing: %s", sql)
+	}
+	if args[len(args)-1] != "%dark mode%" {
+		t.Errorf("ILIKE arg missing: %v", args)
+	}
+}
+
+func TestBuildMultiTierQuery_DefaultCandidateFloor(t *testing.T) {
+	sql, _, err := buildMultiTierQuery(MultiTierRequest{WorkspaceID: "ws-1"})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	// Candidate pool of 200 is the SQL-level floor regardless of client Limit.
+	if !strings.Contains(sql, "LIMIT 200") {
+		t.Errorf("expected candidate LIMIT 200: %s", sql)
+	}
+}
+
+func TestClassifyTier(t *testing.T) {
+	u := "u"
+	a := "a"
+	cases := []struct {
+		name    string
+		userID  *string
+		agentID *string
+		want    Tier
+	}{
+		{"institutional", nil, nil, TierInstitutional},
+		{"agent", nil, &a, TierAgent},
+		{"user", &u, nil, TierUser},
+		{"user-for-agent", &u, &a, TierUserForAgent},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyTier(c.userID, c.agentID)
+			if got != c.want {
+				t.Errorf("got %s, want %s", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRankResults_OrdersByScoreDesc(t *testing.T) {
+	now := parseTime("2026-04-22T12:00:00Z")
+	hour := time.Hour
+	results := []*MultiTierMemory{
+		{Memory: &Memory{Confidence: 0.5, AccessedAt: now.Add(-24 * hour)}, Tier: TierUser, AccessCount: 2},
+		{Memory: &Memory{Confidence: 0.9, AccessedAt: now.Add(-1 * hour)}, Tier: TierUser, AccessCount: 10},
+		{Memory: &Memory{Confidence: 0.7, AccessedAt: now.Add(-30 * 24 * hour)}, Tier: TierInstitutional, AccessCount: 1},
+	}
+	rankResults(results, now)
+	if results[0].Confidence != 0.9 {
+		t.Errorf("expected highest-confidence recent result first, got %+v", results[0])
+	}
+}
+
+func parseTime(s string) time.Time {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		panic(err)
+	}
+	return t
+}
+
+// multiTierAgentID is a stable UUID used as the agent_id in multi-tier
+// integration tests.
+const multiTierAgentID = "b0000000-0000-0000-0000-000000000001"
+
+// insertRawMemory writes a single memory_entities + memory_observations pair
+// directly via the store's pool, bypassing Save()'s user_id-required
+// invariant. It is needed because institutional and agent-only memories
+// legitimately have no user_id, but Save() guards against missing user_id
+// for the single-tier write path. The workspace is hard-coded to
+// testWorkspace1 since every test in this file operates on that scope.
+func insertRawMemory(t *testing.T, store *PostgresMemoryStore, user, agent, kind, content string, confidence float64) {
+	t.Helper()
+	var userArg, agentArg any
+	if user != "" {
+		userArg = user
+	}
+	if agent != "" {
+		agentArg = agent
+	}
+	var entityID string
+	err := store.pool.QueryRow(context.Background(),
+		`INSERT INTO memory_entities (workspace_id, virtual_user_id, agent_id, name, kind, metadata)
+		 VALUES ($1, $2, $3, $4, $5, '{}') RETURNING id`,
+		testWorkspace1, userArg, agentArg, content, kind,
+	).Scan(&entityID)
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(context.Background(),
+		`INSERT INTO memory_observations (entity_id, content, confidence) VALUES ($1, $2, $3)`,
+		entityID, content, confidence,
+	)
+	require.NoError(t, err)
+}
+
+func TestRetrieveMultiTier_RequiresWorkspace(t *testing.T) {
+	store := newStore(t)
+	_, err := store.RetrieveMultiTier(context.Background(), MultiTierRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing workspace_id")
+	}
+}
+
+func TestRetrieveMultiTier_SpansAllTiers(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	insertRawMemory(t, store, "", "", "preference", "institutional fact", 1.0)
+	insertRawMemory(t, store, "", multiTierAgentID, "preference", "agent guideline", 1.0)
+	insertRawMemory(t, store, "user-1", "", "preference", "user prefers dark mode", 1.0)
+	insertRawMemory(t, store, "user-1", multiTierAgentID, "preference", "user-for-agent note", 1.0)
+
+	result, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID: testWorkspace1,
+		UserID:      "user-1",
+		AgentID:     multiTierAgentID,
+		Limit:       10,
+		Now:         time.Now(),
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Memories, 4)
+	assert.Equal(t, 4, result.Total)
+
+	tiers := map[Tier]*MultiTierMemory{}
+	for _, m := range result.Memories {
+		tiers[m.Tier] = m
+	}
+	assert.Contains(t, tiers, TierInstitutional)
+	assert.Contains(t, tiers, TierAgent)
+	assert.Contains(t, tiers, TierUser)
+	assert.Contains(t, tiers, TierUserForAgent)
+
+	// Scope map must include the tier fields that were present on the row.
+	uForA := tiers[TierUserForAgent]
+	assert.Equal(t, testWorkspace1, uForA.Scope[ScopeWorkspaceID])
+	assert.Equal(t, "user-1", uForA.Scope[ScopeUserID])
+	assert.Equal(t, multiTierAgentID, uForA.Scope[ScopeAgentID])
+}
+
+func TestRetrieveMultiTier_InstitutionalOnlyDoesNotBleed(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	insertRawMemory(t, store, "", "", "preference", "institutional only", 1.0)
+	insertRawMemory(t, store, "user-2", "", "preference", "other user's data", 1.0)
+
+	result, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID: testWorkspace1,
+		Limit:       10,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Memories, 1)
+	assert.Equal(t, TierInstitutional, result.Memories[0].Tier)
+	assert.Empty(t, result.Memories[0].Scope[ScopeUserID])
+}
+
+func TestRetrieveMultiTier_TruncatesToLimit(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		insertRawMemory(t, store, "", "", "preference", "fact", 1.0)
+	}
+
+	result, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID: testWorkspace1,
+		Limit:       2,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Memories, 2)
+	assert.Equal(t, 2, result.Total)
+}
+
+func TestRetrieveMultiTier_DefaultLimitApplies(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	insertRawMemory(t, store, "", "", "preference", "fact", 1.0)
+
+	// Leave Limit=0 so the defaultMultiTierLimit path is exercised.
+	result, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID: testWorkspace1,
+	})
+	require.NoError(t, err)
+	assert.Len(t, result.Memories, 1)
+}
+
+func TestRetrieveMultiTier_TypeAndConfidenceFilters(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	insertRawMemory(t, store, "", "", "preference", "high conf", 0.9)
+	insertRawMemory(t, store, "", "", "episodic", "low conf", 0.1)
+	insertRawMemory(t, store, "", "", "fact", "third kind", 0.95)
+
+	// Multi-type filter + confidence threshold.
+	result, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID:   testWorkspace1,
+		Types:         []string{"preference", "fact"},
+		MinConfidence: 0.5,
+		Limit:         10,
+	})
+	require.NoError(t, err)
+	require.Len(t, result.Memories, 2)
+}
+
+func TestComputeScore_FallsBackToCreatedAtWhenAccessedZero(t *testing.T) {
+	now := parseTime("2026-04-22T12:00:00Z")
+	m := &MultiTierMemory{
+		Memory:      &Memory{Confidence: 1.0, CreatedAt: now.Add(-time.Hour)},
+		AccessCount: 0,
+	}
+	score := computeScore(m, now)
+	// Zero AccessedAt must not decay recency to ~0 — CreatedAt kicks in.
+	if score <= 0.5 {
+		t.Errorf("score too low, CreatedAt fallback missed: %v", score)
+	}
+}
+
+func TestComputeScore_FutureAccessedAtClampsToZeroAge(t *testing.T) {
+	now := parseTime("2026-04-22T12:00:00Z")
+	m := &MultiTierMemory{
+		Memory:      &Memory{Confidence: 1.0, AccessedAt: now.Add(time.Hour)},
+		AccessCount: 0,
+	}
+	score := computeScore(m, now)
+	// Clock skew must not push recency above 1.0 (score bounded).
+	if score > 1.0 {
+		t.Errorf("score above 1.0: %v", score)
+	}
+}

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -38,8 +38,11 @@ type (
 // ExportAll is needed for DSAR (data subject access request) data export and is
 // not part of the PromptKit SDK contract.
 // BatchDelete is needed for paginated DSAR deletion (Task 4 cascade).
+// RetrieveMultiTier runs a single query across institutional, agent, user and
+// user-for-agent tiers and returns ranked results for RAG context injection.
 type Store interface {
 	pkmemory.Store
 	ExportAll(ctx context.Context, scope map[string]string) ([]*Memory, error)
 	BatchDelete(ctx context.Context, scope map[string]string, limit int) (int, error)
+	RetrieveMultiTier(ctx context.Context, req MultiTierRequest) (*MultiTierResult, error)
 }

--- a/internal/runtime/config.go
+++ b/internal/runtime/config.go
@@ -31,6 +31,7 @@ import (
 type Config struct {
 	// Agent identification
 	AgentName     string
+	AgentUID      string // Kubernetes UID of the AgentRuntime CR; used as agent_id scope for memory.
 	Namespace     string
 	WorkspaceName string
 

--- a/internal/runtime/config_crd.go
+++ b/internal/runtime/config_crd.go
@@ -49,6 +49,7 @@ func LoadFromCRD(ctx context.Context, c client.Client, name, namespace string) (
 
 	cfg := &Config{
 		AgentName:      name,
+		AgentUID:       string(ar.UID),
 		Namespace:      namespace,
 		WorkspaceName:  workspaceName,
 		PromptPackPath: getEnvOrDefault(envPromptPackPath, defaultPromptPackPath),

--- a/internal/runtime/config_crd_test.go
+++ b/internal/runtime/config_crd_test.go
@@ -85,6 +85,7 @@ func TestLoadFromCRD_NamedProviders(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-agent",
 			Namespace: "test-ns",
+			UID:       "44444444-4444-4444-4444-444444444444",
 		},
 		Spec: v1alpha1.AgentRuntimeSpec{
 			PromptPackRef: v1alpha1.PromptPackRef{Name: "test-pack"},
@@ -109,6 +110,7 @@ func TestLoadFromCRD_NamedProviders(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "test-agent", cfg.AgentName)
+	assert.Equal(t, "44444444-4444-4444-4444-444444444444", cfg.AgentUID)
 	assert.Equal(t, "test-ns", cfg.Namespace)
 	assert.Equal(t, "test-pack", cfg.PromptPackName)
 	assert.Equal(t, "claude", cfg.ProviderType)

--- a/internal/runtime/conversation.go
+++ b/internal/runtime/conversation.go
@@ -173,11 +173,15 @@ func (s *Server) buildConversationOptions(ctx context.Context, sessionID string)
 		if uid := policy.UserID(ctx); uid != "" {
 			scope["user_id"] = uid // Already pseudonymized by the facade
 		}
+		if s.agentUID != "" {
+			scope["agent_id"] = s.agentUID
+		}
 		opts = append(opts, sdk.WithMemory(s.memoryStore, scope))
 		log.V(1).Info("memory store wired",
 			"session_id", sessionID,
 			"trace_id", sessionID,
 			"hasUserID", scope["user_id"] != "",
+			"hasAgentID", scope["agent_id"] != "",
 			"scopeKeys", len(scope),
 		)
 	}

--- a/internal/runtime/server.go
+++ b/internal/runtime/server.go
@@ -59,6 +59,7 @@ type Server struct {
 	sdkLogger         *slog.Logger
 	packPath          string
 	agentName         string
+	agentUID          string
 	namespace         string
 	promptPackName    string
 	promptPackVersion string
@@ -161,6 +162,21 @@ func WithAgentIdentity(agentName, namespace string) ServerOption {
 		s.agentName = agentName
 		s.namespace = namespace
 	}
+}
+
+// WithAgentUID sets the AgentRuntime's Kubernetes UID. This is plumbed into
+// the memory scope as agent_id so retrieval queries can merge institutional,
+// agent, and user tiers.
+func WithAgentUID(uid string) ServerOption {
+	return func(s *Server) {
+		s.agentUID = uid
+	}
+}
+
+// ServerAgentUID returns the configured agent UID. Exposed for wiring tests
+// under cmd/runtime; production code should not depend on this accessor.
+func ServerAgentUID(s *Server) string {
+	return s.agentUID
 }
 
 // WithPromptPackName sets the PromptPack CRD name for tracing.


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/memories/retrieve` on memory-api returning tier-tagged, ranked memories (institutional + agent + user + user-for-agent) from a single SQL query.
- Ranking: `score = 0.5*confidence + 0.3*log-normalized access frequency + 0.2*exponential-decay recency` (~1-week tau).
- Omnia `httpclient.Store.Retrieve` auto-routes to the new endpoint when `agent_id` is present in scope; falls back to the existing `/memories/search` otherwise. No PromptKit changes.
- Runtime threads `AgentRuntime.metadata.uid` into the memory scope as `agent_id` via `Config.AgentUID` + `pkruntime.WithAgentUID`.

## Scope boundaries
- Retrieval only. Institutional write path, dashboard UI, multi-mode (graph/structured) retrieval, and temporal summarization are explicitly out of scope — see `docs/local-backlog/multi-tier-memory-proposal.md` phases 2-4.
- No schema migration. `memory_entities.agent_id UUID` and the `access_count`/`accessed_at` columns already exist.
- No change to existing `/memories/search`, `/memories`, or the dashboard memory views.
- Tier precedence policy (user > agent > institutional for preferences, opposite for compliance) deferred; ranking today is uniform by score.

## Test plan
- [x] `env GOWORK=off go test ./internal/memory/... ./internal/runtime/... ./cmd/runtime/... ./cmd/memory-api/... -count=1` passes locally (768 tests)
- [x] `env GOWORK=off golangci-lint run --new-from-rev=main` clean on all new code
- [x] Per-file coverage ≥80% on every changed production file (handler_retrieve.go 100%, service_retrieve.go 100%, retrieve_multi_tier.go 88%, httpclient 91%)
- [ ] CI: unit, integration, SonarCloud quality gate
- [ ] Manual smoke: save one memory at each tier via the store, hit `POST /api/v1/memories/retrieve` with `{workspace_id, user_id, agent_id}`, confirm all four tiers appear with score annotations