### PR TITLE
fix(doctor): bracket --run-once RunResult with sentinels (#1025)

### DIFF
--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -236,21 +237,43 @@ func resolveWorkspaceURLs(log interface {
 	)
 }
 
+// runOnceResultBegin and runOnceResultEnd bracket the RunResult JSON written
+// to stdout in --run-once mode. Container runtimes merge the doctor pod's
+// stderr (zap log lines, also JSON-shaped) with stdout into a single
+// `kubectl logs` stream, so a downstream parser cannot rely on "the first
+// `{\n` is the result". The sentinels give parsers an unambiguous slice.
+const (
+	runOnceResultBegin = "=== DOCTOR-RUN-RESULT-BEGIN ==="
+	runOnceResultEnd   = "=== DOCTOR-RUN-RESULT-END ==="
+)
+
 func runOnceMode(runner *doctor.Runner, log interface {
 	Info(msg string, keysAndValues ...interface{})
 }, exitOnFail bool) {
 	results := make(chan doctor.TestResult, 100)
+	// Drain the results channel so runner.Run can make progress. The
+	// per-test data is also present in the aggregate `run` value emitted
+	// below; we don't log per-result here because those lines would
+	// interleave with the RunResult JSON in `kubectl logs` output.
 	go func() {
-		for r := range results {
-			log.Info("test completed", "name", r.Name, "status", r.Status, "detail", r.Detail)
+		for range results {
 		}
 	}()
 
 	run := runner.Run(context.Background(), results)
 
-	enc := json.NewEncoder(os.Stdout)
+	// Buffer the JSON before writing so the begin/result/end triplet hits
+	// stdout in a single Write call, minimising the chance of stderr log
+	// lines slicing through it on a noisy run.
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(run); err != nil {
+		log.Info("failed to encode run-once result", "error", err.Error())
+		os.Exit(1)
+	}
+	out := fmt.Sprintf("\n%s\n%s%s\n", runOnceResultBegin, buf.String(), runOnceResultEnd)
+	if _, err := os.Stdout.WriteString(out); err != nil {
 		os.Exit(1)
 	}
 

--- a/test/e2e/doctor_e2e_test.go
+++ b/test/e2e/doctor_e2e_test.go
@@ -135,12 +135,22 @@ spec:
 		logsOut, err := utils.Run(logsCmd)
 		Expect(err).NotTo(HaveOccurred(), "Failed to read doctor pod logs")
 
-		// The doctor's logger writes structured info to stderr; --run-once
-		// writes the RunResult JSON object to stdout. Find the start of the
-		// JSON object and decode from there.
-		jsonStart := strings.Index(logsOut, "{\n")
-		Expect(jsonStart).To(BeNumerically(">=", 0),
-			"could not locate JSON object in doctor logs; got:\n%s", logsOut)
+		// The doctor wraps the RunResult JSON in begin/end sentinels because
+		// `kubectl logs` returns merged stdout+stderr — zap log lines (also
+		// JSON-shaped) interleave with the RunResult on stdout. Sentinels
+		// give the parser an unambiguous slice. See cmd/doctor/main.go.
+		const (
+			runOnceResultBegin = "=== DOCTOR-RUN-RESULT-BEGIN ==="
+			runOnceResultEnd   = "=== DOCTOR-RUN-RESULT-END ==="
+		)
+		beginIdx := strings.Index(logsOut, runOnceResultBegin)
+		Expect(beginIdx).To(BeNumerically(">=", 0),
+			"could not locate %q sentinel in doctor logs; got:\n%s", runOnceResultBegin, logsOut)
+		jsonStart := beginIdx + len(runOnceResultBegin)
+		endIdx := strings.Index(logsOut[jsonStart:], runOnceResultEnd)
+		Expect(endIdx).To(BeNumerically(">=", 0),
+			"could not locate %q sentinel after begin marker; got:\n%s", runOnceResultEnd, logsOut)
+		jsonBytes := []byte(logsOut[jsonStart : jsonStart+endIdx])
 
 		type doctorTest struct {
 			Name   string `json:"name"`
@@ -161,7 +171,7 @@ spec:
 				Tests []doctorTest `json:"tests"`
 			} `json:"categories"`
 		}
-		Expect(json.Unmarshal([]byte(logsOut[jsonStart:]), &run)).To(Succeed(),
+		Expect(json.Unmarshal(jsonBytes, &run)).To(Succeed(),
 			"failed to parse doctor RunResult JSON")
 
 		By("asserting the doctor produced a structured report")


### PR DESCRIPTION
## Summary
Closes #1025. The `Doctor` Core E2E spec was failing on every run with `invalid character '{' looking for beginning of object key string` because `kubectl logs` returns merged stdout+stderr and the parser was slicing into a zap log line on stderr instead of the JSON RunResult on stdout.

- Wraps the `--run-once` RunResult in begin/end sentinel markers (`=== DOCTOR-RUN-RESULT-BEGIN ===` / `... -END ===`) so the e2e spec can find it unambiguously regardless of any zap output that interleaves on the merged stream.
- Buffers the JSON before writing so the begin/JSON/end triplet hits stdout atomically (within PIPE_BUF for any realistic check count).
- Drops the per-result `log.Info("test completed", ...)` lines that the runOnceMode goroutine was emitting on stderr — that data is already in the aggregate `run` value emitted as JSON, and removing the lines reduces the noise on the merged log stream.

Updates `test/e2e/doctor_e2e_test.go` to slice between the sentinels.

## Test plan
- [x] `env GOWORK=off go run ./cmd/doctor --run-once 2>/dev/null` — output begins with `=== DOCTOR-RUN-RESULT-BEGIN ===`, then the indented RunResult, then `=== DOCTOR-RUN-RESULT-END ===`.
- [x] `env GOWORK=off go vet -tags=e2e ./test/e2e/` — clean.
- [ ] CI runs the full Core E2E suite — Doctor spec should pass.

## Notes for reviewers
This was discovered while shipping #1024 — the Doctor spec failed both the original CI run and a re-run, and the same shape of failure was visible in earlier PR runs. #1024 was admin-merged after confirming its own spec passed; this PR unblocks the merge gate for everyone else.
