### PR TITLE
feat(memory): analytics:aggregate enforcement foundation (#1007)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -36,6 +36,21 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
   Prometheus metric. Suppressed-write log line promoted from V(1) to V(0)
   and enriched with layer + grants.
 
+### Added (analytics:aggregate enforcement foundation, #1007)
+
+- New `memory.AggregateConsentJoin(alias)` helper produces SQL JOIN +
+  WHERE fragments restricting a cross-user aggregate to users who have
+  granted `analytics:aggregate`. Institutional and agent-tier rows pass.
+- New Prometheus metrics:
+  - `omnia_memory_consent_analytics_optin_ratio` (gauge, 0..1)
+  - `omnia_memory_consent_analytics_users_total{granted}` (gauge pair)
+  - `omnia_memory_consent_analytics_worker_errors_total{reason}` (counter)
+- `AnalyticsOptInWorker` queries `user_privacy_preferences` every 5
+  minutes to refresh the gauges.
+- No existing queries retrofitted — memory-api has zero cross-user
+  aggregation today. The helper lands as foundation for the upcoming
+  #1004 dashboard.
+
 ### Breaking
 
 - `SessionPrivacyPolicy.spec.level`, `spec.workspaceRef`, and `spec.agentRef` removed. Policies are now reusable namespaced documents; binding has moved to consumers (`Workspace` service groups and `AgentRuntime`).

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -293,6 +293,22 @@ func run() error {
 	// --- Retention worker ---
 	startRetentionWorker(ctx, store, f.retentionInterval, log)
 
+	// --- Analytics opt-in metric + worker ---
+	// Computes the fraction of users who have granted the
+	// analytics:aggregate consent category. Runs in any mode (EE or
+	// OSS); in OSS the grant is never set so the ratio reports 0 which
+	// is correct (no cross-user analytics consent).
+	optInMetrics := memory.NewAnalyticsOptInMetrics()
+	if err := memory.RegisterAnalyticsOptInMetrics(prometheus.DefaultRegisterer, optInMetrics); err != nil {
+		log.Error(err, "analytics opt-in metrics registration failed")
+	} else {
+		optInWorker := memory.NewAnalyticsOptInWorker(pool, optInMetrics, log)
+		go optInWorker.Run(ctx)
+		log.Info("analytics opt-in worker started",
+			"interval", memory.DefaultAnalyticsOptInInterval,
+		)
+	}
+
 	// --- Compaction worker ---
 	// Temporal summarization of old memories. Uses NoopSummarizer by default —
 	// memory growth is still bounded because the worker supersedes originals,

--- a/cmd/memory-api/wiring_test.go
+++ b/cmd/memory-api/wiring_test.go
@@ -255,6 +255,24 @@ func TestWrapPrivacyMiddleware_DoesNotPanicWithNilEmbeddingSvc(t *testing.T) {
 	_ = wrapPrivacyMiddleware(context.Background(), next, nil, nil, logr.Discard())
 }
 
+// TestMemoryAnalyticsOptInMetrics_Registered verifies that the
+// analytics:aggregate opt-in metric surface registers cleanly on a
+// fresh Prometheus registry, and that duplicate registration is
+// rejected (proves the collectors actually hit the registry).
+// Hermetic — no running Postgres needed.
+func TestMemoryAnalyticsOptInMetrics_Registered(t *testing.T) {
+	freshPromRegistry(t)
+	m := memory.NewAnalyticsOptInMetrics()
+	if err := memory.RegisterAnalyticsOptInMetrics(prometheus.DefaultRegisterer, m); err != nil {
+		t.Fatalf("first RegisterAnalyticsOptInMetrics: %v", err)
+	}
+	// Second registration must fail — otherwise the first didn't land.
+	m2 := memory.NewAnalyticsOptInMetrics()
+	if err := memory.RegisterAnalyticsOptInMetrics(prometheus.DefaultRegisterer, m2); err == nil {
+		t.Error("second RegisterAnalyticsOptInMetrics: want AlreadyRegistered error, got nil")
+	}
+}
+
 // TestBuildAPIMux_HealthzAlwaysReachable verifies /healthz is wired regardless
 // of enterprise mode. This is a smoke test that the middleware chain does not
 // incorrectly gate health checks.

--- a/internal/memory/README.md
+++ b/internal/memory/README.md
@@ -1,0 +1,43 @@
+# internal/memory
+
+Per-workspace memory store for agentic memory operations. Backed by
+PostgreSQL + pgvector, called by memory-api.
+
+## Aggregate query rules
+
+Any query that scans `memory_entities` across more than one
+`virtual_user_id` MUST use `AggregateConsentJoin` (see
+`aggregate_consent.go`) to filter out users who have not granted the
+`analytics:aggregate` consent category.
+
+- Institutional rows (`virtual_user_id IS NULL AND agent_id IS NULL`)
+  are exempt — they are not user data.
+- Agent-tier rows (`virtual_user_id IS NULL AND agent_id IS NOT NULL`)
+  are exempt for the same reason.
+- Single-user queries (scoped by a specific `virtual_user_id`) do NOT
+  need this filter; per-user analytics are governed by the existing
+  binary opt-out / per-category grants via `ShouldRememberCategory` in
+  the privacy middleware.
+
+Example:
+
+```go
+join, where := memory.AggregateConsentJoin("e")
+sql := `SELECT COUNT(*) FROM memory_entities e ` + join +
+       ` WHERE e.workspace_id = $1 AND e.forgotten = false AND ` + where
+```
+
+See `aggregate_consent.go` for the full contract and
+`aggregate_consent_integration_test.go` for the decision table.
+
+## Opt-in visibility
+
+The `AnalyticsOptInWorker` exposes:
+
+- `omnia_memory_consent_analytics_optin_ratio` — gauge (0..1), global
+- `omnia_memory_consent_analytics_users_total{granted="true"|"false"}` —
+  absolute count gauges
+- `omnia_memory_consent_analytics_worker_errors_total{reason}` — counter
+
+Per-workspace granularity is deferred; `user_privacy_preferences` is
+user-scoped, not workspace-scoped.

--- a/internal/memory/aggregate_consent.go
+++ b/internal/memory/aggregate_consent.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package memory
+
+// AnalyticsAggregateCategory is the canonical consent category string
+// enforced by AggregateConsentJoin. The memory-api wire contract
+// depends on this exact literal.
+const AnalyticsAggregateCategory = "analytics:aggregate"
+
+// AggregateConsentJoin returns SQL fragments that restrict a cross-user
+// aggregate over memory_entities to users who have granted the
+// analytics:aggregate consent category.
+//
+// entityAlias is the table alias used for memory_entities in the
+// caller's query (e.g. "e" in "FROM memory_entities e"). The returned
+// JOIN clause adds a LEFT JOIN against user_privacy_preferences; the
+// WHERE clause restricts to rows where either:
+//   - virtual_user_id IS NULL (institutional or agent-tier; not user data)
+//   - the user has 'analytics:aggregate' in their consent_grants array
+//
+// LEFT JOIN (not inner JOIN) is critical: institutional and agent-tier
+// rows have no matching user_privacy_preferences row, and an inner JOIN
+// would silently drop them.
+//
+// Usage:
+//
+//	join, where := AggregateConsentJoin("e")
+//	sql := `SELECT COUNT(*) FROM memory_entities e ` + join +
+//	       ` WHERE e.workspace_id = $1 AND ` + where
+//
+// The helper does NOT add workspace / forgotten filters — callers
+// compose those themselves.
+func AggregateConsentJoin(entityAlias string) (joinClause, whereClause string) {
+	joinClause = "LEFT JOIN user_privacy_preferences p ON p.user_id = " +
+		entityAlias + ".virtual_user_id"
+	whereClause = "(" + entityAlias + ".virtual_user_id IS NULL OR " +
+		"'" + AnalyticsAggregateCategory + "' = ANY(p.consent_grants))"
+	return
+}

--- a/internal/memory/aggregate_consent_integration_test.go
+++ b/internal/memory/aggregate_consent_integration_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestAggregateConsentJoin_FiltersUsersByGrant seeds memory_entities
+// with mixed user/tier rows plus user_privacy_preferences exercising
+// every branch of the helper's decision table, then runs a sample
+// COUNT(*) via the helper and verifies the expected row count.
+//
+// This is the contract test #1004 relies on: institutional rows always
+// count, user rows count only when the user has granted
+// analytics:aggregate.
+func TestAggregateConsentJoin_FiltersUsersByGrant(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	workspaceID := "b0000000-0000-0000-0000-000000001007"
+
+	// Seed user-tier memories via the public Save API (which requires
+	// user_id scope). Institutional rows go in via direct SQL because
+	// Save() rejects nil user_id.
+	for _, userID := range []string{"user-granted", "user-not-granted", "user-no-prefs", "user-opted-out"} {
+		mem := &Memory{
+			Type:    "fact",
+			Content: "sample",
+			Scope:   map[string]string{ScopeWorkspaceID: workspaceID, ScopeUserID: userID},
+		}
+		require.NoError(t, store.Save(ctx, mem))
+	}
+
+	pool := store.Pool()
+	// Insert one institutional row directly (virtual_user_id NULL,
+	// agent_id NULL) — Save() can't produce these without user_id.
+	_, err := pool.Exec(ctx, `
+		INSERT INTO memory_entities (workspace_id, virtual_user_id, agent_id, name, kind, metadata)
+		VALUES ($1, NULL, NULL, $2, $3, '{}'::jsonb)`,
+		workspaceID, "institutional-fact", "fact",
+	)
+	require.NoError(t, err)
+
+	// Seed preferences via direct pool access — the privacy store API
+	// lives in EE; we don't want to import it from core tests.
+	_, err = pool.Exec(ctx, `
+		INSERT INTO user_privacy_preferences (user_id, consent_grants)
+		VALUES ($1, $2), ($3, $4)
+		ON CONFLICT (user_id) DO UPDATE SET consent_grants = EXCLUDED.consent_grants`,
+		"user-granted", []string{"analytics:aggregate", "memory:preferences"},
+		"user-not-granted", []string{"memory:preferences"},
+	)
+	require.NoError(t, err)
+
+	_, err = pool.Exec(ctx, `
+		INSERT INTO user_privacy_preferences (user_id, opt_out_all)
+		VALUES ($1, TRUE)
+		ON CONFLICT (user_id) DO UPDATE SET opt_out_all = EXCLUDED.opt_out_all`,
+		"user-opted-out",
+	)
+	require.NoError(t, err)
+
+	// Run the sample aggregate query via the helper.
+	join, where := AggregateConsentJoin("e")
+	var count int
+	err = pool.QueryRow(ctx, `
+		SELECT COUNT(*) FROM memory_entities e `+join+
+		` WHERE e.workspace_id = $1 AND e.forgotten = false AND `+where,
+		workspaceID).Scan(&count)
+	require.NoError(t, err)
+
+	// Expected: user-granted (✓) + institutional (✓) = 2.
+	// Excluded: user-not-granted, user-no-prefs, user-opted-out.
+	if count != 2 {
+		t.Errorf("count = %d, want 2 (one granted user + one institutional row); SQL: SELECT COUNT(*) FROM memory_entities e %s WHERE e.workspace_id = $1 AND e.forgotten = false AND %s", count, join, where)
+	}
+}

--- a/internal/memory/aggregate_consent_test.go
+++ b/internal/memory/aggregate_consent_test.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package memory
+
+import "testing"
+
+func TestAggregateConsentJoin_DefaultAlias(t *testing.T) {
+	join, where := AggregateConsentJoin("e")
+	wantJoin := "LEFT JOIN user_privacy_preferences p ON p.user_id = e.virtual_user_id"
+	wantWhere := "(e.virtual_user_id IS NULL OR 'analytics:aggregate' = ANY(p.consent_grants))"
+	if join != wantJoin {
+		t.Errorf("join = %q, want %q", join, wantJoin)
+	}
+	if where != wantWhere {
+		t.Errorf("where = %q, want %q", where, wantWhere)
+	}
+}
+
+func TestAggregateConsentJoin_CustomAlias(t *testing.T) {
+	join, where := AggregateConsentJoin("entity")
+	if join != "LEFT JOIN user_privacy_preferences p ON p.user_id = entity.virtual_user_id" {
+		t.Errorf("unexpected join for custom alias: %q", join)
+	}
+	if where != "(entity.virtual_user_id IS NULL OR 'analytics:aggregate' = ANY(p.consent_grants))" {
+		t.Errorf("unexpected where for custom alias: %q", where)
+	}
+}
+
+func TestAnalyticsAggregateCategory_Constant(t *testing.T) {
+	// Guard against accidental renaming — the memory-api wire contract
+	// depends on this literal.
+	if AnalyticsAggregateCategory != "analytics:aggregate" {
+		t.Errorf("AnalyticsAggregateCategory = %q, want \"analytics:aggregate\"", AnalyticsAggregateCategory)
+	}
+}

--- a/internal/memory/analytics_optin_metric.go
+++ b/internal/memory/analytics_optin_metric.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Metric name constants for the analytics:aggregate opt-in worker.
+const (
+	metricAnalyticsOptInRatio   = "omnia_memory_consent_analytics_optin_ratio"
+	metricAnalyticsUsersTotal   = "omnia_memory_consent_analytics_users_total"
+	metricAnalyticsWorkerErrors = "omnia_memory_consent_analytics_worker_errors_total"
+)
+
+// DefaultAnalyticsOptInInterval is the default period between worker
+// queries. Exported so operators can override via a future flag without
+// changing the default behaviour.
+const DefaultAnalyticsOptInInterval = 5 * time.Minute
+
+// AnalyticsOptInMetrics groups the Prometheus collectors for the
+// analytics:aggregate consent opt-in worker. Construct via
+// NewAnalyticsOptInMetrics, register via RegisterAnalyticsOptInMetrics.
+type AnalyticsOptInMetrics struct {
+	OptInRatio   prometheus.Gauge
+	UsersTotal   *prometheus.GaugeVec
+	WorkerErrors *prometheus.CounterVec
+}
+
+// NewAnalyticsOptInMetrics constructs a fresh collector set without
+// registering it anywhere.
+func NewAnalyticsOptInMetrics() *AnalyticsOptInMetrics {
+	return &AnalyticsOptInMetrics{
+		OptInRatio: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: metricAnalyticsOptInRatio,
+			Help: "Fraction of users who have granted the analytics:aggregate consent category (0..1). Global across all workspaces.",
+		}),
+		UsersTotal: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: metricAnalyticsUsersTotal,
+			Help: "Absolute count of users with / without the analytics:aggregate consent category. Labels: granted (\"true\"|\"false\").",
+		}, []string{"granted"}),
+		WorkerErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: metricAnalyticsWorkerErrors,
+			Help: "Errors observed by the analytics opt-in worker. Labels: reason.",
+		}, []string{"reason"}),
+	}
+}
+
+// RegisterAnalyticsOptInMetrics registers the collectors on the given
+// registry. Returns the first registration error encountered.
+func RegisterAnalyticsOptInMetrics(reg prometheus.Registerer, m *AnalyticsOptInMetrics) error {
+	collectors := []prometheus.Collector{m.OptInRatio, m.UsersTotal, m.WorkerErrors}
+	for _, c := range collectors {
+		if err := reg.Register(c); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// AnalyticsOptInWorker periodically queries user_privacy_preferences to
+// compute the fraction of users who have granted analytics:aggregate
+// consent, updating AnalyticsOptInMetrics.
+type AnalyticsOptInWorker struct {
+	pool     *pgxpool.Pool
+	metrics  *AnalyticsOptInMetrics
+	interval time.Duration
+	log      logr.Logger
+}
+
+// NewAnalyticsOptInWorker constructs a worker with the default interval.
+func NewAnalyticsOptInWorker(pool *pgxpool.Pool, metrics *AnalyticsOptInMetrics, log logr.Logger) *AnalyticsOptInWorker {
+	return &AnalyticsOptInWorker{
+		pool:     pool,
+		metrics:  metrics,
+		interval: DefaultAnalyticsOptInInterval,
+		log:      log.WithName("analytics-optin-worker"),
+	}
+}
+
+// Run ticks until ctx is cancelled. Each tick calls RunOnce.
+// Errors from RunOnce are logged but do not stop the worker.
+func (w *AnalyticsOptInWorker) Run(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	// Run once immediately so metrics are populated before the first tick.
+	if err := w.RunOnce(ctx); err != nil {
+		w.log.Error(err, "analytics opt-in worker initial run failed")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := w.RunOnce(ctx); err != nil {
+				w.log.Error(err, "analytics opt-in worker tick failed")
+			}
+		}
+	}
+}
+
+// RunOnce executes a single query + metric update. Separated from Run
+// so tests can exercise the computation without a ticker.
+func (w *AnalyticsOptInWorker) RunOnce(ctx context.Context) error {
+	var granted, total int64
+	err := w.pool.QueryRow(ctx, `
+		SELECT
+			COUNT(*) FILTER (WHERE '`+AnalyticsAggregateCategory+`' = ANY(consent_grants)) AS granted,
+			COUNT(*) AS total
+		FROM user_privacy_preferences`).Scan(&granted, &total)
+	if err != nil {
+		w.metrics.WorkerErrors.WithLabelValues("query").Inc()
+		return err
+	}
+
+	// Leave the ratio gauge unchanged when no users exist — oscillating
+	// to 0 on every empty-DB tick creates misleading dashboards on
+	// fresh deployments. The absolute-count gauges still update to 0/0.
+	w.metrics.UsersTotal.WithLabelValues("true").Set(float64(granted))
+	w.metrics.UsersTotal.WithLabelValues("false").Set(float64(total - granted))
+	if total > 0 {
+		w.metrics.OptInRatio.Set(float64(granted) / float64(total))
+	}
+	return nil
+}

--- a/internal/memory/analytics_optin_metric_test.go
+++ b/internal/memory/analytics_optin_metric_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 Altaira Labs.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnalyticsOptInWorker_ComputesRatio(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	_, err := store.Pool().Exec(ctx, `
+		INSERT INTO user_privacy_preferences (user_id, consent_grants)
+		VALUES
+			($1, $2),
+			($3, $4),
+			($5, $6),
+			($7, $8)`,
+		"u1", []string{"analytics:aggregate"},
+		"u2", []string{"analytics:aggregate", "memory:preferences"},
+		"u3", []string{"memory:preferences"},
+		"u4", []string{},
+	)
+	require.NoError(t, err)
+
+	metrics := NewAnalyticsOptInMetrics()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterAnalyticsOptInMetrics(reg, metrics))
+
+	worker := NewAnalyticsOptInWorker(store.Pool(), metrics, logr.Discard())
+	require.NoError(t, worker.RunOnce(ctx))
+
+	if got := testutil.ToFloat64(metrics.OptInRatio); got != 0.5 {
+		t.Errorf("ratio = %v, want 0.5", got)
+	}
+	if got := testutil.ToFloat64(metrics.UsersTotal.WithLabelValues("true")); got != 2 {
+		t.Errorf("granted = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(metrics.UsersTotal.WithLabelValues("false")); got != 2 {
+		t.Errorf("not granted = %v, want 2", got)
+	}
+}
+
+func TestAnalyticsOptInWorker_QueryError_IncrementsCounter(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	// Close the pool so the query fails, exercising the error path.
+	store.Pool().Close()
+
+	metrics := NewAnalyticsOptInMetrics()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterAnalyticsOptInMetrics(reg, metrics))
+
+	// Pre-seed the gauge so we can confirm it stays put on error.
+	metrics.OptInRatio.Set(0.42)
+
+	worker := NewAnalyticsOptInWorker(store.Pool(), metrics, logr.Discard())
+	if err := worker.RunOnce(ctx); err == nil {
+		t.Fatal("RunOnce on closed pool: want error, got nil")
+	}
+
+	if got := testutil.ToFloat64(metrics.WorkerErrors.WithLabelValues("query")); got != 1 {
+		t.Errorf("WorkerErrors{query} = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(metrics.OptInRatio); got != 0.42 {
+		t.Errorf("ratio changed on error: got %v, want 0.42 (unchanged)", got)
+	}
+}
+
+func TestAnalyticsOptInWorker_Run_StopsOnCtxCancel(t *testing.T) {
+	store := newStore(t)
+	metrics := NewAnalyticsOptInMetrics()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterAnalyticsOptInMetrics(reg, metrics))
+
+	worker := NewAnalyticsOptInWorker(store.Pool(), metrics, logr.Discard())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before Run so the ticker select exits on the first case
+
+	done := make(chan struct{})
+	go func() {
+		worker.Run(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Run returned promptly after ctx cancel.
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return within 5s of context cancellation")
+	}
+}
+
+func TestAnalyticsOptInWorker_EmptyTableLeavesGaugeUnchanged(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+
+	metrics := NewAnalyticsOptInMetrics()
+	reg := prometheus.NewRegistry()
+	require.NoError(t, RegisterAnalyticsOptInMetrics(reg, metrics))
+
+	// Pre-seed the gauge with a known value.
+	metrics.OptInRatio.Set(0.7)
+
+	worker := NewAnalyticsOptInWorker(store.Pool(), metrics, logr.Discard())
+	require.NoError(t, worker.RunOnce(ctx))
+
+	// Empty user_privacy_preferences → gauge MUST stay at 0.7 (not reset).
+	if got := testutil.ToFloat64(metrics.OptInRatio); got != 0.7 {
+		t.Errorf("ratio changed on empty table: got %v, want 0.7 (unchanged)", got)
+	}
+}


### PR DESCRIPTION
## Summary

Phase D of the memory consent model. Foundation for enforcing the
\`analytics:aggregate\` consent category across future cross-user
aggregate queries. Memory-api has zero cross-user aggregation today —
this lands the plumbing so the upcoming #1004 dashboard can do the
right thing from day one.

- \`memory.AggregateConsentJoin(alias)\` — reusable SQL JOIN + WHERE
  helper. LEFT JOIN preserves institutional / agent-tier rows
  (\`virtual_user_id IS NULL\`); user-tier rows pass only when the user
  has granted \`analytics:aggregate\`.
- \`AnalyticsOptInWorker\` — periodic (5 min) refresh of
  \`omnia_memory_consent_analytics_optin_ratio\` gauge + absolute-count
  gauges. Useful immediately for operators even before #1004 lands.
- \`internal/memory/README.md\` — contract: any cross-user aggregate
  MUST use the helper.

Spec: \`docs/superpowers/specs/2026-04-24-analytics-aggregate-enforcement-design.md\`
Closes #1007

## Stacked on

PR #1009 (Phase C). The base is set to that branch so the diff shows
only Phase D changes. When #1008 and #1009 merge to main, the base
auto-rebases.

## Test plan

- [x] \`go test ./... -count=1\` — 7213 passed in 93 packages
- [x] Unit tests for the helper (string shape, alias substitution)
- [x] Integration test exercising the decision table against a real
  Postgres (granted, not-granted, no-prefs, institutional, opted-out)
- [x] Worker tests (ratio computation, empty-table behaviour, query
  error path, ctx cancel exits Run)
- [x] Wiring regression test (collector registers cleanly + duplicate
  registration rejected)
- [ ] Manual: run memory-api with seeded \`user_privacy_preferences\`
  and curl \`/metrics\` to confirm the gauge reports the expected ratio