### PR TITLE
feat(memory): supersession cleanup (phase 5)

### DIFF
--- a/internal/memory/retention.go
+++ b/internal/memory/retention.go
@@ -140,6 +140,12 @@ func (w *RetentionWorker) runOnce(ctx context.Context) {
 		anyErr = true
 	}
 
+	superseded, supersessionErr := w.runSupersessionCleanup(ctx,
+		policy.Spec.Default.Supersession, batchSize)
+	if supersessionErr != nil {
+		anyErr = true
+	}
+
 	hard, err := w.store.HardDeleteForgottenOlderThan(ctx,
 		resolveGraceDays(policy.Spec.Default.ConsentRevocation), int(batchSize))
 	if err != nil {
@@ -155,7 +161,53 @@ func (w *RetentionWorker) runOnce(ctx context.Context) {
 		"hardDeleted", hard,
 		"consentSoftDeleted", cascadeSoft,
 		"consentHardDeleted", cascadeHard,
+		"supersededObservations", superseded,
 		"ok", !anyErr)
+}
+
+// runSupersessionCleanup hard-deletes observations that have been
+// superseded by a temporal summary once the policy's grace window
+// has elapsed. The branch is a no-op when the policy's
+// supersession.enabled flag is false (the default) — operators opt
+// in after confirming their summarizer agent is producing summaries
+// they're willing to commit to.
+//
+// Superseded observations are already hidden from retrieval via the
+// `superseded_by IS NULL` filter in retrieve_multi_tier.go, so this
+// branch only reclaims storage and does not change API behaviour.
+func (w *RetentionWorker) runSupersessionCleanup(
+	ctx context.Context,
+	cfg *omniav1alpha1.MemorySupersessionConfig,
+	batchSize int32,
+) (int64, error) {
+	if cfg == nil || !cfg.Enabled {
+		return 0, nil
+	}
+	metrics := defaultRetentionMetrics.Load()
+	grace := resolveSupersessionGraceDays(cfg)
+	n, err := w.store.HardDeleteSupersededObservations(ctx, grace, int(batchSize))
+	if err != nil {
+		metrics.observeBranchError(TierInstitutional, BranchSupersession)
+		w.log.Error(err, "supersession cleanup failed")
+		return 0, err
+	}
+	metrics.observeHardDelete(n)
+	if n > 0 {
+		w.log.Info("memory supersession cleanup",
+			"observationsDeleted", n,
+			"graceDays", grace,
+		)
+	}
+	return n, nil
+}
+
+// resolveSupersessionGraceDays pulls the grace window from the
+// policy, defaulting to the CRD's documented default (14 days).
+func resolveSupersessionGraceDays(cfg *omniav1alpha1.MemorySupersessionConfig) int32 {
+	if cfg != nil && cfg.GraceDays != nil {
+		return *cfg.GraceDays
+	}
+	return 14
 }
 
 // runConsentRevocation cascades user consent revocations to memory

--- a/internal/memory/retention_types.go
+++ b/internal/memory/retention_types.go
@@ -32,6 +32,7 @@ const (
 	BranchHardClean        RetentionBranch = "hard_clean"
 	BranchConsentRevoke    RetentionBranch = "consent_revoke"
 	BranchConsentHardClean RetentionBranch = "consent_hard_clean"
+	BranchSupersession     RetentionBranch = "supersession"
 )
 
 // sqlPredicate returns the SQL where-clause fragment that isolates rows

--- a/internal/memory/supersession_store.go
+++ b/internal/memory/supersession_store.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"fmt"
+)
+
+// HardDeleteSupersededObservations removes up to batchSize observations
+// whose superseded_by pointer references a summary observation that was
+// created more than graceDays ago. The grace window is measured from
+// the summary's creation so operators get the same rollback budget
+// regardless of when the original observation was written.
+//
+// Superseded observations are already invisible to retrieval
+// (retrieve_multi_tier.go:288 filters on `o.superseded_by IS NULL`)
+// so hard-deleting them doesn't change API behaviour — it only
+// reclaims storage.
+func (s *PostgresMemoryStore) HardDeleteSupersededObservations(
+	ctx context.Context, graceDays int32, batchSize int,
+) (int64, error) {
+	if batchSize <= 0 {
+		return 0, nil
+	}
+	if graceDays < 0 {
+		return 0, fmt.Errorf("memory: negative grace days (%d)", graceDays)
+	}
+	q := `
+WITH target AS (
+  SELECT old.id FROM memory_observations old
+  JOIN memory_observations new ON new.id = old.superseded_by
+  WHERE old.superseded_by IS NOT NULL
+    AND new.created_at < now() - $1::interval
+  ORDER BY new.created_at ASC
+  LIMIT $2
+  FOR UPDATE SKIP LOCKED
+)
+DELETE FROM memory_observations
+WHERE id IN (SELECT id FROM target)`
+
+	interval := fmt.Sprintf("%d days", graceDays)
+	tag, err := s.pool.Exec(ctx, q, interval, batchSize)
+	if err != nil {
+		return 0, fmt.Errorf("memory: hard-delete superseded observations: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/memory/supersession_test.go
+++ b/internal/memory/supersession_test.go
@@ -1,0 +1,186 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// createSupersession seeds an entity with n old observations, runs
+// compaction, then backdates the summary observation's created_at so
+// the grace window has elapsed. Returns the summary entity id and the
+// superseded observation IDs so tests can assert deletion state.
+func createSupersession(
+	t *testing.T, store *PostgresMemoryStore,
+	workspace, userID string, n int, summaryAge time.Duration,
+) (summaryEntityID string, superseded []string) {
+	t.Helper()
+	ctx := context.Background()
+
+	mustInsertOldEntities(t, store, workspace, userID, "", n,
+		"will be summarized", time.Now().Add(-90*24*time.Hour))
+
+	candidates, err := store.FindCompactionCandidates(ctx, FindCompactionCandidatesOptions{
+		WorkspaceID:  workspace,
+		OlderThan:    time.Now().Add(-30 * 24 * time.Hour),
+		MinGroupSize: 1,
+	})
+	require.NoError(t, err)
+	require.Len(t, candidates, 1)
+
+	superseded = candidates[0].ObservationIDs
+	summaryEntityID, err = store.SaveCompactionSummary(ctx, CompactionSummary{
+		WorkspaceID:            workspace,
+		UserID:                 userID,
+		Content:                "Summary: older notes.",
+		SupersededObservations: superseded,
+	})
+	require.NoError(t, err)
+
+	// Backdate the summary observation so the grace window has elapsed.
+	if summaryAge > 0 {
+		_, err := store.pool.Exec(ctx,
+			`UPDATE memory_observations
+			 SET created_at = now() - $1::interval
+			 WHERE entity_id = $2`,
+			durationToInterval(summaryAge), summaryEntityID)
+		require.NoError(t, err)
+	}
+	return summaryEntityID, superseded
+}
+
+// durationToInterval renders a Go duration as a Postgres interval
+// string. Testcontainers are fast; sub-second granularity isn't
+// needed for retention tests.
+func durationToInterval(d time.Duration) string {
+	return fmt.Sprintf("%d seconds", int64(d.Seconds()))
+}
+
+// mustSupersededObservationsCount returns how many observations have a
+// non-null superseded_by pointer. Used to assert delete vs skip.
+func mustSupersededObservationsCount(t *testing.T, store *PostgresMemoryStore) int {
+	t.Helper()
+	var n int
+	err := store.pool.QueryRow(context.Background(),
+		"SELECT COUNT(*) FROM memory_observations WHERE superseded_by IS NOT NULL").Scan(&n)
+	require.NoError(t, err)
+	return n
+}
+
+func TestHardDeleteSupersededObservations_RemovesOnlyPastGrace(t *testing.T) {
+	store := newStore(t)
+	ws := "cc000000-0000-0000-0000-000000000001"
+	user := "cc000000-0000-0000-0000-000000000002"
+
+	// Summary aged beyond grace; the 3 superseded observations should go.
+	createSupersession(t, store, ws, user, 3, 30*24*time.Hour)
+	require.Equal(t, 3, mustSupersededObservationsCount(t, store))
+
+	n, err := store.HardDeleteSupersededObservations(context.Background(), 14, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), n)
+	assert.Equal(t, 0, mustSupersededObservationsCount(t, store))
+}
+
+func TestHardDeleteSupersededObservations_RespectsGrace(t *testing.T) {
+	store := newStore(t)
+	ws := "cc000000-0000-0000-0000-000000000003"
+	user := "cc000000-0000-0000-0000-000000000004"
+
+	// Summary only 3 days old; grace is 14 days, so nothing should be
+	// deleted yet.
+	createSupersession(t, store, ws, user, 2, 3*24*time.Hour)
+	require.Equal(t, 2, mustSupersededObservationsCount(t, store))
+
+	n, err := store.HardDeleteSupersededObservations(context.Background(), 14, 100)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+	assert.Equal(t, 2, mustSupersededObservationsCount(t, store))
+}
+
+func TestHardDeleteSupersededObservations_BatchSizeZeroIsNoOp(t *testing.T) {
+	store := newStore(t)
+	n, err := store.HardDeleteSupersededObservations(context.Background(), 14, 0)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), n)
+}
+
+func TestHardDeleteSupersededObservations_NegativeGraceErrors(t *testing.T) {
+	store := newStore(t)
+	_, err := store.HardDeleteSupersededObservations(context.Background(), -1, 100)
+	require.Error(t, err)
+}
+
+func TestRetentionWorker_Supersession_SkipsWhenDisabled(t *testing.T) {
+	store := newStore(t)
+	ws := "cc000000-0000-0000-0000-000000000005"
+	user := "cc000000-0000-0000-0000-000000000006"
+	createSupersession(t, store, ws, user, 2, 30*24*time.Hour)
+
+	disabled := &omniav1alpha1.MemorySupersessionConfig{Enabled: false}
+	policy := &omniav1alpha1.MemoryRetentionPolicy{
+		Spec: omniav1alpha1.MemoryRetentionPolicySpec{
+			Default: omniav1alpha1.MemoryRetentionDefaults{
+				Tiers:        omniav1alpha1.MemoryRetentionTierSet{},
+				Schedule:     "@every 1m",
+				Supersession: disabled,
+			},
+		},
+	}
+	w := NewRetentionWorker(store, &StaticPolicyLoader{Policy: policy},
+		zap.New(zap.UseDevMode(true)))
+	w.runOnce(context.Background())
+
+	assert.Equal(t, 2, mustSupersededObservationsCount(t, store),
+		"disabled supersession must not touch rows")
+}
+
+func TestRetentionWorker_Supersession_DeletesWhenEnabled(t *testing.T) {
+	store := newStore(t)
+	ws := "cc000000-0000-0000-0000-000000000007"
+	user := "cc000000-0000-0000-0000-000000000008"
+	createSupersession(t, store, ws, user, 2, 30*24*time.Hour)
+
+	grace := int32(14)
+	policy := &omniav1alpha1.MemoryRetentionPolicy{
+		Spec: omniav1alpha1.MemoryRetentionPolicySpec{
+			Default: omniav1alpha1.MemoryRetentionDefaults{
+				Tiers:    omniav1alpha1.MemoryRetentionTierSet{},
+				Schedule: "@every 1m",
+				Supersession: &omniav1alpha1.MemorySupersessionConfig{
+					Enabled:   true,
+					GraceDays: &grace,
+				},
+			},
+		},
+	}
+	w := NewRetentionWorker(store, &StaticPolicyLoader{Policy: policy},
+		zap.New(zap.UseDevMode(true)))
+	w.runOnce(context.Background())
+
+	assert.Equal(t, 0, mustSupersededObservationsCount(t, store),
+		"enabled supersession must hard-delete rows past grace")
+}
+
+func TestResolveSupersessionGraceDays(t *testing.T) {
+	assert.Equal(t, int32(14), resolveSupersessionGraceDays(nil))
+	assert.Equal(t, int32(14), resolveSupersessionGraceDays(
+		&omniav1alpha1.MemorySupersessionConfig{Enabled: true}))
+
+	g := int32(30)
+	cfg := &omniav1alpha1.MemorySupersessionConfig{Enabled: true, GraceDays: &g}
+	assert.Equal(t, int32(30), resolveSupersessionGraceDays(cfg))
+}


### PR DESCRIPTION
## Summary

Final phase of the memory retention proposal. Hard-deletes observations that have been superseded by a temporal summary (compaction worker output) once the policy's `graceDays` window has elapsed. Builds on #1001.

Gated behind `spec.default.supersession.enabled` — off by default so operators only flip it on once their summarizer agent is producing summaries they're willing to commit to.

## How it works

- **`HardDeleteSupersededObservations`** joins `memory_observations` against itself: old rows point to summary rows via `superseded_by`, and we hard-delete the old row once the summary's `created_at` is older than `graceDays`. Grace is measured from the summary, not the original, so operators get the same rollback window regardless of how far back the source data was.
- **Retention worker** gains a new branch (`runSupersessionCleanup`) that runs after consent cascade and before the generic hard-delete pass. No-op when `supersession.enabled=false`.
- **Safe to delete**: superseded observations are already invisible to retrieval (`retrieve_multi_tier.go:288` filters on `o.superseded_by IS NULL`), so this branch only reclaims storage — no behaviour change.
- **No schema migration** — the `superseded_by` column and `ON DELETE CASCADE` FK landed in the initial memory migration.

## Test plan

- [x] 7 new tests pass (unit + testcontainer)
- [x] Per-file coverage: retention.go 82%, supersession_store.go 90%
- [x] Grace-respect test: rows with a summary newer than `graceDays` are untouched
- [x] Disabled-by-default test: `Enabled=false` is a no-op even with eligible rows
- [x] Full memory suite green, lint + vet clean on changed files