### PR TITLE
feat: tier-aware memory browsing (#1017)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,16 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Added (memory-entity tier field, #1017)
+
+- `GET /api/v1/memories`, `/api/v1/memories/search`, `/api/v1/memories/export`,
+  `/api/v1/institutional/memories`, and `/api/v1/agent-memories` now return a
+  `tier` field on each memory row (`"institutional" | "agent" | "user"`),
+  derived from the scope map (`user_id` → `user`, `agent_id` without `user_id`
+  → `agent`, neither → `institutional`). No schema change; additive on the
+  JSON response. Mirrors the SQL CASE expression used by the
+  `groupBy=tier` branch of `/memories/aggregate` (#1004).
+
 ### Breaking (MemoryPolicy schema flatten + tier-precedence)
 
 - `MemoryPolicy.spec.default` and `spec.perWorkspace` removed. Fields

--- a/cmd/memory-api/SERVICE.md
+++ b/cmd/memory-api/SERVICE.md
@@ -23,6 +23,9 @@ and searches memory entries with optional semantic search via embeddings.
     `virtual_user_id` / `agent_id` columns.
   - `GET /api/v1/privacy/consent/stats` (EE only) — workspace-wide consent
     posture for the operator dashboard.
+  - All memory list responses (`/api/v1/memories`, `/memories/search`,
+    `/memories/export`, `/institutional/memories`, `/agent-memories`) carry a
+    derived `tier` field (institutional / agent / user) on each row (#1017).
 - Health/readiness probes on port 8081
 - Metrics on port 9090
 

--- a/dashboard/src/components/memories/institutional-knowledge-panel.test.tsx
+++ b/dashboard/src/components/memories/institutional-knowledge-panel.test.tsx
@@ -81,6 +81,8 @@ describe("InstitutionalKnowledgePanel", () => {
     expect(screen.getByText("snake_case rule")).toBeInTheDocument();
     expect(screen.getByText("API terms")).toBeInTheDocument();
     expect(screen.getByText(/Workspace knowledge \(2\)/)).toBeInTheDocument();
+    // Each entry shows an Institutional tier badge.
+    expect(screen.getAllByText("Institutional")).toHaveLength(2);
   });
 
   it("renders error alert when load fails", () => {

--- a/dashboard/src/components/memories/institutional-knowledge-panel.tsx
+++ b/dashboard/src/components/memories/institutional-knowledge-panel.tsx
@@ -7,6 +7,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
+import { TierBadge } from "./tier-badge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import {
   Dialog,
@@ -154,8 +155,11 @@ function renderBody({ isLoading, error, memories, onDelete }: BodyProps) {
           className="flex items-start justify-between gap-3 rounded border bg-card p-3"
         >
           <div className="min-w-0 flex-1">
-            <p className="text-xs font-mono text-muted-foreground">{m.type}</p>
-            <p className="text-sm whitespace-pre-wrap break-words">{m.content}</p>
+            <div className="flex items-center gap-2">
+              <TierBadge tier="institutional" />
+              <p className="text-xs font-mono text-muted-foreground">{m.type}</p>
+            </div>
+            <p className="text-sm whitespace-pre-wrap break-words mt-1">{m.content}</p>
           </div>
           <DeleteButton id={m.id} onConfirm={onDelete} />
         </li>

--- a/dashboard/src/components/memories/memory-card.test.tsx
+++ b/dashboard/src/components/memories/memory-card.test.tsx
@@ -123,4 +123,16 @@ describe("MemoryCard", () => {
 
     expect(screen.queryByText("Session:")).not.toBeInTheDocument();
   });
+
+  it("shows the tier badge when tier is set", () => {
+    render(<MemoryCard memory={makeMemory({ tier: "user" })} />);
+    expect(screen.getByText("User")).toBeInTheDocument();
+  });
+
+  it("does not show a tier badge when tier is absent (legacy mock)", () => {
+    render(<MemoryCard memory={makeMemory({ tier: undefined })} />);
+    expect(screen.queryByText("User")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Institutional")).not.toBeInTheDocument();
+  });
 });

--- a/dashboard/src/components/memories/memory-card.tsx
+++ b/dashboard/src/components/memories/memory-card.tsx
@@ -15,6 +15,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { CategoryBadge } from "./category-badge";
+import { TierBadge } from "./tier-badge";
 import { ChevronDown, ChevronRight } from "lucide-react";
 import type { MemoryEntity } from "@/lib/data/types";
 
@@ -57,6 +58,7 @@ export function MemoryCard({ memory }: { memory: MemoryEntity }) {
               <div className="flex-1 min-w-0">
                 <p className="text-sm leading-snug">{truncate(memory.content, 100)}</p>
                 <div className="flex items-center gap-2 mt-1.5">
+                  <TierBadge tier={memory.tier} />
                   <CategoryBadge category={category} />
                   <div className="h-1.5 w-12 bg-muted rounded-full overflow-hidden">
                     <div

--- a/dashboard/src/components/memories/memory-detail-panel.test.tsx
+++ b/dashboard/src/components/memories/memory-detail-panel.test.tsx
@@ -63,6 +63,30 @@ describe("MemoryDetailPanel", () => {
     expect(screen.getByTestId("category-badge")).toHaveTextContent("Identity");
   });
 
+  it("shows tier badge when memory has a tier", () => {
+    render(
+      <MemoryDetailPanel
+        memory={makeMemory({ tier: "agent" })}
+        onClose={onClose}
+        onDelete={onDelete}
+      />
+    );
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+  });
+
+  it("omits the tier badge when memory has no tier (legacy mock)", () => {
+    render(
+      <MemoryDetailPanel
+        memory={makeMemory({ tier: undefined })}
+        onClose={onClose}
+        onDelete={onDelete}
+      />
+    );
+    expect(screen.queryByText("User")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent")).not.toBeInTheDocument();
+    expect(screen.queryByText("Institutional")).not.toBeInTheDocument();
+  });
+
   it("shows Unknown badge when no category metadata", () => {
     render(
       <MemoryDetailPanel memory={makeMemory()} onClose={onClose} onDelete={onDelete} />

--- a/dashboard/src/components/memories/memory-detail-panel.tsx
+++ b/dashboard/src/components/memories/memory-detail-panel.tsx
@@ -30,6 +30,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Trash2, ExternalLink } from "lucide-react";
 import { CategoryBadge } from "./category-badge";
+import { TierBadge } from "./tier-badge";
 import type { MemoryEntity } from "@/lib/data/types";
 
 interface MemoryDetailPanelProps {
@@ -48,6 +49,7 @@ export function MemoryDetailPanel({ memory, onClose, onDelete }: MemoryDetailPan
         <SheetHeader>
           <SheetTitle className="flex items-center gap-2">
             Memory Detail
+            <TierBadge tier={memory?.tier} />
             <CategoryBadge category={category} />
           </SheetTitle>
           <SheetDescription>

--- a/dashboard/src/components/memories/memory-sidebar.test.tsx
+++ b/dashboard/src/components/memories/memory-sidebar.test.tsx
@@ -36,7 +36,11 @@ vi.mock("next/link", () => ({
 
 import { MemorySidebar } from "./memory-sidebar";
 
-function makeMemory(id: string, content: string): MemoryEntity {
+function makeMemory(
+  id: string,
+  content: string,
+  tier?: MemoryEntity["tier"],
+): MemoryEntity {
   return {
     id,
     type: "fact",
@@ -44,6 +48,7 @@ function makeMemory(id: string, content: string): MemoryEntity {
     confidence: 0.8,
     scope: { workspace: "ws-1" },
     createdAt: new Date().toISOString(),
+    tier,
   };
 }
 
@@ -155,5 +160,47 @@ describe("MemorySidebar", () => {
     const closeButton = screen.getByRole("button", { name: /close/i });
     await user.click(closeButton);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it("renders the tier filter chips for authenticated users", () => {
+    setup([makeMemory("m1", "hello", "user")]);
+    render(<MemorySidebar agentName="my-agent" open={true} onClose={vi.fn()} />);
+    expect(screen.getByTestId("tier-filter-chips")).toBeInTheDocument();
+    expect(screen.getByTestId("tier-filter-all")).toBeInTheDocument();
+    expect(screen.getByTestId("tier-filter-institutional")).toBeInTheDocument();
+    expect(screen.getByTestId("tier-filter-agent")).toBeInTheDocument();
+    expect(screen.getByTestId("tier-filter-user")).toBeInTheDocument();
+  });
+
+  it("filters memories by tier when a chip is clicked", async () => {
+    const user = userEvent.setup();
+    setup([
+      makeMemory("u1", "user prefers dark mode", "user"),
+      makeMemory("a1", "agent learned support escalation", "agent"),
+      makeMemory("i1", "company refund policy", "institutional"),
+    ]);
+    render(<MemorySidebar agentName="my-agent" open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText("user prefers dark mode")).toBeInTheDocument();
+    expect(screen.getByText("agent learned support escalation")).toBeInTheDocument();
+    expect(screen.getByText("company refund policy")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("tier-filter-institutional"));
+
+    expect(screen.queryByText("user prefers dark mode")).not.toBeInTheDocument();
+    expect(screen.queryByText("agent learned support escalation")).not.toBeInTheDocument();
+    expect(screen.getByText("company refund policy")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("tier-filter-all"));
+
+    expect(screen.getByText("user prefers dark mode")).toBeInTheDocument();
+    expect(screen.getByText("agent learned support escalation")).toBeInTheDocument();
+    expect(screen.getByText("company refund policy")).toBeInTheDocument();
+  });
+
+  it("does not render filter chips for anonymous users", () => {
+    setupAnonymous();
+    render(<MemorySidebar agentName="my-agent" open={true} onClose={vi.fn()} />);
+    expect(screen.queryByTestId("tier-filter-chips")).not.toBeInTheDocument();
   });
 });

--- a/dashboard/src/components/memories/memory-sidebar.tsx
+++ b/dashboard/src/components/memories/memory-sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import {
   Sheet,
   SheetContent,
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/sheet";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
 import { Brain, LogIn } from "lucide-react";
 import Link from "next/link";
 import { useAuth } from "@/hooks/use-auth";
@@ -16,6 +17,8 @@ import { useMemories } from "@/hooks/use-memories";
 import { MemoryCard } from "./memory-card";
 import { Skeleton } from "@/components/ui/skeleton";
 import type { MemoryEntity } from "@/lib/data/types";
+import { TIERS, type Tier } from "@/lib/memory-analytics/types";
+import { TIER_LABELS } from "@/lib/memory-analytics/colors";
 
 interface MemorySidebarProps {
   agentName: string;
@@ -24,6 +27,15 @@ interface MemorySidebarProps {
 }
 
 const SKELETON_KEYS = ["sk-a", "sk-b", "sk-c"];
+
+type TierFilter = Tier | "all";
+
+const TIER_FILTERS: TierFilter[] = ["all", ...TIERS];
+
+const TIER_FILTER_LABELS: Record<TierFilter, string> = {
+  all: "All",
+  ...TIER_LABELS,
+};
 
 function LoadingSkeletons() {
   return (
@@ -57,6 +69,35 @@ function AnonymousNotice() {
   );
 }
 
+function TierFilterChips({
+  active,
+  onChange,
+}: {
+  active: TierFilter;
+  onChange: (next: TierFilter) => void;
+}) {
+  return (
+    <div className="flex flex-wrap gap-1 px-4 pb-2" data-testid="tier-filter-chips">
+      {TIER_FILTERS.map((tier) => (
+        <Button
+          key={tier}
+          size="sm"
+          variant={tier === active ? "default" : "outline"}
+          onClick={() => onChange(tier)}
+          data-testid={`tier-filter-${tier}`}
+        >
+          {TIER_FILTER_LABELS[tier]}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+function applyTierFilter(memories: MemoryEntity[], filter: TierFilter): MemoryEntity[] {
+  if (filter === "all") return memories;
+  return memories.filter((m) => m.tier === filter);
+}
+
 function renderBody(
   isAuthenticated: boolean,
   isLoading: boolean,
@@ -80,10 +121,10 @@ export function MemorySidebar({ agentName: _agentName, open, onClose }: MemorySi
     userId: memoryUserId,
     enabled: hasMemoryIdentity,
   });
+  const [tierFilter, setTierFilter] = useState<TierFilter>("all");
 
-  // No agent-specific filtering for now — show all memories
-  // (agent scoping requires agent_id in scope, which may not be set)
   const memories = data?.memories ?? [];
+  const filtered = applyTierFilter(memories, tierFilter);
 
   return (
     <Sheet open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
@@ -98,8 +139,12 @@ export function MemorySidebar({ agentName: _agentName, open, onClose }: MemorySi
           </p>
         </SheetHeader>
 
-        <ScrollArea className="h-[calc(100vh-120px)] px-4">
-          {renderBody(hasMemoryIdentity, isLoading, memories)}
+        {hasMemoryIdentity && (
+          <TierFilterChips active={tierFilter} onChange={setTierFilter} />
+        )}
+
+        <ScrollArea className="h-[calc(100vh-160px)] px-4">
+          {renderBody(hasMemoryIdentity, isLoading, filtered)}
         </ScrollArea>
 
         <div className="border-t p-3">

--- a/dashboard/src/components/memories/tier-badge.test.tsx
+++ b/dashboard/src/components/memories/tier-badge.test.tsx
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TierBadge } from "./tier-badge";
+
+describe("TierBadge", () => {
+  it.each([
+    ["institutional", "Institutional"],
+    ["agent", "Agent"],
+    ["user", "User"],
+  ] as const)("renders the %s tier as %s", (tier, label) => {
+    render(<TierBadge tier={tier} />);
+    expect(screen.getByText(label)).toBeInTheDocument();
+  });
+
+  it("renders nothing when tier is undefined", () => {
+    const { container } = render(<TierBadge tier={undefined} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("forwards className", () => {
+    render(<TierBadge tier="user" className="custom-class" />);
+    const badge = screen.getByText("User");
+    expect(badge.className).toContain("custom-class");
+  });
+});

--- a/dashboard/src/components/memories/tier-badge.tsx
+++ b/dashboard/src/components/memories/tier-badge.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import type { Tier } from "@/lib/memory-analytics/types";
+import { TIER_COLORS, TIER_LABELS } from "@/lib/memory-analytics/colors";
+
+interface TierBadgeProps {
+  tier: Tier | undefined;
+  className?: string;
+}
+
+/**
+ * Visual indicator of which memory tier an entry belongs to. Returns null if
+ * `tier` is undefined so the caller can render `<TierBadge tier={memory.tier} />`
+ * unconditionally without worrying about legacy responses.
+ */
+export function TierBadge({ tier, className }: Readonly<TierBadgeProps>) {
+  if (!tier) return null;
+  return (
+    <Badge
+      variant="outline"
+      className={cn("font-normal", className)}
+      style={{
+        borderColor: TIER_COLORS[tier],
+        color: TIER_COLORS[tier],
+      }}
+    >
+      {TIER_LABELS[tier]}
+    </Badge>
+  );
+}

--- a/dashboard/src/lib/data/types.ts
+++ b/dashboard/src/lib/data/types.ts
@@ -468,6 +468,8 @@ export interface MemoryEntity {
   createdAt: string;
   accessedAt?: string;
   expiresAt?: string;
+  /** Server-derived tier. Absent on legacy mocks; populated by memory-api. */
+  tier?: import("@/lib/memory-analytics/types").Tier;
 }
 
 export interface MemoryListResponse {

--- a/internal/memory/api/handler.go
+++ b/internal/memory/api/handler.go
@@ -46,10 +46,39 @@ const (
 	maxBatchDeleteLimit = 10000
 )
 
+// MemoryWithTier wraps memory.Memory with a derived "tier" string for
+// dashboard rendering. Tier is computed from the scope map; no schema change.
+type MemoryWithTier struct {
+	*memory.Memory
+	Tier string `json:"tier"`
+}
+
+// deriveTier returns "user" / "agent" / "institutional" based on which scope
+// keys are populated. Mirrors the SQL CASE expression used by Aggregate's
+// groupBy=tier branch in internal/memory/stats.go.
+func deriveTier(scope map[string]string) string {
+	if scope[memory.ScopeUserID] != "" {
+		return "user"
+	}
+	if scope[memory.ScopeAgentID] != "" {
+		return "agent"
+	}
+	return "institutional"
+}
+
+// wrapMemoriesWithTier maps a slice of *memory.Memory into the tier-tagged DTO.
+func wrapMemoriesWithTier(rows []*memory.Memory) []*MemoryWithTier {
+	out := make([]*MemoryWithTier, len(rows))
+	for i, m := range rows {
+		out[i] = &MemoryWithTier{Memory: m, Tier: deriveTier(m.Scope)}
+	}
+	return out
+}
+
 // MemoryListResponse is the JSON response for memory list/search endpoints.
 type MemoryListResponse struct {
-	Memories []*memory.Memory `json:"memories"`
-	Total    int              `json:"total"`
+	Memories []*MemoryWithTier `json:"memories"`
+	Total    int               `json:"total"`
 }
 
 // MemoryResponse is the JSON response for a single memory creation.
@@ -148,7 +177,7 @@ func (h *Handler) handleListMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, MemoryListResponse{
-		Memories: memories,
+		Memories: wrapMemoriesWithTier(memories),
 		Total:    len(memories),
 	})
 }
@@ -182,7 +211,7 @@ func (h *Handler) handleSearchMemories(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, MemoryListResponse{
-		Memories: memories,
+		Memories: wrapMemoriesWithTier(memories),
 		Total:    len(memories),
 	})
 }
@@ -209,7 +238,7 @@ func (h *Handler) handleExportMemories(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
 	w.Header().Set("Content-Disposition", exportFilename)
 	_ = json.NewEncoder(w).Encode(MemoryListResponse{
-		Memories: memories,
+		Memories: wrapMemoriesWithTier(memories),
 		Total:    len(memories),
 	})
 }

--- a/internal/memory/api/handler_agent_scoped.go
+++ b/internal/memory/api/handler_agent_scoped.go
@@ -46,8 +46,8 @@ type SaveAgentScopedRequest struct {
 // ListAgentScopedResponse is the JSON response for
 // GET /api/v1/agent-memories.
 type ListAgentScopedResponse struct {
-	Memories []*memory.Memory `json:"memories"`
-	Total    int              `json:"total"`
+	Memories []*MemoryWithTier `json:"memories"`
+	Total    int               `json:"total"`
 }
 
 // handleSaveAgentScoped handles POST /api/v1/agent-memories.
@@ -126,7 +126,10 @@ func (h *Handler) handleListAgentScoped(w http.ResponseWriter, r *http.Request) 
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, ListAgentScopedResponse{Memories: mems, Total: len(mems)})
+	writeJSON(w, ListAgentScopedResponse{
+		Memories: wrapMemoriesWithTier(mems),
+		Total:    len(mems),
+	})
 }
 
 // handleDeleteAgentScoped handles DELETE /api/v1/agent-memories/{id}?workspace=X&agent=Y.

--- a/internal/memory/api/handler_agent_scoped_test.go
+++ b/internal/memory/api/handler_agent_scoped_test.go
@@ -142,7 +142,14 @@ func TestHandleSaveAgentScoped_RejectsBadJSON(t *testing.T) {
 
 func TestHandleListAgentScoped_HappyPath(t *testing.T) {
 	stub := &agentScopedStub{
-		listResult: []*memory.Memory{{ID: "m-1"}, {ID: "m-2"}},
+		listResult: []*memory.Memory{
+			{ID: "m-1", Scope: map[string]string{
+				memory.ScopeWorkspaceID: "ws-1", memory.ScopeAgentID: "agent-1",
+			}},
+			{ID: "m-2", Scope: map[string]string{
+				memory.ScopeWorkspaceID: "ws-1", memory.ScopeAgentID: "agent-1",
+			}},
+		},
 	}
 	mux := newAgentScopedHandler(t, stub)
 
@@ -157,6 +164,9 @@ func TestHandleListAgentScoped_HappyPath(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
 	assert.Equal(t, 2, out.Total)
 	assert.Len(t, out.Memories, 2)
+	for _, m := range out.Memories {
+		assert.Equal(t, "agent", m.Tier, "row %s tier", m.ID)
+	}
 	require.Len(t, stub.listCalls, 1)
 	assert.Equal(t, "ws-1", stub.listCalls[0].ws)
 	assert.Equal(t, "agent-1", stub.listCalls[0].agent)

--- a/internal/memory/api/handler_institutional.go
+++ b/internal/memory/api/handler_institutional.go
@@ -47,8 +47,8 @@ type SaveInstitutionalRequest struct {
 
 // ListInstitutionalResponse is the JSON response for GET /api/v1/institutional/memories.
 type ListInstitutionalResponse struct {
-	Memories []*memory.Memory `json:"memories"`
-	Total    int              `json:"total"`
+	Memories []*MemoryWithTier `json:"memories"`
+	Total    int               `json:"total"`
 }
 
 // handleSaveInstitutional handles POST /api/v1/institutional/memories.
@@ -118,7 +118,10 @@ func (h *Handler) handleListInstitutional(w http.ResponseWriter, r *http.Request
 		writeError(w, err)
 		return
 	}
-	writeJSON(w, ListInstitutionalResponse{Memories: mems, Total: len(mems)})
+	writeJSON(w, ListInstitutionalResponse{
+		Memories: wrapMemoriesWithTier(mems),
+		Total:    len(mems),
+	})
 }
 
 // handleDeleteInstitutional handles DELETE /api/v1/institutional/memories/{id}?workspace=X.

--- a/internal/memory/api/handler_institutional_test.go
+++ b/internal/memory/api/handler_institutional_test.go
@@ -155,7 +155,10 @@ func TestHandleSaveInstitutional_BodyTooLarge(t *testing.T) {
 
 func TestHandleListInstitutional_HappyPath(t *testing.T) {
 	stub := &institutionalStub{
-		listResult: []*memory.Memory{{ID: "m-1"}, {ID: "m-2"}},
+		listResult: []*memory.Memory{
+			{ID: "m-1", Scope: map[string]string{memory.ScopeWorkspaceID: "ws-1"}},
+			{ID: "m-2", Scope: map[string]string{memory.ScopeWorkspaceID: "ws-1"}},
+		},
 	}
 	mux := newInstitutionalHandler(t, stub)
 
@@ -169,6 +172,9 @@ func TestHandleListInstitutional_HappyPath(t *testing.T) {
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&out))
 	assert.Equal(t, 2, out.Total)
 	assert.Len(t, out.Memories, 2)
+	for _, m := range out.Memories {
+		assert.Equal(t, "institutional", m.Tier, "row %s tier", m.ID)
+	}
 }
 
 func TestHandleListInstitutional_RejectsMissingWorkspace(t *testing.T) {

--- a/internal/memory/api/handler_test.go
+++ b/internal/memory/api/handler_test.go
@@ -182,6 +182,45 @@ func TestHandleListMemories_Success(t *testing.T) {
 	assert.Len(t, resp.Memories, 2)
 }
 
+// TestHandleListMemories_IncludesTier verifies the derived tier field appears
+// on each row. Tier is computed from the scope map: virtual_user_id → "user",
+// agent_id (no user) → "agent", neither → "institutional".
+func TestHandleListMemories_IncludesTier(t *testing.T) {
+	store := &mockStore{
+		memories: []*memory.Memory{
+			{ID: "u-1", Scope: map[string]string{
+				memory.ScopeWorkspaceID: "ws", memory.ScopeUserID: "alice",
+			}},
+			{ID: "a-1", Scope: map[string]string{
+				memory.ScopeWorkspaceID: "ws", memory.ScopeAgentID: "support",
+			}},
+			{ID: "i-1", Scope: map[string]string{
+				memory.ScopeWorkspaceID: "ws",
+			}},
+		},
+	}
+	h := newTestHandler(store)
+	mux := setupMux(h)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/memories?workspace=ws", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+	require.Equal(t, http.StatusOK, rr.Code)
+
+	var raw struct {
+		Memories []map[string]any `json:"memories"`
+		Total    int              `json:"total"`
+	}
+	require.NoError(t, json.NewDecoder(rr.Body).Decode(&raw))
+	require.Len(t, raw.Memories, 3)
+	want := map[string]string{"u-1": "user", "a-1": "agent", "i-1": "institutional"}
+	for _, m := range raw.Memories {
+		id, _ := m["id"].(string)
+		tier, _ := m["tier"].(string)
+		assert.Equal(t, want[id], tier, "tier for %s", id)
+	}
+}
+
 func TestHandleListMemories_MissingWorkspace(t *testing.T) {
 	h := newTestHandler(&mockStore{})
 	mux := setupMux(h)

--- a/internal/memory/api/openapi.yaml
+++ b/internal/memory/api/openapi.yaml
@@ -661,6 +661,16 @@ components:
         expiresAt:
           type: string
           format: date-time
+        tier:
+          type: string
+          enum: [institutional, agent, user]
+          readOnly: true
+          description: |
+            Derived from the scope map at response-build time:
+            `user` if `user_id` is set, `agent` if `agent_id` is set
+            (and no `user_id`), otherwise `institutional`. Mirrors the
+            GROUP BY tier expression on /memories/aggregate. Server-derived;
+            ignored on writes.
       required:
         - type
         - content


### PR DESCRIPTION
## Summary
- Backend: derives a `tier` field (`"institutional" | "agent" | "user"`) on every memory list response — `/api/v1/memories`, `/memories/search`, `/memories/export`, `/institutional/memories`, `/agent-memories`. No schema change; tier is computed from existing scope columns and mirrors the SQL CASE used by `/memories/aggregate?groupBy=tier`.
- Frontend: new `TierBadge` component; wired into `/memories` cards + detail panel, the institutional admin panel, and the in-session memory sidebar (with All / Institutional / Agent / User filter chips).
- Closes #1017. Builds on #1004 (#1019 — color tokens reused from `dashboard/src/lib/memory-analytics/colors.ts`).

## Test plan
- [x] `env GOWORK=off go test ./internal/memory/... -count=1` — passes.
- [x] `npm --prefix dashboard test` — passes.
- [x] `npm --prefix dashboard run lint` — passes.
- [x] `npm --prefix dashboard run typecheck` — passes.
- [ ] Manual: navigate to `/memories` against a workspace with mixed-tier rows, verify tier badges per card and in the detail sheet.
- [ ] Manual: open `/workspaces/<ws>/knowledge`, verify each entry shows an Institutional badge.
- [ ] Manual: open the in-session memory sidebar, click each tier chip, verify filtering.

## Notes for reviewers
- Backend uses a thin `MemoryWithTier` wrapper (embeds `*memory.Memory`, adds `Tier string` json:"tier"`). PromptKit's `Memory` is a SDK type, so embedding rather than mutating it.
- The institutional admin panel hardcodes `tier="institutional"` on each entry — every workspace-scope row is institutional by definition, and the API also returns it, but rendering it explicitly reinforces the visual cue without depending on a hook-shape change.
- The sidebar's filter chips render only for authenticated users (anonymous users see the existing sign-in alert).
