### PR TITLE
ci(arena-e2e): stabilize workspace-content PVC with Immediate binding

### DIFF
--- a/scripts/setup-arena-e2e.sh
+++ b/scripts/setup-arena-e2e.sh
@@ -244,6 +244,25 @@ while IFS='|' read -r name repo version required; do
     fi
 done <<< "$DEPS"
 
+# The chart-level workspace-content PVC is mounted by both omnia-controller-manager
+# and omnia-arena-controller. Kind's default `standard` storage class uses
+# volumeBindingMode: WaitForFirstConsumer, which means the PVC stays Pending
+# until a pod schedules. When two pods race to be the first consumer of the
+# same RWO PVC, the scheduler's PreBind optimistic-concurrency retry loop can
+# stall for minutes ("object has been modified" on the PVC). We side-step this
+# by giving workspaceContent its own StorageClass with Immediate binding — the
+# PVC gets a PV at creation time, before any pod tries to schedule.
+log_info "Creating immediate-binding storage class for workspaceContent..."
+kubectl apply -f - <<EOF
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: omnia-workspace-content-immediate
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+EOF
+
 log_info "Deploying via Helm..."
 
 retry 2 15 helm upgrade --install omnia charts/omnia \
@@ -295,7 +314,7 @@ retry 2 15 helm upgrade --install omnia charts/omnia \
     --set nfs.csiDriver.enabled=false \
     --set workspaceContent.enabled=true \
     --set workspaceContent.persistence.accessModes[0]=ReadWriteOnce \
-    --set workspaceContent.persistence.storageClass=standard \
+    --set workspaceContent.persistence.storageClass=omnia-workspace-content-immediate \
     --set prometheus.enabled=false \
     --set grafana.enabled=false \
     --set loki.enabled=false \


### PR DESCRIPTION
## Problem
Arena E2E started failing on main after the multi-tier memory rollout merge wave. The \`omnia-controller-manager\` pod stuck in \`FailedScheduling\` for 4+ minutes with:

\`\`\`
PreBind plugin "VolumeBinding": Operation cannot be fulfilled on persistentvolumeclaims "omnia-workspace-content": the object has been modified; please apply your changes to the latest version and try again
\`\`\`

When the operator pod doesn't schedule, no CRDs are reconciled, the test's \`eval-e2e-agent\` \`AgentRuntime\` never exists, session-api URL resolution never succeeds, and the eval test's 120s \`Eventually\` loop times out.

## Root cause
The chart-level \`workspace-content\` PVC (\`ReadWriteOnce\`) is mounted by both \`omnia-controller-manager\` and \`omnia-arena-controller\`. The arena-e2e setup script used kind's \`standard\` storage class, which is \`volumeBindingMode: WaitForFirstConsumer\`. When two pods race to be the "first consumer" of the same RWO PVC, the scheduler's PreBind optimistic-concurrency retry loop collides with the local-path provisioner's own PVC updates and stalls indefinitely.

The regression was latent — it depends on startup-time contention that varies across commits, so individual PR branches passed even though main eventually failed.

## Fix
Create a dedicated \`omnia-workspace-content-immediate\` StorageClass with \`volumeBindingMode: Immediate\` and point \`workspaceContent\` at it. The PVC now binds to a PV at creation time, before any pod tries to schedule, so the PreBind race can't happen.

## Scope boundaries
- No chart changes. The arena-controller still unconditionally mounts \`workspace-content\` (needed for ArenaSource content sync).
- The separate per-workspace PVC used by the ArenaSource test keeps its \`omnia-nfs\` \`WaitForFirstConsumer\` class — only the chart-level RWO PVC moves to Immediate.
- No code changes to the eval-worker or arena-controller.

## Test plan
- [ ] Arena E2E on main goes green (was failing both initial + rerun on \`eed3ef9e\`)
- [ ] No other E2E regressions (Core / Agent / Doctor / Multimodal should be unaffected)