### PR TITLE
feat(memory): multi-tier phase 2a — institutional CRUD API

### DIFF
--- a/cmd/memory-api/wiring_test.go
+++ b/cmd/memory-api/wiring_test.go
@@ -59,6 +59,11 @@ func (fakeMemoryStore) BatchDelete(_ context.Context, _ map[string]string, _ int
 func (fakeMemoryStore) RetrieveMultiTier(_ context.Context, _ memory.MultiTierRequest) (*memory.MultiTierResult, error) {
 	return &memory.MultiTierResult{Memories: []*memory.MultiTierMemory{}, Total: 0}, nil
 }
+func (fakeMemoryStore) SaveInstitutional(_ context.Context, _ *memory.Memory) error { return nil }
+func (fakeMemoryStore) ListInstitutional(_ context.Context, _ string, _ memory.ListOptions) ([]*memory.Memory, error) {
+	return nil, nil
+}
+func (fakeMemoryStore) DeleteInstitutional(_ context.Context, _, _ string) error { return nil }
 
 // TestBuildAPIMux_POSTMemoryWithoutUserIDReturns400 verifies the wiring
 // contract that the POST /api/v1/memories route is registered and reaches the

--- a/internal/memory/api/event_publisher_test.go
+++ b/internal/memory/api/event_publisher_test.go
@@ -85,6 +85,14 @@ func (m *mockMemoryStore) BatchDelete(_ context.Context, _ map[string]string, _ 
 	return 0, nil
 }
 
+func (m *mockMemoryStore) SaveInstitutional(_ context.Context, _ *memory.Memory) error { return nil }
+
+func (m *mockMemoryStore) ListInstitutional(_ context.Context, _ string, _ memory.ListOptions) ([]*memory.Memory, error) {
+	return nil, nil
+}
+
+func (m *mockMemoryStore) DeleteInstitutional(_ context.Context, _, _ string) error { return nil }
+
 // --- mockMemoryEventPublisher -----------------------------------------------
 
 // mockMemoryEventPublisher records published events and can be configured to

--- a/internal/memory/api/handler.go
+++ b/internal/memory/api/handler.go
@@ -111,6 +111,10 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("DELETE /api/v1/memories", h.handleDeleteAllMemories)
 	mux.HandleFunc("POST /api/v1/memories/retrieve", h.handleRetrieveMultiTier)
 
+	mux.HandleFunc("POST /api/v1/institutional/memories", h.handleSaveInstitutional)
+	mux.HandleFunc("GET /api/v1/institutional/memories", h.handleListInstitutional)
+	mux.HandleFunc("DELETE /api/v1/institutional/memories/{id}", h.handleDeleteInstitutional)
+
 	h.registerDocsRoutes(mux)
 }
 

--- a/internal/memory/api/handler_institutional.go
+++ b/internal/memory/api/handler_institutional.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+
+	"github.com/altairalabs/omnia/internal/httputil"
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// SaveInstitutionalRequest is the JSON body for POST /api/v1/institutional/memories.
+type SaveInstitutionalRequest struct {
+	WorkspaceID string         `json:"workspace_id"`
+	Type        string         `json:"type"`
+	Content     string         `json:"content"`
+	Metadata    map[string]any `json:"metadata,omitempty"`
+	Confidence  float64        `json:"confidence"`
+}
+
+// ListInstitutionalResponse is the JSON response for GET /api/v1/institutional/memories.
+type ListInstitutionalResponse struct {
+	Memories []*memory.Memory `json:"memories"`
+	Total    int              `json:"total"`
+}
+
+// handleSaveInstitutional handles POST /api/v1/institutional/memories.
+// Writes are restricted to workspace scope (no user_id, no agent_id).
+func (h *Handler) handleSaveInstitutional(w http.ResponseWriter, r *http.Request) {
+	r.Body = http.MaxBytesReader(w, r.Body, h.maxBodySize)
+
+	var req SaveInstitutionalRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		if isMaxBytesError(err) {
+			writeError(w, ErrBodyTooLarge)
+			return
+		}
+		writeError(w, ErrMissingBody)
+		return
+	}
+	if req.WorkspaceID == "" {
+		writeError(w, ErrMissingWorkspace)
+		return
+	}
+
+	mem := &memory.Memory{
+		Type:       req.Type,
+		Content:    req.Content,
+		Metadata:   req.Metadata,
+		Confidence: req.Confidence,
+		Scope:      map[string]string{memory.ScopeWorkspaceID: req.WorkspaceID},
+	}
+	if err := h.service.SaveInstitutionalMemory(r.Context(), mem); err != nil {
+		h.log.Error(err, "SaveInstitutionalMemory failed", "workspace", req.WorkspaceID)
+		writeError(w, err)
+		return
+	}
+
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(MemoryResponse{Memory: mem})
+}
+
+// handleListInstitutional handles GET /api/v1/institutional/memories?workspace=X.
+func (h *Handler) handleListInstitutional(w http.ResponseWriter, r *http.Request) {
+	workspace := truncateParam(r.URL.Query().Get("workspace"))
+	if workspace == "" {
+		writeError(w, ErrMissingWorkspace)
+		return
+	}
+	limit := parseIntParam(r, "limit", defaultListLimit)
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > maxListLimit {
+		limit = maxListLimit
+	}
+	opts := memory.ListOptions{
+		Limit:  limit,
+		Offset: parseIntParam(r, "offset", 0),
+	}
+
+	mems, err := h.service.ListInstitutionalMemories(r.Context(), workspace, opts)
+	if err != nil {
+		h.log.Error(err, "ListInstitutionalMemories failed", "workspace", workspace)
+		writeError(w, err)
+		return
+	}
+	writeJSON(w, ListInstitutionalResponse{Memories: mems, Total: len(mems)})
+}
+
+// handleDeleteInstitutional handles DELETE /api/v1/institutional/memories/{id}?workspace=X.
+// Returns 400 (not 500) when the target row is not institutional so callers
+// can distinguish operator misuse from infrastructure failures.
+func (h *Handler) handleDeleteInstitutional(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if id == "" {
+		writeError(w, ErrMissingMemoryID)
+		return
+	}
+	workspace := truncateParam(r.URL.Query().Get("workspace"))
+	if workspace == "" {
+		writeError(w, ErrMissingWorkspace)
+		return
+	}
+
+	err := h.service.DeleteInstitutionalMemory(r.Context(), workspace, id)
+	if err != nil {
+		if errors.Is(err, memory.ErrNotInstitutional) {
+			writeNotInstitutionalError(w)
+			return
+		}
+		h.log.Error(err, "DeleteInstitutionalMemory failed", "workspace", workspace, "memoryID", id)
+		writeError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+}
+
+// writeNotInstitutionalError emits a 400 with the sentinel message. Kept
+// separate from writeError so the sentinel from the memory package doesn't
+// need to be plumbed into the writeError switch.
+func writeNotInstitutionalError(w http.ResponseWriter) {
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{Error: memory.ErrNotInstitutional.Error()})
+}

--- a/internal/memory/api/handler_institutional_test.go
+++ b/internal/memory/api/handler_institutional_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+func newInstitutionalHandler(t *testing.T, store memory.Store) *http.ServeMux {
+	t.Helper()
+	svc := NewMemoryService(store, nil, MemoryServiceConfig{}, logr.Discard())
+	h := NewHandler(svc, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return mux
+}
+
+func TestHandleSaveInstitutional_HappyPath(t *testing.T) {
+	stub := &institutionalStub{saveMemID: "inst-1"}
+	mux := newInstitutionalHandler(t, stub)
+
+	body := `{"workspace_id":"ws-1","type":"policy","content":"snake_case rule","confidence":1.0}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/institutional/memories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	var resp MemoryResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+	assert.Equal(t, "inst-1", resp.Memory.ID)
+	assert.Equal(t, "ws-1", resp.Memory.Scope[memory.ScopeWorkspaceID])
+}
+
+func TestHandleSaveInstitutional_RejectsMissingWorkspace(t *testing.T) {
+	mux := newInstitutionalHandler(t, &institutionalStub{})
+
+	body := `{"type":"policy","content":"x"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/institutional/memories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSaveInstitutional_RejectsBadJSON(t *testing.T) {
+	mux := newInstitutionalHandler(t, &institutionalStub{})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/institutional/memories", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSaveInstitutional_BodyTooLarge(t *testing.T) {
+	stub := &institutionalStub{}
+	svc := NewMemoryService(stub, nil, MemoryServiceConfig{}, logr.Discard())
+	h := NewHandler(svc, logr.Discard())
+	h.maxBodySize = 16
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	body := `{"workspace_id":"a-workspace-that-exceeds-16-bytes"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/institutional/memories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestHandleListInstitutional_HappyPath(t *testing.T) {
+	stub := &institutionalStub{
+		listResult: []*memory.Memory{{ID: "m-1"}, {ID: "m-2"}},
+	}
+	mux := newInstitutionalHandler(t, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/institutional/memories?workspace=ws-1", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	var out ListInstitutionalResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
+	assert.Equal(t, 2, out.Total)
+	assert.Len(t, out.Memories, 2)
+}
+
+func TestHandleListInstitutional_RejectsMissingWorkspace(t *testing.T) {
+	mux := newInstitutionalHandler(t, &institutionalStub{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/institutional/memories", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleListInstitutional_CapsLimit(t *testing.T) {
+	stub := &institutionalStub{listResult: []*memory.Memory{}}
+	mux := newInstitutionalHandler(t, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/institutional/memories?workspace=ws-1&limit=99999", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandleDeleteInstitutional_HappyPath(t *testing.T) {
+	mux := newInstitutionalHandler(t, &institutionalStub{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/institutional/memories/m-1?workspace=ws-1", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandleDeleteInstitutional_RejectsMissingWorkspace(t *testing.T) {
+	mux := newInstitutionalHandler(t, &institutionalStub{})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/institutional/memories/m-1", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleDeleteInstitutional_NonInstitutionalReturns400(t *testing.T) {
+	stub := &institutionalStub{deleteErr: memory.ErrNotInstitutional}
+	mux := newInstitutionalHandler(t, stub)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/institutional/memories/m-1?workspace=ws-1", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	var errResp ErrorResponse
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&errResp))
+	assert.Contains(t, errResp.Error, "not an institutional")
+}
+
+func TestHandleListInstitutional_ServiceError(t *testing.T) {
+	stub := &institutionalStub{listErr: assertErr{msg: "db down"}}
+	mux := newInstitutionalHandler(t, stub)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/institutional/memories?workspace=ws-1", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandleListInstitutional_NegativeLimitNormalizes(t *testing.T) {
+	stub := &institutionalStub{listResult: []*memory.Memory{}}
+	mux := newInstitutionalHandler(t, stub)
+
+	// Negative limit defaults to defaultListLimit via parseIntParam, then
+	// goes through the >=1 clamp — exercises the "limit < 1" branch.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/institutional/memories?workspace=ws-1&limit=0", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestHandleDeleteInstitutional_MissingID(t *testing.T) {
+	mux := newInstitutionalHandler(t, &institutionalStub{})
+
+	// No trailing ID — go's router makes this path 404. Assert that explicitly.
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/institutional/memories/?workspace=ws-1", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	// 404 because the {id} path-variable requires at least one char.
+	assert.Equal(t, http.StatusNotFound, rec.Code)
+}
+
+func TestHandleDeleteInstitutional_ServiceError(t *testing.T) {
+	stub := &institutionalStub{deleteErr: assertErr{msg: "boom"}}
+	mux := newInstitutionalHandler(t, stub)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/institutional/memories/m-1?workspace=ws-1", nil)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rec.Code)
+}
+
+func TestHandler_RegisterRoutes_IncludesInstitutional(t *testing.T) {
+	mux := newInstitutionalHandler(t, &institutionalStub{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/institutional/memories?workspace=ws-1", nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code == http.StatusNotFound {
+		t.Fatalf("GET /api/v1/institutional/memories not routed (404); routes not registered")
+	}
+}

--- a/internal/memory/api/handler_test.go
+++ b/internal/memory/api/handler_test.go
@@ -77,6 +77,14 @@ func (m *mockStore) RetrieveMultiTier(_ context.Context, _ memory.MultiTierReque
 	return &memory.MultiTierResult{Memories: []*memory.MultiTierMemory{}, Total: 0}, nil
 }
 
+func (m *mockStore) SaveInstitutional(_ context.Context, _ *memory.Memory) error { return nil }
+
+func (m *mockStore) ListInstitutional(_ context.Context, _ string, _ memory.ListOptions) ([]*memory.Memory, error) {
+	return nil, nil
+}
+
+func (m *mockStore) DeleteInstitutional(_ context.Context, _, _ string) error { return nil }
+
 func (m *mockStore) Delete(_ context.Context, _ map[string]string, _ string) error {
 	return m.delErr
 }

--- a/internal/memory/api/service_institutional.go
+++ b/internal/memory/api/service_institutional.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// institutionalScopeTag tags audit events on the institutional admin path so
+// dashboards can filter workspace-knowledge activity from user-data activity.
+const institutionalScopeTag = "institutional"
+
+// operation tags emitted on the Metadata.operation key for institutional audit
+// events. Kept as constants so dashboards and tests share the same strings.
+const (
+	saveInstitutionalOp   = "save_institutional"
+	listInstitutionalOp   = "list_institutional"
+	deleteInstitutionalOp = "delete_institutional"
+)
+
+// SaveInstitutionalMemory persists a workspace-scoped memory (no user_id, no
+// agent_id) and emits a memory_created audit tagged scope=institutional.
+// Audit fires only on success, matching Save/List/Search semantics.
+func (s *MemoryService) SaveInstitutionalMemory(ctx context.Context, mem *memory.Memory) error {
+	if err := s.store.SaveInstitutional(ctx, mem); err != nil {
+		return err
+	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   eventTypeMemoryCreated,
+		MemoryID:    mem.ID,
+		WorkspaceID: mem.Scope[memory.ScopeWorkspaceID],
+		Kind:        mem.Type,
+		Metadata: map[string]string{
+			"scope":     institutionalScopeTag,
+			"operation": saveInstitutionalOp,
+		},
+	})
+	return nil
+}
+
+// ListInstitutionalMemories returns all institutional memories in a workspace
+// and emits a memory_accessed audit tagged operation=list_institutional.
+func (s *MemoryService) ListInstitutionalMemories(ctx context.Context, workspaceID string, opts memory.ListOptions) ([]*memory.Memory, error) {
+	mems, err := s.store.ListInstitutional(ctx, workspaceID, opts)
+	if err != nil {
+		return nil, err
+	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   auditEventMemoryAccessed,
+		WorkspaceID: workspaceID,
+		Metadata: map[string]string{
+			"scope":     institutionalScopeTag,
+			"operation": listInstitutionalOp,
+		},
+	})
+	return mems, nil
+}
+
+// DeleteInstitutionalMemory soft-deletes an institutional memory. The store
+// layer refuses to delete user- or agent-scoped rows via this path, returning
+// memory.ErrNotInstitutional; the error propagates unchanged so the HTTP
+// handler can map it to a 400 response.
+func (s *MemoryService) DeleteInstitutionalMemory(ctx context.Context, workspaceID, memoryID string) error {
+	if err := s.store.DeleteInstitutional(ctx, workspaceID, memoryID); err != nil {
+		return err
+	}
+	s.emitAuditEvent(ctx, &MemoryAuditEntry{
+		EventType:   eventTypeMemoryDeleted,
+		MemoryID:    memoryID,
+		WorkspaceID: workspaceID,
+		Metadata: map[string]string{
+			"scope":     institutionalScopeTag,
+			"operation": deleteInstitutionalOp,
+		},
+	})
+	return nil
+}

--- a/internal/memory/api/service_institutional_test.go
+++ b/internal/memory/api/service_institutional_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package api
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// institutionalStub extends mockMemoryStore with configurable
+// institutional-path responses and call recording.
+type institutionalStub struct {
+	mockMemoryStore
+	mu sync.Mutex
+
+	saveCalls []*memory.Memory
+	saveErr   error
+	saveMemID string // ID written back on the passed Memory
+
+	listCalls  []string
+	listResult []*memory.Memory
+	listErr    error
+
+	deleteCalls []struct{ ws, id string }
+	deleteErr   error
+}
+
+func (i *institutionalStub) SaveInstitutional(_ context.Context, mem *memory.Memory) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.saveCalls = append(i.saveCalls, mem)
+	if i.saveErr != nil {
+		return i.saveErr
+	}
+	if i.saveMemID != "" {
+		mem.ID = i.saveMemID
+	}
+	return nil
+}
+
+func (i *institutionalStub) ListInstitutional(_ context.Context, ws string, _ memory.ListOptions) ([]*memory.Memory, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.listCalls = append(i.listCalls, ws)
+	return i.listResult, i.listErr
+}
+
+func (i *institutionalStub) DeleteInstitutional(_ context.Context, ws, id string) error {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+	i.deleteCalls = append(i.deleteCalls, struct{ ws, id string }{ws, id})
+	return i.deleteErr
+}
+
+func newInstitutionalService(t *testing.T, store *institutionalStub) (*MemoryService, *mockAuditLogger) {
+	t.Helper()
+	svc := NewMemoryService(store, nil, MemoryServiceConfig{}, logr.Discard())
+	audit := newMockAuditLogger()
+	svc.SetAuditLogger(audit)
+	return svc, audit
+}
+
+func TestSaveInstitutionalMemory_ForwardsAndEmitsAudit(t *testing.T) {
+	store := &institutionalStub{saveMemID: "inst-1"}
+	svc, audit := newInstitutionalService(t, store)
+
+	mem := &memory.Memory{
+		Type:    "policy",
+		Content: "API uses snake_case",
+		Scope:   map[string]string{memory.ScopeWorkspaceID: "ws-1"},
+	}
+	require.NoError(t, svc.SaveInstitutionalMemory(context.Background(), mem))
+
+	store.mu.Lock()
+	require.Len(t, store.saveCalls, 1)
+	store.mu.Unlock()
+	assert.Equal(t, "inst-1", mem.ID)
+
+	entry := audit.receiveEntry(t)
+	assert.Equal(t, eventTypeMemoryCreated, entry.EventType)
+	assert.Equal(t, "ws-1", entry.WorkspaceID)
+	assert.Equal(t, institutionalScopeTag, entry.Metadata["scope"])
+	assert.Equal(t, saveInstitutionalOp, entry.Metadata["operation"])
+}
+
+func TestSaveInstitutionalMemory_PropagatesStoreError(t *testing.T) {
+	store := &institutionalStub{saveErr: errors.New("boom")}
+	svc, audit := newInstitutionalService(t, store)
+
+	err := svc.SaveInstitutionalMemory(context.Background(), &memory.Memory{
+		Scope: map[string]string{memory.ScopeWorkspaceID: "ws-1"},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+
+	select {
+	case e := <-audit.entries:
+		t.Fatalf("unexpected audit on error: %+v", e)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func TestListInstitutionalMemories_ForwardsAndEmitsAudit(t *testing.T) {
+	store := &institutionalStub{
+		listResult: []*memory.Memory{{ID: "m-1"}, {ID: "m-2"}},
+	}
+	svc, audit := newInstitutionalService(t, store)
+
+	got, err := svc.ListInstitutionalMemories(context.Background(), "ws-1", memory.ListOptions{Limit: 20})
+	require.NoError(t, err)
+	require.Len(t, got, 2)
+
+	entry := audit.receiveEntry(t)
+	assert.Equal(t, auditEventMemoryAccessed, entry.EventType)
+	assert.Equal(t, listInstitutionalOp, entry.Metadata["operation"])
+	assert.Equal(t, institutionalScopeTag, entry.Metadata["scope"])
+}
+
+func TestListInstitutionalMemories_PropagatesStoreError(t *testing.T) {
+	store := &institutionalStub{listErr: errors.New("db down")}
+	svc, _ := newInstitutionalService(t, store)
+
+	_, err := svc.ListInstitutionalMemories(context.Background(), "ws-1", memory.ListOptions{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "db down")
+}
+
+func TestDeleteInstitutionalMemory_ForwardsAndEmitsAudit(t *testing.T) {
+	store := &institutionalStub{}
+	svc, audit := newInstitutionalService(t, store)
+
+	require.NoError(t, svc.DeleteInstitutionalMemory(context.Background(), "ws-1", "m-1"))
+
+	store.mu.Lock()
+	require.Len(t, store.deleteCalls, 1)
+	assert.Equal(t, "ws-1", store.deleteCalls[0].ws)
+	assert.Equal(t, "m-1", store.deleteCalls[0].id)
+	store.mu.Unlock()
+
+	entry := audit.receiveEntry(t)
+	assert.Equal(t, eventTypeMemoryDeleted, entry.EventType)
+	assert.Equal(t, deleteInstitutionalOp, entry.Metadata["operation"])
+	assert.Equal(t, "m-1", entry.MemoryID)
+}
+
+func TestDeleteInstitutionalMemory_PropagatesNotInstitutional(t *testing.T) {
+	store := &institutionalStub{deleteErr: memory.ErrNotInstitutional}
+	svc, audit := newInstitutionalService(t, store)
+
+	err := svc.DeleteInstitutionalMemory(context.Background(), "ws-1", "m-1")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, memory.ErrNotInstitutional)
+
+	select {
+	case e := <-audit.entries:
+		t.Fatalf("unexpected audit on error: %+v", e)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/internal/memory/cache.go
+++ b/internal/memory/cache.go
@@ -103,6 +103,32 @@ func (c *CachedStore) RetrieveMultiTier(ctx context.Context, req MultiTierReques
 	return c.inner.RetrieveMultiTier(ctx, req)
 }
 
+// SaveInstitutional delegates to the inner store then invalidates the
+// workspace-scoped cache so any cached list/search sees the new row.
+func (c *CachedStore) SaveInstitutional(ctx context.Context, mem *Memory) error {
+	if err := c.inner.SaveInstitutional(ctx, mem); err != nil {
+		return err
+	}
+	c.bumpVersion(ctx, map[string]string{ScopeWorkspaceID: mem.Scope[ScopeWorkspaceID]})
+	return nil
+}
+
+// ListInstitutional delegates to the inner store without caching. The admin
+// list path is infrequent and needs to reflect writes immediately.
+func (c *CachedStore) ListInstitutional(ctx context.Context, workspaceID string, opts ListOptions) ([]*Memory, error) {
+	return c.inner.ListInstitutional(ctx, workspaceID, opts)
+}
+
+// DeleteInstitutional delegates to the inner store then invalidates the
+// workspace-scoped cache.
+func (c *CachedStore) DeleteInstitutional(ctx context.Context, workspaceID, memoryID string) error {
+	if err := c.inner.DeleteInstitutional(ctx, workspaceID, memoryID); err != nil {
+		return err
+	}
+	c.bumpVersion(ctx, map[string]string{ScopeWorkspaceID: workspaceID})
+	return nil
+}
+
 // List returns cached results when available, falling back to the inner store on miss or Redis error.
 func (c *CachedStore) List(ctx context.Context, scope map[string]string, opts ListOptions) ([]*Memory, error) {
 	key := c.listKey(ctx, scope, opts)

--- a/internal/memory/cache_test.go
+++ b/internal/memory/cache_test.go
@@ -73,6 +73,14 @@ func (m *cacheTestStore) RetrieveMultiTier(_ context.Context, _ MultiTierRequest
 	return &MultiTierResult{Memories: []*MultiTierMemory{}, Total: 0}, nil
 }
 
+func (m *cacheTestStore) SaveInstitutional(_ context.Context, _ *Memory) error { return nil }
+
+func (m *cacheTestStore) ListInstitutional(_ context.Context, _ string, _ ListOptions) ([]*Memory, error) {
+	return nil, nil
+}
+
+func (m *cacheTestStore) DeleteInstitutional(_ context.Context, _, _ string) error { return nil }
+
 func (m *cacheTestStore) List(_ context.Context, _ map[string]string, _ ListOptions) ([]*Memory, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/memory/extractor_test.go
+++ b/internal/memory/extractor_test.go
@@ -61,6 +61,14 @@ func (m *mockStore) RetrieveMultiTier(_ context.Context, _ MultiTierRequest) (*M
 	return &MultiTierResult{Memories: []*MultiTierMemory{}, Total: 0}, nil
 }
 
+func (m *mockStore) SaveInstitutional(_ context.Context, _ *Memory) error { return nil }
+
+func (m *mockStore) ListInstitutional(_ context.Context, _ string, _ ListOptions) ([]*Memory, error) {
+	return nil, nil
+}
+
+func (m *mockStore) DeleteInstitutional(_ context.Context, _, _ string) error { return nil }
+
 func (m *mockStore) Delete(_ context.Context, _ map[string]string, _ string) error {
 	return nil
 }

--- a/internal/memory/institutional.go
+++ b/internal/memory/institutional.go
@@ -1,0 +1,169 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/jackc/pgx/v5"
+)
+
+// institutionalTrustModel is the trust_model value stamped on every
+// institutional write. Operator-curated rows are trusted data by definition.
+const institutionalTrustModel = "curated"
+
+// institutionalSourceType is the source_type value stamped on every
+// institutional write. Separate from the conversation_extraction default
+// used for agent-extracted memories.
+const institutionalSourceType = "operator_curated"
+
+// ErrNotInstitutional is returned when DeleteInstitutional is called with a
+// memory ID that belongs to a user- or agent-scoped row. Callers MUST use
+// errors.Is against this sentinel so the HTTP handler in the institutional
+// admin API can map it to a 400 response rather than a 500.
+var ErrNotInstitutional = errors.New("memory: target is not an institutional memory")
+
+// SaveInstitutional persists a workspace-scoped memory with no user_id and no
+// agent_id. Provenance is forced to operator_curated and trust_model to
+// curated regardless of caller input — callers of this method are operators
+// by definition, so we overwrite any spoofed provenance and sanitize the
+// scope map before the insert path runs.
+func (s *PostgresMemoryStore) SaveInstitutional(ctx context.Context, mem *Memory) error {
+	workspaceID := mem.Scope[ScopeWorkspaceID]
+	if workspaceID == "" {
+		return errors.New(errWorkspaceRequired)
+	}
+
+	// Replace the scope map entirely so user/agent keys cannot leak into the
+	// insert path via scopeOrNil().
+	mem.Scope = map[string]string{ScopeWorkspaceID: workspaceID}
+
+	if mem.Metadata == nil {
+		mem.Metadata = map[string]any{}
+	}
+	mem.Metadata[pkmemory.MetaKeyProvenance] = string(pkmemory.ProvenanceOperatorCurated)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return fmt.Errorf("memory: begin tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := insertInstitutionalEntity(ctx, tx, mem); err != nil {
+		return err
+	}
+	if err := insertObservation(ctx, tx, mem); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// insertInstitutionalEntity inserts a memory_entities row with virtual_user_id
+// and agent_id both NULL and stamps the curated trust_model / operator_curated
+// source_type so downstream retention and PII pipelines know this row was not
+// extracted from conversation.
+func insertInstitutionalEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
+	metaJSON, err := marshalMetadata(mem.Metadata)
+	if err != nil {
+		return err
+	}
+	row := tx.QueryRow(ctx, `
+		INSERT INTO memory_entities
+		  (workspace_id, virtual_user_id, agent_id, name, kind, metadata, trust_model, source_type, expires_at)
+		VALUES
+		  ($1, NULL, NULL, $2, $3, $4, $5, $6, $7)
+		RETURNING id, created_at`,
+		mem.Scope[ScopeWorkspaceID],
+		mem.Content,
+		mem.Type,
+		metaJSON,
+		institutionalTrustModel,
+		institutionalSourceType,
+		mem.ExpiresAt,
+	)
+	return row.Scan(&mem.ID, &mem.CreatedAt)
+}
+
+// ListInstitutional returns every institutional memory in a workspace.
+// Institutional is defined as virtual_user_id IS NULL AND agent_id IS NULL.
+// Results are ordered by most-recent observation and paginated.
+func (s *PostgresMemoryStore) ListInstitutional(ctx context.Context, workspaceID string, opts ListOptions) ([]*Memory, error) {
+	if workspaceID == "" {
+		return nil, errors.New(errWorkspaceRequired)
+	}
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = defaultMemoryLimit
+	}
+	sql := `
+		SELECT DISTINCT ON (e.id)
+		  e.id, e.kind, e.metadata, e.created_at, e.expires_at,
+		  o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at
+		FROM memory_entities e
+		JOIN memory_observations o ON o.entity_id = e.id
+		WHERE e.workspace_id = $1
+		  AND e.virtual_user_id IS NULL
+		  AND e.agent_id IS NULL
+		  AND e.forgotten = false
+		ORDER BY e.id, o.observed_at DESC
+		LIMIT $2 OFFSET $3`
+	rows, err := s.pool.Query(ctx, sql, workspaceID, limit, opts.Offset)
+	if err != nil {
+		return nil, fmt.Errorf("memory: list institutional: %w", err)
+	}
+	defer rows.Close()
+	return scanMemories(rows, map[string]string{ScopeWorkspaceID: workspaceID})
+}
+
+// DeleteInstitutional soft-deletes an institutional memory. It first verifies
+// that the target row has no user_id and no agent_id; otherwise the admin API
+// could be misused to erase user-scoped data through the institutional path.
+// Returns ErrNotInstitutional when the row belongs to a user or agent tier.
+func (s *PostgresMemoryStore) DeleteInstitutional(ctx context.Context, workspaceID, memoryID string) error {
+	if workspaceID == "" {
+		return errors.New(errWorkspaceRequired)
+	}
+	var userID, agentID *string
+	row := s.pool.QueryRow(ctx, `
+		SELECT virtual_user_id, agent_id
+		FROM memory_entities
+		WHERE id = $1 AND workspace_id = $2 AND forgotten = false`,
+		memoryID, workspaceID,
+	)
+	if err := row.Scan(&userID, &agentID); err != nil {
+		return fmt.Errorf("memory: lookup institutional: %w", err)
+	}
+	if userID != nil || agentID != nil {
+		return ErrNotInstitutional
+	}
+	tag, err := s.pool.Exec(ctx, `
+		UPDATE memory_entities SET forgotten = true, updated_at = now()
+		WHERE id = $1 AND workspace_id = $2`,
+		memoryID, workspaceID)
+	if err != nil {
+		return fmt.Errorf("memory: delete institutional: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("memory: entity %s not found", memoryID)
+	}
+	return nil
+}

--- a/internal/memory/institutional_test.go
+++ b/internal/memory/institutional_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+)
+
+// TestSaveInstitutional_RequiresWorkspace is a pure unit test: the workspace
+// guard must short-circuit before the nil pool is dereferenced. Using a zero-
+// value store exercises the guard without a database.
+func TestSaveInstitutional_RequiresWorkspace(t *testing.T) {
+	s := &PostgresMemoryStore{}
+	err := s.SaveInstitutional(context.Background(), &Memory{Scope: map[string]string{}})
+	if err == nil || err.Error() != errWorkspaceRequired {
+		t.Fatalf("want %q, got %v", errWorkspaceRequired, err)
+	}
+}
+
+func TestSaveInstitutional_WritesRow(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	mem := &Memory{
+		Type:       "policy",
+		Content:    "API uses snake_case",
+		Confidence: 1.0,
+		Scope:      map[string]string{ScopeWorkspaceID: testWorkspace1},
+	}
+	if err := store.SaveInstitutional(ctx, mem); err != nil {
+		t.Fatalf("SaveInstitutional: %v", err)
+	}
+	if mem.ID == "" {
+		t.Fatalf("ID not populated")
+	}
+	// Provenance must be forced regardless of caller input.
+	if got, _ := mem.Metadata[pkmemory.MetaKeyProvenance].(string); got != string(pkmemory.ProvenanceOperatorCurated) {
+		t.Errorf("provenance=%q, want %q", got, pkmemory.ProvenanceOperatorCurated)
+	}
+	// Scope must be sanitized — no user/agent keys should remain.
+	if _, ok := mem.Scope[ScopeUserID]; ok {
+		t.Errorf("scope still contains user_id after sanitization: %+v", mem.Scope)
+	}
+	if _, ok := mem.Scope[ScopeAgentID]; ok {
+		t.Errorf("scope still contains agent_id after sanitization: %+v", mem.Scope)
+	}
+
+	got, err := store.ListInstitutional(ctx, testWorkspace1, ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListInstitutional: %v", err)
+	}
+	if len(got) == 0 {
+		t.Fatalf("expected at least 1 institutional memory, got 0")
+	}
+}
+
+// TestSaveInstitutional_OverwritesConflictingProvenance guards the rule that
+// any caller-supplied provenance is overwritten with operator_curated — an
+// operator API by definition emits operator_curated rows and a client must not
+// be able to spoof user_requested, etc.
+func TestSaveInstitutional_OverwritesConflictingProvenance(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	mem := &Memory{
+		Type:       "policy",
+		Content:    "spoof attempt",
+		Confidence: 1.0,
+		Scope:      map[string]string{ScopeWorkspaceID: testWorkspace1},
+		Metadata: map[string]any{
+			pkmemory.MetaKeyProvenance: string(pkmemory.ProvenanceUserRequested),
+		},
+	}
+	must(t, store.SaveInstitutional(ctx, mem))
+
+	if got, _ := mem.Metadata[pkmemory.MetaKeyProvenance].(string); got != string(pkmemory.ProvenanceOperatorCurated) {
+		t.Errorf("provenance=%q, want %q", got, pkmemory.ProvenanceOperatorCurated)
+	}
+}
+
+func TestListInstitutional_RequiresWorkspace(t *testing.T) {
+	s := &PostgresMemoryStore{}
+	_, err := s.ListInstitutional(context.Background(), "", ListOptions{})
+	if err == nil || err.Error() != errWorkspaceRequired {
+		t.Fatalf("want %q, got %v", errWorkspaceRequired, err)
+	}
+}
+
+func TestListInstitutional_ExcludesUserAndAgentRows(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	user := "33333333-3333-3333-3333-333333333333"
+	agent := "44444444-4444-4444-4444-444444444444"
+
+	// Institutional (should appear).
+	must(t, store.SaveInstitutional(ctx, &Memory{
+		Type: "policy", Content: "inst", Confidence: 1.0,
+		Scope: map[string]string{ScopeWorkspaceID: testWorkspace1},
+	}))
+	// User-scoped (should NOT appear).
+	must(t, store.Save(ctx, &Memory{
+		Type: "pref", Content: "user", Confidence: 0.8,
+		Scope: map[string]string{ScopeWorkspaceID: testWorkspace1, ScopeUserID: user},
+	}))
+	// Agent-only via raw insert (Save enforces user_id).
+	insertRawMemory(t, store, "", agent, "fact", "agent", 0.9)
+
+	got, err := store.ListInstitutional(ctx, testWorkspace1, ListOptions{Limit: 20})
+	if err != nil {
+		t.Fatalf("ListInstitutional: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected exactly 1 institutional row, got %d: %+v", len(got), got)
+	}
+	for _, m := range got {
+		if m.Scope[ScopeUserID] != "" || m.Scope[ScopeAgentID] != "" {
+			t.Errorf("leaked non-institutional row: %+v", m)
+		}
+	}
+}
+
+func TestDeleteInstitutional_RequiresWorkspace(t *testing.T) {
+	s := &PostgresMemoryStore{}
+	err := s.DeleteInstitutional(context.Background(), "", "some-id")
+	if err == nil || err.Error() != errWorkspaceRequired {
+		t.Fatalf("want %q, got %v", errWorkspaceRequired, err)
+	}
+}
+
+func TestDeleteInstitutional_SoftDeletesOnlyInstitutional(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	user := "66666666-6666-6666-6666-666666666666"
+
+	inst := &Memory{
+		Type: "policy", Content: "inst", Confidence: 1.0,
+		Scope: map[string]string{ScopeWorkspaceID: testWorkspace1},
+	}
+	must(t, store.SaveInstitutional(ctx, inst))
+
+	userMem := &Memory{
+		Type: "pref", Content: "user", Confidence: 0.8,
+		Scope: map[string]string{ScopeWorkspaceID: testWorkspace1, ScopeUserID: user},
+	}
+	must(t, store.Save(ctx, userMem))
+
+	// Delete institutional -> succeeds.
+	if err := store.DeleteInstitutional(ctx, testWorkspace1, inst.ID); err != nil {
+		t.Fatalf("DeleteInstitutional (inst): %v", err)
+	}
+
+	// The institutional row must no longer appear in the list.
+	after, err := store.ListInstitutional(ctx, testWorkspace1, ListOptions{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListInstitutional after delete: %v", err)
+	}
+	for _, m := range after {
+		if m.ID == inst.ID {
+			t.Errorf("soft-deleted institutional row still listed: %+v", m)
+		}
+	}
+
+	// Delete user-scoped via institutional endpoint -> must refuse with the
+	// exported sentinel so Task 4's handler can map to HTTP 400.
+	err = store.DeleteInstitutional(ctx, testWorkspace1, userMem.ID)
+	if err == nil {
+		t.Fatal("expected DeleteInstitutional to refuse user-scoped row")
+	}
+	if !errors.Is(err, ErrNotInstitutional) {
+		t.Errorf("err=%v, want ErrNotInstitutional (errors.Is)", err)
+	}
+}
+
+func must(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/memory/types.go
+++ b/internal/memory/types.go
@@ -40,9 +40,14 @@ type (
 // BatchDelete is needed for paginated DSAR deletion (Task 4 cascade).
 // RetrieveMultiTier runs a single query across institutional, agent, user and
 // user-for-agent tiers and returns ranked results for RAG context injection.
+// The three Institutional methods are the admin path for workspace-scoped
+// memories (no user_id, no agent_id) — see institutional.go.
 type Store interface {
 	pkmemory.Store
 	ExportAll(ctx context.Context, scope map[string]string) ([]*Memory, error)
 	BatchDelete(ctx context.Context, scope map[string]string, limit int) (int, error)
 	RetrieveMultiTier(ctx context.Context, req MultiTierRequest) (*MultiTierResult, error)
+	SaveInstitutional(ctx context.Context, mem *Memory) error
+	ListInstitutional(ctx context.Context, workspaceID string, opts ListOptions) ([]*Memory, error)
+	DeleteInstitutional(ctx context.Context, workspaceID, memoryID string) error
 }


### PR DESCRIPTION
## Summary
- New memory-api endpoints for workspace-scoped (institutional) memories:
  - `POST /api/v1/institutional/memories`
  - `GET /api/v1/institutional/memories?workspace=X`
  - `DELETE /api/v1/institutional/memories/{id}?workspace=X`
- Store methods `SaveInstitutional` / `ListInstitutional` / `DeleteInstitutional` bypass the user_id guard and enforce `virtual_user_id IS NULL AND agent_id IS NULL` at both write and read time.
- `DeleteInstitutional` guards against the admin path being used to remove user-scoped data (returns `ErrNotInstitutional` → 400).
- Provenance forced to `operator_curated`, `trust_model` to `curated` on all writes.
- Audit events tagged `scope=institutional` so dashboards can filter admin actions from user activity.
- `CachedStore` delegates to inner on all three methods and bumps the workspace cache version on writes/deletes.

## Scope boundaries
- Server-side only. Dashboard "Workspace Knowledge" page + bulk import come in Phase 2b.
- No workspace-admin authorization gate — defers to existing facade edge auth. A follow-up will add a role check via JWT claim or header.

## Test plan
- [x] Local `go test ./internal/memory/... ./cmd/memory-api/... -count=1` passes
- [x] Per-file coverage ≥80% on every changed production file (institutional.go 80.9%, service_institutional.go 100%, handler_institutional.go 90.9%, cache.go 81.4%)
- [x] Lint clean on new code vs origin/main
- [ ] CI green