### PR TITLE
ci(images): publish omnia-a2a-invoker container image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -64,6 +64,9 @@ jobs:
           - image: omnia-compaction
             dockerfile: Dockerfile.compaction
             context: .
+          - image: omnia-a2a-invoker
+            dockerfile: Dockerfile.a2a-invoker
+            context: .
           - image: omnia-arena-controller
             dockerfile: ee/Dockerfile.arena-controller
             context: .

--- a/.github/workflows/docker-push.yml
+++ b/.github/workflows/docker-push.yml
@@ -100,6 +100,10 @@ jobs:
               - 'cmd/compaction/**'
               - 'internal/compaction/**'
 
+            omnia-a2a-invoker:
+              - 'cmd/a2a-invoker/**'
+              - 'Dockerfile.a2a-invoker'
+
             # --- Per-service filters (enterprise) ---
             omnia-arena-controller:
               - 'ee/cmd/omnia-arena-controller/**'
@@ -129,7 +133,7 @@ jobs:
           MATCHED: ${{ steps.filter.outputs.changes }}
         run: |
           # Full image list — matches docker-build.yml + release.yml matrices.
-          ALL='["omnia-operator","omnia-facade","omnia-runtime","omnia-dashboard","omnia-session-api","omnia-memory-api","omnia-doctor","omnia-compaction","omnia-arena-controller","omnia-arena-worker","omnia-arena-dev-console","omnia-eval-worker","omnia-policy-proxy","omnia-promptkit-lsp"]'
+          ALL='["omnia-operator","omnia-facade","omnia-runtime","omnia-dashboard","omnia-session-api","omnia-memory-api","omnia-doctor","omnia-compaction","omnia-a2a-invoker","omnia-arena-controller","omnia-arena-worker","omnia-arena-dev-console","omnia-eval-worker","omnia-policy-proxy","omnia-promptkit-lsp"]'
 
           if [[ "$SHARED" == "true" ]]; then
             echo "Shared paths changed — rebuilding all services."
@@ -194,6 +198,11 @@ jobs:
             context: .
             title: Omnia Session Compaction
             description: Batch job that compacts warm session storage into cold Parquet archives according to SessionRetentionPolicy.
+          - image: omnia-a2a-invoker
+            dockerfile: Dockerfile.a2a-invoker
+            context: .
+            title: Omnia A2A Invoker
+            description: Small CLI that makes a one-shot A2A JSON-RPC call to a target AgentRuntime. Intended to run in a Kubernetes CronJob so scheduled agents (e.g. the memory summarizer) fire on an operator-defined cadence.
           - image: omnia-arena-controller
             dockerfile: ee/Dockerfile.arena-controller
             context: .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,6 +100,9 @@ jobs:
           - image: omnia-compaction
             dockerfile: Dockerfile.compaction
             context: .
+          - image: omnia-a2a-invoker
+            dockerfile: Dockerfile.a2a-invoker
+            context: .
           # --- Enterprise (chart gates these behind enterprise.enabled) ---
           - image: omnia-arena-controller
             dockerfile: ee/Dockerfile.arena-controller
@@ -201,6 +204,7 @@ jobs:
           - omnia-memory-api
           - omnia-doctor
           - omnia-compaction
+          - omnia-a2a-invoker
           - omnia-arena-controller
           - omnia-arena-worker
           - omnia-arena-dev-console
@@ -541,6 +545,7 @@ jobs:
           - `ghcr.io/altairalabs/omnia-memory-api:${{ needs.parse-version.outputs.version }}` (memory API)
           - `ghcr.io/altairalabs/omnia-doctor:${{ needs.parse-version.outputs.version }}` (in-cluster doctor)
           - `ghcr.io/altairalabs/omnia-compaction:${{ needs.parse-version.outputs.version }}` (retention/compaction job)
+          - `ghcr.io/altairalabs/omnia-a2a-invoker:${{ needs.parse-version.outputs.version }}` (A2A one-shot CronJob image)
 
           Enterprise:
           - `ghcr.io/altairalabs/omnia-arena-controller:${{ needs.parse-version.outputs.version }}`


### PR DESCRIPTION
## Summary

Adds the `omnia-a2a-invoker` image (landed in #997 with `Dockerfile.a2a-invoker`) to every Docker workflow so operators can actually pull it from GHCR. Without this, the sample CronJob in `config/samples/omnia_v1alpha1_memory_summarizer.yaml` references `ghcr.io/altairalabs/omnia-a2a-invoker:latest` — an image that has never been built or published.

## Changes

- **`docker-build.yml`**: include in per-PR build matrix so broken Dockerfile changes surface on the PR that causes them.
- **`docker-push.yml`**: include in the per-service path filter (rebuilds only when `cmd/a2a-invoker/**` or `Dockerfile.a2a-invoker` change), the `ALL` services list, and the build-push matrix with title + description for the GHCR package page.
- **`release.yml`**: include in the `docker-release` matrix, the `trivy-scan` matrix, and the release-notes "Docker Images" section.

## Test plan

- [x] Local `docker build -f Dockerfile.a2a-invoker .` succeeds (verified on this branch).
- [ ] CI's Docker Build workflow runs the new matrix entry and pushes to GHCR on merge to main.
- [ ] Next tagged release includes `omnia-a2a-invoker:vX.Y.Z` in the release notes.