### PR TITLE
feat(memory): expose expires_at on institutional POST

### DIFF
--- a/dashboard/src/components/memories/institutional-knowledge-panel.tsx
+++ b/dashboard/src/components/memories/institutional-knowledge-panel.tsx
@@ -303,7 +303,7 @@ function BulkImportDialog() {
 
 async function importAll(
   memories: ParsedMemory[],
-  doCreate: (input: { type: string; content: string; confidence?: number; metadata?: Record<string, unknown> }) => Promise<unknown>
+  doCreate: (input: { type: string; content: string; confidence?: number; metadata?: Record<string, unknown>; expiresAt?: string }) => Promise<unknown>
 ): Promise<{ ok: number; failures: string[] }> {
   let ok = 0;
   const failures: string[] = [];

--- a/dashboard/src/lib/data/institutional-memory-service.ts
+++ b/dashboard/src/lib/data/institutional-memory-service.ts
@@ -22,6 +22,12 @@ export interface InstitutionalCreateInput {
   content: string;
   confidence?: number;
   metadata?: Record<string, unknown>;
+  /**
+   * Optional ISO-8601 UTC timestamp at which the memory should auto-retire.
+   * Omit for permanent operator-curated memories (the default). The backend
+   * rejects past timestamps with HTTP 400.
+   */
+  expiresAt?: string;
 }
 
 /**
@@ -66,6 +72,7 @@ export class InstitutionalMemoryService {
           content: body.content,
           confidence: body.confidence ?? 1.0,
           metadata: body.metadata ?? {},
+          ...(body.expiresAt ? { expires_at: body.expiresAt } : {}),
         }),
       }
     );

--- a/dashboard/src/lib/memories/bulk-import-parser.test.ts
+++ b/dashboard/src/lib/memories/bulk-import-parser.test.ts
@@ -43,6 +43,26 @@ describe("parseJsonBulk", () => {
     expect(res.memories).toHaveLength(1);
     expect(res.memories[0].metadata).toBeUndefined();
   });
+
+  it("forwards expires_at (snake_case) verbatim", () => {
+    const res = parseJsonBulk(
+      `[{"type":"t","content":"c","expires_at":"2027-01-01T00:00:00Z"}]`
+    );
+    expect(res.memories).toHaveLength(1);
+    expect(res.memories[0].expiresAt).toBe("2027-01-01T00:00:00Z");
+  });
+
+  it("accepts expiresAt (camelCase) as a convenience", () => {
+    const res = parseJsonBulk(
+      `[{"type":"t","content":"c","expiresAt":"2027-02-01T00:00:00Z"}]`
+    );
+    expect(res.memories[0].expiresAt).toBe("2027-02-01T00:00:00Z");
+  });
+
+  it("omits expiresAt when absent", () => {
+    const res = parseJsonBulk(`[{"type":"t","content":"c"}]`);
+    expect(res.memories[0].expiresAt).toBeUndefined();
+  });
 });
 
 describe("parseMarkdownBulk", () => {

--- a/dashboard/src/lib/memories/bulk-import-parser.ts
+++ b/dashboard/src/lib/memories/bulk-import-parser.ts
@@ -12,6 +12,12 @@ export interface ParsedMemory {
   content: string;
   confidence?: number;
   metadata?: Record<string, unknown>;
+  /**
+   * Optional ISO-8601 UTC timestamp. Forwarded verbatim to the institutional
+   * POST body; the memory-api rejects past timestamps. Only emitted from the
+   * JSON parser — Markdown import has no syntax for it.
+   */
+  expiresAt?: string;
 }
 
 export interface ParseError {
@@ -69,6 +75,11 @@ export function parseJsonBulk(input: string): ParseResult {
     }
     if (rec.metadata && typeof rec.metadata === "object" && !Array.isArray(rec.metadata)) {
       out.metadata = rec.metadata as Record<string, unknown>;
+    }
+    // Accept camelCase and snake_case; the API expects snake_case.
+    const rawExpiresAt = rec.expiresAt ?? rec.expires_at;
+    if (typeof rawExpiresAt === "string" && rawExpiresAt) {
+      out.expiresAt = rawExpiresAt;
     }
     memories.push(out);
   });

--- a/internal/memory/api/handler.go
+++ b/internal/memory/api/handler.go
@@ -420,6 +420,9 @@ func writeError(w http.ResponseWriter, err error) {
 	case errors.Is(err, ErrBodyTooLarge) || isMaxBytesError(err):
 		status = http.StatusRequestEntityTooLarge
 		msg = ErrBodyTooLarge.Error()
+	case errors.Is(err, ErrExpiresAtInPast):
+		status = http.StatusBadRequest
+		msg = ErrExpiresAtInPast.Error()
 	}
 
 	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)

--- a/internal/memory/api/handler_institutional.go
+++ b/internal/memory/api/handler_institutional.go
@@ -22,18 +22,27 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"time"
 
 	"github.com/altairalabs/omnia/internal/httputil"
 	"github.com/altairalabs/omnia/internal/memory"
 )
 
 // SaveInstitutionalRequest is the JSON body for POST /api/v1/institutional/memories.
+//
+// ExpiresAt is optional and is NOT defaulted from MemoryServiceConfig.DefaultTTL —
+// institutional memories are operator-curated and permanent by default. Callers
+// opt in to expiry only when they intentionally want a rule or policy to
+// self-retire (e.g. a time-boxed promotion or regulatory freeze). Values in
+// the past are rejected with 400 to prevent accidental insert-then-expire
+// races that would hide the write from ListInstitutional.
 type SaveInstitutionalRequest struct {
 	WorkspaceID string         `json:"workspace_id"`
 	Type        string         `json:"type"`
 	Content     string         `json:"content"`
 	Metadata    map[string]any `json:"metadata,omitempty"`
 	Confidence  float64        `json:"confidence"`
+	ExpiresAt   *time.Time     `json:"expires_at,omitempty"`
 }
 
 // ListInstitutionalResponse is the JSON response for GET /api/v1/institutional/memories.
@@ -60,12 +69,17 @@ func (h *Handler) handleSaveInstitutional(w http.ResponseWriter, r *http.Request
 		writeError(w, ErrMissingWorkspace)
 		return
 	}
+	if req.ExpiresAt != nil && !req.ExpiresAt.After(time.Now()) {
+		writeError(w, ErrExpiresAtInPast)
+		return
+	}
 
 	mem := &memory.Memory{
 		Type:       req.Type,
 		Content:    req.Content,
 		Metadata:   req.Metadata,
 		Confidence: req.Confidence,
+		ExpiresAt:  req.ExpiresAt,
 		Scope:      map[string]string{memory.ScopeWorkspaceID: req.WorkspaceID},
 	}
 	if err := h.service.SaveInstitutionalMemory(r.Context(), mem); err != nil {

--- a/internal/memory/api/handler_institutional_test.go
+++ b/internal/memory/api/handler_institutional_test.go
@@ -9,10 +9,12 @@ package api
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
@@ -71,6 +73,65 @@ func TestHandleSaveInstitutional_RejectsBadJSON(t *testing.T) {
 	mux.ServeHTTP(rec, req)
 
 	assert.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestHandleSaveInstitutional_ForwardsExpiresAt(t *testing.T) {
+	stub := &institutionalStub{saveMemID: "inst-exp"}
+	mux := newInstitutionalHandler(t, stub)
+
+	future := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	body := fmt.Sprintf(
+		`{"workspace_id":"ws-1","type":"policy","content":"time-boxed rule","confidence":1.0,"expires_at":%q}`,
+		future.Format(time.RFC3339),
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/institutional/memories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	require.Len(t, stub.saveCalls, 1)
+	got := stub.saveCalls[0]
+	require.NotNil(t, got.ExpiresAt, "ExpiresAt should be forwarded to the store")
+	assert.True(t, got.ExpiresAt.Equal(future),
+		"ExpiresAt mismatch: want %s got %s", future, got.ExpiresAt)
+}
+
+func TestHandleSaveInstitutional_OmittedExpiresAtIsNil(t *testing.T) {
+	stub := &institutionalStub{saveMemID: "inst-perm"}
+	mux := newInstitutionalHandler(t, stub)
+
+	body := `{"workspace_id":"ws-1","type":"policy","content":"permanent rule","confidence":1.0}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/institutional/memories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusCreated, rec.Code, rec.Body.String())
+	require.Len(t, stub.saveCalls, 1)
+	assert.Nil(t, stub.saveCalls[0].ExpiresAt,
+		"omitted expires_at must NOT be defaulted — institutional memories are permanent by default")
+}
+
+func TestHandleSaveInstitutional_RejectsExpiresAtInPast(t *testing.T) {
+	stub := &institutionalStub{}
+	mux := newInstitutionalHandler(t, stub)
+
+	past := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	body := fmt.Sprintf(
+		`{"workspace_id":"ws-1","type":"policy","content":"backdated","expires_at":%q}`,
+		past,
+	)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/institutional/memories", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, stub.saveCalls, "store should NOT be called when expires_at is in the past")
 }
 
 func TestHandleSaveInstitutional_BodyTooLarge(t *testing.T) {

--- a/internal/memory/api/service.go
+++ b/internal/memory/api/service.go
@@ -50,6 +50,7 @@ var (
 	ErrMissingMemoryID  = errors.New("memory ID is required")
 	ErrMissingBody      = errors.New("request body is required")
 	ErrBodyTooLarge     = errors.New("request body too large")
+	ErrExpiresAtInPast  = errors.New("expires_at must be in the future")
 )
 
 // MemoryServiceConfig holds runtime configuration for the MemoryService.


### PR DESCRIPTION
## Summary
Institutional memories are operator-curated and permanent by default — the store has always persisted `expires_at`, but there was no API path to set it. Expose it on the request body and plumb through the dashboard bulk-import path.

**Backend**
- `SaveInstitutionalRequest.ExpiresAt` (`*time.Time`, optional) forwarded to the store unchanged.
- Validation rejects past timestamps with 400 (`ErrExpiresAtInPast`) to prevent insert-then-expire races that would hide the write from `ListInstitutional`.
- `MemoryServiceConfig.DefaultTTL` is intentionally NOT applied on the institutional path — operator-curated rows stay indefinite unless the caller opts in.

**Dashboard**
- `InstitutionalCreateInput` accepts optional `expiresAt`.
- `InstitutionalMemoryService.create` serialises `expires_at` (snake_case) only when set.
- Bulk-import parser accepts both `expires_at` (snake) and `expiresAt` (camel) on JSON entries and forwards verbatim. Markdown format has no syntax for it — unchanged.

## Test plan
- [x] `go test ./internal/memory/api/... -count=1` — 153 passed
- [x] `npx vitest run src/lib/memories/bulk-import-parser.test.ts` — 14 passed
- [x] Pre-commit Go coverage: handler.go 94.3%, handler_institutional.go 91.4%, service.go 92.6%
- [x] Pre-commit dashboard coverage: institutional-memory-service.ts 100%, bulk-import-parser.ts 100%