### PR TITLE
feat(memory): redactor honors trust_model / provenance

### DIFF
--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -483,12 +483,13 @@ func wrapPrivacyMiddleware(next http.Handler, pool *pgxpool.Pool, log logr.Logge
 		return privacy.ShouldRememberCategory(ctx, prefStore, source, userID, workspace, "", cat)
 	})
 
-	contentRedactor := memoryapi.ContentRedactor(func(ctx context.Context, workspace, content string) (string, error) {
+	contentRedactor := memoryapi.ContentRedactor(func(ctx context.Context, workspace, content, provenance string) (string, error) {
 		policy := watcher.GetEffectivePolicy(workspace, "")
 		if policy == nil || policy.Recording.PII == nil || !policy.Recording.PII.Redact {
 			return content, nil
 		}
-		redacted, _, err := redactor.Redact(ctx, content, policy.Recording.PII)
+		trust := trustLevelForProvenance(provenance)
+		redacted, _, err := redactor.RedactWithTrust(ctx, content, policy.Recording.PII, trust)
 		return redacted, err
 	})
 
@@ -496,6 +497,22 @@ func wrapPrivacyMiddleware(next http.Handler, pool *pgxpool.Pool, log logr.Logge
 	mw := memoryapi.NewMemoryPrivacyMiddleware(checkOptOut, contentRedactor, classifier, log)
 	log.Info("memory privacy middleware enabled")
 	return mw.Wrap(next)
+}
+
+// trustLevelForProvenance maps a PromptKit provenance string to the
+// redaction trust level. user_requested and operator_curated memories are
+// content the caller intentionally asked to persist, so personal-detail
+// patterns (email, phone) are dropped from the redaction set and only
+// structural identifiers (SSN, credit-card, IP, custom patterns) get
+// scrubbed. Agent-extracted, system-generated, and unrecognised provenance
+// values fall back to TrustInferred so the full pattern set applies.
+func trustLevelForProvenance(provenance string) redaction.TrustLevel {
+	switch provenance {
+	case "user_requested", "operator_curated":
+		return redaction.TrustExplicit
+	default:
+		return redaction.TrustInferred
+	}
 }
 
 // traceLogMiddleware injects the OTel trace ID into the logging context.

--- a/ee/pkg/redaction/patterns.go
+++ b/ee/pkg/redaction/patterns.go
@@ -15,10 +15,17 @@ import (
 )
 
 // patternDef defines a built-in PII pattern with its compiled regex and replacement token.
+//
+// Structural marks patterns that match regulatory / compliance identifiers
+// which must be redacted regardless of who asked for the memory (SSN,
+// credit-card, IP). Non-structural patterns match personal details (phone,
+// email) that a user_requested / operator_curated memory may legitimately
+// need to preserve (e.g. "remember my work email is ...").
 type patternDef struct {
-	Name  string
-	Regex *regexp.Regexp
-	Token string
+	Name       string
+	Regex      *regexp.Regexp
+	Token      string
+	Structural bool
 }
 
 // builtinPatterns is the registry of compiled built-in PII patterns, keyed by name.
@@ -26,31 +33,56 @@ var builtinPatterns map[string]patternDef
 
 func init() {
 	defs := []struct {
-		name  string
-		regex string
-		token string
+		name       string
+		regex      string
+		token      string
+		structural bool
 	}{
-		{"ssn", `\b\d{3}-\d{2}-\d{4}\b`, "[REDACTED_SSN]"},
-		{"credit_card", `\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`, "[REDACTED_CC]"},
-		{"phone_number", `\b\d{3}[-.)\\s]?\d{3}[-.)\\s]?\d{4}\b`, "[REDACTED_PHONE]"},
-		{"email", `(?i)\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`, "[REDACTED_EMAIL]"},
-		{"ip_address", `\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`, "[REDACTED_IP]"},
+		{"ssn", `\b\d{3}-\d{2}-\d{4}\b`, "[REDACTED_SSN]", true},
+		{"credit_card", `\b\d{4}[- ]?\d{4}[- ]?\d{4}[- ]?\d{4}\b`, "[REDACTED_CC]", true},
+		{"phone_number", `\b\d{3}[-.)\\s]?\d{3}[-.)\\s]?\d{4}\b`, "[REDACTED_PHONE]", false},
+		{"email", `(?i)\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b`, "[REDACTED_EMAIL]", false},
+		{"ip_address", `\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`, "[REDACTED_IP]", true},
 	}
 
 	builtinPatterns = make(map[string]patternDef, len(defs))
 	for _, d := range defs {
 		builtinPatterns[d.name] = patternDef{
-			Name:  d.name,
-			Regex: regexp.MustCompile(d.regex),
-			Token: d.token,
+			Name:       d.name,
+			Regex:      regexp.MustCompile(d.regex),
+			Token:      d.token,
+			Structural: d.structural,
 		}
 	}
+}
+
+// filterPatternsByTrust returns the subset of patterns that apply at the
+// given trust level. TrustInferred returns the input unchanged;
+// TrustExplicit drops non-structural patterns so intentional personal
+// details (emails, phone numbers) in user_requested / operator_curated
+// memories survive while compliance identifiers still get scrubbed.
+func filterPatternsByTrust(patterns []patternDef, trust TrustLevel) []patternDef {
+	if trust != TrustExplicit {
+		return patterns
+	}
+	out := patterns[:0]
+	for _, p := range patterns {
+		if p.Structural {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 // resolvePatterns resolves pattern names to compiled patternDefs.
 // Built-in names (e.g. "ssn") are looked up from the registry.
 // Names with the "custom:" prefix are compiled as user-provided regex.
 // Unknown built-in names return an error.
+//
+// Custom patterns are marked Structural — operators who define custom rules
+// intend them to apply regardless of provenance (that's the point of a
+// custom rule). If an operator wants a "personal detail" custom pattern
+// they can simply skip it on trusted content upstream.
 func resolvePatterns(names []string) ([]patternDef, error) {
 	resolved := make([]patternDef, 0, len(names))
 	for _, name := range names {
@@ -60,9 +92,10 @@ func resolvePatterns(names []string) ([]patternDef, error) {
 				return nil, fmt.Errorf("invalid custom pattern %q: %w", expr, err)
 			}
 			resolved = append(resolved, patternDef{
-				Name:  name,
-				Regex: re,
-				Token: "[REDACTED_CUSTOM]",
+				Name:       name,
+				Regex:      re,
+				Token:      "[REDACTED_CUSTOM]",
+				Structural: true,
 			})
 			continue
 		}

--- a/ee/pkg/redaction/redaction.go
+++ b/ee/pkg/redaction/redaction.go
@@ -29,12 +29,41 @@ type RedactionEvent struct {
 	EndIndex int
 }
 
+// TrustLevel controls which patterns a redactor applies. Structural-only mode
+// limits redaction to compliance-relevant identifiers (SSN, credit-card, IP)
+// so user-curated and operator-curated memories can preserve the personal
+// details the caller explicitly asked to remember (phone, email) while still
+// scrubbing identifiers that always require protection.
+type TrustLevel int
+
+const (
+	// TrustInferred applies the full configured pattern set. Default for
+	// agent-extracted memories where the content is not something the user
+	// explicitly asked to store.
+	TrustInferred TrustLevel = iota
+	// TrustExplicit skips non-structural patterns and only redacts
+	// structural identifiers. Used for provenance=user_requested or
+	// provenance=operator_curated memories.
+	TrustExplicit
+)
+
 // Redactor performs PII redaction on text and session messages.
 type Redactor interface {
 	// Redact applies PII redaction to the given text using the provided PIIConfig.
-	Redact(ctx context.Context, text string, pii *omniav1alpha1.PIIConfig) (string, []RedactionEvent, error)
+	Redact(
+		ctx context.Context, text string, pii *omniav1alpha1.PIIConfig,
+	) (string, []RedactionEvent, error)
+	// RedactWithTrust is like Redact but filters the active pattern set by
+	// trust level — TrustExplicit content skips personal-detail patterns so
+	// callers who intentionally asked to persist (e.g.) their work email
+	// keep that detail, while structural identifiers are still redacted.
+	RedactWithTrust(
+		ctx context.Context, text string, pii *omniav1alpha1.PIIConfig, trust TrustLevel,
+	) (string, []RedactionEvent, error)
 	// RedactMessage applies PII redaction to a session Message, returning a copy.
-	RedactMessage(ctx context.Context, msg *session.Message, pii *omniav1alpha1.PIIConfig) (*session.Message, error)
+	RedactMessage(
+		ctx context.Context, msg *session.Message, pii *omniav1alpha1.PIIConfig,
+	) (*session.Message, error)
 }
 
 // Option configures a redactor.
@@ -71,6 +100,16 @@ type match struct {
 func (r *redactor) Redact(
 	ctx context.Context, text string, pii *omniav1alpha1.PIIConfig,
 ) (string, []RedactionEvent, error) {
+	return r.RedactWithTrust(ctx, text, pii, TrustInferred)
+}
+
+// RedactWithTrust is Redact with trust-level-aware pattern filtering.
+// TrustExplicit drops non-structural patterns from the active set before
+// matching — the structural identifiers in the config (SSN, credit-card,
+// IP, custom patterns) are still enforced.
+func (r *redactor) RedactWithTrust(
+	ctx context.Context, text string, pii *omniav1alpha1.PIIConfig, trust TrustLevel,
+) (string, []RedactionEvent, error) {
 	if pii == nil || !pii.Redact || len(pii.Patterns) == 0 || text == "" {
 		return text, nil, nil
 	}
@@ -78,6 +117,11 @@ func (r *redactor) Redact(
 	patterns, err := resolvePatterns(pii.Patterns)
 	if err != nil {
 		return "", nil, err
+	}
+
+	patterns = filterPatternsByTrust(patterns, trust)
+	if len(patterns) == 0 {
+		return text, nil, nil
 	}
 
 	strategy := pii.Strategy

--- a/ee/pkg/redaction/redaction_test.go
+++ b/ee/pkg/redaction/redaction_test.go
@@ -338,6 +338,82 @@ func TestRedact_AuditMode(t *testing.T) {
 	})
 }
 
+func TestRedactWithTrust_ExplicitKeepsPersonalDetails(t *testing.T) {
+	ctx := context.Background()
+	r := NewRedactor()
+
+	cfg := piiConfig("ssn", "credit_card", "ip_address", "email", "phone_number")
+	text := "I'm alice@example.com at 555-123-4567, card 4111 1111 1111 1111 SSN 123-45-6789, from 10.0.0.1"
+
+	// Inferred mode (agent-extracted): everything is redacted.
+	inferred, _, err := r.RedactWithTrust(ctx, text, cfg, TrustInferred)
+	require.NoError(t, err)
+	wants := []string{
+		"[REDACTED_EMAIL]",
+		"[REDACTED_PHONE]",
+		"[REDACTED_CC]",
+		"[REDACTED_SSN]",
+		"[REDACTED_IP]",
+	}
+	for _, want := range wants {
+		assert.Contains(t, inferred, want, "inferred: %q should redact %s", text, want)
+	}
+
+	// Explicit mode (user_requested / operator_curated): personal details
+	// (email, phone) stay; structural identifiers still get scrubbed.
+	explicit, _, err := r.RedactWithTrust(ctx, text, cfg, TrustExplicit)
+	require.NoError(t, err)
+	assert.Contains(t, explicit, "alice@example.com", "explicit trust should KEEP email")
+	assert.Contains(t, explicit, "555-123-4567", "explicit trust should KEEP phone")
+	assert.Contains(t, explicit, "[REDACTED_CC]", "explicit trust must still redact credit-card")
+	assert.Contains(t, explicit, "[REDACTED_SSN]", "explicit trust must still redact SSN")
+	assert.Contains(t, explicit, "[REDACTED_IP]", "explicit trust must still redact IP")
+}
+
+func TestRedactWithTrust_ExplicitNoStructuralPatternsIsNoop(t *testing.T) {
+	ctx := context.Background()
+	r := NewRedactor()
+
+	// Only personal-detail patterns configured — explicit mode should be a no-op.
+	cfg := piiConfig("email", "phone_number")
+	text := "alice@example.com at 555-123-4567"
+
+	got, events, err := r.RedactWithTrust(ctx, text, cfg, TrustExplicit)
+	require.NoError(t, err)
+	assert.Equal(t, text, got, "explicit trust + personal-only config should pass through")
+	assert.Empty(t, events)
+}
+
+func TestRedactWithTrust_CustomPatternsAreStructural(t *testing.T) {
+	ctx := context.Background()
+	r := NewRedactor()
+
+	// Custom patterns default to Structural — a compliance-style "token
+	// must never leak" rule keeps firing in explicit mode.
+	cfg := piiConfig(`custom:\bSECRET-\d+\b`)
+	text := "leak: SECRET-123"
+
+	got, _, err := r.RedactWithTrust(ctx, text, cfg, TrustExplicit)
+	require.NoError(t, err)
+	assert.Contains(t, got, "[REDACTED_CUSTOM]", "custom patterns must apply in explicit mode")
+	assert.NotContains(t, got, "SECRET-123")
+}
+
+func TestRedactWithTrust_BackwardCompatibleWithRedact(t *testing.T) {
+	ctx := context.Background()
+	r := NewRedactor()
+
+	cfg := piiConfig("ssn", "email")
+	text := "SSN 123-45-6789, email a@b.com"
+
+	viaRedact, _, err := r.Redact(ctx, text, cfg)
+	require.NoError(t, err)
+	viaInferred, _, err := r.RedactWithTrust(ctx, text, cfg, TrustInferred)
+	require.NoError(t, err)
+	assert.Equal(t, viaRedact, viaInferred,
+		"Redact must remain equivalent to RedactWithTrust(...TrustInferred)")
+}
+
 func TestRedact_EventPositions(t *testing.T) {
 	ctx := context.Background()
 	r := NewRedactor()

--- a/ee/pkg/redaction/redactor.go
+++ b/ee/pkg/redaction/redactor.go
@@ -21,6 +21,16 @@ type TextRedactor interface {
 	RedactText(ctx context.Context, text string) (string, error)
 }
 
+// TrustAwareRedactor is a TextRedactor whose active pattern set varies by
+// trust level — user_requested / operator_curated memories only get
+// structural patterns applied; everything else gets the full set.
+type TrustAwareRedactor interface {
+	TextRedactor
+	// RedactTextWithTrust applies PII redaction using the given trust level.
+	// TrustExplicit drops non-structural patterns; TrustInferred applies all.
+	RedactTextWithTrust(ctx context.Context, text string, trust TrustLevel) (string, error)
+}
+
 // PatternRedactor is a TextRedactor that applies a fixed PIIConfig on every call.
 // It validates and pre-compiles patterns at construction time.
 type PatternRedactor struct {
@@ -60,4 +70,19 @@ func NewPatternRedactor(config *omniav1alpha1.PIIConfig) (TextRedactor, error) {
 func (r *PatternRedactor) RedactText(ctx context.Context, text string) (string, error) {
 	redacted, _, err := r.inner.Redact(ctx, text, r.pii)
 	return redacted, err
+}
+
+// RedactTextWithTrust applies the configured PIIConfig with the given trust
+// level — TrustExplicit content (user_requested / operator_curated) only
+// gets structural patterns redacted, TrustInferred gets the full set.
+func (r *PatternRedactor) RedactTextWithTrust(
+	ctx context.Context, text string, trust TrustLevel,
+) (string, error) {
+	redacted, _, err := r.inner.RedactWithTrust(ctx, text, r.pii, trust)
+	return redacted, err
+}
+
+// RedactTextWithTrust on NoOpRedactor is a no-op like RedactText.
+func (NoOpRedactor) RedactTextWithTrust(_ context.Context, text string, _ TrustLevel) (string, error) {
+	return text, nil
 }

--- a/ee/pkg/redaction/redactor_test.go
+++ b/ee/pkg/redaction/redactor_test.go
@@ -325,3 +325,72 @@ func TestNoOpRedactor_PassthroughDirectly(t *testing.T) {
 		t.Errorf("expected passthrough, got %q", got)
 	}
 }
+
+// TestNoOpRedactor_RedactTextWithTrustPassthrough ensures the trust-aware
+// entrypoint stays a no-op on NoOpRedactor regardless of trust level.
+func TestNoOpRedactor_RedactTextWithTrustPassthrough(t *testing.T) {
+	var r redaction.NoOpRedactor
+	text := "alice@example.com at 555-867-5309"
+
+	for _, trust := range []redaction.TrustLevel{redaction.TrustInferred, redaction.TrustExplicit} {
+		got, err := r.RedactTextWithTrust(context.Background(), text, trust)
+		if err != nil {
+			t.Fatalf("unexpected error at trust=%d: %v", trust, err)
+		}
+		if got != text {
+			t.Errorf("trust=%d: expected passthrough, got %q", trust, got)
+		}
+	}
+}
+
+// TestPatternRedactor_RedactTextWithTrust_ExplicitKeepsPersonalDetails
+// exercises the trust-aware entrypoint on the PatternRedactor wrapper so the
+// coverage gate on redactor.go is satisfied.
+func TestPatternRedactor_RedactTextWithTrust_ExplicitKeepsPersonalDetails(t *testing.T) {
+	cfg := piiConfig(
+		[]string{"ssn", "credit_card", "ip_address", "email", "phone_number"},
+		omniav1alpha1.RedactionStrategyReplace,
+	)
+	r, err := redaction.NewPatternRedactor(cfg)
+	if err != nil {
+		t.Fatalf("new pattern redactor: %v", err)
+	}
+
+	text := "alice@example.com, 555-867-5309, 4111 1111 1111 1111, 123-45-6789, 10.0.0.1"
+
+	// Inferred: all five patterns apply.
+	inferred, err := r.(redaction.TrustAwareRedactor).
+		RedactTextWithTrust(context.Background(), text, redaction.TrustInferred)
+	if err != nil {
+		t.Fatalf("RedactTextWithTrust inferred: %v", err)
+	}
+	for _, want := range []string{
+		"[REDACTED_EMAIL]", "[REDACTED_PHONE]", "[REDACTED_CC]", "[REDACTED_SSN]", "[REDACTED_IP]",
+	} {
+		if !strings.Contains(inferred, want) {
+			t.Errorf("inferred: expected %s, got %q", want, inferred)
+		}
+	}
+
+	// Explicit: personal patterns drop, structural ones stay.
+	explicit, err := r.(redaction.TrustAwareRedactor).
+		RedactTextWithTrust(context.Background(), text, redaction.TrustExplicit)
+	if err != nil {
+		t.Fatalf("RedactTextWithTrust explicit: %v", err)
+	}
+	if !strings.Contains(explicit, "alice@example.com") {
+		t.Errorf("explicit should KEEP email, got %q", explicit)
+	}
+	if !strings.Contains(explicit, "555-867-5309") {
+		t.Errorf("explicit should KEEP phone, got %q", explicit)
+	}
+	if !strings.Contains(explicit, "[REDACTED_SSN]") {
+		t.Errorf("explicit should still redact SSN, got %q", explicit)
+	}
+	if !strings.Contains(explicit, "[REDACTED_CC]") {
+		t.Errorf("explicit should still redact credit-card, got %q", explicit)
+	}
+	if !strings.Contains(explicit, "[REDACTED_IP]") {
+		t.Errorf("explicit should still redact IP, got %q", explicit)
+	}
+}

--- a/internal/memory/api/privacy_middleware.go
+++ b/internal/memory/api/privacy_middleware.go
@@ -44,7 +44,16 @@ type OptOutChecker func(ctx context.Context, userID, workspace, category string,
 // ContentRedactor redacts PII from memory content text.
 // Returns the redacted string; if redaction is not configured it returns the
 // original text unchanged.
-type ContentRedactor func(ctx context.Context, workspace, content string) (string, error)
+//
+// provenance is the PromptKit Provenance string carried on the memory's
+// metadata (user_requested, agent_extracted, system_generated,
+// operator_curated) — empty when the caller didn't set one. Implementations
+// use it to decide whether to apply the full pattern set (agent-extracted /
+// system-generated / unknown) or only the structural subset
+// (user_requested / operator_curated) so intentionally-persisted personal
+// details (e.g. "my work email is ...") survive while SSN / CC / IP remain
+// scrubbed.
+type ContentRedactor func(ctx context.Context, workspace, content, provenance string) (string, error)
 
 // ContentClassifier infers a consent category from memory content.
 // Returns a category string (e.g. "memory:identity") or empty string for default.
@@ -79,6 +88,21 @@ func NewMemoryPrivacyMiddleware(
 		classifier:  classifier,
 		log:         log.WithName("memory-privacy"),
 	}
+}
+
+// provenanceMetaKey mirrors pkmemory.MetaKeyProvenance — duplicated here as
+// a string literal to keep the middleware dependency-free from the memory
+// package's PromptKit re-export.
+const provenanceMetaKey = "provenance"
+
+// provenanceFromMetadata extracts the provenance string from a memory's
+// metadata map. Returns "" when unset or wrong type.
+func provenanceFromMetadata(meta map[string]any) string {
+	if meta == nil {
+		return ""
+	}
+	v, _ := meta[provenanceMetaKey].(string)
+	return v
 }
 
 // readAndDecode reads the request body and attempts to decode it as a SaveMemoryRequest.
@@ -136,7 +160,8 @@ func (m *MemoryPrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 
 		// Apply PII redaction when body was successfully decoded.
 		if decoded {
-			redacted, redactErr := m.redact(r.Context(), workspace, req.Content)
+			provenance := provenanceFromMetadata(req.Metadata)
+			redacted, redactErr := m.redact(r.Context(), workspace, req.Content, provenance)
 			if redactErr != nil {
 				m.log.Error(redactErr, "content redaction failed, blocking request", "workspace", workspace)
 				http.Error(w, "redaction failed", http.StatusInternalServerError)

--- a/internal/memory/api/privacy_middleware_test.go
+++ b/internal/memory/api/privacy_middleware_test.go
@@ -37,7 +37,7 @@ import (
 var passthroughOptOut OptOutChecker = func(_ context.Context, _, _, _ string, _ []string) bool { return true }
 
 // noOpRedact returns content unchanged.
-var noOpRedact ContentRedactor = func(_ context.Context, _, content string) (string, error) {
+var noOpRedact ContentRedactor = func(_ context.Context, _, content, _ string) (string, error) {
 	return content, nil
 }
 
@@ -50,7 +50,7 @@ var panicOptOut OptOutChecker = func(_ context.Context, _, _, _ string, _ []stri
 }
 
 // panicRedact panics if called — use to assert redaction is never invoked.
-var panicRedact ContentRedactor = func(_ context.Context, _, _ string) (string, error) {
+var panicRedact ContentRedactor = func(_ context.Context, _, _, _ string) (string, error) {
 	panic("ContentRedactor must not be called for this request")
 }
 
@@ -154,7 +154,7 @@ func TestMemoryPrivacyMiddleware_PIIRedaction_ContentRedacted(t *testing.T) {
 		receivedContent = req.Content
 	})
 
-	redactor := ContentRedactor(func(_ context.Context, _, content string) (string, error) {
+	redactor := ContentRedactor(func(_ context.Context, _, content, _ string) (string, error) {
 		if content == originalContent {
 			return redactedContent, nil
 		}
@@ -171,12 +171,62 @@ func TestMemoryPrivacyMiddleware_PIIRedaction_ContentRedacted(t *testing.T) {
 	assert.Equal(t, redactedContent, receivedContent, "handler should receive redacted content")
 }
 
+func TestMemoryPrivacyMiddleware_ForwardsProvenance(t *testing.T) {
+	var seenProvenance string
+	redactor := ContentRedactor(func(_ context.Context, _, content, provenance string) (string, error) {
+		seenProvenance = provenance
+		return content, nil
+	})
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+	mw := newTestMiddleware(passthroughOptOut, redactor)
+	handler := mw.Wrap(next)
+
+	// Build a request whose metadata carries provenance=user_requested.
+	body := SaveMemoryRequest{
+		Type:    "fact",
+		Content: "my work email is alice@example.com",
+		Scope: map[string]string{
+			"workspace_id": "ws-1",
+			"user_id":      "user-1",
+		},
+		Metadata: map[string]any{"provenance": "user_requested"},
+	}
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/memories?workspace=ws-1&user_id=user-1", bytes.NewReader(raw))
+	r.Header.Set("Content-Type", "application/json")
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	assert.Equal(t, "user_requested", seenProvenance,
+		"redactor must receive the provenance from the request metadata")
+}
+
+func TestMemoryPrivacyMiddleware_EmptyProvenanceWhenMetadataMissing(t *testing.T) {
+	var seenProvenance string
+	redactor := ContentRedactor(func(_ context.Context, _, content, provenance string) (string, error) {
+		seenProvenance = provenance
+		return content, nil
+	})
+
+	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
+	mw := newTestMiddleware(passthroughOptOut, redactor)
+	handler := mw.Wrap(next)
+
+	r := makePostRequest(t, "hello", "ws-1", "user-1")
+	handler.ServeHTTP(httptest.NewRecorder(), r)
+
+	assert.Empty(t, seenProvenance,
+		"redactor must receive empty provenance when metadata is absent")
+}
+
 func TestMemoryPrivacyMiddleware_RedactionError_Returns500(t *testing.T) {
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 	})
 
-	errRedact := ContentRedactor(func(_ context.Context, _, _ string) (string, error) {
+	errRedact := ContentRedactor(func(_ context.Context, _, _, _ string) (string, error) {
 		return "", errors.New("regex engine failure")
 	})
 
@@ -232,7 +282,7 @@ func TestMemoryPrivacyMiddleware_NoRedactionWhenContentUnchanged(t *testing.T) {
 
 	// Track that redactor was called but content unchanged.
 	redactorCallCount := 0
-	redactor := ContentRedactor(func(_ context.Context, _, content string) (string, error) {
+	redactor := ContentRedactor(func(_ context.Context, _, content, _ string) (string, error) {
 		redactorCallCount++
 		return content, nil // no change
 	})

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -30,6 +30,8 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	pgvector "github.com/pgvector/pgvector-go"
 
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+
 	"github.com/altairalabs/omnia/internal/pgutil"
 )
 
@@ -115,15 +117,27 @@ func (s *PostgresMemoryStore) Save(ctx context.Context, mem *Memory) error {
 }
 
 // insertEntity inserts a new memory_entities row and populates mem.ID / mem.CreatedAt.
+//
+// trust_model and source_type are derived from the provenance metadata key
+// (pkmemory.MetaKeyProvenance) so the redactor and retention pipelines can
+// tell operator-curated / user-requested rows from agent-extracted ones.
+// When the caller didn't set a provenance, we keep the schema defaults
+// (trust_model='inferred', source_type='conversation_extraction').
 func insertEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 	metaJSON, err := marshalMetadata(mem.Metadata)
 	if err != nil {
 		return err
 	}
 
+	trustModel, sourceType := trustFromProvenance(mem.Metadata)
+
 	row := tx.QueryRow(ctx, `
-		INSERT INTO memory_entities (workspace_id, virtual_user_id, agent_id, name, kind, metadata, expires_at)
-		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		INSERT INTO memory_entities
+		  (workspace_id, virtual_user_id, agent_id, name, kind, metadata, expires_at, trust_model, source_type)
+		VALUES
+		  ($1, $2, $3, $4, $5, $6, $7,
+		    COALESCE($8, 'inferred'),
+		    COALESCE($9, 'conversation_extraction'))
 		RETURNING id, created_at`,
 		mem.Scope[ScopeWorkspaceID],
 		scopeOrNil(mem.Scope, ScopeUserID),
@@ -132,9 +146,38 @@ func insertEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 		mem.Type,
 		metaJSON,
 		mem.ExpiresAt,
+		trustModel,
+		sourceType,
 	)
 
 	return row.Scan(&mem.ID, &mem.CreatedAt)
+}
+
+// trustFromProvenance maps a PromptKit provenance value to the
+// (trust_model, source_type) pair persisted on memory_entities.
+// Returns (nil, nil) when the caller didn't set a provenance so the
+// schema-level defaults apply.
+func trustFromProvenance(meta map[string]any) (trustModel, sourceType *string) {
+	if meta == nil {
+		return nil, nil
+	}
+	prov, _ := meta[pkmemory.MetaKeyProvenance].(string)
+	switch prov {
+	case string(pkmemory.ProvenanceUserRequested):
+		tm, st := "explicit", "user_requested"
+		return &tm, &st
+	case string(pkmemory.ProvenanceOperatorCurated):
+		tm, st := "curated", "operator_curated"
+		return &tm, &st
+	case string(pkmemory.ProvenanceAgentExtracted):
+		tm, st := "inferred", "conversation_extraction"
+		return &tm, &st
+	case string(pkmemory.ProvenanceSystemGenerated):
+		tm, st := "inferred", "system_generated"
+		return &tm, &st
+	default:
+		return nil, nil
+	}
 }
 
 // updateEntity updates the entity metadata and updated_at timestamp.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+
 	pgmigrate "github.com/altairalabs/omnia/internal/memory/postgres"
 )
 
@@ -167,6 +169,47 @@ func TestPostgresMemoryStore_Save(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotEmpty(t, mem.ID, "ID should be populated after save")
 	assert.False(t, mem.CreatedAt.IsZero(), "CreatedAt should be populated")
+}
+
+func TestPostgresMemoryStore_Save_TrustModelFromProvenance(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	scope := testScope(testWorkspace1)
+
+	cases := []struct {
+		name           string
+		provenance     string
+		wantTrustModel string
+		wantSourceType string
+	}{
+		{"user_requested", "user_requested", "explicit", "user_requested"},
+		{"operator_curated", "operator_curated", "curated", "operator_curated"},
+		{"agent_extracted", "agent_extracted", "inferred", "conversation_extraction"},
+		{"system_generated", "system_generated", "inferred", "system_generated"},
+		{"no_provenance_uses_schema_defaults", "", "inferred", "conversation_extraction"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			meta := map[string]any{}
+			if tc.provenance != "" {
+				meta[pkmemory.MetaKeyProvenance] = tc.provenance
+			}
+			mem := &Memory{
+				Type: "fact", Content: "trust-" + tc.name, Confidence: 1.0,
+				Scope: scope, Metadata: meta,
+			}
+			require.NoError(t, store.Save(ctx, mem))
+			require.NotEmpty(t, mem.ID)
+
+			var trustModel, sourceType string
+			row := store.Pool().QueryRow(ctx,
+				`SELECT trust_model, source_type FROM memory_entities WHERE id = $1`, mem.ID)
+			require.NoError(t, row.Scan(&trustModel, &sourceType))
+			assert.Equal(t, tc.wantTrustModel, trustModel, "trust_model")
+			assert.Equal(t, tc.wantSourceType, sourceType, "source_type")
+		})
+	}
 }
 
 func TestPostgresMemoryStore_Save_MissingWorkspace(t *testing.T) {


### PR DESCRIPTION
## Summary
Trust-aware redaction. Built-in PII patterns are classified:

- **structural** (always redact): `ssn`, `credit_card`, `ip_address`
- **personal** (keep when trusted): `email`, `phone_number`
- **custom:** (always redact): operator-defined rules stay strict

`Redactor.RedactWithTrust(ctx, text, pii, trust)` filters the active pattern set by trust level. `TrustExplicit` — used for provenance `user_requested` or `operator_curated` — drops the personal-detail subset so intentionally-persisted memories (\"remember my work email is …\") retain those details while SSN / credit-card / IP still get scrubbed. `TrustInferred` (default) applies the full set.

## Wiring
- `internal/memory/store.go` — `insertEntity` derives `trust_model` + `source_type` from `Metadata[pkmemory.MetaKeyProvenance]` so the DB row reflects PromptKit's provenance instead of the schema default.
- `internal/memory/api/privacy_middleware.go` — `ContentRedactor` signature takes a provenance string extracted from `SaveMemoryRequest.Metadata`, forwarded to the redactor closure.
- `cmd/memory-api/main.go` — closure maps provenance → `TrustLevel` via `trustLevelForProvenance` and calls `RedactWithTrust`, falling back to `TrustInferred` for unknown / missing provenance.

## Test plan
- [x] Redaction matrix: `TestRedactWithTrust_ExplicitKeepsPersonalDetails`, `_ExplicitNoStructuralPatternsIsNoop`, `_CustomPatternsAreStructural`, `_BackwardCompatibleWithRedact`
- [x] Store persistence: `TestPostgresMemoryStore_Save_TrustModelFromProvenance` runs table-driven across all five provenance values
- [x] Middleware forwarding: `TestMemoryPrivacyMiddleware_ForwardsProvenance`, `_EmptyProvenanceWhenMetadataMissing`
- [x] Per-file coverage: redaction.go 95.3%, redactor.go 97.3%, store.go 87.6%, privacy_middleware.go 93.8%, patterns.go 100%
- [x] `go test ./... -count=1` and `golangci-lint run ./...` clean