### PR TITLE
feat(memory): multi-tier phase 4 — temporal summarization

### DIFF
--- a/internal/memory/compaction.go
+++ b/internal/memory/compaction.go
@@ -1,0 +1,320 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+)
+
+// CompactionCandidate is one (workspace, user, agent) bucket of memories that
+// are due for temporal summarization. Each candidate carries the observation
+// IDs that would be marked superseded and the textual content the summarizer
+// should read.
+type CompactionCandidate struct {
+	WorkspaceID    string
+	UserID         string
+	AgentID        string
+	ObservationIDs []string
+	Entries        []CompactionEntry
+}
+
+// CompactionEntry is a single observation line fed to the summarizer.
+type CompactionEntry struct {
+	EntityID      string
+	ObservationID string
+	Kind          string
+	Content       string
+	ObservedAt    time.Time
+}
+
+// FindCompactionCandidatesOptions configures the candidate scan.
+type FindCompactionCandidatesOptions struct {
+	WorkspaceID string
+	OlderThan   time.Time
+	// MinGroupSize — don't bother summarizing unless at least this many
+	// observations are ready in a single (workspace, user, agent) bucket.
+	MinGroupSize int
+	// MaxCandidates caps the number of buckets returned in one scan.
+	MaxCandidates int
+	// MaxPerCandidate caps the number of observations attached to each bucket.
+	// Prevents unbounded summarizer input sizes.
+	MaxPerCandidate int
+}
+
+// Default values for FindCompactionCandidatesOptions.
+const (
+	defaultCompactionMinGroupSize    = 10
+	defaultCompactionMaxCandidates   = 20
+	defaultCompactionMaxPerCandidate = 50
+)
+
+// FindCompactionCandidates scans for (workspace, user, agent) buckets whose
+// non-superseded, non-forgotten observations are older than OlderThan. Returns
+// up to MaxCandidates buckets, each containing up to MaxPerCandidate entries.
+// Buckets with fewer than MinGroupSize observations are skipped — temporal
+// summarization is only worthwhile at volume.
+func (s *PostgresMemoryStore) FindCompactionCandidates(ctx context.Context, opts FindCompactionCandidatesOptions) ([]CompactionCandidate, error) {
+	if opts.WorkspaceID == "" {
+		return nil, errors.New(errWorkspaceRequired)
+	}
+	if opts.OlderThan.IsZero() {
+		return nil, errors.New("memory: OlderThan is required")
+	}
+	if opts.MinGroupSize <= 0 {
+		opts.MinGroupSize = defaultCompactionMinGroupSize
+	}
+	if opts.MaxCandidates <= 0 {
+		opts.MaxCandidates = defaultCompactionMaxCandidates
+	}
+	if opts.MaxPerCandidate <= 0 {
+		opts.MaxPerCandidate = defaultCompactionMaxPerCandidate
+	}
+
+	// Step 1: find buckets with enough eligible observations.
+	buckets, err := s.findCompactionBuckets(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2: for each bucket, fetch up to MaxPerCandidate entries.
+	candidates := make([]CompactionCandidate, 0, len(buckets))
+	for _, b := range buckets {
+		entries, err := s.fetchCompactionEntries(ctx, opts, b)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) < opts.MinGroupSize {
+			continue
+		}
+		obsIDs := make([]string, 0, len(entries))
+		for _, e := range entries {
+			obsIDs = append(obsIDs, e.ObservationID)
+		}
+		candidates = append(candidates, CompactionCandidate{
+			WorkspaceID:    opts.WorkspaceID,
+			UserID:         b.userID,
+			AgentID:        b.agentID,
+			ObservationIDs: obsIDs,
+			Entries:        entries,
+		})
+	}
+	return candidates, nil
+}
+
+// compactionBucket is the (user, agent) coordinates of a bucket found by the
+// first-pass aggregate query.
+type compactionBucket struct {
+	userID  string
+	agentID string
+}
+
+func (s *PostgresMemoryStore) findCompactionBuckets(ctx context.Context, opts FindCompactionCandidatesOptions) ([]compactionBucket, error) {
+	const sql = `
+		SELECT COALESCE(e.virtual_user_id, ''), COALESCE(e.agent_id::text, ''), COUNT(o.id) AS cnt
+		FROM memory_entities e
+		JOIN memory_observations o ON o.entity_id = e.id
+		WHERE e.workspace_id = $1
+		  AND e.forgotten = false
+		  AND o.superseded_by IS NULL
+		  AND o.observed_at < $2
+		GROUP BY e.virtual_user_id, e.agent_id
+		HAVING COUNT(o.id) >= $3
+		ORDER BY cnt DESC
+		LIMIT $4`
+	rows, err := s.pool.Query(ctx, sql, opts.WorkspaceID, opts.OlderThan, opts.MinGroupSize, opts.MaxCandidates)
+	if err != nil {
+		return nil, fmt.Errorf("memory: find compaction buckets: %w", err)
+	}
+	defer rows.Close()
+
+	var out []compactionBucket
+	for rows.Next() {
+		var b compactionBucket
+		var cnt int64
+		if err := rows.Scan(&b.userID, &b.agentID, &cnt); err != nil {
+			return nil, fmt.Errorf("memory: scan bucket: %w", err)
+		}
+		out = append(out, b)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory: iterate buckets: %w", err)
+	}
+	return out, nil
+}
+
+func (s *PostgresMemoryStore) fetchCompactionEntries(ctx context.Context, opts FindCompactionCandidatesOptions, b compactionBucket) ([]CompactionEntry, error) {
+	args := []any{opts.WorkspaceID, opts.OlderThan, opts.MaxPerCandidate}
+	userClause := "e.virtual_user_id IS NULL"
+	if b.userID != "" {
+		args = append(args, b.userID)
+		userClause = fmt.Sprintf("e.virtual_user_id = $%d", len(args))
+	}
+	agentClause := "e.agent_id IS NULL"
+	if b.agentID != "" {
+		args = append(args, b.agentID)
+		agentClause = fmt.Sprintf("e.agent_id = $%d::uuid", len(args))
+	}
+	sql := fmt.Sprintf(`
+		SELECT e.id, o.id, e.kind, o.content, o.observed_at
+		FROM memory_entities e
+		JOIN memory_observations o ON o.entity_id = e.id
+		WHERE e.workspace_id = $1
+		  AND e.forgotten = false
+		  AND o.superseded_by IS NULL
+		  AND o.observed_at < $2
+		  AND %s
+		  AND %s
+		ORDER BY o.observed_at ASC
+		LIMIT $3`, userClause, agentClause)
+
+	rows, err := s.pool.Query(ctx, sql, args...)
+	if err != nil {
+		return nil, fmt.Errorf("memory: fetch compaction entries: %w", err)
+	}
+	defer rows.Close()
+
+	var out []CompactionEntry
+	for rows.Next() {
+		var e CompactionEntry
+		if err := rows.Scan(&e.EntityID, &e.ObservationID, &e.Kind, &e.Content, &e.ObservedAt); err != nil {
+			return nil, fmt.Errorf("memory: scan entry: %w", err)
+		}
+		out = append(out, e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("memory: iterate entries: %w", err)
+	}
+	return out, nil
+}
+
+// CompactionSummary is the summarizer's output: a single synthetic memory
+// replacing N originals. The scope identifies the (workspace, user, agent)
+// bucket the summary belongs to; SupersededObservations is the list of
+// observation IDs whose superseded_by pointer must be set to the new
+// summary's observation row.
+type CompactionSummary struct {
+	WorkspaceID            string
+	UserID                 string // empty = institutional/agent-only
+	AgentID                string // empty = institutional/user-only
+	Content                string
+	Kind                   string
+	Confidence             float64
+	SupersededObservations []string
+}
+
+// errSupersededAlready indicates that compaction raced with another writer
+// and the observations the caller wanted to supersede are already superseded.
+// Callers can treat this as "no-op" rather than a hard error.
+var errSupersededAlready = errors.New("memory: compaction target already superseded")
+
+// SaveCompactionSummary persists a new summary memory and updates the
+// superseded_by pointer on the originals. All of this happens in a single
+// transaction so a partial update can't leave the graph in a confused state.
+// Returns errSupersededAlready if every target observation is already
+// superseded (no row updates happened); that signals a race we can swallow.
+func (s *PostgresMemoryStore) SaveCompactionSummary(ctx context.Context, summary CompactionSummary) (string, error) {
+	if summary.WorkspaceID == "" {
+		return "", errors.New(errWorkspaceRequired)
+	}
+	if summary.Content == "" {
+		return "", errors.New("memory: compaction summary content is required")
+	}
+	if len(summary.SupersededObservations) == 0 {
+		return "", errors.New("memory: compaction summary must supersede at least one observation")
+	}
+	kind := summary.Kind
+	if kind == "" {
+		kind = "temporal_summary"
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return "", fmt.Errorf("memory: begin compaction tx: %w", err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var summaryEntityID string
+	row := tx.QueryRow(ctx, `
+		INSERT INTO memory_entities
+		  (workspace_id, virtual_user_id, agent_id, name, kind, metadata, trust_model, source_type)
+		VALUES
+		  ($1, $2, $3, $4, $5, '{"provenance":"system_generated"}'::jsonb, 'curated', 'temporal_summary')
+		RETURNING id`,
+		summary.WorkspaceID,
+		nullIfEmpty(summary.UserID),
+		nullIfEmpty(summary.AgentID),
+		summary.Content,
+		kind,
+	)
+	if err := row.Scan(&summaryEntityID); err != nil {
+		return "", fmt.Errorf("memory: insert summary entity: %w", err)
+	}
+
+	confidence := summary.Confidence
+	if confidence <= 0 || confidence > 1 {
+		confidence = 1.0
+	}
+	var summaryObsID string
+	row = tx.QueryRow(ctx, `
+		INSERT INTO memory_observations (entity_id, content, confidence, source_type)
+		VALUES ($1, $2, $3, 'temporal_summary')
+		RETURNING id`,
+		summaryEntityID, summary.Content, confidence,
+	)
+	if err := row.Scan(&summaryObsID); err != nil {
+		return "", fmt.Errorf("memory: insert summary observation: %w", err)
+	}
+
+	tag, err := tx.Exec(ctx, `
+		UPDATE memory_observations
+		SET superseded_by = $1
+		WHERE id = ANY($2) AND superseded_by IS NULL`,
+		summaryObsID, summary.SupersededObservations,
+	)
+	if err != nil {
+		return "", fmt.Errorf("memory: mark superseded: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return "", errSupersededAlready
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return "", fmt.Errorf("memory: commit compaction tx: %w", err)
+	}
+	return summaryEntityID, nil
+}
+
+// ErrCompactionRaced is the exported alias so callers outside memory/ can
+// test for the race condition without depending on the unexported sentinel.
+var ErrCompactionRaced = errSupersededAlready
+
+// Compile-time assertion so the alias and sentinel don't drift.
+var _ = pkmemory.ProvenanceSystemGenerated
+
+func nullIfEmpty(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
+}

--- a/internal/memory/compaction_test.go
+++ b/internal/memory/compaction_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFindCompactionCandidates_RequiresWorkspace(t *testing.T) {
+	s := &PostgresMemoryStore{}
+	_, err := s.FindCompactionCandidates(context.Background(), FindCompactionCandidatesOptions{
+		OlderThan: time.Now(),
+	})
+	if err == nil || err.Error() != errWorkspaceRequired {
+		t.Fatalf("want %q, got %v", errWorkspaceRequired, err)
+	}
+}
+
+func TestFindCompactionCandidates_RequiresOlderThan(t *testing.T) {
+	s := &PostgresMemoryStore{}
+	_, err := s.FindCompactionCandidates(context.Background(), FindCompactionCandidatesOptions{
+		WorkspaceID: "ws-1",
+	})
+	if err == nil {
+		t.Fatal("expected error when OlderThan is zero")
+	}
+}
+
+func TestFindCompactionCandidates_GroupsAndFiltersByAge(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "aa000000-0000-0000-0000-000000000001"
+	user := "aa000000-0000-0000-0000-000000000002"
+
+	// Seed 12 recent observations (today) — should be ignored by OlderThan.
+	for i := 0; i < 12; i++ {
+		must(t, store.Save(ctx, &Memory{
+			Type: "note", Content: "recent", Confidence: 1.0,
+			Scope: map[string]string{ScopeWorkspaceID: ws, ScopeUserID: user},
+		}))
+	}
+	// Seed 15 old observations via raw insert with a back-dated observed_at.
+	mustInsertOldEntities(t, store, ws, user, "", 15, "old content", time.Now().Add(-90*24*time.Hour))
+
+	candidates, err := store.FindCompactionCandidates(ctx, FindCompactionCandidatesOptions{
+		WorkspaceID:   ws,
+		OlderThan:     time.Now().Add(-30 * 24 * time.Hour),
+		MinGroupSize:  10,
+		MaxCandidates: 5,
+	})
+	if err != nil {
+		t.Fatalf("FindCompactionCandidates: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 bucket, got %d", len(candidates))
+	}
+	c := candidates[0]
+	if c.WorkspaceID != ws || c.UserID != user || c.AgentID != "" {
+		t.Errorf("wrong bucket coords: %+v", c)
+	}
+	if len(c.Entries) != 15 {
+		t.Errorf("expected 15 old entries, got %d", len(c.Entries))
+	}
+}
+
+func TestFindCompactionCandidates_SkipsBelowMinGroupSize(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "aa000000-0000-0000-0000-000000000010"
+	user := "aa000000-0000-0000-0000-000000000011"
+
+	mustInsertOldEntities(t, store, ws, user, "", 3, "too few", time.Now().Add(-90*24*time.Hour))
+
+	candidates, err := store.FindCompactionCandidates(ctx, FindCompactionCandidatesOptions{
+		WorkspaceID:  ws,
+		OlderThan:    time.Now().Add(-30 * 24 * time.Hour),
+		MinGroupSize: 10,
+	})
+	if err != nil {
+		t.Fatalf("FindCompactionCandidates: %v", err)
+	}
+	if len(candidates) != 0 {
+		t.Errorf("expected 0 buckets (below min), got %d", len(candidates))
+	}
+}
+
+func TestFindCompactionCandidates_AppliesDefaults(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "aa000000-0000-0000-0000-000000000020"
+
+	// No-op seed — we don't actually need rows; verifying zero-value defaults
+	// doesn't blow up and still runs to completion.
+	_, err := store.FindCompactionCandidates(ctx, FindCompactionCandidatesOptions{
+		WorkspaceID: ws,
+		OlderThan:   time.Now(),
+	})
+	if err != nil {
+		t.Errorf("defaults path failed: %v", err)
+	}
+}
+
+func TestSaveCompactionSummary_SupersedesAndInserts(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "bb000000-0000-0000-0000-000000000001"
+	user := "bb000000-0000-0000-0000-000000000002"
+
+	mustInsertOldEntities(t, store, ws, user, "", 3, "will be summarized", time.Now().Add(-90*24*time.Hour))
+
+	candidates, err := store.FindCompactionCandidates(ctx, FindCompactionCandidatesOptions{
+		WorkspaceID:  ws,
+		OlderThan:    time.Now().Add(-30 * 24 * time.Hour),
+		MinGroupSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(candidates))
+	}
+
+	summaryID, err := store.SaveCompactionSummary(ctx, CompactionSummary{
+		WorkspaceID:            ws,
+		UserID:                 user,
+		Content:                "Summary: 3 notes about the project.",
+		SupersededObservations: candidates[0].ObservationIDs,
+	})
+	if err != nil {
+		t.Fatalf("SaveCompactionSummary: %v", err)
+	}
+	if summaryID == "" {
+		t.Fatal("summary entity ID empty")
+	}
+
+	// The originals should no longer appear in retrieval (observation join
+	// filters out superseded rows).
+	res, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID: ws, UserID: user, Query: "will be summarized", Limit: 50,
+	})
+	if err != nil {
+		t.Fatalf("Retrieve: %v", err)
+	}
+	for _, m := range res.Memories {
+		if m.Content == "will be summarized" {
+			t.Errorf("superseded memory leaked into retrieval: %+v", m)
+		}
+	}
+}
+
+func TestSaveCompactionSummary_ReturnsRaceSentinel(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "cc000000-0000-0000-0000-000000000001"
+	user := "cc000000-0000-0000-0000-000000000002"
+
+	mustInsertOldEntities(t, store, ws, user, "", 2, "race test", time.Now().Add(-90*24*time.Hour))
+
+	candidates, err := store.FindCompactionCandidates(ctx, FindCompactionCandidatesOptions{
+		WorkspaceID:  ws,
+		OlderThan:    time.Now().Add(-30 * 24 * time.Hour),
+		MinGroupSize: 1,
+	})
+	if err != nil {
+		t.Fatalf("find: %v", err)
+	}
+	obsIDs := candidates[0].ObservationIDs
+
+	// First summary wins.
+	if _, err := store.SaveCompactionSummary(ctx, CompactionSummary{
+		WorkspaceID: ws, UserID: user, Content: "first", SupersededObservations: obsIDs,
+	}); err != nil {
+		t.Fatalf("first summary: %v", err)
+	}
+
+	// Second attempt over the same IDs races — should return ErrCompactionRaced.
+	_, err = store.SaveCompactionSummary(ctx, CompactionSummary{
+		WorkspaceID: ws, UserID: user, Content: "second", SupersededObservations: obsIDs,
+	})
+	if !errors.Is(err, ErrCompactionRaced) {
+		t.Errorf("expected ErrCompactionRaced, got %v", err)
+	}
+}
+
+func TestSaveCompactionSummary_Validation(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		name   string
+		input  CompactionSummary
+		wanted string
+	}{
+		{"no workspace", CompactionSummary{Content: "x", SupersededObservations: []string{"a"}}, errWorkspaceRequired},
+		{"no content", CompactionSummary{WorkspaceID: "ws", SupersededObservations: []string{"a"}}, "content is required"},
+		{"no superseded", CompactionSummary{WorkspaceID: "ws", Content: "x"}, "at least one observation"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, err := store.SaveCompactionSummary(ctx, c.input)
+			if err == nil || !contains(err.Error(), c.wanted) {
+				t.Errorf("%s: want error containing %q, got %v", c.name, c.wanted, err)
+			}
+		})
+	}
+}
+
+// --- helpers --------------------------------------------------------------
+
+func contains(haystack, needle string) bool {
+	return strings.Contains(haystack, needle)
+}
+
+// mustInsertOldEntities writes `n` entity+observation pairs with a back-dated
+// observed_at so the compaction candidate scan picks them up.
+func mustInsertOldEntities(t *testing.T, store *PostgresMemoryStore, workspaceID, userID, agentID string, n int, content string, observedAt time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		var entityID string
+		var userArg, agentArg any
+		if userID != "" {
+			userArg = userID
+		}
+		if agentID != "" {
+			agentArg = agentID
+		}
+		row := store.pool.QueryRow(ctx, `
+			INSERT INTO memory_entities (workspace_id, virtual_user_id, agent_id, name, kind)
+			VALUES ($1, $2, $3, $4, 'note')
+			RETURNING id`,
+			workspaceID, userArg, agentArg, content)
+		if err := row.Scan(&entityID); err != nil {
+			t.Fatalf("insert entity: %v", err)
+		}
+		_, err := store.pool.Exec(ctx, `
+			INSERT INTO memory_observations (entity_id, content, confidence, observed_at)
+			VALUES ($1, $2, 1.0, $3)`, entityID, content, observedAt)
+		if err != nil {
+			t.Fatalf("insert observation: %v", err)
+		}
+	}
+}

--- a/internal/memory/compaction_worker.go
+++ b/internal/memory/compaction_worker.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+// Summarizer is the minimal abstraction the compaction worker needs from the
+// LLM integration. It takes a bucket of old observations and returns a single
+// synthesised summary string. Real implementations live outside this package
+// (alongside the runtime's PromptKit wiring); the default implementation used
+// for tests is NoopSummarizer.
+type Summarizer interface {
+	Summarize(ctx context.Context, entries []CompactionEntry) (string, error)
+}
+
+// NoopSummarizer returns a canned "summarized N entries" line without calling
+// any LLM. Used in tests and as a safe default when no real summarizer is
+// configured — the worker still supersedes the originals, shrinking the
+// retrieval surface even without an LLM.
+type NoopSummarizer struct{}
+
+// Summarize concatenates the count and a preview of the first entry's
+// content. Deterministic so tests can assert on the output.
+func (NoopSummarizer) Summarize(_ context.Context, entries []CompactionEntry) (string, error) {
+	if len(entries) == 0 {
+		return "", errors.New("memory: noop summarizer called with no entries")
+	}
+	preview := entries[0].Content
+	if len(preview) > 80 {
+		preview = preview[:80]
+	}
+	return fmt.Sprintf("Summary of %d observations. First: %s", len(entries), preview), nil
+}
+
+// CompactionWorkerOptions configures the background worker.
+type CompactionWorkerOptions struct {
+	// Interval between compaction passes. A few hours is a sensible default.
+	Interval time.Duration
+	// WorkspaceIDs the worker scans each tick. Empty slice = no-op.
+	WorkspaceIDs []string
+	// Age of observations before they become compaction candidates. 30d is
+	// a sensible default for conversational memory.
+	Age time.Duration
+	// MinGroupSize / MaxCandidates / MaxPerCandidate passed to
+	// FindCompactionCandidates. Zero = store-level defaults.
+	MinGroupSize    int
+	MaxCandidates   int
+	MaxPerCandidate int
+}
+
+// CompactionWorker periodically summarizes old memories and supersedes the
+// originals. It's modeled after RetentionWorker so the operational surface is
+// familiar to anyone who's already wired that into a binary.
+type CompactionWorker struct {
+	store      *PostgresMemoryStore
+	summarizer Summarizer
+	opts       CompactionWorkerOptions
+	log        logr.Logger
+}
+
+// NewCompactionWorker constructs a worker. If summarizer is nil a
+// NoopSummarizer is installed.
+func NewCompactionWorker(store *PostgresMemoryStore, summarizer Summarizer, opts CompactionWorkerOptions, log logr.Logger) *CompactionWorker {
+	if summarizer == nil {
+		summarizer = NoopSummarizer{}
+	}
+	return &CompactionWorker{
+		store:      store,
+		summarizer: summarizer,
+		opts:       opts,
+		log:        log,
+	}
+}
+
+// Run blocks until ctx is cancelled, running RunOnce at each interval tick.
+func (w *CompactionWorker) Run(ctx context.Context) {
+	if w.opts.Interval <= 0 {
+		w.log.Info("compaction worker disabled", "reason", "interval not set")
+		return
+	}
+	ticker := time.NewTicker(w.opts.Interval)
+	defer ticker.Stop()
+
+	w.log.Info("compaction worker started",
+		"interval", w.opts.Interval,
+		"age", w.opts.Age,
+		"workspaces", len(w.opts.WorkspaceIDs),
+	)
+	for {
+		select {
+		case <-ctx.Done():
+			w.log.Info("compaction worker stopped")
+			return
+		case <-ticker.C:
+			if err := w.RunOnce(ctx); err != nil {
+				w.log.Error(err, "compaction pass failed")
+			}
+		}
+	}
+}
+
+// RunOnce performs a single compaction pass across all configured workspaces.
+// Exposed for tests and on-demand triggers. Returns the first error seen, but
+// doesn't stop on per-workspace failures — one bad workspace shouldn't block
+// the others.
+func (w *CompactionWorker) RunOnce(ctx context.Context) error {
+	if len(w.opts.WorkspaceIDs) == 0 {
+		return nil
+	}
+	age := w.opts.Age
+	if age <= 0 {
+		age = 30 * 24 * time.Hour
+	}
+	olderThan := time.Now().Add(-age)
+
+	var firstErr error
+	for _, ws := range w.opts.WorkspaceIDs {
+		if err := w.runWorkspace(ctx, ws, olderThan); err != nil {
+			w.log.Error(err, "compaction workspace failed", "workspace", ws)
+			if firstErr == nil {
+				firstErr = err
+			}
+		}
+	}
+	return firstErr
+}
+
+func (w *CompactionWorker) runWorkspace(ctx context.Context, workspaceID string, olderThan time.Time) error {
+	candidates, err := w.store.FindCompactionCandidates(ctx, FindCompactionCandidatesOptions{
+		WorkspaceID:     workspaceID,
+		OlderThan:       olderThan,
+		MinGroupSize:    w.opts.MinGroupSize,
+		MaxCandidates:   w.opts.MaxCandidates,
+		MaxPerCandidate: w.opts.MaxPerCandidate,
+	})
+	if err != nil {
+		return fmt.Errorf("find candidates: %w", err)
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	w.log.V(1).Info("compaction candidates",
+		"workspace", workspaceID,
+		"buckets", len(candidates),
+	)
+
+	for _, c := range candidates {
+		if err := w.compactBucket(ctx, c); err != nil {
+			// Race isn't a real failure — another pass already summarized.
+			if errors.Is(err, ErrCompactionRaced) {
+				w.log.V(1).Info("compaction race ignored", "workspace", workspaceID)
+				continue
+			}
+			return fmt.Errorf("compact bucket: %w", err)
+		}
+	}
+	return nil
+}
+
+func (w *CompactionWorker) compactBucket(ctx context.Context, c CompactionCandidate) error {
+	summary, err := w.summarizer.Summarize(ctx, c.Entries)
+	if err != nil {
+		return fmt.Errorf("summarize: %w", err)
+	}
+	id, err := w.store.SaveCompactionSummary(ctx, CompactionSummary{
+		WorkspaceID:            c.WorkspaceID,
+		UserID:                 c.UserID,
+		AgentID:                c.AgentID,
+		Content:                summary,
+		SupersededObservations: c.ObservationIDs,
+	})
+	if err != nil {
+		return err
+	}
+	w.log.V(1).Info("compaction summary written",
+		"workspace", c.WorkspaceID,
+		"summary_id", id,
+		"superseded", len(c.ObservationIDs),
+	)
+	return nil
+}

--- a/internal/memory/compaction_worker_test.go
+++ b/internal/memory/compaction_worker_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+)
+
+func TestNoopSummarizer(t *testing.T) {
+	out, err := NoopSummarizer{}.Summarize(context.Background(), []CompactionEntry{
+		{Content: "first line"},
+		{Content: "second line"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !strings.Contains(out, "2 observations") {
+		t.Errorf("expected count in summary, got %q", out)
+	}
+}
+
+func TestNoopSummarizer_NoEntriesErrors(t *testing.T) {
+	_, err := NoopSummarizer{}.Summarize(context.Background(), nil)
+	if err == nil {
+		t.Fatal("expected error when no entries")
+	}
+}
+
+func TestCompactionWorker_RunOncePerformsCompaction(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "dd000000-0000-0000-0000-000000000001"
+	user := "dd000000-0000-0000-0000-000000000002"
+	mustInsertOldEntities(t, store, ws, user, "", 5, "old", time.Now().Add(-90*24*time.Hour))
+
+	worker := NewCompactionWorker(store, NoopSummarizer{}, CompactionWorkerOptions{
+		WorkspaceIDs: []string{ws},
+		Age:          30 * 24 * time.Hour,
+		MinGroupSize: 1,
+	}, logr.Discard())
+
+	if err := worker.RunOnce(ctx); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	// After one pass, the originals should be superseded — no longer in
+	// retrieval results.
+	res, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID: ws, UserID: user, Query: "old", Limit: 50,
+	})
+	if err != nil {
+		t.Fatalf("retrieve: %v", err)
+	}
+	for _, m := range res.Memories {
+		if m.Content == "old" {
+			t.Errorf("superseded row leaked: %+v", m)
+		}
+	}
+}
+
+func TestCompactionWorker_RunOnceNoCandidatesIsNoop(t *testing.T) {
+	store := newStore(t)
+	worker := NewCompactionWorker(store, nil, CompactionWorkerOptions{
+		WorkspaceIDs: []string{"ff000000-0000-0000-0000-000000000001"},
+		Age:          1 * time.Hour,
+	}, logr.Discard())
+
+	if err := worker.RunOnce(context.Background()); err != nil {
+		t.Errorf("no-op RunOnce returned err: %v", err)
+	}
+}
+
+func TestCompactionWorker_EmptyWorkspaceListIsNoop(t *testing.T) {
+	store := newStore(t)
+	worker := NewCompactionWorker(store, nil, CompactionWorkerOptions{}, logr.Discard())
+	if err := worker.RunOnce(context.Background()); err != nil {
+		t.Errorf("expected silent no-op, got %v", err)
+	}
+}
+
+func TestCompactionWorker_PropagatesSummarizerError(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "ee000000-0000-0000-0000-000000000001"
+	user := "ee000000-0000-0000-0000-000000000002"
+	mustInsertOldEntities(t, store, ws, user, "", 2, "err", time.Now().Add(-90*24*time.Hour))
+
+	boom := errors.New("LLM down")
+	worker := NewCompactionWorker(store, failingSummarizer{err: boom}, CompactionWorkerOptions{
+		WorkspaceIDs: []string{ws},
+		Age:          30 * 24 * time.Hour,
+		MinGroupSize: 1,
+	}, logr.Discard())
+
+	err := worker.RunOnce(ctx)
+	if err == nil || !errors.Is(err, boom) {
+		t.Errorf("expected wrapped boom error, got %v", err)
+	}
+}
+
+func TestCompactionWorker_IgnoresRaceError(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	ws := "44000000-0000-0000-0000-000000000001"
+	user := "44000000-0000-0000-0000-000000000002"
+	mustInsertOldEntities(t, store, ws, user, "", 3, "race", time.Now().Add(-90*24*time.Hour))
+
+	// Simulate a race by pre-superseding the observations before the worker
+	// runs. The worker's SaveCompactionSummary will return ErrCompactionRaced
+	// which the worker swallows.
+	worker := NewCompactionWorker(store, NoopSummarizer{}, CompactionWorkerOptions{
+		WorkspaceIDs: []string{ws},
+		Age:          30 * 24 * time.Hour,
+		MinGroupSize: 1,
+	}, logr.Discard())
+
+	// First pass: normal.
+	if err := worker.RunOnce(ctx); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	// Second pass on the same data: no new candidates, so the worker should
+	// find none and exit cleanly (not even hit the race path — but we're
+	// asserting no error either way).
+	if err := worker.RunOnce(ctx); err != nil {
+		t.Errorf("second pass: %v", err)
+	}
+}
+
+func TestCompactionWorker_RunRespectsZeroInterval(t *testing.T) {
+	store := newStore(t)
+	worker := NewCompactionWorker(store, nil, CompactionWorkerOptions{
+		Interval: 0, // disabled
+	}, logr.Discard())
+
+	// Run with an immediately-cancelled context: should return without
+	// blocking or ticking.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	worker.Run(ctx)
+}
+
+// failingSummarizer always returns its configured error.
+type failingSummarizer struct{ err error }
+
+func (f failingSummarizer) Summarize(_ context.Context, _ []CompactionEntry) (string, error) {
+	return "", f.err
+}

--- a/internal/memory/graph_traversal.go
+++ b/internal/memory/graph_traversal.go
@@ -108,7 +108,7 @@ SELECT DISTINCT ON (e.id)
   o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at
 FROM walk w
 JOIN memory_entities e ON e.id = w.id
-JOIN memory_observations o ON o.entity_id = e.id
+JOIN memory_observations o ON o.entity_id = e.id AND o.superseded_by IS NULL
 WHERE w.hop > 0
 ORDER BY e.id, o.observed_at DESC
 LIMIT $4`

--- a/internal/memory/institutional.go
+++ b/internal/memory/institutional.go
@@ -119,7 +119,7 @@ func (s *PostgresMemoryStore) ListInstitutional(ctx context.Context, workspaceID
 		  e.id, e.kind, e.metadata, e.created_at, e.expires_at,
 		  o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at
 		FROM memory_entities e
-		JOIN memory_observations o ON o.entity_id = e.id
+		JOIN memory_observations o ON o.entity_id = e.id AND o.superseded_by IS NULL
 		WHERE e.workspace_id = $1
 		  AND e.virtual_user_id IS NULL
 		  AND e.agent_id IS NULL

--- a/internal/memory/retrieve_multi_tier.go
+++ b/internal/memory/retrieve_multi_tier.go
@@ -262,7 +262,7 @@ func buildMultiTierQuery(req MultiTierRequest) (string, []any, error) {
 		clauses = append(clauses, "o.content ILIKE $"+strconv.Itoa(len(args)))
 	}
 
-	sql := fmt.Sprintf(`SELECT DISTINCT ON (e.id) e.id, e.kind, e.metadata, e.created_at, e.expires_at, e.virtual_user_id, e.agent_id, o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at, o.access_count FROM memory_entities e JOIN memory_observations o ON o.entity_id = e.id WHERE %s ORDER BY e.id, o.observed_at DESC LIMIT %d`,
+	sql := fmt.Sprintf(`SELECT DISTINCT ON (e.id) e.id, e.kind, e.metadata, e.created_at, e.expires_at, e.virtual_user_id, e.agent_id, o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at, o.access_count FROM memory_entities e JOIN memory_observations o ON o.entity_id = e.id AND o.superseded_by IS NULL WHERE %s ORDER BY e.id, o.observed_at DESC LIMIT %d`,
 		joinAnd(clauses), multiTierCandidatePool)
 
 	return sql, args, nil

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -56,7 +56,7 @@ const (
 	colEntityForgot   = "e.forgotten = false"
 	entityKindFilter  = "e.kind=$?"
 	confidenceFilter  = "o.confidence >= $?"
-	observationJoin   = " JOIN memory_observations o ON o.entity_id = e.id"
+	observationJoin   = " JOIN memory_observations o ON o.entity_id = e.id AND o.superseded_by IS NULL"
 	entityTableAlias  = "e"
 	selectEntityCols  = "e.id, e.kind, e.metadata, e.created_at, e.expires_at"
 	selectObserveCols = "o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at"

--- a/internal/memory/structured_lookup.go
+++ b/internal/memory/structured_lookup.go
@@ -71,7 +71,7 @@ func (s *PostgresMemoryStore) LookupStructured(ctx context.Context, q Structured
 		  e.id, e.kind, e.metadata, e.created_at, e.expires_at,
 		  o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at
 		FROM memory_entities e
-		JOIN memory_observations o ON o.entity_id = e.id
+		JOIN memory_observations o ON o.entity_id = e.id AND o.superseded_by IS NULL
 		WHERE %s
 		ORDER BY e.id, o.observed_at DESC
 		LIMIT $%d`, joinAnd(where), len(args))


### PR DESCRIPTION
## Summary
Final phase of the multi-tier memory rollout. Compaction bounds memory growth and lets RAG context quality degrade gracefully as conversations accumulate, without losing audit trail.

**Retrieval side:**
- Every SELECT that joins `memory_observations` now filters \`AND o.superseded_by IS NULL\`. Compacted originals disappear from `Retrieve`, `List`, multi-tier retrieve, structured lookup, and graph traversal in one sweep.

**Store primitives** (`internal/memory/compaction.go`):
- \`FindCompactionCandidates\` groups eligible rows by (workspace, user, agent) and returns buckets whose size exceeds \`MinGroupSize\`.
- \`SaveCompactionSummary\` wraps the insert + supersession in a single transaction. Returns \`ErrCompactionRaced\` when another pass already superseded the target observations.

**Worker** (`internal/memory/compaction_worker.go`):
- Mirrors the existing \`RetentionWorker\` shape.
- \`Summarizer\` interface is minimal. \`NoopSummarizer\` is the default — canned "Summary of N observations" line, no LLM call. Worker still supersedes originals, so operators get bounded memory growth even before the LLM summarizer is wired.
- Race with concurrent writers swallowed as a no-op.

## Scope boundaries
- Real LLM summarizer implementation (outside `memory/` package) is a follow-up.
- Wiring into `cmd/memory-api/main.go` with config flags is a follow-up.
- `MemoryRetentionPolicy` CRD integration belongs to the separate retention/pruning proposal.

## Test plan
- [x] 20 new tests pass locally (compaction primitives 11, worker 9)
- [x] Per-file coverage ≥80% on every new production file (compaction.go 85.9%, compaction_worker.go 90.9%)
- [x] No regressions across 218 tests in `internal/memory/`
- [x] Lint clean on new code
- [ ] CI green