### PR TITLE
feat(memory): consent revocation cascade (phase 4)

### DIFF
--- a/internal/memory/consent_revocation_store.go
+++ b/internal/memory/consent_revocation_store.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"fmt"
+)
+
+// SoftDeleteRevokedConsent soft-deletes up to batchSize user-tier rows
+// whose consent_category is no longer present in the user's
+// consent_grants array. Non-user-tier rows (virtual_user_id IS NULL)
+// are skipped — consent is user-scoped.
+//
+// The join against user_privacy_preferences is safe because that
+// table lives in the memory-api's own database (see migration
+// 000001_initial_schema.up.sql).
+func (s *PostgresMemoryStore) SoftDeleteRevokedConsent(
+	ctx context.Context, batchSize int,
+) (int64, error) {
+	if batchSize <= 0 {
+		return 0, nil
+	}
+	q := `
+WITH target AS (
+  SELECT e.id FROM memory_entities e
+  JOIN user_privacy_preferences p ON p.user_id = e.virtual_user_id
+  WHERE e.forgotten = false
+    AND e.virtual_user_id IS NOT NULL
+    AND e.consent_category IS NOT NULL
+    AND NOT (e.consent_category = ANY(p.consent_grants))
+  ORDER BY e.created_at ASC
+  LIMIT $1
+  FOR UPDATE SKIP LOCKED
+)
+UPDATE memory_entities
+SET forgotten = true, forgotten_at = now(), updated_at = now()
+WHERE id IN (SELECT id FROM target)`
+
+	tag, err := s.pool.Exec(ctx, q, batchSize)
+	if err != nil {
+		return 0, fmt.Errorf("memory: soft-delete revoked consent: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// HardDeleteRevokedConsent removes up to batchSize user-tier rows
+// whose consent_category is no longer granted, skipping the soft-
+// delete phase. Used when the policy's consentRevocation.action is
+// HardDelete — operators explicitly want immediate removal.
+func (s *PostgresMemoryStore) HardDeleteRevokedConsent(
+	ctx context.Context, batchSize int,
+) (int64, error) {
+	if batchSize <= 0 {
+		return 0, nil
+	}
+	q := `
+WITH target AS (
+  SELECT e.id FROM memory_entities e
+  JOIN user_privacy_preferences p ON p.user_id = e.virtual_user_id
+  WHERE e.virtual_user_id IS NOT NULL
+    AND e.consent_category IS NOT NULL
+    AND NOT (e.consent_category = ANY(p.consent_grants))
+  ORDER BY e.created_at ASC
+  LIMIT $1
+  FOR UPDATE SKIP LOCKED
+)
+DELETE FROM memory_entities
+WHERE id IN (SELECT id FROM target)`
+
+	tag, err := s.pool.Exec(ctx, q, batchSize)
+	if err != nil {
+		return 0, fmt.Errorf("memory: hard-delete revoked consent: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+// HardDeleteForgottenByConsentOlderThan clears rows that were soft-
+// deleted through the consent cascade once the policy's grace window
+// expires. Mirrors HardDeleteForgottenOlderThan but keys on
+// forgotten_at so a row flipped by TTL / LRU doesn't get picked up
+// here — that's the session of the general hard-delete pass.
+//
+// The distinction matters because operators tend to give consent-
+// driven deletions a shorter grace than regular TTL deletions.
+func (s *PostgresMemoryStore) HardDeleteForgottenByConsentOlderThan(
+	ctx context.Context, graceDays int32, batchSize int,
+) (int64, error) {
+	if batchSize <= 0 {
+		return 0, nil
+	}
+	if graceDays < 0 {
+		return 0, fmt.Errorf("memory: negative grace days (%d)", graceDays)
+	}
+	q := `
+WITH target AS (
+  SELECT id FROM memory_entities
+  WHERE forgotten = true
+    AND forgotten_at IS NOT NULL
+    AND forgotten_at < now() - $1::interval
+  ORDER BY forgotten_at ASC
+  LIMIT $2
+  FOR UPDATE SKIP LOCKED
+)
+DELETE FROM memory_entities
+WHERE id IN (SELECT id FROM target)`
+
+	interval := fmt.Sprintf("%d days", graceDays)
+	tag, err := s.pool.Exec(ctx, q, interval, batchSize)
+	if err != nil {
+		return 0, fmt.Errorf("memory: hard-delete forgotten by consent: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/memory/consent_revocation_store_test.go
+++ b/internal/memory/consent_revocation_store_test.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// seedPrivacyPrefs writes a preferences row with the given grants
+// array so the JOIN against user_privacy_preferences resolves.
+func seedPrivacyPrefs(t *testing.T, store *PostgresMemoryStore, userID string, grants []string) {
+	t.Helper()
+	_, err := store.pool.Exec(context.Background(),
+		`INSERT INTO user_privacy_preferences (user_id, consent_grants)
+		 VALUES ($1, $2)
+		 ON CONFLICT (user_id) DO UPDATE SET consent_grants = EXCLUDED.consent_grants`,
+		userID, grants)
+	require.NoError(t, err)
+}
+
+// saveUserMemWithCategory saves a user-tier memory tagged with the
+// given consent category. The helper wraps the common scope +
+// metadata dance so tests stay readable.
+func saveUserMemWithCategory(t *testing.T, store *PostgresMemoryStore, userID, category string) string {
+	t.Helper()
+	mem := &Memory{
+		Type: "fact", Content: "user memory", Confidence: 0.9,
+		Scope: map[string]string{
+			ScopeWorkspaceID: testWorkspace1,
+			ScopeUserID:      userID,
+		},
+		Metadata: map[string]any{MetaKeyConsentCategory: category},
+	}
+	require.NoError(t, store.Save(context.Background(), mem))
+	return mem.ID
+}
+
+func TestSoftDeleteRevokedConsent_FlipsRowsMissingFromGrants(t *testing.T) {
+	store := newStore(t)
+	userID := "user-phase4-a"
+
+	// User grants "memory:context" but not "memory:health".
+	seedPrivacyPrefs(t, store, userID, []string{"memory:context"})
+	healthID := saveUserMemWithCategory(t, store, userID, "memory:health")
+	contextID := saveUserMemWithCategory(t, store, userID, "memory:context")
+
+	n, err := store.SoftDeleteRevokedConsent(context.Background(), 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	assert.True(t, mustFetchEntityForgotten(t, store, healthID))
+	assert.False(t, mustFetchEntityForgotten(t, store, contextID))
+}
+
+func TestSoftDeleteRevokedConsent_IgnoresRowsWithoutCategory(t *testing.T) {
+	// A row with NULL consent_category is not part of the cascade —
+	// it's either institutional (no category) or untagged legacy data.
+	store := newStore(t)
+	userID := "user-phase4-b"
+	seedPrivacyPrefs(t, store, userID, []string{})
+
+	untagged := &Memory{
+		Type: "fact", Content: "no category", Confidence: 0.9,
+		Scope: map[string]string{
+			ScopeWorkspaceID: testWorkspace1,
+			ScopeUserID:      userID,
+		},
+	}
+	require.NoError(t, store.Save(context.Background(), untagged))
+
+	n, err := store.SoftDeleteRevokedConsent(context.Background(), 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	assert.False(t, mustFetchEntityForgotten(t, store, untagged.ID))
+}
+
+func TestSoftDeleteRevokedConsent_SkipsInstitutionalRows(t *testing.T) {
+	// Institutional rows have virtual_user_id IS NULL and therefore
+	// don't join against user_privacy_preferences — they should never
+	// be touched by the consent cascade even if their category is
+	// present on them (which it shouldn't be, but defensively).
+	store := newStore(t)
+	userID := "user-phase4-c"
+	seedPrivacyPrefs(t, store, userID, []string{}) // no grants
+
+	inst := &Memory{
+		Type: "policy", Content: "inst policy", Confidence: 1.0,
+		Scope:    map[string]string{ScopeWorkspaceID: testWorkspace1},
+		Metadata: map[string]any{MetaKeyConsentCategory: "memory:health"},
+	}
+	require.NoError(t, store.SaveInstitutional(context.Background(), inst))
+
+	n, err := store.SoftDeleteRevokedConsent(context.Background(), 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	assert.False(t, mustFetchEntityForgotten(t, store, inst.ID))
+}
+
+func TestSoftDeleteRevokedConsent_BatchSizeZeroIsNoOp(t *testing.T) {
+	store := newStore(t)
+	n, err := store.SoftDeleteRevokedConsent(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+func TestHardDeleteRevokedConsent_RemovesRowsMissingFromGrants(t *testing.T) {
+	store := newStore(t)
+	userID := "user-phase4-d"
+	seedPrivacyPrefs(t, store, userID, []string{}) // all revoked
+	id := saveUserMemWithCategory(t, store, userID, "memory:location")
+
+	n, err := store.HardDeleteRevokedConsent(context.Background(), 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	assert.False(t, mustFetchEntityExists(t, store, id))
+}
+
+func TestHardDeleteRevokedConsent_BatchSizeZeroIsNoOp(t *testing.T) {
+	store := newStore(t)
+	n, err := store.HardDeleteRevokedConsent(context.Background(), 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+func TestHardDeleteForgottenByConsentOlderThan_UsesForgottenAt(t *testing.T) {
+	// Set forgotten_at to 30 days ago; a 7-day grace window should
+	// hard-delete the row. updated_at is not consulted — the test
+	// leaves it at now() to guard against regressions.
+	store := newStore(t)
+	userID := "user-phase4-e"
+	seedPrivacyPrefs(t, store, userID, []string{})
+	id := saveUserMemWithCategory(t, store, userID, "memory:location")
+	_, err := store.pool.Exec(context.Background(),
+		"UPDATE memory_entities SET forgotten = true, forgotten_at = now() - interval '30 days' WHERE id = $1",
+		id)
+	require.NoError(t, err)
+
+	n, err := store.HardDeleteForgottenByConsentOlderThan(context.Background(), 7, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), n)
+	assert.False(t, mustFetchEntityExists(t, store, id))
+}
+
+func TestHardDeleteForgottenByConsentOlderThan_SkipsTTLForgottenRows(t *testing.T) {
+	// A row flipped by the TTL branch has forgotten=true but
+	// forgotten_at=NULL. The consent-grace pass must skip it so the
+	// general hard-delete pass handles it on its own cadence.
+	store := newStore(t)
+	mem := &Memory{
+		Type: "fact", Content: "ttl-flipped", Confidence: 0.9,
+		Scope: map[string]string{ScopeWorkspaceID: testWorkspace1},
+	}
+	require.NoError(t, store.SaveInstitutional(context.Background(), mem))
+	_, err := store.pool.Exec(context.Background(),
+		"UPDATE memory_entities SET forgotten = true, updated_at = now() - interval '30 days' WHERE id = $1",
+		mem.ID)
+	require.NoError(t, err)
+
+	n, err := store.HardDeleteForgottenByConsentOlderThan(context.Background(), 7, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	assert.True(t, mustFetchEntityExists(t, store, mem.ID))
+}
+
+func TestHardDeleteForgottenByConsentOlderThan_NegativeGraceErrors(t *testing.T) {
+	store := newStore(t)
+	_, err := store.HardDeleteForgottenByConsentOlderThan(context.Background(), -1, 100)
+	require.Error(t, err)
+}
+
+func TestHardDeleteForgottenByConsentOlderThan_BatchSizeZeroIsNoOp(t *testing.T) {
+	store := newStore(t)
+	n, err := store.HardDeleteForgottenByConsentOlderThan(context.Background(), 7, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+func TestConsentCategoryPersistsOnWrite(t *testing.T) {
+	// Round-trips MetaKeyConsentCategory through the store to confirm
+	// insertEntity writes the column (not just the metadata JSON).
+	store := newStore(t)
+	id := saveUserMemWithCategory(t, store, "user-persist", "memory:health")
+
+	var got *string
+	err := store.pool.QueryRow(context.Background(),
+		"SELECT consent_category FROM memory_entities WHERE id = $1", id).Scan(&got)
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "memory:health", *got)
+}
+
+func TestConsentCategoryNilWhenMetadataMissing(t *testing.T) {
+	// A write without MetaKeyConsentCategory should leave the column
+	// NULL so the row falls under the default policy.
+	store := newStore(t)
+	mem := &Memory{
+		Type: "fact", Content: "no category", Confidence: 0.9,
+		Scope: map[string]string{
+			ScopeWorkspaceID: testWorkspace1,
+			ScopeUserID:      "user-no-cat",
+		},
+	}
+	require.NoError(t, store.Save(context.Background(), mem))
+
+	var got *string
+	err := store.pool.QueryRow(context.Background(),
+		"SELECT consent_category FROM memory_entities WHERE id = $1", mem.ID).Scan(&got)
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}

--- a/internal/memory/consent_revocation_worker_test.go
+++ b/internal/memory/consent_revocation_worker_test.go
@@ -1,0 +1,136 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// revocationPolicy returns a minimal MemoryRetentionPolicy configured
+// with the given consentRevocation action, and no per-tier modes so
+// the TTL/LRU branches stay out of the way.
+func revocationPolicy(action omniav1alpha1.ConsentRevocationAction) *omniav1alpha1.MemoryRetentionPolicy {
+	grace := int32(7)
+	return &omniav1alpha1.MemoryRetentionPolicy{
+		Spec: omniav1alpha1.MemoryRetentionPolicySpec{
+			Default: omniav1alpha1.MemoryRetentionDefaults{
+				Tiers:    omniav1alpha1.MemoryRetentionTierSet{},
+				Schedule: "@every 1m",
+				ConsentRevocation: &omniav1alpha1.MemoryConsentRevocationConfig{
+					Action:    action,
+					GraceDays: &grace,
+				},
+			},
+		},
+	}
+}
+
+func TestRetentionWorker_ConsentCascade_SoftDeleteAction(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	userID := "user-cascade-soft"
+	seedPrivacyPrefs(t, store, userID, []string{"memory:context"})
+	revokedID := saveUserMemWithCategory(t, store, userID, "memory:health")
+	keptID := saveUserMemWithCategory(t, store, userID, "memory:context")
+
+	w := NewRetentionWorker(store,
+		&StaticPolicyLoader{Policy: revocationPolicy(omniav1alpha1.ConsentRevocationSoftDelete)},
+		zap.New(zap.UseDevMode(true)))
+	w.runOnce(ctx)
+
+	assert.True(t, mustFetchEntityForgotten(t, store, revokedID),
+		"revoked-category row must be soft-deleted")
+	assert.False(t, mustFetchEntityForgotten(t, store, keptID),
+		"still-granted row must be untouched")
+}
+
+func TestRetentionWorker_ConsentCascade_HardDeleteAction(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	userID := "user-cascade-hard"
+	seedPrivacyPrefs(t, store, userID, []string{})
+	id := saveUserMemWithCategory(t, store, userID, "memory:location")
+
+	w := NewRetentionWorker(store,
+		&StaticPolicyLoader{Policy: revocationPolicy(omniav1alpha1.ConsentRevocationHardDelete)},
+		zap.New(zap.UseDevMode(true)))
+	w.runOnce(ctx)
+
+	assert.False(t, mustFetchEntityExists(t, store, id),
+		"HardDelete action must remove the row immediately")
+}
+
+func TestRetentionWorker_ConsentCascade_StopAction(t *testing.T) {
+	// Stop is the escape hatch: existing rows stay as-is, only future
+	// writes are blocked (by the privacy middleware, not the worker).
+	store := newStore(t)
+	ctx := context.Background()
+
+	userID := "user-cascade-stop"
+	seedPrivacyPrefs(t, store, userID, []string{})
+	id := saveUserMemWithCategory(t, store, userID, "memory:location")
+
+	w := NewRetentionWorker(store,
+		&StaticPolicyLoader{Policy: revocationPolicy(omniav1alpha1.ConsentRevocationStop)},
+		zap.New(zap.UseDevMode(true)))
+	w.runOnce(ctx)
+
+	assert.False(t, mustFetchEntityForgotten(t, store, id),
+		"Stop action must not touch existing rows")
+	assert.True(t, mustFetchEntityExists(t, store, id))
+}
+
+func TestRetentionWorker_ConsentCascade_SoftDeleteGraceCleanup(t *testing.T) {
+	// A row already soft-deleted by the cascade, with forgotten_at
+	// backdated beyond grace, should be hard-deleted on the same
+	// pass (the cascade calls the grace cleanup after soft-delete).
+	store := newStore(t)
+	ctx := context.Background()
+
+	userID := "user-cascade-grace"
+	seedPrivacyPrefs(t, store, userID, []string{"memory:context"})
+	expired := saveUserMemWithCategory(t, store, userID, "memory:health")
+	_, err := store.pool.Exec(ctx,
+		`UPDATE memory_entities
+		 SET forgotten = true,
+		     forgotten_at = now() - interval '30 days'
+		 WHERE id = $1`, expired)
+	require.NoError(t, err)
+
+	w := NewRetentionWorker(store,
+		&StaticPolicyLoader{Policy: revocationPolicy(omniav1alpha1.ConsentRevocationSoftDelete)},
+		zap.New(zap.UseDevMode(true)))
+	w.runOnce(ctx)
+
+	assert.False(t, mustFetchEntityExists(t, store, expired),
+		"soft-deleted row past grace must be hard-deleted")
+}
+
+func TestResolveConsentAction(t *testing.T) {
+	// Nil config defaults to SoftDelete so a policy with consentRevocation
+	// unset still cascades safely rather than silently skipping.
+	assert.Equal(t, omniav1alpha1.ConsentRevocationSoftDelete, resolveConsentAction(nil))
+
+	// Empty Action defaults to SoftDelete.
+	assert.Equal(t, omniav1alpha1.ConsentRevocationSoftDelete,
+		resolveConsentAction(&omniav1alpha1.MemoryConsentRevocationConfig{}))
+
+	// Explicit action round-trips.
+	assert.Equal(t, omniav1alpha1.ConsentRevocationHardDelete,
+		resolveConsentAction(&omniav1alpha1.MemoryConsentRevocationConfig{
+			Action: omniav1alpha1.ConsentRevocationHardDelete,
+		}))
+}

--- a/internal/memory/postgres/migrations/000002_consent_category.down.sql
+++ b/internal/memory/postgres/migrations/000002_consent_category.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_memory_entities_forgotten_at;
+DROP INDEX IF EXISTS idx_memory_entities_consent_category;
+ALTER TABLE memory_entities
+    DROP COLUMN IF EXISTS forgotten_at,
+    DROP COLUMN IF EXISTS consent_category;

--- a/internal/memory/postgres/migrations/000002_consent_category.up.sql
+++ b/internal/memory/postgres/migrations/000002_consent_category.up.sql
@@ -1,0 +1,21 @@
+-- Phase 4: consent revocation cascade.
+--
+-- Adds a nullable consent_category column so the memory-api knows which
+-- rows to cascade when a user revokes a consent grant. Rows created
+-- before this migration have NULL and fall under the default policy.
+
+ALTER TABLE memory_entities
+    ADD COLUMN IF NOT EXISTS consent_category TEXT,
+    ADD COLUMN IF NOT EXISTS forgotten_at TIMESTAMPTZ;
+
+-- Partial index keeps writes cheap — most rows will have NULL category.
+CREATE INDEX IF NOT EXISTS idx_memory_entities_consent_category
+    ON memory_entities (workspace_id, virtual_user_id, consent_category)
+    WHERE consent_category IS NOT NULL AND forgotten = false;
+
+-- forgotten_at lets the hard-delete pass find rows past grace without
+-- scanning every row. updated_at was serving that role in Phase 3 but
+-- drifts whenever the row is touched for unrelated reasons.
+CREATE INDEX IF NOT EXISTS idx_memory_entities_forgotten_at
+    ON memory_entities (forgotten_at)
+    WHERE forgotten = true AND forgotten_at IS NOT NULL;

--- a/internal/memory/retention.go
+++ b/internal/memory/retention.go
@@ -134,6 +134,12 @@ func (w *RetentionWorker) runOnce(ctx context.Context) {
 		}
 	}
 
+	cascadeSoft, cascadeHard, cascadeErr := w.runConsentRevocation(ctx,
+		policy.Spec.Default.ConsentRevocation, batchSize)
+	if cascadeErr != nil {
+		anyErr = true
+	}
+
 	hard, err := w.store.HardDeleteForgottenOlderThan(ctx,
 		resolveGraceDays(policy.Spec.Default.ConsentRevocation), int(batchSize))
 	if err != nil {
@@ -147,7 +153,94 @@ func (w *RetentionWorker) runOnce(ctx context.Context) {
 	w.log.V(1).Info("retention pass finished",
 		"duration", time.Since(start).String(),
 		"hardDeleted", hard,
+		"consentSoftDeleted", cascadeSoft,
+		"consentHardDeleted", cascadeHard,
 		"ok", !anyErr)
+}
+
+// runConsentRevocation cascades user consent revocations to memory
+// rows. For action=SoftDelete it flips forgotten=true with
+// forgotten_at=now so the grace-period pass later hard-deletes. For
+// action=HardDelete it removes rows immediately. action=Stop is a
+// no-op — operators chose it explicitly to keep existing rows.
+//
+// Returns (softCount, hardCount, err) so callers can log totals
+// without re-querying.
+func (w *RetentionWorker) runConsentRevocation(
+	ctx context.Context,
+	cfg *omniav1alpha1.MemoryConsentRevocationConfig,
+	batchSize int32,
+) (int64, int64, error) {
+	metrics := defaultRetentionMetrics.Load()
+	action := resolveConsentAction(cfg)
+	switch action {
+	case omniav1alpha1.ConsentRevocationStop:
+		return 0, 0, nil
+	case omniav1alpha1.ConsentRevocationHardDelete:
+		n, err := w.store.HardDeleteRevokedConsent(ctx, int(batchSize))
+		if err != nil {
+			metrics.observeBranchError(TierUser, BranchConsentRevoke)
+			w.log.Error(err, "consent revocation hard-delete failed")
+			return 0, 0, err
+		}
+		metrics.observeHardDelete(n)
+		if n > 0 {
+			w.emitConsentAudit(ctx, action, 0, n)
+		}
+		return 0, n, nil
+	}
+
+	// SoftDelete path (default).
+	soft, err := w.store.SoftDeleteRevokedConsent(ctx, int(batchSize))
+	if err != nil {
+		metrics.observeBranchError(TierUser, BranchConsentRevoke)
+		w.log.Error(err, "consent revocation soft-delete failed")
+		return 0, 0, err
+	}
+	metrics.observeSoftDelete(TierUser, BranchConsentRevoke, soft)
+
+	// Hard-delete rows whose consent-driven soft-delete grace has
+	// elapsed. Keyed on forgotten_at so we don't double-count rows
+	// whose forgotten=true came from TTL/LRU elsewhere.
+	hard, err := w.store.HardDeleteForgottenByConsentOlderThan(ctx,
+		resolveGraceDays(cfg), int(batchSize))
+	if err != nil {
+		metrics.observeBranchError(TierUser, BranchConsentHardClean)
+		w.log.Error(err, "consent revocation grace hard-delete failed")
+		return soft, 0, err
+	}
+	metrics.observeHardDelete(hard)
+
+	if soft > 0 || hard > 0 {
+		w.emitConsentAudit(ctx, action, soft, hard)
+	}
+	return soft, hard, nil
+}
+
+// resolveConsentAction returns the policy's action, defaulting to
+// SoftDelete so absent config doesn't silently skip the cascade.
+func resolveConsentAction(cfg *omniav1alpha1.MemoryConsentRevocationConfig) omniav1alpha1.ConsentRevocationAction {
+	if cfg != nil && cfg.Action != "" {
+		return cfg.Action
+	}
+	return omniav1alpha1.ConsentRevocationSoftDelete
+}
+
+// emitConsentAudit records a consent-cascade event. Audit output is
+// best-effort — failure here must not abort the retention cycle, so
+// we stick to structured log output. The operator's Prometheus
+// omnia_memory_retention_soft_deleted_total / _hard_deleted_total
+// counters carry the same signal and drive alerting.
+func (w *RetentionWorker) emitConsentAudit(
+	_ context.Context,
+	action omniav1alpha1.ConsentRevocationAction,
+	soft, hard int64,
+) {
+	w.log.Info("memory retention consent cascade",
+		"action", string(action),
+		"softDeleted", soft,
+		"hardDeleted", hard,
+	)
 }
 
 // runBranch dispatches one (tier, branch) pair to the appropriate

--- a/internal/memory/retention_types.go
+++ b/internal/memory/retention_types.go
@@ -26,10 +26,12 @@ func retentionTiers() []Tier {
 type RetentionBranch string
 
 const (
-	BranchTTL       RetentionBranch = "ttl"
-	BranchLRU       RetentionBranch = "lru"
-	BranchDecay     RetentionBranch = "decay"
-	BranchHardClean RetentionBranch = "hard_clean"
+	BranchTTL              RetentionBranch = "ttl"
+	BranchLRU              RetentionBranch = "lru"
+	BranchDecay            RetentionBranch = "decay"
+	BranchHardClean        RetentionBranch = "hard_clean"
+	BranchConsentRevoke    RetentionBranch = "consent_revoke"
+	BranchConsentHardClean RetentionBranch = "consent_hard_clean"
 )
 
 // sqlPredicate returns the SQL where-clause fragment that isolates rows

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -123,6 +123,15 @@ func (s *PostgresMemoryStore) Save(ctx context.Context, mem *Memory) error {
 // fall through to the schema default ('support_continuity').
 const MetaKeyPurpose = "purpose"
 
+// MetaKeyConsentCategory is the metadata key carrying the consent
+// category tag (e.g. "memory:health", "memory:location"). Read at
+// insert time and written to memory_entities.consent_category so
+// the retention worker's consent revocation cascade can match rows
+// against the user's current grants without scanning JSON metadata.
+// Empty / missing values leave the column NULL — those rows fall
+// under the default (non-per-category) retention policy.
+const MetaKeyConsentCategory = "consent_category"
+
 // insertEntity inserts a new memory_entities row and populates mem.ID / mem.CreatedAt.
 //
 // trust_model and source_type are derived from the provenance metadata key
@@ -139,16 +148,18 @@ func insertEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 
 	trustModel, sourceType := trustFromProvenance(mem.Metadata)
 	purpose := purposeFromMetadata(mem.Metadata)
+	consentCategory := consentCategoryFromMetadata(mem.Metadata)
 
 	row := tx.QueryRow(ctx, `
 		INSERT INTO memory_entities
 		  (workspace_id, virtual_user_id, agent_id, name, kind, metadata, expires_at,
-		   trust_model, source_type, purpose)
+		   trust_model, source_type, purpose, consent_category)
 		VALUES
 		  ($1, $2, $3, $4, $5, $6, $7,
 		    COALESCE($8, 'inferred'),
 		    COALESCE($9, 'conversation_extraction'),
-		    COALESCE($10, 'support_continuity'))
+		    COALESCE($10, 'support_continuity'),
+		    $11)
 		RETURNING id, created_at`,
 		mem.Scope[ScopeWorkspaceID],
 		scopeOrNil(mem.Scope, ScopeUserID),
@@ -160,6 +171,7 @@ func insertEntity(ctx context.Context, tx pgx.Tx, mem *Memory) error {
 		trustModel,
 		sourceType,
 		purpose,
+		consentCategory,
 	)
 
 	return row.Scan(&mem.ID, &mem.CreatedAt)
@@ -199,6 +211,21 @@ func purposeFromMetadata(meta map[string]any) *string {
 		return nil
 	}
 	v, ok := meta[MetaKeyPurpose].(string)
+	if !ok || v == "" {
+		return nil
+	}
+	return &v
+}
+
+// consentCategoryFromMetadata reads MetaKeyConsentCategory from the
+// memory metadata, returning nil when absent so the column stays NULL
+// and the row falls under the default retention policy rather than a
+// per-category override.
+func consentCategoryFromMetadata(meta map[string]any) *string {
+	if meta == nil {
+		return nil
+	}
+	v, ok := meta[MetaKeyConsentCategory].(string)
 	if !ok || v == "" {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Cascades user consent revocations to stored memory rows on every retention pass. When a user removes a consent grant (drops a category from `user_privacy_preferences.consent_grants`), rows tagged with that category are soft-deleted or hard-deleted per `MemoryRetentionPolicy.spec.default.consentRevocation.action`. Builds on phase 3 (#1000).

## How it works

- **Migration 000002** adds `consent_category TEXT` and `forgotten_at TIMESTAMPTZ` columns to `memory_entities`, with partial indexes so the new columns don't bloat writes for untagged rows.
- **Category persistence**: `insertEntity()` now reads `MetaKeyConsentCategory` from the caller's metadata and writes it to the column. Legacy writes that don't set the key leave the column NULL and fall under the default (non-per-category) policy.
- **Cascade via reconciliation**: each retention tick joins `memory_entities` against `user_privacy_preferences.consent_grants`. Any user-tier row whose `consent_category` isn't in the current grants is considered revoked. This is stateless — no event bus, no snapshot tracking, and missed revocations surface on the next tick.
- **Per-action dispatch**:
  - `SoftDelete` (default): `forgotten=true`, `forgotten_at=now()`. The cascade then invokes a grace-period cleanup keyed on `forgotten_at` so the general TTL hard-delete pass doesn't double-count.
  - `HardDelete`: immediate `DELETE ... FOR UPDATE SKIP LOCKED` for operators who need immediate removal.
  - `Stop`: no-op — existing rows untouched, future writes blocked by the privacy middleware.

## Not in this PR

- Dashboard confirmation modal on consent toggle-off (dashboard team).
- Explicit audit events via `ee/pkg/audit` — worker logs structured events for now; audit wiring can follow if operators need them.
- Category backfill job for rows predating this migration (proposal phase 4 line 290).
- `perCategory` TTL/LRU overrides in the composite worker (follow-up; only the cascade action is wired here).

## Test plan

- [x] 17 new tests (unit + testcontainer) pass
- [x] Per-file coverage: retention.go 83%, consent_revocation_store.go 88%, store.go 88%
- [x] Full memory test suite green
- [x] Lint + vet clean on changed files