### PR TITLE
feat(memory): purpose-filtered retrieval

### DIFF
--- a/internal/memory/api/handler_retrieve.go
+++ b/internal/memory/api/handler_retrieve.go
@@ -32,12 +32,17 @@ const (
 )
 
 // RetrieveMultiTierRequest is the JSON body for POST /api/v1/memories/retrieve.
+//
+// Purposes narrows the result set to memories tagged with one of the listed
+// purpose values (e.g. "support_continuity", "personalisation"). Omit to
+// return every purpose — the pre-filter default.
 type RetrieveMultiTierRequest struct {
 	WorkspaceID   string   `json:"workspace_id"`
 	UserID        string   `json:"user_id,omitempty"`
 	AgentID       string   `json:"agent_id,omitempty"`
 	Query         string   `json:"query,omitempty"`
 	Types         []string `json:"types,omitempty"`
+	Purposes      []string `json:"purposes,omitempty"`
 	MinConfidence float64  `json:"min_confidence,omitempty"`
 	Limit         int      `json:"limit,omitempty"`
 }
@@ -83,6 +88,7 @@ func (h *Handler) handleRetrieveMultiTier(w http.ResponseWriter, r *http.Request
 		AgentID:       req.AgentID,
 		Query:         req.Query,
 		Types:         req.Types,
+		Purposes:      req.Purposes,
 		MinConfidence: req.MinConfidence,
 		Limit:         limit,
 	}

--- a/internal/memory/api/service.go
+++ b/internal/memory/api/service.go
@@ -140,6 +140,17 @@ func (s *MemoryService) SaveMemory(ctx context.Context, mem *memory.Memory) erro
 		exp := time.Now().Add(s.config.DefaultTTL)
 		mem.ExpiresAt = &exp
 	}
+	// Stamp the service-configured purpose when the caller didn't set one.
+	// Same shape as DefaultTTL — the store reads Metadata[MetaKeyPurpose]
+	// into memory_entities.purpose at insert time.
+	if s.config.Purpose != "" {
+		if mem.Metadata == nil {
+			mem.Metadata = map[string]any{}
+		}
+		if _, ok := mem.Metadata[memory.MetaKeyPurpose]; !ok {
+			mem.Metadata[memory.MetaKeyPurpose] = s.config.Purpose
+		}
+	}
 	if err := s.store.Save(ctx, mem); err != nil {
 		return err
 	}

--- a/internal/memory/api/service_test.go
+++ b/internal/memory/api/service_test.go
@@ -439,6 +439,49 @@ func TestMemoryService_SaveWithExplicitExpiry(t *testing.T) {
 		"explicit ExpiresAt should not be overridden by DefaultTTL")
 }
 
+func TestMemoryService_SaveStampsDefaultPurpose(t *testing.T) {
+	pool := freshDB(t)
+	store := memory.NewPostgresMemoryStore(pool)
+	cfg := MemoryServiceConfig{Purpose: "personalisation"}
+	svc := NewMemoryService(store, nil, cfg, logr.Discard())
+
+	ctx := context.Background()
+	mem := &memory.Memory{
+		Type: "fact", Content: "purpose default", Confidence: 1.0,
+		Scope: map[string]string{memory.ScopeWorkspaceID: testWorkspaceID, memory.ScopeUserID: "u"},
+	}
+
+	require.NoError(t, svc.SaveMemory(ctx, mem))
+
+	var got string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT purpose FROM memory_entities WHERE id = $1`, mem.ID).Scan(&got))
+	assert.Equal(t, "personalisation", got,
+		"service Purpose config must propagate to the DB column via Metadata[MetaKeyPurpose]")
+}
+
+func TestMemoryService_SaveRespectsExplicitPurpose(t *testing.T) {
+	pool := freshDB(t)
+	store := memory.NewPostgresMemoryStore(pool)
+	cfg := MemoryServiceConfig{Purpose: "personalisation"}
+	svc := NewMemoryService(store, nil, cfg, logr.Discard())
+
+	ctx := context.Background()
+	mem := &memory.Memory{
+		Type: "fact", Content: "explicit purpose", Confidence: 1.0,
+		Scope:    map[string]string{memory.ScopeWorkspaceID: testWorkspaceID, memory.ScopeUserID: "u"},
+		Metadata: map[string]any{memory.MetaKeyPurpose: "compliance"},
+	}
+
+	require.NoError(t, svc.SaveMemory(ctx, mem))
+
+	var got string
+	require.NoError(t, pool.QueryRow(ctx,
+		`SELECT purpose FROM memory_entities WHERE id = $1`, mem.ID).Scan(&got))
+	assert.Equal(t, "compliance", got,
+		"explicit metadata purpose must override service Purpose config")
+}
+
 func TestServiceBatchDeleteMemories(t *testing.T) {
 	svc := newTestService(t)
 	ctx := context.Background()

--- a/internal/memory/httpclient/retrieve_multi_tier.go
+++ b/internal/memory/httpclient/retrieve_multi_tier.go
@@ -33,12 +33,16 @@ const multiTierPath = "/api/v1/memories/retrieve"
 // MultiTierRequest is the client-side body for POST /api/v1/memories/retrieve.
 // Mirrors memory/api.RetrieveMultiTierRequest — redeclared here to preserve
 // dependency direction (httpclient must not import the api package).
+//
+// Purposes narrows the result set to entities tagged with one of the listed
+// purpose values. Omit to return every purpose.
 type MultiTierRequest struct {
 	WorkspaceID   string   `json:"workspace_id"`
 	UserID        string   `json:"user_id,omitempty"`
 	AgentID       string   `json:"agent_id,omitempty"`
 	Query         string   `json:"query,omitempty"`
 	Types         []string `json:"types,omitempty"`
+	Purposes      []string `json:"purposes,omitempty"`
 	MinConfidence float64  `json:"min_confidence,omitempty"`
 	Limit         int      `json:"limit,omitempty"`
 }

--- a/internal/memory/retrieve_multi_tier.go
+++ b/internal/memory/retrieve_multi_tier.go
@@ -64,6 +64,15 @@ type MultiTierRequest struct {
 	Limit         int
 	Now           time.Time
 
+	// Purposes narrows the result set to memories tagged with one of the
+	// listed purpose values (e.g. "support_continuity", "personalisation").
+	// Empty means "no purpose filter" — all purposes are returned, preserving
+	// the pre-filter default for callers that don't yet supply the field.
+	// A nil-purpose memory (entity.purpose IS NULL) only matches when the
+	// caller doesn't pass a filter; an explicit non-empty Purposes list
+	// requires a match.
+	Purposes []string
+
 	// Multi-mode retrieval additions (Phase 3).
 	SeedEntityIDs     []string
 	MaxGraphHops      int
@@ -260,6 +269,14 @@ func buildMultiTierQuery(req MultiTierRequest) (string, []any, error) {
 	if req.Query != "" {
 		args = append(args, "%"+req.Query+"%")
 		clauses = append(clauses, "o.content ILIKE $"+strconv.Itoa(len(args)))
+	}
+
+	if len(req.Purposes) == 1 {
+		args = append(args, req.Purposes[0])
+		clauses = append(clauses, "e.purpose=$"+strconv.Itoa(len(args)))
+	} else if len(req.Purposes) > 1 {
+		args = append(args, req.Purposes)
+		clauses = append(clauses, "e.purpose = ANY($"+strconv.Itoa(len(args))+")")
 	}
 
 	sql := fmt.Sprintf(`SELECT DISTINCT ON (e.id) e.id, e.kind, e.metadata, e.created_at, e.expires_at, e.virtual_user_id, e.agent_id, o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at, o.access_count FROM memory_entities e JOIN memory_observations o ON o.entity_id = e.id AND o.superseded_by IS NULL WHERE %s ORDER BY e.id, o.observed_at DESC LIMIT %d`,

--- a/internal/memory/retrieve_multi_tier_test.go
+++ b/internal/memory/retrieve_multi_tier_test.go
@@ -268,6 +268,93 @@ func TestRetrieveMultiTier_DefaultLimitApplies(t *testing.T) {
 	assert.Len(t, result.Memories, 1)
 }
 
+// insertRawMemoryWithPurpose seeds a memory_entities row with an explicit
+// purpose so purpose-filtered retrieval tests can exercise non-default
+// values without routing through Save()'s user_id-required invariant.
+func insertRawMemoryWithPurpose(t *testing.T, store *PostgresMemoryStore, purpose, user, agent, kind, content string, confidence float64) {
+	t.Helper()
+	var userArg, agentArg any
+	if user != "" {
+		userArg = user
+	}
+	if agent != "" {
+		agentArg = agent
+	}
+	var entityID string
+	err := store.pool.QueryRow(context.Background(),
+		`INSERT INTO memory_entities (workspace_id, virtual_user_id, agent_id, name, kind, metadata, purpose)
+		 VALUES ($1, $2, $3, $4, $5, '{}', $6) RETURNING id`,
+		testWorkspace1, userArg, agentArg, content, kind, purpose,
+	).Scan(&entityID)
+	require.NoError(t, err)
+
+	_, err = store.pool.Exec(context.Background(),
+		`INSERT INTO memory_observations (entity_id, content, confidence) VALUES ($1, $2, $3)`,
+		entityID, content, confidence,
+	)
+	require.NoError(t, err)
+}
+
+func TestRetrieveMultiTier_PurposeFilter(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	insertRawMemoryWithPurpose(t, store, "support_continuity", "user-1", "", "fact", "support row", 1.0)
+	insertRawMemoryWithPurpose(t, store, "personalisation", "user-1", "", "fact", "personalisation row", 1.0)
+	insertRawMemoryWithPurpose(t, store, "compliance", "user-1", "", "fact", "compliance row", 1.0)
+
+	t.Run("single purpose filters to matching rows", func(t *testing.T) {
+		res, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+			WorkspaceID: testWorkspace1,
+			UserID:      "user-1",
+			Purposes:    []string{"personalisation"},
+			Limit:       10,
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Memories, 1)
+		assert.Equal(t, "personalisation row", res.Memories[0].Content)
+	})
+
+	t.Run("multiple purposes act as OR", func(t *testing.T) {
+		res, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+			WorkspaceID: testWorkspace1,
+			UserID:      "user-1",
+			Purposes:    []string{"personalisation", "compliance"},
+			Limit:       10,
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Memories, 2)
+		seen := map[string]bool{}
+		for _, m := range res.Memories {
+			seen[m.Content] = true
+		}
+		assert.True(t, seen["personalisation row"])
+		assert.True(t, seen["compliance row"])
+		assert.False(t, seen["support row"])
+	})
+
+	t.Run("empty purposes returns everything", func(t *testing.T) {
+		res, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+			WorkspaceID: testWorkspace1,
+			UserID:      "user-1",
+			Limit:       10,
+		})
+		require.NoError(t, err)
+		require.Len(t, res.Memories, 3, "no filter should return all 3 rows")
+	})
+
+	t.Run("non-matching purpose returns empty", func(t *testing.T) {
+		res, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+			WorkspaceID: testWorkspace1,
+			UserID:      "user-1",
+			Purposes:    []string{"never_used"},
+			Limit:       10,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, res.Memories)
+	})
+}
+
 func TestRetrieveMultiTier_TypeAndConfidenceFilters(t *testing.T) {
 	store := newStore(t)
 	ctx := context.Background()

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -116,13 +116,21 @@ func (s *PostgresMemoryStore) Save(ctx context.Context, mem *Memory) error {
 	return tx.Commit(ctx)
 }
 
+// MetaKeyPurpose is the metadata key carrying the Omnia purpose tag
+// (e.g. "support_continuity", "personalisation"). The value is read at
+// insert time and written to memory_entities.purpose so retrieval can
+// filter on it without re-parsing JSON metadata. Empty / missing values
+// fall through to the schema default ('support_continuity').
+const MetaKeyPurpose = "purpose"
+
 // insertEntity inserts a new memory_entities row and populates mem.ID / mem.CreatedAt.
 //
 // trust_model and source_type are derived from the provenance metadata key
 // (pkmemory.MetaKeyProvenance) so the redactor and retention pipelines can
 // tell operator-curated / user-requested rows from agent-extracted ones.
-// When the caller didn't set a provenance, we keep the schema defaults
-// (trust_model='inferred', source_type='conversation_extraction').
+// purpose is derived from the MetaKeyPurpose metadata key. In both cases a
+// missing value falls through to the schema default, preserving behaviour
+// for callers that haven't started tagging.
 func insertEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 	metaJSON, err := marshalMetadata(mem.Metadata)
 	if err != nil {
@@ -130,14 +138,17 @@ func insertEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 	}
 
 	trustModel, sourceType := trustFromProvenance(mem.Metadata)
+	purpose := purposeFromMetadata(mem.Metadata)
 
 	row := tx.QueryRow(ctx, `
 		INSERT INTO memory_entities
-		  (workspace_id, virtual_user_id, agent_id, name, kind, metadata, expires_at, trust_model, source_type)
+		  (workspace_id, virtual_user_id, agent_id, name, kind, metadata, expires_at,
+		   trust_model, source_type, purpose)
 		VALUES
 		  ($1, $2, $3, $4, $5, $6, $7,
 		    COALESCE($8, 'inferred'),
-		    COALESCE($9, 'conversation_extraction'))
+		    COALESCE($9, 'conversation_extraction'),
+		    COALESCE($10, 'support_continuity'))
 		RETURNING id, created_at`,
 		mem.Scope[ScopeWorkspaceID],
 		scopeOrNil(mem.Scope, ScopeUserID),
@@ -148,6 +159,7 @@ func insertEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 		mem.ExpiresAt,
 		trustModel,
 		sourceType,
+		purpose,
 	)
 
 	return row.Scan(&mem.ID, &mem.CreatedAt)
@@ -178,6 +190,19 @@ func trustFromProvenance(meta map[string]any) (trustModel, sourceType *string) {
 	default:
 		return nil, nil
 	}
+}
+
+// purposeFromMetadata returns a pointer to the Metadata[MetaKeyPurpose] value
+// when set, or nil so the INSERT falls through to the schema default.
+func purposeFromMetadata(meta map[string]any) *string {
+	if meta == nil {
+		return nil
+	}
+	v, ok := meta[MetaKeyPurpose].(string)
+	if !ok || v == "" {
+		return nil
+	}
+	return &v
 }
 
 // updateEntity updates the entity metadata and updated_at timestamp.

--- a/internal/memory/store_test.go
+++ b/internal/memory/store_test.go
@@ -212,6 +212,39 @@ func TestPostgresMemoryStore_Save_TrustModelFromProvenance(t *testing.T) {
 	}
 }
 
+func TestPostgresMemoryStore_Save_PurposeFromMetadata(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	scope := testScope(testWorkspace1)
+
+	mem := &Memory{
+		Type: "fact", Content: "purpose-tagged", Confidence: 1.0, Scope: scope,
+		Metadata: map[string]any{MetaKeyPurpose: "personalisation"},
+	}
+	require.NoError(t, store.Save(ctx, mem))
+
+	var got string
+	require.NoError(t, store.Pool().QueryRow(ctx,
+		`SELECT purpose FROM memory_entities WHERE id = $1`, mem.ID).Scan(&got))
+	assert.Equal(t, "personalisation", got)
+}
+
+func TestPostgresMemoryStore_Save_MissingPurposeUsesSchemaDefault(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	scope := testScope(testWorkspace1)
+
+	mem := &Memory{
+		Type: "fact", Content: "no purpose tag", Confidence: 1.0, Scope: scope,
+	}
+	require.NoError(t, store.Save(ctx, mem))
+
+	var got string
+	require.NoError(t, store.Pool().QueryRow(ctx,
+		`SELECT purpose FROM memory_entities WHERE id = $1`, mem.ID).Scan(&got))
+	assert.Equal(t, "support_continuity", got, "missing purpose must fall through to schema default")
+}
+
 func TestPostgresMemoryStore_Save_MissingWorkspace(t *testing.T) {
 
 	store := newStore(t)


### PR DESCRIPTION
## Summary
Lights up `memory_entities.purpose` end-to-end. The column has existed since the initial schema but nothing read or wrote it from Go code — retrieval ignored it and `Save()` always fell through to the schema default.

**Store**
- `insertEntity` writes `purpose` from `Metadata[MetaKeyPurpose]`. Missing values fall through to the schema default (`support_continuity`), so existing callers see no change.
- `MultiTierRequest.Purposes []string` filters by `memory_entities.purpose`. Single-element renders as `e.purpose = \$N`; multi-element as `e.purpose = ANY(\$N)`; empty returns every purpose.

**Service**
- `MemoryService.SaveMemory` stamps `Config.Purpose` into `Metadata[MetaKeyPurpose]` when the caller didn't set one, so the memory-api `--purpose` flag finally has an effect. Explicit caller metadata wins.

**HTTP / httpclient**
- `RetrieveMultiTierRequest` and `httpclient.MultiTierRequest` expose a top-level `purposes` JSON array.

## Test plan
- [x] Filter matrix: `TestRetrieveMultiTier_PurposeFilter` covers single, multi (OR), empty (no filter), and no-match
- [x] Store persistence: `TestPostgresMemoryStore_Save_PurposeFromMetadata` and `_MissingPurposeUsesSchemaDefault`
- [x] Service default stamping: `TestMemoryService_SaveStampsDefaultPurpose` and `_SaveRespectsExplicitPurpose`
- [x] `go test ./internal/memory/... -count=1` — 384 passed
- [x] `golangci-lint run ./internal/memory/...` clean