### PR TITLE
feat(dashboard): multi-tier phase 2b — institutional memory data layer

### DIFF
--- a/dashboard/src/app/api/workspaces/[name]/institutional-memory/[memoryId]/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/institutional-memory/[memoryId]/route.ts
@@ -1,0 +1,49 @@
+/**
+ * Institutional single-memory proxy route.
+ *
+ * DELETE /api/workspaces/{name}/institutional-memory/{memoryId}
+ *   → MEMORY_API_URL/api/v1/institutional/memories/{memoryId}?workspace={uid}
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+import { resolveWorkspaceUID } from "../../memory/proxy-helpers";
+import { resolveServiceURLs } from "@/lib/k8s/service-url-resolver";
+
+export const DELETE = withWorkspaceAccess(
+  "editor",
+  async (
+    _request: NextRequest,
+    context: WorkspaceRouteContext,
+    _access: WorkspaceAccess,
+    _user: User
+  ): Promise<NextResponse> => {
+    const { name, memoryId } = await context.params as { name: string; memoryId: string };
+
+    const urls = await resolveServiceURLs(name);
+    if (!urls) {
+      return NextResponse.json({ error: "Memory API not configured" }, { status: 503 });
+    }
+    const workspaceUID = await resolveWorkspaceUID(name);
+    if (!workspaceUID) {
+      return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+    }
+
+    const baseUrl = urls.memoryURL.endsWith("/") ? urls.memoryURL.slice(0, -1) : urls.memoryURL;
+    const targetUrl = `${baseUrl}/api/v1/institutional/memories/${encodeURIComponent(memoryId)}?workspace=${encodeURIComponent(workspaceUID)}`;
+
+    try {
+      const response = await fetch(targetUrl, { method: "DELETE" });
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({ error: "Delete failed" }));
+        return NextResponse.json(data, { status: response.status });
+      }
+      return new NextResponse(null, { status: 200 });
+    } catch (error) {
+      console.error("Institutional memory proxy error:", error);
+      return NextResponse.json({ error: "Failed to connect to Memory API" }, { status: 502 });
+    }
+  }
+);

--- a/dashboard/src/app/api/workspaces/[name]/institutional-memory/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/institutional-memory/route.test.ts
@@ -43,12 +43,15 @@ function ctx(overrides: Record<string, string> = {}) {
 }
 
 function createReq(method: string, path: string, body?: unknown): NextRequest {
-  const init: RequestInit = { method };
-  if (body !== undefined) {
-    init.body = typeof body === "string" ? body : JSON.stringify(body);
-    init.headers = { "Content-Type": "application/json" };
+  if (body === undefined) {
+    return new NextRequest(`https://localhost:3000${path}`, { method });
   }
-  return new NextRequest(`https://localhost:3000${path}`, init);
+  const bodyStr = typeof body === "string" ? body : JSON.stringify(body);
+  return new NextRequest(`https://localhost:3000${path}`, {
+    method,
+    body: bodyStr,
+    headers: { "Content-Type": "application/json" },
+  });
 }
 
 function mockResp(data: unknown, status = 200) {
@@ -73,7 +76,7 @@ describe("GET /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockResp({ memories: [{ id: "inst-1" }], total: 1 });
 
@@ -114,7 +117,7 @@ describe("GET /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
     vi.mocked(getWorkspace).mockResolvedValue(null as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     const { GET } = await import("./route");
     const res = await GET(createReq("GET", "/api/workspaces/my-ws/institutional-memory"), ctx());
@@ -130,7 +133,7 @@ describe("GET /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockFetch.mockResolvedValueOnce({
       ok: false,
@@ -152,7 +155,7 @@ describe("GET /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockFetch.mockRejectedValueOnce(new Error("net down"));
 
@@ -187,7 +190,7 @@ describe("POST /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockResp({ memory: { id: "inst-new", type: "policy", content: "c", confidence: 1, scope: {}, createdAt: "" } }, 201);
 
@@ -230,7 +233,7 @@ describe("POST /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     const { POST } = await import("./route");
     const res = await POST(createReq("POST", "/api/workspaces/my-ws/institutional-memory", "not json"), ctx());
@@ -260,7 +263,7 @@ describe("POST /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(null as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     const { POST } = await import("./route");
     const res = await POST(createReq("POST", "/api/workspaces/my-ws/institutional-memory", { type: "t", content: "c" }), ctx());
@@ -276,7 +279,7 @@ describe("POST /api/workspaces/[name]/institutional-memory", () => {
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockFetch.mockRejectedValueOnce(new Error("boom"));
 
@@ -303,7 +306,7 @@ describe("DELETE /api/workspaces/[name]/institutional-memory/[memoryId]", () => 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({}) });
 
@@ -325,7 +328,7 @@ describe("DELETE /api/workspaces/[name]/institutional-memory/[memoryId]", () => 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockFetch.mockResolvedValueOnce({
       ok: false,
@@ -363,7 +366,7 @@ describe("DELETE /api/workspaces/[name]/institutional-memory/[memoryId]", () => 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(null as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     const { DELETE } = await import("./[memoryId]/route");
     const res = await DELETE(createReq("DELETE", "/api/workspaces/my-ws/institutional-memory/inst-1"), deleteCtx());
@@ -379,7 +382,7 @@ describe("DELETE /api/workspaces/[name]/institutional-memory/[memoryId]", () => 
     vi.mocked(getUser).mockResolvedValue(mockUser);
     vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
     vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
-    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "https://s:8080", memoryURL: "https://m:8080" });
 
     mockFetch.mockRejectedValueOnce(new Error("net"));
 

--- a/dashboard/src/app/api/workspaces/[name]/institutional-memory/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/institutional-memory/route.test.ts
@@ -1,0 +1,390 @@
+/**
+ * Tests for institutional memory proxy routes (list + create + delete).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/workspace-authz", () => ({
+  checkWorkspaceAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/service-url-resolver", () => ({
+  resolveServiceURLs: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockUser = {
+  id: "testuser-id",
+  provider: "oauth" as const,
+  username: "testuser",
+  email: "test@example.com",
+  groups: ["users"],
+  role: "editor" as const,
+};
+const viewerPerms = { read: true, write: false, delete: false, manageMembers: false };
+const editorPerms = { read: true, write: true, delete: true, manageMembers: false };
+const noPerms = { read: false, write: false, delete: false, manageMembers: false };
+
+const mockWorkspace = { metadata: { uid: "ws-uid-42", name: "my-ws" }, spec: {} };
+
+function ctx(overrides: Record<string, string> = {}) {
+  return { params: Promise.resolve({ name: "my-ws", ...overrides }) };
+}
+
+function createReq(method: string, path: string, body?: unknown): NextRequest {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+    init.headers = { "Content-Type": "application/json" };
+  }
+  return new NextRequest(`https://localhost:3000${path}`, init);
+}
+
+function mockResp(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+    json: () => Promise.resolve(data),
+  });
+}
+
+describe("GET /api/workspaces/[name]/institutional-memory", () => {
+  beforeEach(() => { vi.resetModules(); });
+  afterEach(() => { vi.resetAllMocks(); });
+
+  it("returns the memory-api list response", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockResp({ memories: [{ id: "inst-1" }], total: 1 });
+
+    const { GET } = await import("./route");
+    const res = await GET(createReq("GET", "/api/workspaces/my-ws/institutional-memory?limit=10&offset=5"), ctx());
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.memories).toHaveLength(1);
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/api/v1/institutional/memories");
+    expect(url).toContain("workspace=ws-uid-42");
+    expect(url).toContain("limit=10");
+    expect(url).toContain("offset=5");
+  });
+
+  it("returns 503 when memoryURL is not configured", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
+    vi.mocked(resolveServiceURLs).mockResolvedValue(null);
+
+    const { GET } = await import("./route");
+    const res = await GET(createReq("GET", "/api/workspaces/my-ws/institutional-memory"), ctx());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 404 when workspace not found", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(null as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    const { GET } = await import("./route");
+    const res = await GET(createReq("GET", "/api/workspaces/my-ws/institutional-memory"), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 502 on non-JSON backend response", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+      text: () => Promise.resolve("plain text"),
+    });
+
+    const { GET } = await import("./route");
+    const res = await GET(createReq("GET", "/api/workspaces/my-ws/institutional-memory"), ctx());
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 502 on backend network error", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "viewer", permissions: viewerPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockFetch.mockRejectedValueOnce(new Error("net down"));
+
+    const { GET } = await import("./route");
+    const res = await GET(createReq("GET", "/api/workspaces/my-ws/institutional-memory"), ctx());
+    expect(res.status).toBe(502);
+  });
+
+  it("returns 403 when viewer access is denied", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: false, role: null, permissions: noPerms });
+
+    const { GET } = await import("./route");
+    const res = await GET(createReq("GET", "/api/workspaces/my-ws/institutional-memory"), ctx());
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /api/workspaces/[name]/institutional-memory", () => {
+  beforeEach(() => { vi.resetModules(); });
+  afterEach(() => { vi.resetAllMocks(); });
+
+  it("forwards body with workspace_id substituted to the UID", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockResp({ memory: { id: "inst-new", type: "policy", content: "c", confidence: 1, scope: {}, createdAt: "" } }, 201);
+
+    const { POST } = await import("./route");
+    const res = await POST(
+      createReq("POST", "/api/workspaces/my-ws/institutional-memory", {
+        workspace_id: "attacker-forged-uid",
+        type: "policy",
+        content: "c",
+      }),
+      ctx()
+    );
+
+    expect(res.status).toBe(201);
+
+    const requestInit = mockFetch.mock.calls[0][1] as RequestInit;
+    const forwardedBody = JSON.parse(requestInit.body as string);
+    expect(forwardedBody.workspace_id).toBe("ws-uid-42");
+    expect(forwardedBody.type).toBe("policy");
+  });
+
+  it("rejects editor-missing with 403", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: false, role: null, permissions: viewerPerms });
+
+    const { POST } = await import("./route");
+    const res = await POST(createReq("POST", "/api/workspaces/my-ws/institutional-memory", { type: "t", content: "c" }), ctx());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 400 on invalid JSON body", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    const { POST } = await import("./route");
+    const res = await POST(createReq("POST", "/api/workspaces/my-ws/institutional-memory", "not json"), ctx());
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 503 when memoryURL missing", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(resolveServiceURLs).mockResolvedValue(null);
+
+    const { POST } = await import("./route");
+    const res = await POST(createReq("POST", "/api/workspaces/my-ws/institutional-memory", { type: "t", content: "c" }), ctx());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 404 when workspace missing", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(null as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    const { POST } = await import("./route");
+    const res = await POST(createReq("POST", "/api/workspaces/my-ws/institutional-memory", { type: "t", content: "c" }), ctx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 502 on backend network error", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockFetch.mockRejectedValueOnce(new Error("boom"));
+
+    const { POST } = await import("./route");
+    const res = await POST(createReq("POST", "/api/workspaces/my-ws/institutional-memory", { type: "t", content: "c" }), ctx());
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("DELETE /api/workspaces/[name]/institutional-memory/[memoryId]", () => {
+  beforeEach(() => { vi.resetModules(); });
+  afterEach(() => { vi.resetAllMocks(); });
+
+  function deleteCtx() {
+    return { params: Promise.resolve({ name: "my-ws", memoryId: "inst-1" }) };
+  }
+
+  it("deletes the memory and returns 200", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 200, json: () => Promise.resolve({}) });
+
+    const { DELETE } = await import("./[memoryId]/route");
+    const res = await DELETE(createReq("DELETE", "/api/workspaces/my-ws/institutional-memory/inst-1"), deleteCtx());
+    expect(res.status).toBe(200);
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/api/v1/institutional/memories/inst-1");
+    expect(url).toContain("workspace=ws-uid-42");
+  });
+
+  it("forwards backend 400 (ErrNotInstitutional)", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: "memory: target is not an institutional memory" }),
+    });
+
+    const { DELETE } = await import("./[memoryId]/route");
+    const res = await DELETE(createReq("DELETE", "/api/workspaces/my-ws/institutional-memory/inst-1"), deleteCtx());
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain("not an institutional");
+  });
+
+  it("returns 503 when service URL not configured", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(resolveServiceURLs).mockResolvedValue(null);
+
+    const { DELETE } = await import("./[memoryId]/route");
+    const res = await DELETE(createReq("DELETE", "/api/workspaces/my-ws/institutional-memory/inst-1"), deleteCtx());
+    expect(res.status).toBe(503);
+  });
+
+  it("returns 404 when workspace missing", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(null as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    const { DELETE } = await import("./[memoryId]/route");
+    const res = await DELETE(createReq("DELETE", "/api/workspaces/my-ws/institutional-memory/inst-1"), deleteCtx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 502 on backend network error", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({ granted: true, role: "editor", permissions: editorPerms });
+    vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+    vi.mocked(resolveServiceURLs).mockResolvedValue({ sessionURL: "http://s:8080", memoryURL: "http://m:8080" });
+
+    mockFetch.mockRejectedValueOnce(new Error("net"));
+
+    const { DELETE } = await import("./[memoryId]/route");
+    const res = await DELETE(createReq("DELETE", "/api/workspaces/my-ws/institutional-memory/inst-1"), deleteCtx());
+    expect(res.status).toBe(502);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/institutional-memory/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/institutional-memory/route.ts
@@ -1,0 +1,119 @@
+/**
+ * Institutional memory list/create proxy route.
+ *
+ * GET  /api/workspaces/{name}/institutional-memory → MEMORY_API_URL/api/v1/institutional/memories?workspace={uid}
+ * POST /api/workspaces/{name}/institutional-memory → MEMORY_API_URL/api/v1/institutional/memories
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+import { resolveWorkspaceUID } from "../memory/proxy-helpers";
+import { resolveServiceURLs } from "@/lib/k8s/service-url-resolver";
+
+export const GET = withWorkspaceAccess(
+  "viewer",
+  async (
+    _request: NextRequest,
+    context: WorkspaceRouteContext,
+    _access: WorkspaceAccess,
+    _user: User
+  ): Promise<NextResponse> => {
+    const { name } = await context.params;
+    return proxyList(name, _request);
+  }
+);
+
+export const POST = withWorkspaceAccess(
+  "editor",
+  async (
+    request: NextRequest,
+    context: WorkspaceRouteContext,
+    _access: WorkspaceAccess,
+    _user: User
+  ): Promise<NextResponse> => {
+    const { name } = await context.params;
+    return proxyCreate(name, request);
+  }
+);
+
+async function proxyList(workspaceName: string, request: NextRequest): Promise<NextResponse> {
+  const urls = await resolveServiceURLs(workspaceName);
+  if (!urls) {
+    return NextResponse.json(
+      { error: "Memory API not configured", memories: [], total: 0 },
+      { status: 503 }
+    );
+  }
+  const workspaceUID = await resolveWorkspaceUID(workspaceName);
+  if (!workspaceUID) {
+    return NextResponse.json(
+      { error: "Workspace not found", memories: [], total: 0 },
+      { status: 404 }
+    );
+  }
+
+  const params = new URLSearchParams({ workspace: workspaceUID });
+  for (const key of ["limit", "offset"]) {
+    const v = request.nextUrl.searchParams.get(key);
+    if (v) params.set(key, v);
+  }
+
+  const baseUrl = urls.memoryURL.endsWith("/") ? urls.memoryURL.slice(0, -1) : urls.memoryURL;
+  const targetUrl = `${baseUrl}/api/v1/institutional/memories?${params.toString()}`;
+
+  return fetchAndForward(targetUrl, { method: "GET", headers: { Accept: "application/json" } });
+}
+
+async function proxyCreate(workspaceName: string, request: NextRequest): Promise<NextResponse> {
+  const urls = await resolveServiceURLs(workspaceName);
+  if (!urls) {
+    return NextResponse.json({ error: "Memory API not configured" }, { status: 503 });
+  }
+  const workspaceUID = await resolveWorkspaceUID(workspaceName);
+  if (!workspaceUID) {
+    return NextResponse.json({ error: "Workspace not found" }, { status: 404 });
+  }
+
+  // Parse the incoming body and substitute workspace_id with the UID so
+  // callers cannot write into a workspace they don't have access to.
+  let body: Record<string, unknown>;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+  body.workspace_id = workspaceUID;
+
+  const baseUrl = urls.memoryURL.endsWith("/") ? urls.memoryURL.slice(0, -1) : urls.memoryURL;
+  const targetUrl = `${baseUrl}/api/v1/institutional/memories`;
+
+  return fetchAndForward(targetUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function fetchAndForward(targetUrl: string, init: RequestInit): Promise<NextResponse> {
+  try {
+    const response = await fetch(targetUrl, init);
+    const text = await response.text();
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: response.status });
+    } catch {
+      return NextResponse.json(
+        { error: `Memory API returned non-JSON (HTTP ${response.status})` },
+        { status: 502 }
+      );
+    }
+  } catch (error) {
+    console.error("Institutional memory API proxy error:", error);
+    return NextResponse.json(
+      { error: "Failed to connect to Memory API" },
+      { status: 502 }
+    );
+  }
+}

--- a/dashboard/src/hooks/use-institutional-memories.test.ts
+++ b/dashboard/src/hooks/use-institutional-memories.test.ts
@@ -1,0 +1,156 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import React from "react";
+
+const { mockList, mockCreate, mockDelete } = vi.hoisted(() => ({
+  mockList: vi.fn(),
+  mockCreate: vi.fn(),
+  mockDelete: vi.fn(),
+}));
+
+vi.mock("@/lib/data/institutional-memory-service", () => ({
+  InstitutionalMemoryService: class MockInstitutionalMemoryService {
+    list = mockList;
+    create = mockCreate;
+    delete = mockDelete;
+  },
+}));
+
+const { mockUseWorkspace } = vi.hoisted(() => ({
+  mockUseWorkspace: vi.fn(() => ({ currentWorkspace: { name: "test-workspace" } })),
+}));
+
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+import {
+  useInstitutionalMemories,
+  useCreateInstitutionalMemory,
+  useDeleteInstitutionalMemory,
+} from "./use-institutional-memories";
+
+const mockMemory = {
+  id: "inst-1",
+  type: "policy",
+  content: "snake_case",
+  confidence: 1.0,
+  scope: {},
+  createdAt: "2026-04-22T00:00:00Z",
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  function TestQueryProvider({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+  return TestQueryProvider;
+}
+
+describe("useInstitutionalMemories", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: { name: "test-workspace" } });
+  });
+
+  it("fetches memories for the current workspace", async () => {
+    mockList.mockResolvedValue({ memories: [mockMemory], total: 1 });
+
+    const { result } = renderHook(() => useInstitutionalMemories(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockList).toHaveBeenCalledWith({ workspace: "test-workspace", limit: undefined, offset: undefined });
+    expect(result.current.data?.memories).toEqual([mockMemory]);
+  });
+
+  it("passes limit and offset through", async () => {
+    mockList.mockResolvedValue({ memories: [], total: 0 });
+
+    const { result } = renderHook(
+      () => useInstitutionalMemories({ limit: 25, offset: 10 }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockList).toHaveBeenCalledWith({ workspace: "test-workspace", limit: 25, offset: 10 });
+  });
+
+  it("returns empty when no workspace is selected", async () => {
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: null });
+
+    const { result } = renderHook(() => useInstitutionalMemories(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("skips fetch when enabled=false", async () => {
+    const { result } = renderHook(
+      () => useInstitutionalMemories({ enabled: false }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.fetchStatus).toBe("idle"));
+    expect(mockList).not.toHaveBeenCalled();
+  });
+});
+
+describe("useCreateInstitutionalMemory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: { name: "test-workspace" } });
+  });
+
+  it("posts with workspace injected", async () => {
+    mockCreate.mockResolvedValue(mockMemory);
+
+    const { result } = renderHook(() => useCreateInstitutionalMemory(), { wrapper: createWrapper() });
+
+    await result.current.mutateAsync({ type: "policy", content: "snake_case" });
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      workspace: "test-workspace",
+      type: "policy",
+      content: "snake_case",
+    });
+  });
+
+  it("rejects when no workspace", async () => {
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: null });
+
+    const { result } = renderHook(() => useCreateInstitutionalMemory(), { wrapper: createWrapper() });
+
+    await expect(
+      result.current.mutateAsync({ type: "policy", content: "x" })
+    ).rejects.toThrow(/No workspace/);
+  });
+});
+
+describe("useDeleteInstitutionalMemory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: { name: "test-workspace" } });
+  });
+
+  it("deletes by ID", async () => {
+    mockDelete.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteInstitutionalMemory(), { wrapper: createWrapper() });
+
+    await result.current.mutateAsync("inst-1");
+
+    expect(mockDelete).toHaveBeenCalledWith("test-workspace", "inst-1");
+  });
+
+  it("rejects when no workspace", async () => {
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: null });
+
+    const { result } = renderHook(() => useDeleteInstitutionalMemory(), { wrapper: createWrapper() });
+
+    await expect(result.current.mutateAsync("inst-1")).rejects.toThrow(/No workspace/);
+  });
+});

--- a/dashboard/src/hooks/use-institutional-memories.test.ts
+++ b/dashboard/src/hooks/use-institutional-memories.test.ts
@@ -80,7 +80,7 @@ describe("useInstitutionalMemories", () => {
   });
 
   it("returns empty when no workspace is selected", async () => {
-    mockUseWorkspace.mockReturnValue({ currentWorkspace: null });
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: null as unknown as { name: string } });
 
     const { result } = renderHook(() => useInstitutionalMemories(), { wrapper: createWrapper() });
 
@@ -120,7 +120,7 @@ describe("useCreateInstitutionalMemory", () => {
   });
 
   it("rejects when no workspace", async () => {
-    mockUseWorkspace.mockReturnValue({ currentWorkspace: null });
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: null as unknown as { name: string } });
 
     const { result } = renderHook(() => useCreateInstitutionalMemory(), { wrapper: createWrapper() });
 
@@ -147,7 +147,7 @@ describe("useDeleteInstitutionalMemory", () => {
   });
 
   it("rejects when no workspace", async () => {
-    mockUseWorkspace.mockReturnValue({ currentWorkspace: null });
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: null as unknown as { name: string } });
 
     const { result } = renderHook(() => useDeleteInstitutionalMemory(), { wrapper: createWrapper() });
 

--- a/dashboard/src/hooks/use-institutional-memories.ts
+++ b/dashboard/src/hooks/use-institutional-memories.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useWorkspace } from "@/contexts/workspace-context";
+import {
+  InstitutionalMemoryService,
+  type InstitutionalCreateInput,
+} from "@/lib/data/institutional-memory-service";
+import type { MemoryEntity } from "@/lib/data/types";
+
+const institutionalMemoriesKey = (workspace: string | undefined) =>
+  ["institutional-memories", workspace] as const;
+
+/**
+ * Fetch workspace-scoped institutional memories.
+ */
+export function useInstitutionalMemories(options?: { limit?: number; offset?: number; enabled?: boolean }) {
+  const { currentWorkspace } = useWorkspace();
+  const enabled = options?.enabled ?? true;
+  return useQuery({
+    queryKey: institutionalMemoriesKey(currentWorkspace?.name),
+    queryFn: async () => {
+      if (!currentWorkspace) {
+        return { memories: [] as MemoryEntity[], total: 0 };
+      }
+      const service = new InstitutionalMemoryService();
+      return service.list({
+        workspace: currentWorkspace.name,
+        limit: options?.limit,
+        offset: options?.offset,
+      });
+    },
+    enabled: !!currentWorkspace && enabled,
+    staleTime: 30000,
+  });
+}
+
+/**
+ * Create a new institutional memory. Invalidates the list on success so the
+ * new entry appears without a manual refetch.
+ */
+export function useCreateInstitutionalMemory() {
+  const { currentWorkspace } = useWorkspace();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: Omit<InstitutionalCreateInput, "workspace">) => {
+      if (!currentWorkspace) {
+        throw new Error("No workspace selected");
+      }
+      const service = new InstitutionalMemoryService();
+      return service.create({ ...input, workspace: currentWorkspace.name });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: institutionalMemoriesKey(currentWorkspace?.name) });
+    },
+  });
+}
+
+/**
+ * Soft-delete an institutional memory by ID.
+ */
+export function useDeleteInstitutionalMemory() {
+  const { currentWorkspace } = useWorkspace();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (memoryId: string) => {
+      if (!currentWorkspace) {
+        throw new Error("No workspace selected");
+      }
+      const service = new InstitutionalMemoryService();
+      await service.delete(currentWorkspace.name, memoryId);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: institutionalMemoriesKey(currentWorkspace?.name) });
+    },
+  });
+}

--- a/dashboard/src/lib/data/institutional-memory-service.test.ts
+++ b/dashboard/src/lib/data/institutional-memory-service.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { InstitutionalMemoryService } from "./institutional-memory-service";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe("InstitutionalMemoryService", () => {
+  let service: InstitutionalMemoryService;
+
+  beforeEach(() => {
+    service = new InstitutionalMemoryService();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("list", () => {
+    it("fetches institutional memories for a workspace", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            memories: [
+              {
+                id: "inst-1",
+                type: "policy",
+                content: "snake_case rule",
+                confidence: 1.0,
+                scope: {},
+                createdAt: "2026-04-22T00:00:00Z",
+              },
+            ],
+            total: 1,
+          }),
+      });
+
+      const result = await service.list({ workspace: "my-ws" });
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/workspaces/my-ws/institutional-memory");
+      expect(result.memories).toHaveLength(1);
+      expect(result.total).toBe(1);
+    });
+
+    it("passes limit and offset as query params", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ memories: [], total: 0 }),
+      });
+
+      await service.list({ workspace: "ws", limit: 10, offset: 5 });
+
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain("limit=10");
+      expect(url).toContain("offset=5");
+    });
+
+    it("returns empty on 401/403/404", async () => {
+      for (const status of [401, 403, 404]) {
+        mockFetch.mockResolvedValueOnce({
+          ok: false,
+          status,
+          statusText: "denied",
+        });
+        const result = await service.list({ workspace: "ws" });
+        expect(result).toEqual({ memories: [], total: 0 });
+      }
+    });
+
+    it("throws on other errors", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 500, statusText: "server" });
+      await expect(service.list({ workspace: "ws" })).rejects.toThrow();
+    });
+
+    it("handles missing memories field", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: () => Promise.resolve({}) });
+      const result = await service.list({ workspace: "ws" });
+      expect(result.memories).toEqual([]);
+      expect(result.total).toBe(0);
+    });
+  });
+
+  describe("create", () => {
+    it("posts a new memory and returns the created entity", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            memory: {
+              id: "new-1",
+              type: "policy",
+              content: "API returns ISO timestamps",
+              confidence: 1.0,
+              scope: {},
+              createdAt: "2026-04-22T00:00:00Z",
+            },
+          }),
+      });
+
+      const result = await service.create({
+        workspace: "ws",
+        type: "policy",
+        content: "API returns ISO timestamps",
+      });
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/workspaces/ws/institutional-memory",
+        expect.objectContaining({
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body).toMatchObject({
+        type: "policy",
+        content: "API returns ISO timestamps",
+        confidence: 1.0,
+      });
+      expect(result.id).toBe("new-1");
+    });
+
+    it("defaults confidence to 1.0 and metadata to empty", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ memory: { id: "x", type: "t", content: "c", confidence: 1, scope: {}, createdAt: "" } }),
+      });
+
+      await service.create({ workspace: "ws", type: "t", content: "c" });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.confidence).toBe(1.0);
+      expect(body.metadata).toEqual({});
+    });
+
+    it("forwards metadata and explicit confidence", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ memory: { id: "x", type: "t", content: "c", confidence: 0.8, scope: {}, createdAt: "" } }),
+      });
+
+      await service.create({
+        workspace: "ws",
+        type: "t",
+        content: "c",
+        confidence: 0.8,
+        metadata: { source: "doc" },
+      });
+
+      const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+      expect(body.confidence).toBe(0.8);
+      expect(body.metadata).toEqual({ source: "doc" });
+    });
+
+    it("throws on non-ok responses with the server error message", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "bad",
+        json: () => Promise.resolve({ error: "validation failed" }),
+      });
+      await expect(service.create({ workspace: "ws", type: "t", content: "c" })).rejects.toThrow(/validation failed/);
+    });
+
+    it("falls back to statusText when error body is not JSON", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "server",
+        json: () => Promise.reject(new Error("not json")),
+      });
+      await expect(service.create({ workspace: "ws", type: "t", content: "c" })).rejects.toThrow(/server/);
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes a memory by ID", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+
+      await service.delete("ws", "inst-1");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/workspaces/ws/institutional-memory/inst-1",
+        { method: "DELETE" }
+      );
+    });
+
+    it("encodes URL-unsafe IDs", async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true });
+      await service.delete("ws", "a/b c");
+      const url = mockFetch.mock.calls[0][0] as string;
+      expect(url).toContain("a%2Fb%20c");
+    });
+
+    it("throws on non-ok with server message", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: "bad",
+        json: () => Promise.resolve({ error: "not institutional" }),
+      });
+      await expect(service.delete("ws", "m-1")).rejects.toThrow(/not institutional/);
+    });
+
+    it("falls back to statusText", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "server",
+        json: () => Promise.reject(new Error("nope")),
+      });
+      await expect(service.delete("ws", "m-1")).rejects.toThrow(/server/);
+    });
+  });
+});

--- a/dashboard/src/lib/data/institutional-memory-service.ts
+++ b/dashboard/src/lib/data/institutional-memory-service.ts
@@ -1,0 +1,90 @@
+/**
+ * Institutional memory service for workspace-scoped operator-curated memories.
+ *
+ * Calls the workspace-scoped institutional memory proxy routes:
+ *   /api/workspaces/{name}/institutional-memory
+ *   /api/workspaces/{name}/institutional-memory/{memoryId}
+ */
+
+import type { MemoryEntity, MemoryListResponse } from "./types";
+
+const API_BASE = "/api/workspaces";
+
+export interface InstitutionalListOptions {
+  workspace: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface InstitutionalCreateInput {
+  workspace: string;
+  type: string;
+  content: string;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Service for operator-curated workspace memory CRUD.
+ */
+export class InstitutionalMemoryService {
+  readonly name = "InstitutionalMemoryService";
+
+  async list(options: InstitutionalListOptions): Promise<MemoryListResponse> {
+    const { workspace, limit, offset } = options;
+    const params = new URLSearchParams();
+    if (limit !== undefined) params.set("limit", String(limit));
+    if (offset !== undefined) params.set("offset", String(offset));
+
+    const qs = params.toString();
+    const suffix = qs ? `?${qs}` : "";
+    const response = await fetch(
+      `${API_BASE}/${encodeURIComponent(workspace)}/institutional-memory${suffix}`
+    );
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403 || response.status === 404) {
+        return { memories: [], total: 0 };
+      }
+      throw new Error(`Failed to list institutional memories: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return {
+      memories: data.memories || [],
+      total: data.total ?? 0,
+    };
+  }
+
+  async create(input: InstitutionalCreateInput): Promise<MemoryEntity> {
+    const { workspace, ...body } = input;
+    const response = await fetch(
+      `${API_BASE}/${encodeURIComponent(workspace)}/institutional-memory`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: body.type,
+          content: body.content,
+          confidence: body.confidence ?? 1.0,
+          metadata: body.metadata ?? {},
+        }),
+      }
+    );
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: response.statusText }));
+      throw new Error(`Failed to create institutional memory: ${err.error ?? response.statusText}`);
+    }
+    const data = await response.json();
+    return data.memory as MemoryEntity;
+  }
+
+  async delete(workspace: string, memoryId: string): Promise<void> {
+    const response = await fetch(
+      `${API_BASE}/${encodeURIComponent(workspace)}/institutional-memory/${encodeURIComponent(memoryId)}`,
+      { method: "DELETE" }
+    );
+    if (!response.ok) {
+      const err = await response.json().catch(() => ({ error: response.statusText }));
+      throw new Error(`Failed to delete institutional memory: ${err.error ?? response.statusText}`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds the dashboard backend layer (no UI yet) for the Phase 2a institutional CRUD API:

- Proxy routes at `/api/workspaces/{name}/institutional-memory` (GET+POST) and `/api/workspaces/{name}/institutional-memory/{memoryId}` (DELETE). List is viewer-scoped; create and delete require editor role. The POST proxy substitutes any caller-provided \`workspace_id\` with the authoritative UID so a viewer can't forge writes.
- \`InstitutionalMemoryService\` with list/create/delete methods.
- React Query hooks: \`useInstitutionalMemories\`, \`useCreateInstitutionalMemory\`, \`useDeleteInstitutionalMemory\` with list-cache invalidation on mutations.

## Scope boundaries
- Data layer only. Dashboard page + bulk import UI land in Phase 2c.

## Test plan
- [x] 39 new tests pass locally (service 14, hooks 8, proxy routes 17)
- [x] Per-file coverage ≥80% on every new production file (service 100%, hooks 96%, list/create route 100%, delete route 94.7%)
- [x] ESLint and TypeScript clean
- [ ] CI green