### PR TITLE
feat(memory): per-session consent grants (#1006)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -20,6 +20,22 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
   `mem.Metadata[consent_category]` in the handler (was a silent dropped
   field). EE middleware classification results now reach the column.
 
+### Added (per-session consent grants, #1006)
+
+- WebSocket: `ClientMessage.session_consent_grants` (`[]string`, optional).
+  First message with a non-empty list stamps the per-session default on the
+  Connection. Subsequent messages with a non-empty list replace the cached
+  value (last-writer-wins). Empty / omitted lists are ignored — to revoke
+  all categories for a session use the binary opt-out.
+- gRPC: `x-omnia-consent-layer` metadata key carries which layer
+  (`per-message` | `session` | `persistent`) produced the per-request grants
+  forwarded by the facade.
+- Memory API: `X-Consent-Layer` request header (forwarded by the runtime
+  httpclient). `X-Consent-Decision` response header on 204 dropped writes.
+  New `omnia_memory_writes_suppressed_total{layer,category,reason}`
+  Prometheus metric. Suppressed-write log line promoted from V(1) to V(0)
+  and enriched with layer + grants.
+
 ### Breaking
 
 - `SessionPrivacyPolicy.spec.level`, `spec.workspaceRef`, and `spec.agentRef` removed. Policies are now reusable namespaced documents; binding has moved to consumers (`Workspace` service groups and `AgentRuntime`).

--- a/api/websocket/asyncapi.yaml
+++ b/api/websocket/asyncapi.yaml
@@ -141,6 +141,40 @@ components:
             type: object
             additionalProperties:
               type: string
+          consent_grants:
+            type: array
+            items:
+              type: string
+              enum:
+                - memory:identity
+                - memory:preferences
+                - memory:context
+                - memory:location
+                - memory:health
+                - memory:history
+                - analytics:aggregate
+            description: |
+              Per-message consent override. Replaces session and persistent
+              grants for this single turn (last-writer-wins).
+          session_consent_grants:
+            type: array
+            items:
+              type: string
+              enum:
+                - memory:identity
+                - memory:preferences
+                - memory:context
+                - memory:location
+                - memory:health
+                - memory:history
+                - analytics:aggregate
+            description: |
+              Per-session consent grants. The first message with a non-empty
+              list stamps the per-session default on the connection.
+              Subsequent messages with a non-empty list replace the cached
+              value (last-writer-wins). Empty / omitted lists are ignored —
+              to revoke all categories for a session use the binary opt-out
+              via the privacy preferences API.
 
     ClientToolResult:
       name: ClientToolResult

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -547,7 +547,11 @@ func wrapPrivacyMiddleware(ctx context.Context, next http.Handler, pool *pgxpool
 	})
 
 	validator := buildConsentValidator(ctx, embeddingSvc, log)
-	mw := memoryapi.NewMemoryPrivacyMiddleware(checkOptOut, contentRedactor, validator, log)
+	suppressMetrics := memoryapi.NewSuppressionMetrics()
+	if err := suppressMetrics.Register(prometheus.DefaultRegisterer); err != nil {
+		log.Error(err, "memory suppression metrics registration failed")
+	}
+	mw := memoryapi.NewMemoryPrivacyMiddlewareWithMetrics(checkOptOut, contentRedactor, validator, suppressMetrics, log)
 	log.Info("memory privacy middleware enabled")
 	return mw.Wrap(next)
 }

--- a/cmd/memory-api/wiring_test.go
+++ b/cmd/memory-api/wiring_test.go
@@ -225,6 +225,36 @@ func TestWrapPrivacyMiddleware_NoEmbeddingProvider_StillBuildsValidator(t *testi
 	}
 }
 
+// TestWrapPrivacyMiddleware_RegistersSuppressionMetrics verifies that
+// wrapPrivacyMiddleware registers the suppression metric on the default
+// Prometheus registry. The wrap path tolerates nil pool/embeddingSvc — it
+// short-circuits when no kubeconfig is available, but the metrics
+// registration happens before that branch (in this test environment the
+// short-circuit means the metric won't actually be wired into the
+// middleware, but the registration itself is exercised when the kubeconfig
+// path runs in production).
+//
+// In the no-kubeconfig branch (this test) the function returns the
+// untouched handler before constructing the middleware, so we can't
+// assert registration directly. The unit-level coverage in
+// suppression_metrics_test.go + the middleware_test.go observability
+// tests prove the metric works end-to-end.
+func TestWrapPrivacyMiddleware_DoesNotPanicWithNilEmbeddingSvc(t *testing.T) {
+	// Smoke test — the validator and metrics construction in
+	// wrapPrivacyMiddleware must tolerate nil embedding service in any
+	// future code path that doesn't short-circuit on missing kubeconfig.
+	freshPromRegistry(t)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("wrapPrivacyMiddleware panicked: %v", r)
+		}
+	}()
+	_ = wrapPrivacyMiddleware(context.Background(), next, nil, nil, logr.Discard())
+}
+
 // TestBuildAPIMux_HealthzAlwaysReachable verifies /healthz is wired regardless
 // of enterprise mode. This is a smoke test that the middleware chain does not
 // incorrectly gate health checks.

--- a/dashboard/src/types/generated/websocket.ts
+++ b/dashboard/src/types/generated/websocket.ts
@@ -220,6 +220,17 @@ export interface ClientMessage {
    * When present, these override stored consent for this request.
    */
   consent_grants?: string[];
+  /**
+   * SessionConsentGrants captures per-session consent grants. The first
+   * message with a non-empty list stamps the per-session default on the
+   * Connection. Subsequent messages with a non-empty list replace the
+   * cached value (last-writer-wins within the session).
+   * Empty / omitted is treated identically: the facade does NOT clear
+   * the cached value when an empty list arrives. To revoke all
+   * categories for a session use the binary opt-out via the privacy
+   * preferences API; per-session grants are additive only.
+   */
+  session_consent_grants?: string[];
 }
 /**
  * ServerMessage represents a message sent from server to client.

--- a/internal/facade/connection.go
+++ b/internal/facade/connection.go
@@ -52,6 +52,14 @@ type Connection struct {
 	cohortID string
 	variant  string
 
+	// sessionConsentGrants holds the per-session consent grants captured
+	// from the first non-empty ClientMessage.SessionConsentGrants the
+	// facade saw on this connection. Subsequent non-empty lists replace
+	// the cached value (last-writer-wins). Empty / omitted lists are
+	// ignored. nil means "no session-level grants set." Mutex-protected
+	// via c.mu.
+	sessionConsentGrants []string
+
 	// rateLimiter enforces per-connection message rate limiting. Nil when disabled.
 	rateLimiter *rate.Limiter
 

--- a/internal/facade/protocol.go
+++ b/internal/facade/protocol.go
@@ -166,6 +166,16 @@ type ClientMessage struct {
 	// ConsentGrants carries per-message consent category grants from the client.
 	// When present, these override stored consent for this request.
 	ConsentGrants []string `json:"consent_grants,omitempty"`
+	// SessionConsentGrants captures per-session consent grants. The first
+	// message with a non-empty list stamps the per-session default on the
+	// Connection. Subsequent messages with a non-empty list replace the
+	// cached value (last-writer-wins within the session).
+	//
+	// Empty / omitted is treated identically: the facade does NOT clear
+	// the cached value when an empty list arrives. To revoke all
+	// categories for a session use the binary opt-out via the privacy
+	// preferences API; per-session grants are additive only.
+	SessionConsentGrants []string `json:"session_consent_grants,omitempty"`
 }
 
 // ServerMessage represents a message sent from server to client.

--- a/internal/facade/protocol_test.go
+++ b/internal/facade/protocol_test.go
@@ -1000,3 +1000,38 @@ func TestServerMessageWithMediaChunk(t *testing.T) {
 		t.Errorf("MediaChunk.MediaID = %v, want 'stream-1'", decoded.MediaChunk.MediaID)
 	}
 }
+
+func TestClientMessage_SessionConsentGrants_OmittedRoundTrip(t *testing.T) {
+	raw := []byte(`{"type":"message","content":"hello"}`)
+	var msg ClientMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(msg.SessionConsentGrants) != 0 {
+		t.Errorf("SessionConsentGrants = %v, want empty", msg.SessionConsentGrants)
+	}
+}
+
+func TestClientMessage_SessionConsentGrants_PopulatedRoundTrip(t *testing.T) {
+	raw := []byte(`{"type":"message","content":"hello","session_consent_grants":["memory:identity","memory:preferences"]}`)
+	var msg ClientMessage
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(msg.SessionConsentGrants) != 2 ||
+		msg.SessionConsentGrants[0] != "memory:identity" ||
+		msg.SessionConsentGrants[1] != "memory:preferences" {
+		t.Errorf("SessionConsentGrants = %v, want [memory:identity memory:preferences]", msg.SessionConsentGrants)
+	}
+}
+
+func TestClientMessage_SessionConsentGrants_MarshalsEmptyAsAbsent(t *testing.T) {
+	msg := ClientMessage{Type: MessageTypeMessage, Content: "hi"}
+	b, err := json.Marshal(msg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(b), "session_consent_grants") {
+		t.Errorf("marshalled %q includes session_consent_grants for empty slice", string(b))
+	}
+}

--- a/internal/facade/session.go
+++ b/internal/facade/session.go
@@ -38,6 +38,38 @@ import (
 	"github.com/altairalabs/omnia/pkg/policy"
 )
 
+// captureSessionConsentGrants stamps a non-empty msg.SessionConsentGrants
+// onto the connection. Last-writer-wins: a subsequent non-empty list
+// replaces the previously-cached value. Empty / omitted lists are ignored —
+// they do NOT clear the cache (use the binary opt-out instead). Copies the
+// slice so subsequent client mutation can't corrupt the cached value.
+func captureSessionConsentGrants(c *Connection, msg *ClientMessage) {
+	if len(msg.SessionConsentGrants) == 0 {
+		return
+	}
+	grants := append([]string{}, msg.SessionConsentGrants...)
+	c.mu.Lock()
+	c.sessionConsentGrants = grants
+	c.mu.Unlock()
+}
+
+// effectiveConsentGrants returns the consent grants and layer label to
+// attach to the runtime call. Last-writer-wins: per-message overrides
+// session; session overrides persistent. nil grants + "persistent"
+// means memory-api falls back to its persistent store.
+func effectiveConsentGrants(c *Connection, msg *ClientMessage) ([]string, string) {
+	if len(msg.ConsentGrants) > 0 {
+		return msg.ConsentGrants, "per-message"
+	}
+	c.mu.Lock()
+	cached := c.sessionConsentGrants
+	c.mu.Unlock()
+	if len(cached) > 0 {
+		return cached, "session"
+	}
+	return nil, "persistent"
+}
+
 // processMessage handles processing of an incoming client message.
 func (s *Server) processMessage(ctx context.Context, c *Connection, msg *ClientMessage, log logr.Logger) error {
 	// Get or create session first — the session ID determines the trace ID.
@@ -63,9 +95,12 @@ func (s *Server) processMessage(ctx context.Context, c *Connection, msg *ClientM
 		ctx = httpclient.WithUserID(ctx, c.userID)
 		ctx = policy.WithUserID(ctx, c.userID)
 	}
-	if len(msg.ConsentGrants) > 0 {
-		ctx = policy.WithConsentGrants(ctx, msg.ConsentGrants)
+	captureSessionConsentGrants(c, msg)
+	effective, layer := effectiveConsentGrants(c, msg)
+	if effective != nil {
+		ctx = policy.WithConsentGrants(ctx, effective)
 	}
+	ctx = policy.WithConsentLayer(ctx, layer)
 	log = logctx.LoggerWithContext(s.log, ctx)
 
 	// Update connection's session ID and mark as persisted

--- a/internal/facade/session_test.go
+++ b/internal/facade/session_test.go
@@ -702,3 +702,94 @@ func TestCohortHeaders_SpanOmitsEmptyAttributes(t *testing.T) {
 		t.Error("omnia.variant should not be set when header is empty")
 	}
 }
+
+func TestFacade_FirstMessageCachesSessionConsentGrants(t *testing.T) {
+	c := &Connection{}
+	msg := ClientMessage{
+		Type:                 MessageTypeMessage,
+		Content:              "hi",
+		SessionConsentGrants: []string{"memory:preferences", "memory:context"},
+	}
+	captureSessionConsentGrants(c, &msg)
+
+	c.mu.Lock()
+	cached := c.sessionConsentGrants
+	c.mu.Unlock()
+	if len(cached) != 2 || cached[0] != "memory:preferences" || cached[1] != "memory:context" {
+		t.Errorf("cached = %v, want [memory:preferences memory:context]", cached)
+	}
+}
+
+func TestFacade_EmptySessionGrantsDoNotClearCache(t *testing.T) {
+	c := &Connection{sessionConsentGrants: []string{"memory:preferences"}}
+	msg := ClientMessage{
+		Type:                 MessageTypeMessage,
+		Content:              "hi",
+		SessionConsentGrants: []string{}, // empty must NOT clear
+	}
+	captureSessionConsentGrants(c, &msg)
+
+	c.mu.Lock()
+	cached := c.sessionConsentGrants
+	c.mu.Unlock()
+	if len(cached) != 1 || cached[0] != "memory:preferences" {
+		t.Errorf("cached = %v, want [memory:preferences]", cached)
+	}
+}
+
+func TestFacade_EffectiveGrants_PerMessageWins(t *testing.T) {
+	c := &Connection{sessionConsentGrants: []string{"memory:preferences"}}
+	msg := ClientMessage{
+		Type:          MessageTypeMessage,
+		Content:       "hi",
+		ConsentGrants: []string{"memory:identity"},
+	}
+	effective, layer := effectiveConsentGrants(c, &msg)
+	if layer != "per-message" {
+		t.Errorf("layer = %q, want \"per-message\"", layer)
+	}
+	if len(effective) != 1 || effective[0] != "memory:identity" {
+		t.Errorf("effective = %v, want [memory:identity]", effective)
+	}
+}
+
+func TestFacade_EffectiveGrants_SessionUsedWhenNoPerMessage(t *testing.T) {
+	c := &Connection{sessionConsentGrants: []string{"memory:preferences"}}
+	msg := ClientMessage{Type: MessageTypeMessage, Content: "hi"}
+	effective, layer := effectiveConsentGrants(c, &msg)
+	if layer != "session" {
+		t.Errorf("layer = %q, want \"session\"", layer)
+	}
+	if len(effective) != 1 || effective[0] != "memory:preferences" {
+		t.Errorf("effective = %v, want [memory:preferences]", effective)
+	}
+}
+
+func TestFacade_EffectiveGrants_PersistentWhenNeitherSet(t *testing.T) {
+	c := &Connection{}
+	msg := ClientMessage{Type: MessageTypeMessage, Content: "hi"}
+	effective, layer := effectiveConsentGrants(c, &msg)
+	if layer != "persistent" {
+		t.Errorf("layer = %q, want \"persistent\"", layer)
+	}
+	if effective != nil {
+		t.Errorf("effective = %v, want nil", effective)
+	}
+}
+
+func TestFacade_ResettingSessionGrantsReplaces(t *testing.T) {
+	c := &Connection{sessionConsentGrants: []string{"memory:preferences"}}
+	msg := ClientMessage{
+		Type:                 MessageTypeMessage,
+		Content:              "hi",
+		SessionConsentGrants: []string{"memory:context"},
+	}
+	captureSessionConsentGrants(c, &msg)
+
+	c.mu.Lock()
+	cached := c.sessionConsentGrants
+	c.mu.Unlock()
+	if len(cached) != 1 || cached[0] != "memory:context" {
+		t.Errorf("cached = %v, want [memory:context]", cached)
+	}
+}

--- a/internal/memory/api/privacy_middleware.go
+++ b/internal/memory/api/privacy_middleware.go
@@ -32,6 +32,8 @@ import (
 )
 
 const consentGrantsHeader = "X-Consent-Grants"
+const consentLayerHeader = "X-Consent-Layer"
+const consentDecisionHeader = "X-Consent-Decision"
 
 // OptOutChecker returns false when the user has opted out of memory storage,
 // indicating the write should be silently dropped.
@@ -84,7 +86,8 @@ type ValidatorResult struct {
 type MemoryPrivacyMiddleware struct {
 	checkOptOut OptOutChecker
 	redact      ContentRedactor
-	validator   CategoryValidator // optional, nil when not configured
+	validator   CategoryValidator   // optional, nil when not configured
+	metrics     *SuppressionMetrics // optional, nil when not configured
 	log         logr.Logger
 }
 
@@ -104,6 +107,34 @@ func NewMemoryPrivacyMiddleware(
 		validator:   validator,
 		log:         log.WithName("memory-privacy"),
 	}
+}
+
+// NewMemoryPrivacyMiddlewareWithMetrics is like NewMemoryPrivacyMiddleware
+// but additionally wires a SuppressionMetrics collector for observability
+// on dropped writes. metrics may be nil; nil disables metric recording.
+func NewMemoryPrivacyMiddlewareWithMetrics(
+	checkOptOut OptOutChecker,
+	redact ContentRedactor,
+	validator CategoryValidator,
+	metrics *SuppressionMetrics,
+	log logr.Logger,
+) *MemoryPrivacyMiddleware {
+	mw := NewMemoryPrivacyMiddleware(checkOptOut, redact, validator, log)
+	mw.metrics = metrics
+	return mw
+}
+
+// formatConsentDecision builds the value for the X-Consent-Decision response
+// header. Format: "deny; category=<category>; layer=<layer>". Empty fields
+// become "unknown" to keep the header well-formed.
+func formatConsentDecision(category, layer string) string {
+	if category == "" {
+		category = "unknown"
+	}
+	if layer == "" {
+		layer = "unknown"
+	}
+	return "deny; category=" + category + "; layer=" + layer
 }
 
 // provenanceMetaKey mirrors pkmemory.MetaKeyProvenance — duplicated here as
@@ -184,11 +215,22 @@ func (m *MemoryPrivacyMiddleware) Wrap(next http.Handler) http.Handler {
 
 		// Check opt-out with category (empty string if not decoded).
 		if userID != "" && !m.checkOptOut(r.Context(), userID, workspace, req.Category, consentOverride) {
-			m.log.V(1).Info("memory write suppressed",
-				"reason", "user opt-out",
+			layer := r.Header.Get(consentLayerHeader)
+			if layer == "" {
+				layer = "persistent"
+			}
+			m.log.Info("memory write suppressed",
+				"reason", "opt-out",
+				"category", req.Category,
+				"layer", layer,
+				"grants", consentOverride,
 				"userHash", logging.HashID(userID),
 				"workspace", workspace,
-				"category", req.Category)
+			)
+			if m.metrics != nil {
+				m.metrics.RecordSuppression(layer, req.Category, "opt-out")
+			}
+			w.Header().Set(consentDecisionHeader, formatConsentDecision(req.Category, layer))
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}

--- a/internal/memory/api/privacy_middleware_test.go
+++ b/internal/memory/api/privacy_middleware_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -665,4 +667,82 @@ func TestMemoryPrivacyMiddleware_ConsentOverride_OverridesDB(t *testing.T) {
 
 	assert.Equal(t, http.StatusCreated, w.Code, "header override should allow the write")
 	assert.True(t, handlerCalled)
+}
+
+func TestMemoryPrivacyMiddleware_OptedOut_SetsConsentDecisionHeader(t *testing.T) {
+	mw := newTestMiddleware(optedOutChecker, noOpRedact)
+	handler := mw.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	w := httptest.NewRecorder()
+	body := SaveMemoryRequest{
+		Type:     "fact",
+		Content:  "x",
+		Scope:    map[string]string{"workspace": "ws-1"},
+		Category: "memory:health",
+	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/memories?workspace=ws-1&user_id=user-abc", bytes.NewReader(b))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set(consentLayerHeader, "session")
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	got := w.Header().Get(consentDecisionHeader)
+	if got == "" {
+		t.Fatal("X-Consent-Decision header missing on 204")
+	}
+	assert.Contains(t, got, "deny")
+	assert.Contains(t, got, "category=memory:health")
+	assert.Contains(t, got, "layer=session")
+}
+
+func TestMemoryPrivacyMiddleware_OptedOut_RecordsMetric(t *testing.T) {
+	metrics := NewSuppressionMetrics()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, metrics.Register(reg))
+
+	mw := NewMemoryPrivacyMiddlewareWithMetrics(optedOutChecker, noOpRedact, nil, metrics, logr.Discard())
+	handler := mw.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	w := httptest.NewRecorder()
+	body := SaveMemoryRequest{
+		Type:     "fact",
+		Content:  "x",
+		Scope:    map[string]string{"workspace": "ws-1"},
+		Category: "memory:identity",
+	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	r := httptest.NewRequest(http.MethodPost, "/api/v1/memories?workspace=ws-1&user_id=user-abc", bytes.NewReader(b))
+	r.Header.Set("Content-Type", "application/json")
+	r.Header.Set(consentLayerHeader, "per-message")
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	got := testutil.ToFloat64(
+		metrics.WritesSuppressed.WithLabelValues("per-message", "memory:identity", "opt-out"),
+	)
+	if got != 1 {
+		t.Errorf("counter = %v, want 1", got)
+	}
+}
+
+func TestMemoryPrivacyMiddleware_OptedOut_DefaultsLayerToPersistent(t *testing.T) {
+	mw := newTestMiddleware(optedOutChecker, noOpRedact)
+	handler := mw.Wrap(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+	}))
+
+	w := httptest.NewRecorder()
+	r := makePostRequest(t, "x", "ws-1", "user-abc")
+	// No consentLayerHeader set — middleware should default to "persistent".
+	handler.ServeHTTP(w, r)
+
+	require.Equal(t, http.StatusNoContent, w.Code)
+	assert.Contains(t, w.Header().Get(consentDecisionHeader), "layer=persistent")
 }

--- a/internal/memory/api/suppression_metrics.go
+++ b/internal/memory/api/suppression_metrics.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package api
+
+import "github.com/prometheus/client_golang/prometheus"
+
+// SuppressionMetrics groups the memory-write suppression Prometheus collectors.
+// Operators alert on sudden spikes ("did a deploy break consent capture?").
+type SuppressionMetrics struct {
+	WritesSuppressed *prometheus.CounterVec
+}
+
+// NewSuppressionMetrics builds the collector set. Caller is responsible for
+// registering them on a registry.
+func NewSuppressionMetrics() *SuppressionMetrics {
+	return &SuppressionMetrics{
+		WritesSuppressed: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "omnia_memory_writes_suppressed_total",
+			Help: "Memory writes dropped before storage. Labels: layer (per-message|session|persistent|unknown), category, reason (no-grant|opt-out).",
+		}, []string{"layer", "category", "reason"}),
+	}
+}
+
+// Register registers the collectors on the given registry.
+func (m *SuppressionMetrics) Register(reg prometheus.Registerer) error {
+	return reg.Register(m.WritesSuppressed)
+}
+
+// RecordSuppression increments the suppression counter for the given dimensions.
+// Sanitises empty values to "unknown" so dashboards don't end up with empty-
+// label time series.
+func (m *SuppressionMetrics) RecordSuppression(layer, category, reason string) {
+	if layer == "" {
+		layer = "unknown"
+	}
+	if category == "" {
+		category = "unknown"
+	}
+	if reason == "" {
+		reason = "unknown"
+	}
+	m.WritesSuppressed.WithLabelValues(layer, category, reason).Inc()
+}

--- a/internal/memory/api/suppression_metrics_test.go
+++ b/internal/memory/api/suppression_metrics_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package api
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSuppressionMetrics_RegisterAndRecord(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSuppressionMetrics()
+	if err := m.Register(reg); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.RecordSuppression("session", "memory:health", "no-grant")
+	got := testutil.ToFloat64(
+		m.WritesSuppressed.WithLabelValues("session", "memory:health", "no-grant"),
+	)
+	if got != 1 {
+		t.Errorf("counter = %v, want 1", got)
+	}
+}
+
+func TestSuppressionMetrics_BlankFieldsBecomeUnknown(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	m := NewSuppressionMetrics()
+	if err := m.Register(reg); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	m.RecordSuppression("", "", "")
+	got := testutil.ToFloat64(
+		m.WritesSuppressed.WithLabelValues("unknown", "unknown", "unknown"),
+	)
+	if got != 1 {
+		t.Errorf("counter = %v, want 1", got)
+	}
+}

--- a/internal/memory/httpclient/store.go
+++ b/internal/memory/httpclient/store.go
@@ -243,6 +243,10 @@ func (s *Store) doRequest(ctx context.Context, method, path string, body []byte)
 	if grants := policy.ConsentGrantsFromContext(ctx); len(grants) > 0 {
 		req.Header.Set("X-Consent-Grants", strings.Join(grants, ","))
 	}
+	// Forward consent layer (diagnostic, paired with grants).
+	if layer := policy.ConsentLayerFromContext(ctx); layer != "" {
+		req.Header.Set("X-Consent-Layer", layer)
+	}
 
 	s.log.V(2).Info("memory-api request", "method", method, "path", path)
 

--- a/internal/memory/httpclient/store_test.go
+++ b/internal/memory/httpclient/store_test.go
@@ -271,6 +271,38 @@ func TestStore_Save_ForwardsConsentGrants(t *testing.T) {
 	assert.Equal(t, "memory:identity,memory:preferences", capturedHeader)
 }
 
+func TestStore_Save_ForwardsConsentLayer(t *testing.T) {
+	var capturedLayer string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedLayer = r.Header.Get("X-Consent-Layer")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"memory":{"id":"m1"}}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	ctx := policy.WithConsentLayer(context.Background(), "session")
+	mem := &pkmemory.Memory{Content: "test", Scope: map[string]string{"workspace_id": "ws1"}}
+	err := store.Save(ctx, mem)
+	require.NoError(t, err)
+	assert.Equal(t, "session", capturedLayer)
+}
+
+func TestStore_Save_NoConsentLayer_NoHeader(t *testing.T) {
+	var hasHeader bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hasHeader = r.Header.Get("X-Consent-Layer") != ""
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"memory":{"id":"m1"}}`))
+	}))
+	defer srv.Close()
+
+	store := NewStore(srv.URL, logr.Discard())
+	mem := &pkmemory.Memory{Content: "test", Scope: map[string]string{"workspace_id": "ws1"}}
+	require.NoError(t, store.Save(context.Background(), mem))
+	assert.False(t, hasHeader)
+}
+
 func TestStore_Save_NoConsentGrants_NoHeader(t *testing.T) {
 	var hasHeader bool
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/runtime/interceptor.go
+++ b/internal/runtime/interceptor.go
@@ -90,6 +90,7 @@ func extractPolicyFromMetadata(ctx context.Context) context.Context {
 	if grants := firstValue(md, policy.HeaderConsentGrants); grants != "" {
 		fields.ConsentGrants = strings.Split(grants, ",")
 	}
+	fields.ConsentLayer = firstValue(md, policy.HeaderConsentLayer)
 	return policy.WithPropagationFields(ctx, fields)
 }
 

--- a/internal/runtime/interceptor_test.go
+++ b/internal/runtime/interceptor_test.go
@@ -154,6 +154,25 @@ func TestPolicyStreamServerInterceptor(t *testing.T) {
 	assert.Equal(t, "stream-user", policy.UserID(capturedCtx))
 }
 
+func TestExtractPolicyFromMetadata_ConsentLayer(t *testing.T) {
+	md := metadata.Pairs(
+		policy.HeaderConsentGrants, "memory:identity,memory:preferences",
+		policy.HeaderConsentLayer, "session",
+	)
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx = extractPolicyFromMetadata(ctx)
+	assert.Equal(t, "session", policy.ConsentLayerFromContext(ctx))
+	grants := policy.ConsentGrantsFromContext(ctx)
+	assert.Equal(t, []string{"memory:identity", "memory:preferences"}, grants)
+}
+
+func TestExtractPolicyFromMetadata_NoConsentLayer(t *testing.T) {
+	md := metadata.Pairs()
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+	ctx = extractPolicyFromMetadata(ctx)
+	assert.Equal(t, "", policy.ConsentLayerFromContext(ctx))
+}
+
 // mockServerStream implements grpc.ServerStream for testing.
 type mockServerStream struct {
 	grpc.ServerStream

--- a/pkg/policy/context.go
+++ b/pkg/policy/context.go
@@ -55,6 +55,10 @@ const (
 	ContextKeyClaims contextKey = "omnia-claims"
 	// ContextKeyConsentGrants holds per-request consent grants.
 	ContextKeyConsentGrants contextKey = "omnia-consent-grants"
+	// ContextKeyConsentLayer identifies which layer (per-message, session,
+	// persistent) produced the per-request consent grants. Diagnostic only —
+	// memory-api uses it for log/metric/response-header attribution.
+	ContextKeyConsentLayer contextKey = "omnia-consent-layer"
 	// ContextKeyIdentity holds the AuthenticatedIdentity produced by the
 	// facade's auth chain. Not propagated on the wire — the flat UserID /
 	// UserRoles / UserEmail / Claims fields carry what downstream services
@@ -96,6 +100,10 @@ const (
 	HeaderParamPrefix = "x-omnia-param-"
 	// HeaderConsentGrants carries comma-separated consent category grants.
 	HeaderConsentGrants = "x-omnia-consent-grants"
+	// HeaderConsentLayer attributes per-request consent grants to a layer
+	// (per-message, session, persistent). Used by memory-api for
+	// observability on suppressed writes.
+	HeaderConsentLayer = "x-omnia-consent-layer"
 )
 
 // Istio-injected header names that the facade reads from the WebSocket upgrade request.
@@ -131,6 +139,9 @@ type PropagationFields struct {
 	Claims        map[string]string
 	// ConsentGrants holds per-request consent category grants.
 	ConsentGrants []string
+	// ConsentLayer attributes ConsentGrants to a layer (per-message,
+	// session, persistent). Empty when ConsentGrants is empty.
+	ConsentLayer string
 	// Identity is the authenticated identity produced by the facade's auth
 	// chain. When non-nil, it is the source of truth for UserID /
 	// UserRoles / UserEmail / Claims — callers that build PropagationFields
@@ -233,6 +244,17 @@ func ConsentGrantsFromContext(ctx context.Context) []string {
 	return nil
 }
 
+// WithConsentLayer returns a context with the consent layer label set.
+// Diagnostic only — memory-api uses it for log/metric attribution.
+func WithConsentLayer(ctx context.Context, layer string) context.Context {
+	return context.WithValue(ctx, ContextKeyConsentLayer, layer)
+}
+
+// ConsentLayerFromContext extracts the consent layer label from context.
+func ConsentLayerFromContext(ctx context.Context) string {
+	return getString(ctx, ContextKeyConsentLayer)
+}
+
 // WithPropagationFields returns a context with all propagation fields set.
 // Only non-empty values are stored.
 func WithPropagationFields(ctx context.Context, fields *PropagationFields) context.Context {
@@ -254,6 +276,9 @@ func WithPropagationFields(ctx context.Context, fields *PropagationFields) conte
 	}
 	if len(fields.ConsentGrants) > 0 {
 		ctx = WithConsentGrants(ctx, fields.ConsentGrants)
+	}
+	if fields.ConsentLayer != "" {
+		ctx = WithConsentLayer(ctx, fields.ConsentLayer)
 	}
 	if fields.Identity != nil {
 		ctx = WithIdentity(ctx, fields.Identity)
@@ -284,6 +309,7 @@ func ExtractPropagationFields(ctx context.Context) PropagationFields {
 		Model:         getString(ctx, ContextKeyModel),
 		Claims:        getClaims(ctx),
 		ConsentGrants: ConsentGrantsFromContext(ctx),
+		ConsentLayer:  ConsentLayerFromContext(ctx),
 		Identity:      IdentityFromContext(ctx),
 	}
 }
@@ -371,6 +397,10 @@ func ToOutboundHeaders(ctx context.Context) map[string]string {
 	// Append consent grants header.
 	if grants := ConsentGrantsFromContext(ctx); len(grants) > 0 {
 		headers[HeaderConsentGrants] = strings.Join(grants, ",")
+	}
+	// Append consent layer header (diagnostic, paired with grants).
+	if layer := ConsentLayerFromContext(ctx); layer != "" {
+		headers[HeaderConsentLayer] = layer
 	}
 	return headers
 }

--- a/pkg/policy/context_test.go
+++ b/pkg/policy/context_test.go
@@ -322,3 +322,40 @@ func TestExtractPropagationFieldsConsentGrants(t *testing.T) {
 	fields := ExtractPropagationFields(ctx)
 	assert.Equal(t, grants, fields.ConsentGrants)
 }
+
+func TestWithConsentLayer_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if got := ConsentLayerFromContext(ctx); got != "" {
+		t.Errorf("empty context: got %q, want \"\"", got)
+	}
+	ctx = WithConsentLayer(ctx, "session")
+	if got := ConsentLayerFromContext(ctx); got != "session" {
+		t.Errorf("after WithConsentLayer: got %q, want \"session\"", got)
+	}
+}
+
+func TestPropagationFields_RoundTripsConsentLayer(t *testing.T) {
+	ctx := WithPropagationFields(context.Background(), &PropagationFields{
+		ConsentGrants: []string{"memory:identity"},
+		ConsentLayer:  "per-message",
+	})
+	got := ExtractPropagationFields(ctx)
+	if got.ConsentLayer != "per-message" {
+		t.Errorf("ConsentLayer = %q, want \"per-message\"", got.ConsentLayer)
+	}
+}
+
+func TestToOutboundHeaders_IncludesConsentLayer(t *testing.T) {
+	ctx := WithConsentLayer(context.Background(), "session")
+	headers := ToOutboundHeaders(ctx)
+	if headers[HeaderConsentLayer] != "session" {
+		t.Errorf("headers[%q] = %q, want \"session\"", HeaderConsentLayer, headers[HeaderConsentLayer])
+	}
+}
+
+func TestToOutboundHeaders_OmitsEmptyConsentLayer(t *testing.T) {
+	headers := ToOutboundHeaders(context.Background())
+	if v, present := headers[HeaderConsentLayer]; present {
+		t.Errorf("HeaderConsentLayer present without value: %q", v)
+	}
+}


### PR DESCRIPTION
## Summary

Phase C of the memory consent model. Per-session consent grants
captured once on a WebSocket connection apply to every message in that
session; per-message grants continue to override for a single turn.
Last-writer-wins semantics throughout — no intersection with persistent
grants (see spec for debuggability rationale).

- Facade owns session lifecycle. Runtime stays per-message. Memory-api
  unchanged in logic, gains observability hooks.
- New `[]string ClientMessage.SessionConsentGrants` field. First
  non-empty list stamps the per-session default on the Connection;
  subsequent non-empty lists replace (last-writer-wins). Empty /
  omitted lists are ignored.
- New `policy.HeaderConsentLayer` propagated via gRPC metadata + HTTP
  header so memory-api can attribute suppressions to the right layer.
- Three observability hooks on suppressed writes: V(0) structured log
  with `layer`/`grants`/`category`/`reason`/`userHash`, `X-Consent-Decision`
  response header on 204, and `omnia_memory_writes_suppressed_total{layer,category,reason}`
  Prometheus metric.
- Dashboard SDK TS types + AsyncAPI schema updated.

Spec: ` + "`docs/superpowers/specs/2026-04-24-per-session-consent-grants-design.md`" + `
Closes #1006

## Stacked on

PR #1008 (Phase B classifier). The base is set to that branch so the
diff shows only Phase C changes. When #1008 merges, GitHub auto-rebases
the base to main.

## Test plan

- [x] `go test ./... -count=1` — 7204 passed in 93 packages
- [x] `golangci-lint run` on changed packages — warnings only, no errors
- [x] Facade unit: caching, empty-ignored, override precedence, layer
  attribution, mid-session reset
- [x] Runtime unit: layer extraction from gRPC metadata
- [x] Memory-api unit: response header + metric on suppressed writes
- [ ] Manual: dashboard sends session_consent_grants, verify
  X-Consent-Decision on a denied write