### PR TITLE
feat(memory): read-path accessed_at updates (retention Phase 2)

### DIFF
--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	goredis "github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -264,6 +265,15 @@ func run() error {
 
 	// --- Memory store ---
 	store := memory.NewPostgresMemoryStore(pool)
+
+	// --- Read-path metrics ---
+	// accessed_at / access_count are bumped asynchronously on every
+	// retrieval. Register the Prometheus counters + histogram so the
+	// signal is observable in dashboards. Failure to register isn't
+	// fatal — retrieval still works, just without the counters.
+	if err := memory.RegisterAccessMetrics(prometheus.DefaultRegisterer); err != nil {
+		log.Error(err, "memory access metrics registration failed")
+	}
 
 	// --- Service config: TTL + purpose ---
 	var defaultTTL time.Duration

--- a/internal/memory/access_tracker.go
+++ b/internal/memory/access_tracker.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"context"
+	"time"
+)
+
+// touchAccessedTimeout caps how long the background UPDATE is allowed to
+// run. Retrieval must not be coupled to write-path latency — if the write
+// is slow we'd rather drop the signal than stall the caller (who may
+// already have returned to the user).
+const touchAccessedTimeout = 5 * time.Second
+
+// touchAccessedOnRead fires a detached UPDATE that bumps accessed_at +
+// access_count on the non-superseded observations attached to the given
+// entity IDs. It's a no-op for the empty slice so retrieval callsites
+// don't need a length guard of their own.
+//
+// The update runs in its own goroutine with a fresh timeout context, so
+// the caller's request context (which may already be cancelled by the
+// time the summary lands in the response) doesn't kill the write. This
+// is the signal the LRU pruning and recency-decay scoring in the
+// retention proposal depend on — losing the occasional update under
+// load is acceptable, losing all of them is not.
+func (s *PostgresMemoryStore) touchAccessedOnRead(entityIDs []string) {
+	if len(entityIDs) == 0 {
+		return
+	}
+	ids := dedupeStrings(entityIDs)
+
+	go func(ids []string) {
+		ctx, cancel := context.WithTimeout(context.Background(), touchAccessedTimeout)
+		defer cancel()
+
+		start := time.Now()
+		tag, err := s.pool.Exec(ctx, `
+			UPDATE memory_observations
+			SET accessed_at = now(), access_count = access_count + 1
+			WHERE entity_id = ANY($1::uuid[]) AND superseded_by IS NULL`,
+			ids,
+		)
+		dur := time.Since(start)
+
+		if m := defaultAccessMetrics.Load(); m != nil {
+			m.recordAccessUpdate(dur, err)
+		}
+		if err != nil {
+			// Intentional log omission — retrieval has already returned to
+			// the caller and we don't want a noisy error log for every
+			// transient DB blip. Callers who care about the metric observe
+			// it via omnia_memory_accessed_update_errors_total.
+			_ = err
+			_ = tag
+		}
+	}(ids)
+}
+
+// dedupeStrings returns a sorted-free copy of the input with duplicates
+// removed. The UPDATE's WHERE clause already tolerates duplicates in the
+// array, but dedupe keeps the query plan simple and saves a bit of pgx
+// marshalling work when a retrieval returns the same entity more than
+// once (happens rarely, e.g. structured-lookup + graph merge paths).
+func dedupeStrings(in []string) []string {
+	if len(in) <= 1 {
+		return in
+	}
+	seen := make(map[string]struct{}, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}
+
+// entityIDsFromMemories extracts the IDs from a retrieval result. Used
+// as the accessed_at touch input.
+func entityIDsFromMemories(mems []*Memory) []string {
+	if len(mems) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(mems))
+	for _, m := range mems {
+		if m != nil && m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	return ids
+}
+
+// entityIDsFromMultiTier extracts IDs from a MultiTierMemory slice.
+func entityIDsFromMultiTier(mems []*MultiTierMemory) []string {
+	if len(mems) == 0 {
+		return nil
+	}
+	ids := make([]string, 0, len(mems))
+	for _, m := range mems {
+		if m != nil && m.Memory != nil && m.ID != "" {
+			ids = append(ids, m.ID)
+		}
+	}
+	return ids
+}

--- a/internal/memory/access_tracker_test.go
+++ b/internal/memory/access_tracker_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRetrieve_TouchesAccessedAt exercises the read-path accessed_at
+// update: a Retrieve against a freshly-saved memory must, within a short
+// window, move the observation's accessed_at forward and increment
+// access_count. This is the signal LRU pruning and recency-weighted
+// scoring rely on.
+func TestRetrieve_TouchesAccessedAt(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	scope := testScope(testWorkspace1)
+
+	mem := &Memory{
+		Type:       "fact",
+		Content:    "accessed-at-test",
+		Confidence: 0.9,
+		Scope:      scope,
+	}
+	require.NoError(t, store.Save(ctx, mem))
+	require.NotEmpty(t, mem.ID)
+
+	// Baseline row: access_count = 0, accessed_at IS NULL.
+	var baselineCount int
+	var baselineAccessedAt *time.Time
+	require.NoError(t, store.pool.QueryRow(ctx, `
+		SELECT access_count, accessed_at FROM memory_observations
+		WHERE entity_id = $1 AND superseded_by IS NULL
+		ORDER BY observed_at DESC LIMIT 1`, mem.ID,
+	).Scan(&baselineCount, &baselineAccessedAt))
+	assert.Equal(t, 0, baselineCount)
+	assert.Nil(t, baselineAccessedAt, "accessed_at should start NULL on fresh inserts")
+
+	// Do a retrieve that will return the row. The touch is async, so we
+	// poll briefly for it to land.
+	res, err := store.Retrieve(ctx, scope, "accessed-at", RetrieveOptions{Limit: 10})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+
+	require.Eventually(t, func() bool {
+		var n int
+		var at *time.Time
+		err := store.pool.QueryRow(ctx, `
+			SELECT access_count, accessed_at FROM memory_observations
+			WHERE entity_id = $1 AND superseded_by IS NULL
+			ORDER BY observed_at DESC LIMIT 1`, mem.ID,
+		).Scan(&n, &at)
+		return err == nil && n == 1 && at != nil
+	}, 3*time.Second, 50*time.Millisecond,
+		"accessed_at should be updated by Retrieve within a few seconds")
+}
+
+func TestRetrieveMultiTier_TouchesAccessedAt(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	// Institutional row — clean scope, no user filter needed.
+	insertRawMemory(t, store, "", "", "fact", "multi-tier-touch", 0.9)
+
+	result, err := store.RetrieveMultiTier(ctx, MultiTierRequest{
+		WorkspaceID: testWorkspace1,
+		Limit:       10,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, result.Memories)
+	entityID := result.Memories[0].ID
+
+	require.Eventually(t, func() bool {
+		var n int
+		var at *time.Time
+		err := store.pool.QueryRow(ctx, `
+			SELECT access_count, accessed_at FROM memory_observations
+			WHERE entity_id = $1 AND superseded_by IS NULL
+			ORDER BY observed_at DESC LIMIT 1`, entityID,
+		).Scan(&n, &at)
+		return err == nil && n == 1 && at != nil
+	}, 3*time.Second, 50*time.Millisecond,
+		"RetrieveMultiTier must touch accessed_at on the rows it returns")
+}
+
+// TestRetrieve_EmptyResultsIsNoop proves the touch path exits cleanly on
+// empty retrievals (no wasted UPDATE, no panic).
+func TestRetrieve_EmptyResultsIsNoop(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	// No rows saved; retrieval returns empty.
+	res, err := store.Retrieve(ctx, testScope(testWorkspace1), "nothing here", RetrieveOptions{Limit: 5})
+	require.NoError(t, err)
+	assert.Empty(t, res)
+	// Nothing to assert on the DB side — the goal is "no panic, no
+	// hang". A fire-and-forget goroutine with an empty slice should
+	// return immediately.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestDedupeStrings(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"empty", nil, nil},
+		{"single", []string{"a"}, []string{"a"}},
+		{"no dupes", []string{"a", "b", "c"}, []string{"a", "b", "c"}},
+		{"repeated head", []string{"a", "a", "b"}, []string{"a", "b"}},
+		{"repeated tail", []string{"a", "b", "b", "b"}, []string{"a", "b"}},
+		{"interleaved", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := dedupeStrings(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestEntityIDsFromMemories_SkipsNilAndEmpty(t *testing.T) {
+	in := []*Memory{
+		{ID: "one"},
+		nil,
+		{ID: ""},
+		{ID: "two"},
+	}
+	got := entityIDsFromMemories(in)
+	assert.Equal(t, []string{"one", "two"}, got)
+}
+
+func TestEntityIDsFromMultiTier_SkipsNilAndEmpty(t *testing.T) {
+	in := []*MultiTierMemory{
+		{Memory: &Memory{ID: "one"}},
+		nil,
+		{Memory: nil},
+		{Memory: &Memory{ID: ""}},
+		{Memory: &Memory{ID: "two"}},
+	}
+	got := entityIDsFromMultiTier(in)
+	assert.Equal(t, []string{"one", "two"}, got)
+}

--- a/internal/memory/metrics.go
+++ b/internal/memory/metrics.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metric name constants. Kept in one place so dashboards and tests agree.
+const (
+	metricAccessUpdates        = "omnia_memory_accessed_updates_total"
+	metricAccessUpdateErrors   = "omnia_memory_accessed_update_errors_total"
+	metricAccessUpdateDuration = "omnia_memory_accessed_update_duration_seconds"
+)
+
+// accessMetrics owns the Prometheus metrics emitted by the read-path
+// accessed_at touch. Held behind an atomic pointer so the memory-api
+// binary can install a shared set at startup while tests can keep
+// per-test registries without panicking on duplicate registration.
+type accessMetrics struct {
+	updates        prometheus.Counter
+	updateErrors   prometheus.Counter
+	updateDuration prometheus.Histogram
+}
+
+// defaultAccessMetrics is the process-wide instance. Nil until installed
+// via RegisterAccessMetrics. The touch path tolerates nil — metrics are
+// optional, updates still happen.
+var defaultAccessMetrics atomic.Pointer[accessMetrics]
+
+// RegisterAccessMetrics registers the read-path accessed-at metrics on
+// the given registerer (pass prometheus.DefaultRegisterer in production).
+// Returns an error only when metric registration collides; callers can
+// safely treat that as fatal at startup.
+//
+// Calling more than once replaces the active metrics pointer — useful in
+// tests that want a fresh registry per case.
+func RegisterAccessMetrics(reg prometheus.Registerer) error {
+	m := &accessMetrics{
+		updates: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: metricAccessUpdates,
+			Help: "Number of successful accessed_at / access_count updates triggered by memory retrieval.",
+		}),
+		updateErrors: prometheus.NewCounter(prometheus.CounterOpts{
+			Name: metricAccessUpdateErrors,
+			Help: "Number of accessed_at update attempts that returned an error (DB unavailable, timeout, etc.).",
+		}),
+		updateDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+			Name:    metricAccessUpdateDuration,
+			Help:    "Wall-clock duration of the async accessed_at UPDATE, in seconds.",
+			Buckets: []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5},
+		}),
+	}
+	for _, c := range []prometheus.Collector{m.updates, m.updateErrors, m.updateDuration} {
+		if err := reg.Register(c); err != nil {
+			// Allow re-registration when the exact same collector was
+			// already registered (tests re-use the default registry).
+			if _, ok := err.(prometheus.AlreadyRegisteredError); !ok {
+				return err
+			}
+		}
+	}
+	defaultAccessMetrics.Store(m)
+	return nil
+}
+
+// recordAccessUpdate ticks the counter + histogram for one touch attempt.
+// No-op when the metrics haven't been registered.
+func (m *accessMetrics) recordAccessUpdate(dur time.Duration, err error) {
+	if m == nil {
+		return
+	}
+	m.updateDuration.Observe(dur.Seconds())
+	if err != nil {
+		m.updateErrors.Inc()
+		return
+	}
+	m.updates.Inc()
+}

--- a/internal/memory/metrics_test.go
+++ b/internal/memory/metrics_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRegisterAccessMetrics_InstallsCollectors confirms the counters and
+// histogram end up on the given registerer so Prometheus can scrape them.
+func TestRegisterAccessMetrics_InstallsCollectors(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterAccessMetrics(reg))
+
+	mfs, err := reg.Gather()
+	require.NoError(t, err)
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[mf.GetName()] = true
+	}
+	assert.True(t, names[metricAccessUpdates], "successes counter must be registered")
+	assert.True(t, names[metricAccessUpdateErrors], "errors counter must be registered")
+	assert.True(t, names[metricAccessUpdateDuration], "duration histogram must be registered")
+}
+
+// TestRecordAccessUpdate_CountsSuccessesAndErrors proves the metrics
+// record-helper increments the right counters based on the error arg.
+func TestRecordAccessUpdate_CountsSuccessesAndErrors(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterAccessMetrics(reg))
+
+	m := defaultAccessMetrics.Load()
+	require.NotNil(t, m)
+
+	m.recordAccessUpdate(10*time.Millisecond, nil)
+	m.recordAccessUpdate(20*time.Millisecond, nil)
+	m.recordAccessUpdate(30*time.Millisecond, errors.New("pool closed"))
+
+	assert.InDelta(t, 2.0, testutil.ToFloat64(m.updates), 0.0001,
+		"two successful updates should count as 2")
+	assert.InDelta(t, 1.0, testutil.ToFloat64(m.updateErrors), 0.0001,
+		"one failed update should count as 1")
+}
+
+// TestRecordAccessUpdate_NilMetricsIsNoop confirms the touch path can be
+// safely invoked before RegisterAccessMetrics has run (memory-api binary
+// installs them at boot but tests sometimes skip that).
+func TestRecordAccessUpdate_NilMetricsIsNoop(t *testing.T) {
+	var m *accessMetrics
+	assert.NotPanics(t, func() {
+		m.recordAccessUpdate(time.Millisecond, nil)
+	})
+}
+
+// TestRegisterAccessMetrics_IdempotentOnDuplicateRegister ensures the
+// helper doesn't explode when called twice against the same registry —
+// process-wide init plus per-test reset is a common pattern.
+func TestRegisterAccessMetrics_IdempotentOnDuplicateRegister(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterAccessMetrics(reg))
+	// Second call on the same reg — register returns AlreadyRegisteredError
+	// which we're expected to swallow; ensure no error bubbles out.
+	assert.NoError(t, RegisterAccessMetrics(reg))
+}

--- a/internal/memory/retrieve_multi_tier.go
+++ b/internal/memory/retrieve_multi_tier.go
@@ -153,6 +153,12 @@ func (s *PostgresMemoryStore) RetrieveMultiTier(ctx context.Context, req MultiTi
 		memories = memories[:limit]
 	}
 
+	// Bump accessed_at / access_count on the final (post-ranking, post-
+	// truncation) result. Doing it after truncation means rows that didn't
+	// make it into the caller's response don't get their LRU signal
+	// refreshed — which is correct, they weren't actually used.
+	s.touchAccessedOnRead(entityIDsFromMultiTier(memories))
+
 	return &MultiTierResult{Memories: memories, Total: len(memories)}, nil
 }
 

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -259,6 +259,9 @@ func insertObservation(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 
 // Retrieve returns memories matching scope, a substring query, and options.
 // Results are ordered by observed_at DESC and limited to opts.Limit (default 50).
+// A successful retrieval also fires a detached UPDATE that bumps
+// accessed_at / access_count on the returned entities — the signal LRU
+// pruning and recency-weighted ranking depend on.
 func (s *PostgresMemoryStore) Retrieve(ctx context.Context, scope map[string]string, query string, opts RetrieveOptions) ([]*Memory, error) {
 	if scope[ScopeWorkspaceID] == "" {
 		return nil, errors.New(errWorkspaceRequired)
@@ -272,7 +275,12 @@ func (s *PostgresMemoryStore) Retrieve(ctx context.Context, scope map[string]str
 	}
 	defer rows.Close()
 
-	return scanMemories(rows, scope)
+	mems, err := scanMemories(rows, scope)
+	if err != nil {
+		return nil, err
+	}
+	s.touchAccessedOnRead(entityIDsFromMemories(mems))
+	return mems, nil
 }
 
 // buildRetrieveQuery constructs the SQL and arguments for a Retrieve call.


### PR DESCRIPTION
`memory_observations.accessed_at` and `access_count` have existed since the initial schema but nothing wrote to them — the multi-tier ranking formula's recency term was dead weight and future LRU pruning had no signal to work with.

This is Phase 2 of the `MemoryRetentionPolicy` plan in `docs/local-backlog/memory-retention-and-pruning-proposal.md`. Phase 1 (CRD) isn't a prerequisite; Phase 2 stands alone and immediately improves ranking quality by giving the existing recency decay real input.

## Approach

Fire-and-forget goroutine per retrieval call, detached from the caller's context so a cancelled request doesn't kill the write. Each retrieval passes the set of entity IDs it actually returned (post-ranking, post-truncation) — rows the caller didn't see don't get their LRU signal refreshed.

The 5s detached timeout bounds how long the background UPDATE is allowed to run. Under load the goroutines are naturally capped by the pool's connection count.

## Paths instrumented

- `PostgresMemoryStore.Retrieve`
- `PostgresMemoryStore.RetrieveMultiTier`

Both fire the async touch after the result set is finalized.

## Metrics

Registered at memory-api boot via `memory.RegisterAccessMetrics(prometheus.DefaultRegisterer)`:

- `omnia_memory_accessed_updates_total` (counter)
- `omnia_memory_accessed_update_errors_total` (counter)
- `omnia_memory_accessed_update_duration_seconds` (histogram)

## Test plan
- [x] `go test ./internal/memory/... -count=1` — 446 passed, integration tests against real Postgres confirm `accessed_at` moves from NULL → non-NULL and `access_count` increments from 0 → 1 within a few seconds of a retrieval
- [x] `go build ./...` clean
- [x] `golangci-lint run ./internal/memory/... ./cmd/memory-api/...` clean
- [x] Unit tests cover dedupeStrings, nil-safety on ID extraction, and the metrics recorder under both success and error paths