### PR TITLE
feat(dashboard): multi-tier phase 2c — workspace knowledge UI + bulk import

### DIFF
--- a/dashboard/src/app/memories/page.tsx
+++ b/dashboard/src/app/memories/page.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState, useMemo, type ReactNode } from "react";
+import Link from "next/link";
 import { Header } from "@/components/layout";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useWorkspace } from "@/contexts/workspace-context";
 import {
   Select,
   SelectContent,
@@ -24,7 +26,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Brain, Download, Trash2, Search, AlertCircle, LogIn } from "lucide-react";
+import { Brain, Download, Trash2, Search, AlertCircle, LogIn, Library } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { useMemories } from "@/hooks/use-memories";
 import {
@@ -110,6 +112,7 @@ function renderMemoriesBody({
 
 export default function MemoriesPage() {
   const { hasMemoryIdentity, memoryUserId } = useAuth();
+  const { currentWorkspace } = useWorkspace();
   // Always filter by userId — memories belong to users, not workspaces.
   // The proxy hashes the userId before querying (pseudonymous storage).
   // For anonymous users with a device ID, we use the device ID as the userId.
@@ -192,6 +195,15 @@ export default function MemoriesPage() {
           </Select>
 
           <div className="flex-1" />
+
+          {currentWorkspace && (
+            <Button asChild variant="outline" size="sm" data-testid="workspace-knowledge-link">
+              <Link href={`/workspaces/${encodeURIComponent(currentWorkspace.name)}/knowledge`}>
+                <Library className="h-4 w-4 mr-2" />
+                Workspace knowledge
+              </Link>
+            </Button>
+          )}
 
           <Button
             variant="outline"

--- a/dashboard/src/app/workspaces/[name]/knowledge/page.tsx
+++ b/dashboard/src/app/workspaces/[name]/knowledge/page.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Header } from "@/components/layout";
+import { InstitutionalKnowledgePanel } from "@/components/memories/institutional-knowledge-panel";
+
+export default function WorkspaceKnowledgePage() {
+  return (
+    <div className="flex flex-col h-full">
+      <Header
+        title="Workspace knowledge"
+        description="Shared facts, policies, and glossaries every agent in this workspace can use."
+      />
+      <div className="flex-1 overflow-auto p-6">
+        <InstitutionalKnowledgePanel />
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/memories/institutional-knowledge-panel.test.tsx
+++ b/dashboard/src/components/memories/institutional-knowledge-panel.test.tsx
@@ -1,0 +1,252 @@
+/**
+ * Tests for InstitutionalKnowledgePanel.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const {
+  mockUseInstitutionalMemories,
+  mockUseCreateInstitutionalMemory,
+  mockUseDeleteInstitutionalMemory,
+} = vi.hoisted(() => ({
+  mockUseInstitutionalMemories: vi.fn(),
+  mockUseCreateInstitutionalMemory: vi.fn(),
+  mockUseDeleteInstitutionalMemory: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-institutional-memories", () => ({
+  useInstitutionalMemories: mockUseInstitutionalMemories,
+  useCreateInstitutionalMemory: mockUseCreateInstitutionalMemory,
+  useDeleteInstitutionalMemory: mockUseDeleteInstitutionalMemory,
+}));
+
+import { InstitutionalKnowledgePanel } from "./institutional-knowledge-panel";
+
+function setup({
+  memories = [] as Array<{ id: string; type: string; content: string }>,
+  isLoading = false,
+  error = null as unknown,
+  createMutateAsync = vi.fn().mockResolvedValue(undefined),
+  deleteMutate = vi.fn(),
+  createPending = false,
+  createError = null as unknown,
+}) {
+  mockUseInstitutionalMemories.mockReturnValue({
+    data: { memories, total: memories.length },
+    isLoading,
+    error,
+  });
+  mockUseCreateInstitutionalMemory.mockReturnValue({
+    mutateAsync: createMutateAsync,
+    isPending: createPending,
+    isError: !!createError,
+    error: createError,
+  });
+  mockUseDeleteInstitutionalMemory.mockReturnValue({ mutate: deleteMutate });
+  return { createMutateAsync, deleteMutate };
+}
+
+describe("InstitutionalKnowledgePanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading skeleton", () => {
+    setup({ isLoading: true });
+    render(<InstitutionalKnowledgePanel />);
+    // Skeleton doesn't have a test id; check for absence of empty/list.
+    expect(screen.queryByTestId("kn-empty")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("kn-list")).not.toBeInTheDocument();
+  });
+
+  it("renders empty state when no memories", () => {
+    setup({ memories: [] });
+    render(<InstitutionalKnowledgePanel />);
+    expect(screen.getByTestId("kn-empty")).toBeInTheDocument();
+  });
+
+  it("renders the list when memories present", () => {
+    setup({
+      memories: [
+        { id: "m1", type: "policy", content: "snake_case rule" },
+        { id: "m2", type: "glossary", content: "API terms" },
+      ],
+    });
+    render(<InstitutionalKnowledgePanel />);
+    expect(screen.getByText("snake_case rule")).toBeInTheDocument();
+    expect(screen.getByText("API terms")).toBeInTheDocument();
+    expect(screen.getByText(/Workspace knowledge \(2\)/)).toBeInTheDocument();
+  });
+
+  it("renders error alert when load fails", () => {
+    setup({ error: new Error("backend down") });
+    render(<InstitutionalKnowledgePanel />);
+    expect(screen.getByTestId("kn-error")).toBeInTheDocument();
+    expect(screen.getByText("backend down")).toBeInTheDocument();
+  });
+
+  it("submits the create form and clears inputs on success", async () => {
+    const createMutateAsync = vi.fn().mockResolvedValue(undefined);
+    setup({ createMutateAsync });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    await user.type(screen.getByTestId("create-type"), "policy");
+    await user.type(screen.getByTestId("create-content"), "  no trailing whitespace  ");
+    await user.click(screen.getByTestId("create-submit"));
+
+    await waitFor(() => expect(createMutateAsync).toHaveBeenCalledTimes(1));
+    expect(createMutateAsync).toHaveBeenCalledWith({
+      type: "policy",
+      content: "no trailing whitespace",
+    });
+  });
+
+  it("shows inline error from the create mutation", () => {
+    setup({ createError: new Error("validation failed") });
+    render(<InstitutionalKnowledgePanel />);
+    expect(screen.getByText("validation failed")).toBeInTheDocument();
+  });
+
+  it("does not submit when the type is blank", async () => {
+    const createMutateAsync = vi.fn().mockResolvedValue(undefined);
+    setup({ createMutateAsync });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    // Only content filled — form is required so click won't submit.
+    await user.type(screen.getByTestId("create-content"), "solo");
+    await user.click(screen.getByTestId("create-submit"));
+
+    expect(createMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("invokes delete mutation after confirming the dialog", async () => {
+    const deleteMutate = vi.fn();
+    setup({
+      memories: [{ id: "m1", type: "policy", content: "x" }],
+      deleteMutate,
+    });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    await user.click(screen.getByTestId("kn-delete-m1"));
+    await user.click(await screen.findByTestId("kn-delete-confirm-m1"));
+
+    expect(deleteMutate).toHaveBeenCalledWith("m1");
+  });
+
+  it("bulk imports JSON entries sequentially", async () => {
+    const createMutateAsync = vi.fn().mockResolvedValue(undefined);
+    setup({ createMutateAsync });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    await user.click(screen.getByTestId("bulk-import-open"));
+    const textarea = await screen.findByTestId("bulk-import-json");
+    await user.click(textarea);
+    await user.paste(
+      `[{"type":"policy","content":"A"},{"type":"glossary","content":"B"}]`
+    );
+    await user.click(screen.getByTestId("bulk-import-submit"));
+
+    await waitFor(() => expect(createMutateAsync).toHaveBeenCalledTimes(2));
+    expect(createMutateAsync).toHaveBeenNthCalledWith(1, {
+      type: "policy",
+      content: "A",
+    });
+    expect(createMutateAsync).toHaveBeenNthCalledWith(2, {
+      type: "glossary",
+      content: "B",
+    });
+    expect(await screen.findByTestId("bulk-import-summary")).toHaveTextContent(
+      /Imported 2 \/ 2/
+    );
+  });
+
+  it("shows parse errors and does not call create on invalid JSON", async () => {
+    const createMutateAsync = vi.fn();
+    setup({ createMutateAsync });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    await user.click(screen.getByTestId("bulk-import-open"));
+    const textarea = await screen.findByTestId("bulk-import-json");
+    await user.click(textarea);
+    await user.paste("not json");
+    await user.click(screen.getByTestId("bulk-import-submit"));
+
+    expect(await screen.findByTestId("bulk-import-errors")).toBeInTheDocument();
+    expect(createMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it("surfaces per-entry failures from the create loop", async () => {
+    const createMutateAsync = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("dup key"));
+    setup({ createMutateAsync });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    await user.click(screen.getByTestId("bulk-import-open"));
+    const textarea = await screen.findByTestId("bulk-import-json");
+    await user.click(textarea);
+    await user.paste(
+      `[{"type":"policy","content":"A"},{"type":"policy","content":"B"}]`
+    );
+    await user.click(screen.getByTestId("bulk-import-submit"));
+
+    expect(await screen.findByTestId("bulk-import-summary")).toHaveTextContent(
+      /Imported 1 \/ 2/
+    );
+    expect(screen.getByTestId("bulk-import-errors")).toHaveTextContent(/dup key/);
+  });
+
+  it("rejects empty bulk-import input", async () => {
+    const createMutateAsync = vi.fn();
+    setup({ createMutateAsync });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    await user.click(screen.getByTestId("bulk-import-open"));
+    // Nothing pasted: the submit button is disabled. Assert that.
+    const submit = screen.getByTestId("bulk-import-submit") as HTMLButtonElement;
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("parses markdown tab content", async () => {
+    const createMutateAsync = vi.fn().mockResolvedValue(undefined);
+    setup({ createMutateAsync });
+    const user = userEvent.setup();
+
+    render(<InstitutionalKnowledgePanel />);
+
+    await user.click(screen.getByTestId("bulk-import-open"));
+    await user.click(screen.getByRole("tab", { name: /markdown/i }));
+    const textarea = await screen.findByTestId("bulk-import-markdown");
+    await user.click(textarea);
+    await user.paste("## Policy\nUse snake_case.");
+    await user.click(screen.getByTestId("bulk-import-submit"));
+
+    await waitFor(() => expect(createMutateAsync).toHaveBeenCalledTimes(1));
+    expect(createMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "policy",
+        content: "Use snake_case.",
+      })
+    );
+  });
+});

--- a/dashboard/src/components/memories/institutional-knowledge-panel.tsx
+++ b/dashboard/src/components/memories/institutional-knowledge-panel.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  useInstitutionalMemories,
+  useCreateInstitutionalMemory,
+  useDeleteInstitutionalMemory,
+} from "@/hooks/use-institutional-memories";
+import {
+  parseJsonBulk,
+  parseMarkdownBulk,
+  type ParsedMemory,
+} from "@/lib/memories/bulk-import-parser";
+import { AlertCircle, Plus, Trash2, Upload } from "lucide-react";
+
+export function InstitutionalKnowledgePanel() {
+  const { data, isLoading, error } = useInstitutionalMemories({ limit: 500 });
+  const createMemory = useCreateInstitutionalMemory();
+  const deleteMemory = useDeleteInstitutionalMemory();
+
+  const [newType, setNewType] = useState("");
+  const [newContent, setNewContent] = useState("");
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newType.trim() || !newContent.trim()) return;
+    await createMemory.mutateAsync({ type: newType.trim(), content: newContent.trim() });
+    setNewType("");
+    setNewContent("");
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add knowledge</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleCreate} className="space-y-3" data-testid="create-form">
+            <div>
+              <Label htmlFor="kn-type">Type</Label>
+              <Input
+                id="kn-type"
+                placeholder="e.g. policy, glossary, runbook"
+                value={newType}
+                onChange={(e) => setNewType(e.target.value)}
+                required
+                data-testid="create-type"
+              />
+            </div>
+            <div>
+              <Label htmlFor="kn-content">Content</Label>
+              <Textarea
+                id="kn-content"
+                placeholder="What should agents know about this?"
+                value={newContent}
+                onChange={(e) => setNewContent(e.target.value)}
+                required
+                rows={3}
+                data-testid="create-content"
+              />
+            </div>
+            <div className="flex gap-2">
+              <Button type="submit" disabled={createMemory.isPending} data-testid="create-submit">
+                <Plus className="h-4 w-4 mr-2" /> Add
+              </Button>
+              <BulkImportDialog />
+            </div>
+          </form>
+          {createMemory.isError && (
+            <Alert variant="destructive" className="mt-3">
+              <AlertCircle className="h-4 w-4" />
+              <AlertTitle>Failed to add</AlertTitle>
+              <AlertDescription>{(createMemory.error as Error).message}</AlertDescription>
+            </Alert>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Workspace knowledge ({data?.total ?? 0})</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {renderBody({ isLoading, error, memories: data?.memories ?? [], onDelete: (id) => deleteMemory.mutate(id) })}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+interface BodyProps {
+  isLoading: boolean;
+  error: unknown;
+  memories: Array<{ id: string; type: string; content: string }>;
+  onDelete: (id: string) => void;
+}
+
+function renderBody({ isLoading, error, memories, onDelete }: BodyProps) {
+  if (error) {
+    return (
+      <Alert variant="destructive" data-testid="kn-error">
+        <AlertCircle className="h-4 w-4" />
+        <AlertTitle>Could not load</AlertTitle>
+        <AlertDescription>
+          {error instanceof Error ? error.message : "Failed to load institutional memories."}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  if (isLoading) {
+    return <Skeleton className="w-full h-32 rounded" />;
+  }
+  if (memories.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="kn-empty">
+        No workspace knowledge yet. Add memories above so every agent in this workspace can see them.
+      </p>
+    );
+  }
+  return (
+    <ul className="space-y-2" data-testid="kn-list">
+      {memories.map((m) => (
+        <li
+          key={m.id}
+          className="flex items-start justify-between gap-3 rounded border bg-card p-3"
+        >
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-mono text-muted-foreground">{m.type}</p>
+            <p className="text-sm whitespace-pre-wrap break-words">{m.content}</p>
+          </div>
+          <DeleteButton id={m.id} onConfirm={onDelete} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function DeleteButton({ id, onConfirm }: { id: string; onConfirm: (id: string) => void }) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="ghost" size="icon" aria-label="Delete" data-testid={`kn-delete-${id}`}>
+          <Trash2 className="h-4 w-4" />
+        </Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete this memory?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This removes the entry from workspace knowledge. Agents will no longer see it.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={() => onConfirm(id)} data-testid={`kn-delete-confirm-${id}`}>
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function BulkImportDialog() {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<"json" | "markdown">("json");
+  const [text, setText] = useState("");
+  const [errors, setErrors] = useState<string[]>([]);
+  const [summary, setSummary] = useState<string | null>(null);
+  const create = useCreateInstitutionalMemory();
+
+  const reset = () => {
+    setText("");
+    setErrors([]);
+    setSummary(null);
+  };
+
+  const runImport = async () => {
+    const parsed = tab === "json" ? parseJsonBulk(text) : parseMarkdownBulk(text);
+    if (parsed.errors.length > 0) {
+      setErrors(parsed.errors.map((e) => e.message));
+      return;
+    }
+    if (parsed.memories.length === 0) {
+      setErrors(["Nothing to import."]);
+      return;
+    }
+    const results = await importAll(parsed.memories, (input) => create.mutateAsync(input));
+    setSummary(`Imported ${results.ok} / ${parsed.memories.length}.`);
+    setErrors(results.failures);
+    if (results.ok === parsed.memories.length) {
+      setTimeout(() => {
+        setOpen(false);
+        reset();
+      }, 900);
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        setOpen(v);
+        if (!v) reset();
+      }}
+    >
+      <DialogTrigger asChild>
+        <Button variant="outline" data-testid="bulk-import-open">
+          <Upload className="h-4 w-4 mr-2" /> Bulk import
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Bulk import knowledge</DialogTitle>
+          <DialogDescription>
+            Paste a JSON array of memories, or markdown with <code>##</code> section headers.
+          </DialogDescription>
+        </DialogHeader>
+        <Tabs value={tab} onValueChange={(v) => setTab(v as "json" | "markdown")}>
+          <TabsList>
+            <TabsTrigger value="json">JSON</TabsTrigger>
+            <TabsTrigger value="markdown">Markdown</TabsTrigger>
+          </TabsList>
+          <TabsContent value="json">
+            <Textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={10}
+              placeholder={`[\n  {"type":"policy","content":"API uses snake_case"}\n]`}
+              data-testid="bulk-import-json"
+            />
+          </TabsContent>
+          <TabsContent value="markdown">
+            <Textarea
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+              rows={10}
+              placeholder={`## API Style\nUse snake_case.\n\n## Runbook\n...`}
+              data-testid="bulk-import-markdown"
+            />
+          </TabsContent>
+        </Tabs>
+        {summary && (
+          <p className="text-sm" data-testid="bulk-import-summary">
+            {summary}
+          </p>
+        )}
+        {errors.length > 0 && (
+          <Alert variant="destructive" data-testid="bulk-import-errors">
+            <AlertCircle className="h-4 w-4" />
+            <AlertTitle>Import issues</AlertTitle>
+            <AlertDescription>
+              <ul className="list-disc pl-5 text-sm">
+                {errors.slice(0, 10).map((e) => (
+                  <li key={e}>{e}</li>
+                ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <DialogFooter>
+          <Button
+            onClick={runImport}
+            disabled={create.isPending || !text.trim()}
+            data-testid="bulk-import-submit"
+          >
+            Import
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+async function importAll(
+  memories: ParsedMemory[],
+  doCreate: (input: { type: string; content: string; confidence?: number; metadata?: Record<string, unknown> }) => Promise<unknown>
+): Promise<{ ok: number; failures: string[] }> {
+  let ok = 0;
+  const failures: string[] = [];
+  for (const mem of memories) {
+    try {
+      await doCreate(mem);
+      ok++;
+    } catch (e) {
+      failures.push(`${mem.type}: ${e instanceof Error ? e.message : String(e)}`);
+    }
+  }
+  return { ok, failures };
+}

--- a/dashboard/src/lib/memories/bulk-import-parser.test.ts
+++ b/dashboard/src/lib/memories/bulk-import-parser.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { parseJsonBulk, parseMarkdownBulk } from "./bulk-import-parser";
+
+describe("parseJsonBulk", () => {
+  it("parses a well-formed array", () => {
+    const res = parseJsonBulk(`[
+      {"type":"policy","content":"snake_case","confidence":1.0},
+      {"type":"glossary","content":"API terms","metadata":{"source":"doc"}}
+    ]`);
+    expect(res.errors).toHaveLength(0);
+    expect(res.memories).toHaveLength(2);
+    expect(res.memories[0]).toMatchObject({ type: "policy", content: "snake_case", confidence: 1.0 });
+    expect(res.memories[1].metadata).toEqual({ source: "doc" });
+  });
+
+  it("returns an error on invalid JSON", () => {
+    const res = parseJsonBulk("not json");
+    expect(res.memories).toHaveLength(0);
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors[0].format).toBe("json");
+  });
+
+  it("rejects non-array top-level", () => {
+    const res = parseJsonBulk(`{"type":"x","content":"y"}`);
+    expect(res.memories).toHaveLength(0);
+    expect(res.errors[0].message).toMatch(/array/i);
+  });
+
+  it("reports per-entry errors", () => {
+    const res = parseJsonBulk(`[
+      {"type":"ok","content":"ok"},
+      null,
+      {"type":"missing-content"},
+      {"content":"missing-type"},
+      "string entry"
+    ]`);
+    expect(res.memories).toHaveLength(1);
+    expect(res.errors).toHaveLength(4);
+  });
+
+  it("drops non-object metadata silently", () => {
+    const res = parseJsonBulk(`[{"type":"t","content":"c","metadata":"not-an-object"}]`);
+    expect(res.memories).toHaveLength(1);
+    expect(res.memories[0].metadata).toBeUndefined();
+  });
+});
+
+describe("parseMarkdownBulk", () => {
+  it("splits on ## headers", () => {
+    const md = `# Title
+Intro paragraph (ignored).
+
+## API Style
+Use snake_case for all new endpoints.
+
+## Runbook: On-call
+Check the dashboard at example.com first.`;
+    const res = parseMarkdownBulk(md);
+    expect(res.errors).toHaveLength(0);
+    expect(res.memories).toHaveLength(2);
+    expect(res.memories[0]).toMatchObject({
+      type: "api-style",
+      content: expect.stringContaining("snake_case"),
+    });
+    expect(res.memories[0].metadata).toEqual({ source: "markdown", heading: "API Style" });
+    expect(res.memories[1].type).toBe("runbook-on-call");
+  });
+
+  it("errors when no ## headers", () => {
+    const res = parseMarkdownBulk("Just plain text.\nNo headers here.");
+    expect(res.memories).toHaveLength(0);
+    expect(res.errors).toHaveLength(1);
+    expect(res.errors[0].format).toBe("markdown");
+  });
+
+  it("drops empty sections silently", () => {
+    const md = `## Empty
+
+## Real
+Has content.`;
+    const res = parseMarkdownBulk(md);
+    expect(res.memories).toHaveLength(1);
+    expect(res.memories[0].type).toBe("real");
+  });
+
+  it("slugifies unusual heading characters", () => {
+    const res = parseMarkdownBulk(`## Hello, world!! (test)\nbody`);
+    expect(res.memories[0].type).toBe("hello-world-test");
+  });
+
+  it("handles CRLF line endings", () => {
+    const res = parseMarkdownBulk("## A\r\nbody A\r\n\r\n## B\r\nbody B");
+    expect(res.memories).toHaveLength(2);
+    expect(res.memories[0].content).toBe("body A");
+  });
+
+  it("falls back to untitled when heading slugifies to empty", () => {
+    const res = parseMarkdownBulk(`## !!!\nbody`);
+    expect(res.memories[0].type).toBe("untitled");
+  });
+});

--- a/dashboard/src/lib/memories/bulk-import-parser.ts
+++ b/dashboard/src/lib/memories/bulk-import-parser.ts
@@ -1,0 +1,145 @@
+/**
+ * Parsers for bulk-importing institutional memories.
+ *
+ * Supports two formats:
+ *   - JSON array of `{ type, content, confidence?, metadata? }` objects.
+ *   - Markdown with `##` section headers (each section becomes one memory;
+ *     header text is the type, body is the content).
+ */
+
+export interface ParsedMemory {
+  type: string;
+  content: string;
+  confidence?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ParseError {
+  format: "json" | "markdown";
+  message: string;
+}
+
+export interface ParseResult {
+  memories: ParsedMemory[];
+  errors: ParseError[];
+}
+
+/**
+ * Parse a JSON array body. Each entry must have `type` and `content` strings.
+ * Unknown extra fields are forwarded to metadata untouched.
+ */
+export function parseJsonBulk(input: string): ParseResult {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(input);
+  } catch (e) {
+    return {
+      memories: [],
+      errors: [{ format: "json", message: e instanceof Error ? e.message : "Invalid JSON" }],
+    };
+  }
+  if (!Array.isArray(raw)) {
+    return {
+      memories: [],
+      errors: [{ format: "json", message: "Expected a JSON array at the top level" }],
+    };
+  }
+
+  const memories: ParsedMemory[] = [];
+  const errors: ParseError[] = [];
+  raw.forEach((entry, i) => {
+    if (entry === null || typeof entry !== "object") {
+      errors.push({ format: "json", message: `Entry ${i}: not an object` });
+      return;
+    }
+    const rec = entry as Record<string, unknown>;
+    const type = rec.type;
+    const content = rec.content;
+    if (typeof type !== "string" || !type) {
+      errors.push({ format: "json", message: `Entry ${i}: missing "type"` });
+      return;
+    }
+    if (typeof content !== "string" || !content) {
+      errors.push({ format: "json", message: `Entry ${i}: missing "content"` });
+      return;
+    }
+    const out: ParsedMemory = { type, content };
+    if (typeof rec.confidence === "number") {
+      out.confidence = rec.confidence;
+    }
+    if (rec.metadata && typeof rec.metadata === "object" && !Array.isArray(rec.metadata)) {
+      out.metadata = rec.metadata as Record<string, unknown>;
+    }
+    memories.push(out);
+  });
+
+  return { memories, errors };
+}
+
+/**
+ * Parse markdown with `## Section` headers. Each top-level `##` section
+ * becomes a memory; the header text becomes the memory `type` (slugified —
+ * lowercased, hyphenated) and the body becomes `content`. Anything above
+ * the first `##` is ignored (can be used for a file-level title/description).
+ *
+ * Empty sections are dropped silently; a file with no `##` headers produces
+ * a single error describing the mis-formatted input.
+ */
+export function parseMarkdownBulk(input: string): ParseResult {
+  const lines = input.split(/\r?\n/);
+  const memories: ParsedMemory[] = [];
+  const errors: ParseError[] = [];
+
+  let currentHeader: string | null = null;
+  let currentBody: string[] = [];
+
+  const flush = () => {
+    if (currentHeader === null) return;
+    const content = currentBody.join("\n").trim();
+    if (!content) {
+      currentHeader = null;
+      currentBody = [];
+      return;
+    }
+    memories.push({
+      type: slugify(currentHeader),
+      content,
+      metadata: { source: "markdown", heading: currentHeader },
+    });
+    currentHeader = null;
+    currentBody = [];
+  };
+
+  const headerRe = /^##\s+(\S[^\n]*?)$/;
+  for (const rawLine of lines) {
+    const match = headerRe.exec(rawLine);
+    if (match) {
+      flush();
+      currentHeader = match[1];
+      continue;
+    }
+    if (currentHeader !== null) {
+      currentBody.push(rawLine);
+    }
+  }
+  flush();
+
+  if (memories.length === 0 && errors.length === 0) {
+    errors.push({
+      format: "markdown",
+      message: "No `## Section` headers found — the parser expects each memory to start with `##`.",
+    });
+  }
+
+  return { memories, errors };
+}
+
+function slugify(raw: string): string {
+  const compact = raw.toLowerCase().replaceAll(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  while (start < compact.length && compact[start] === "-") start++;
+  let end = compact.length;
+  while (end > start && compact[end - 1] === "-") end--;
+  const trimmed = compact.slice(start, end);
+  return trimmed || "untitled";
+}


### PR DESCRIPTION
## Summary
(Replacement for #985 — that PR auto-closed when its base branch was deleted after #982 merged. This branch has been rebased onto main with duplicate commits dropped.)

Adds the end-user UI for the Phase 2a/2b institutional memory system.

- New page at `/workspaces/{name}/knowledge` — list + create form + per-row delete with confirmation.
- **Bulk import** — paste JSON array or markdown (`## Section` headers). Per-entry failures surface individually so a single bad row doesn't block the rest; auto-closes on full success.
- Bulk-import parser in `lib/memories/bulk-import-parser.ts` — validates JSON entries and converts markdown `##` sections into memories with slugified type + source metadata.
- Nav: the `/memories` personal-view page gets a "Workspace knowledge" link button.

## Scope boundaries
- No workspace-role gating UI — the editor-role check lives server-side in the Phase 2b proxy routes; this PR surfaces backend rejections as inline error alerts.
- No separate admin-only entry point in the main sidebar.

## Test plan
- [x] 24 tests pass locally (parser 11, panel 13)
- [x] Per-file coverage ≥80% (parser 100%, panel 87%)
- [x] Lint + typecheck clean
- [ ] CI green