### PR TITLE
feat(dashboard): Memory tab on agent detail page

### DIFF
--- a/dashboard/src/app/agents/[name]/page.tsx
+++ b/dashboard/src/app/agents/[name]/page.tsx
@@ -3,10 +3,11 @@
 import { use, useCallback } from "react";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, FileText, MessageSquare, Activity, ShieldCheck } from "lucide-react";
+import { ArrowLeft, FileText, MessageSquare, Activity, ShieldCheck, Brain } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Header } from "@/components/layout";
 import { StatusBadge, ScaleControl, AgentMetricsPanel, EventsPanel, EvalConfigPanel, AgentQualityTab } from "@/components/agents";
+import { AgentMemoryPanel } from "@/components/memories/agent-memory-panel";
 import { AgentConsole } from "@/components/console";
 import { LogViewer } from "@/components/logs";
 import { useDataService } from "@/lib/data";
@@ -161,6 +162,10 @@ export default function AgentDetailPage({ params }: Readonly<AgentDetailPageProp
             <TabsTrigger value="quality" className="gap-1.5">
               <ShieldCheck className="h-4 w-4" />
               Quality
+            </TabsTrigger>
+            <TabsTrigger value="memory" className="gap-1.5">
+              <Brain className="h-4 w-4" />
+              Memory
             </TabsTrigger>
             <TabsTrigger value="config">Configuration</TabsTrigger>
             <TabsTrigger value="events">Events</TabsTrigger>
@@ -395,6 +400,10 @@ export default function AgentDetailPage({ params }: Readonly<AgentDetailPageProp
 
           <TabsContent value="quality" className="mt-4">
             <AgentQualityTab agentName={metadata.name} />
+          </TabsContent>
+
+          <TabsContent value="memory" className="mt-4">
+            <AgentMemoryPanel agentId={metadata.uid} />
           </TabsContent>
 
           <TabsContent value="config" className="mt-4">

--- a/dashboard/src/app/api/workspaces/[name]/agent-memories/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/agent-memories/route.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Tests for the agent-memories proxy route.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/workspace-authz", () => ({
+  checkWorkspaceAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/workspace-route-helpers", () => ({
+  getWorkspace: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/service-url-resolver", () => ({
+  resolveServiceURLs: vi.fn(),
+}));
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+const mockUser = {
+  id: "testuser-id",
+  provider: "oauth" as const,
+  username: "testuser",
+  email: "test@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+const noPermissions = { read: false, write: false, delete: false, manageMembers: false };
+
+const mockWorkspace = {
+  metadata: { uid: "workspace-uid-123", name: "test-ws" },
+  spec: {},
+};
+
+function createMockContext() {
+  return { params: Promise.resolve({ name: "test-ws" }) };
+}
+
+function createRequest(query = ""): NextRequest {
+  const suffix = query ? "?" + query : "";
+  return new NextRequest(
+    `https://localhost:3000/api/workspaces/test-ws/agent-memories${suffix}`,
+    { method: "GET" },
+  );
+}
+
+function mockJsonResponse(data: unknown, status = 200) {
+  mockFetch.mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    text: () => Promise.resolve(JSON.stringify(data)),
+  });
+}
+
+async function authedGET(query = "") {
+  const { getUser } = await import("@/lib/auth");
+  const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+  const { getWorkspace } = await import("@/lib/k8s/workspace-route-helpers");
+  const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+  vi.mocked(getUser).mockResolvedValue(mockUser);
+  vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+    granted: true,
+    role: "viewer",
+    permissions: viewerPermissions,
+  });
+  vi.mocked(getWorkspace).mockResolvedValue(mockWorkspace as never);
+  vi.mocked(resolveServiceURLs).mockResolvedValue({
+    sessionURL: "https://session-api:8080",
+    memoryURL: "https://memory-api:8080",
+  });
+
+  const { GET } = await import("./route");
+  return GET(createRequest(query), createMockContext());
+}
+
+describe("GET /api/workspaces/[name]/agent-memories", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("returns 400 when agent query param is missing", async () => {
+    const response = await authedGET("");
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toContain("agent");
+  });
+
+  it("proxies to memory-api with workspace + agent", async () => {
+    const rows = {
+      memories: [
+        { id: "a-1", tier: "agent", scope: { agent_id: "support" } },
+        { id: "a-2", tier: "agent", scope: { agent_id: "support" } },
+      ],
+      total: 2,
+    };
+    mockJsonResponse(rows);
+
+    const response = await authedGET("agent=support-agent-uid");
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.total).toBe(2);
+
+    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    expect(fetchUrl).toContain("/api/v1/agent-memories");
+    expect(fetchUrl).toContain("workspace=workspace-uid-123");
+    expect(fetchUrl).toContain("agent=support-agent-uid");
+  });
+
+  it("forwards type / limit / offset", async () => {
+    mockJsonResponse({ memories: [], total: 0 });
+
+    await authedGET("agent=a&type=pattern&limit=5&offset=10");
+    const fetchUrl = mockFetch.mock.calls[0][0] as string;
+    expect(fetchUrl).toContain("type=pattern");
+    expect(fetchUrl).toContain("limit=5");
+    expect(fetchUrl).toContain("offset=10");
+  });
+
+  it("returns 403 when user lacks workspace access", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: false,
+      role: null,
+      permissions: noPermissions,
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(createRequest("agent=foo"), createMockContext());
+
+    expect(response.status).toBe(403);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/agent-memories/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/agent-memories/route.ts
@@ -1,0 +1,48 @@
+/**
+ * Agent-tier memory list proxy route.
+ *
+ * GET /api/workspaces/{name}/agent-memories?agent={agentId}&type=&limit=&offset=
+ *   → MEMORY_API_URL/api/v1/agent-memories?workspace={uid}&agent={agentId}&...
+ *
+ * Returns workspace+agent-scoped memory rows (no user_id), each carrying a
+ * derived `tier: "agent"` field. Used by the agent detail page's Memory tab.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  withWorkspaceAccess,
+  type WorkspaceRouteContext,
+} from "@/lib/auth/workspace-guard";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+import { proxyToMemoryApi } from "../memory/proxy-helpers";
+
+export const GET = withWorkspaceAccess(
+  "viewer",
+  async (
+    request: NextRequest,
+    context: WorkspaceRouteContext,
+    _access: WorkspaceAccess,
+    _user: User,
+  ): Promise<NextResponse> => {
+    const { name } = await context.params;
+    const search = request.nextUrl.searchParams;
+
+    const agent = search.get("agent") ?? "";
+    if (!agent) {
+      return NextResponse.json(
+        { error: "agent query param is required" },
+        { status: 400 },
+      );
+    }
+
+    const params = new URLSearchParams();
+    params.set("agent", agent);
+    for (const key of ["type", "limit", "offset"] as const) {
+      const v = search.get(key);
+      if (v) params.set(key, v);
+    }
+
+    return proxyToMemoryApi(request, name, "/api/v1/agent-memories", params);
+  },
+);

--- a/dashboard/src/components/memories/agent-memory-panel.test.tsx
+++ b/dashboard/src/components/memories/agent-memory-panel.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+const { mockUseAgentMemories } = vi.hoisted(() => ({
+  mockUseAgentMemories: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-agent-memories", () => ({
+  useAgentMemories: mockUseAgentMemories,
+}));
+
+import { AgentMemoryPanel } from "./agent-memory-panel";
+
+describe("AgentMemoryPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows skeleton while loading", () => {
+    mockUseAgentMemories.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    render(<AgentMemoryPanel agentId="support" />);
+    expect(screen.queryByTestId("agent-memory-empty")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("agent-memory-list")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no memories", () => {
+    mockUseAgentMemories.mockReturnValue({
+      data: { memories: [], total: 0 },
+      isLoading: false,
+      error: null,
+    });
+    render(<AgentMemoryPanel agentId="support" />);
+    expect(screen.getByTestId("agent-memory-empty")).toBeInTheDocument();
+  });
+
+  it("shows error alert on failure", () => {
+    mockUseAgentMemories.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error("backend offline"),
+    });
+    render(<AgentMemoryPanel agentId="support" />);
+    expect(screen.getByTestId("agent-memory-error")).toBeInTheDocument();
+    expect(screen.getByText("backend offline")).toBeInTheDocument();
+  });
+
+  it("renders rows with tier + category badges", () => {
+    mockUseAgentMemories.mockReturnValue({
+      data: {
+        memories: [
+          {
+            id: "a-1",
+            type: "pattern",
+            content: "Customers reporting slow API → check p99 latency.",
+            confidence: 0.88,
+            scope: { workspace_id: "w", agent_id: "support" },
+            createdAt: "2026-04-01T00:00:00Z",
+            tier: "agent",
+            metadata: { consent_category: "memory:context" },
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      error: null,
+    });
+    render(<AgentMemoryPanel agentId="support" />);
+    expect(
+      screen.getByText("Customers reporting slow API → check p99 latency."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("88% confidence")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/memories/agent-memory-panel.tsx
+++ b/dashboard/src/components/memories/agent-memory-panel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * AgentMemoryPanel — read-only browser for (workspace, agent)-scoped memory.
+ *
+ * Renders the rows the agent has accumulated across sessions (resolution
+ * patterns, learned playbooks, etc.) as a flat list with tier + category
+ * badges. Mounted on the agent detail page's Memory tab. Read-only for v1
+ * — operator-curated agent memories are written via the memory-api directly
+ * (or by the runtime as it learns); editing them in-dashboard is a follow-up.
+ */
+
+import { Brain } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "@/components/ui/alert";
+import { CategoryBadge } from "./category-badge";
+import { TierBadge } from "./tier-badge";
+import { useAgentMemories } from "@/hooks/use-agent-memories";
+import type { MemoryEntity } from "@/lib/data/types";
+
+interface AgentMemoryPanelProps {
+  agentId: string | undefined;
+}
+
+export function AgentMemoryPanel({ agentId }: Readonly<AgentMemoryPanelProps>) {
+  const { data, isLoading, error } = useAgentMemories({ agentId });
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Brain className="h-5 w-5" />
+          Agent memory
+        </CardTitle>
+        <CardDescription>
+          Patterns and facts this agent has accumulated across sessions, shared
+          with every user it talks to. Read-only — entries land here from the
+          runtime as the agent learns.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>{renderBody({ isLoading, error, data })}</CardContent>
+    </Card>
+  );
+}
+
+interface BodyProps {
+  isLoading: boolean;
+  error: unknown;
+  data: { memories: MemoryEntity[]; total: number } | undefined;
+}
+
+function renderBody({ isLoading, error, data }: BodyProps) {
+  if (error) {
+    return (
+      <Alert variant="destructive" data-testid="agent-memory-error">
+        <AlertTitle>Could not load</AlertTitle>
+        <AlertDescription>
+          {error instanceof Error
+            ? error.message
+            : "Failed to load agent memories."}
+        </AlertDescription>
+      </Alert>
+    );
+  }
+  if (isLoading) {
+    return <Skeleton className="w-full h-32 rounded" />;
+  }
+  const memories = data?.memories ?? [];
+  if (memories.length === 0) {
+    return (
+      <p
+        className="text-sm text-muted-foreground"
+        data-testid="agent-memory-empty"
+      >
+        No memories for this agent yet. They will appear here as the agent
+        accumulates patterns from sessions, or when an operator seeds them via
+        the memory-api directly.
+      </p>
+    );
+  }
+  return (
+    <ul className="space-y-2" data-testid="agent-memory-list">
+      {memories.map((m) => (
+        <AgentMemoryRow key={m.id} memory={m} />
+      ))}
+    </ul>
+  );
+}
+
+function AgentMemoryRow({ memory }: { memory: MemoryEntity }) {
+  const category = memory.metadata?.consent_category as string | undefined;
+  const confidence = Math.round((memory.confidence ?? 0) * 100);
+  return (
+    <li className="rounded border bg-card p-3 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <TierBadge tier={memory.tier} />
+        <CategoryBadge category={category} />
+        <span className="text-xs font-mono text-muted-foreground">
+          {memory.type}
+        </span>
+        <span className="ml-auto text-xs text-muted-foreground">
+          {confidence}% confidence
+        </span>
+      </div>
+      <p className="text-sm whitespace-pre-wrap break-words">{memory.content}</p>
+    </li>
+  );
+}

--- a/dashboard/src/hooks/use-agent-memories.test.tsx
+++ b/dashboard/src/hooks/use-agent-memories.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useAgentMemories } from "./use-agent-memories";
+
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: () => ({
+    currentWorkspace: { name: "default" },
+    workspaces: [],
+    setCurrentWorkspace: vi.fn(),
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        memories: [
+          { id: "a-1", tier: "agent", scope: { agent_id: "support" } },
+          { id: "a-2", tier: "agent", scope: { agent_id: "support" } },
+        ],
+        total: 2,
+      }),
+    }),
+  );
+});
+
+describe("useAgentMemories", () => {
+  it("fetches agent memories for the given agent id", async () => {
+    const { result } = renderHook(
+      () => useAgentMemories({ agentId: "support" }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.total).toBe(2);
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/workspaces/default/agent-memories?agent=support",
+    );
+  });
+
+  it("does not fetch when agentId is empty", () => {
+    const { result } = renderHook(
+      () => useAgentMemories({ agentId: undefined }),
+      { wrapper },
+    );
+    expect(result.current.fetchStatus).toBe("idle");
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/dashboard/src/hooks/use-agent-memories.ts
+++ b/dashboard/src/hooks/use-agent-memories.ts
@@ -1,0 +1,32 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useWorkspace } from "@/contexts/workspace-context";
+import { MemoryApiService } from "@/lib/data/memory-api-service";
+import type { MemoryEntity } from "@/lib/data/types";
+
+interface UseAgentMemoriesOptions {
+  agentId: string | undefined;
+  enabled?: boolean;
+}
+
+/**
+ * Fetch the (workspace, agent)-scoped memory rows for the given agent.
+ * Returns an empty list when no workspace is selected or `agentId` is missing.
+ */
+export function useAgentMemories({ agentId, enabled = true }: UseAgentMemoriesOptions) {
+  const { currentWorkspace } = useWorkspace();
+
+  return useQuery({
+    queryKey: ["agent-memories", currentWorkspace?.name, agentId],
+    queryFn: async (): Promise<{ memories: MemoryEntity[]; total: number }> => {
+      if (!currentWorkspace || !agentId) {
+        return { memories: [], total: 0 };
+      }
+      const service = new MemoryApiService();
+      return service.getAgentMemories(currentWorkspace.name, agentId);
+    },
+    enabled: enabled && !!currentWorkspace && !!agentId,
+    refetchInterval: 60 * 1000,
+  });
+}

--- a/dashboard/src/lib/data/memory-api-service.test.ts
+++ b/dashboard/src/lib/data/memory-api-service.test.ts
@@ -390,4 +390,52 @@ describe("MemoryApiService", () => {
       );
     });
   });
+
+  describe("getAgentMemories", () => {
+    it("calls /agent-memories with workspace + agent", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            memories: [
+              { id: "a-1", tier: "agent", scope: { agent_id: "support" } },
+              { id: "a-2", tier: "agent", scope: { agent_id: "support" } },
+            ],
+            total: 2,
+          }),
+      });
+
+      const result = await service.getAgentMemories("default", "support");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/workspaces/default/agent-memories?agent=support",
+      );
+      expect(result.total).toBe(2);
+      expect(result.memories).toHaveLength(2);
+    });
+
+    it("returns empty when agentId is blank without hitting the network", async () => {
+      const result = await service.getAgentMemories("default", "");
+      expect(result).toEqual({ memories: [], total: 0 });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("returns empty on 401 / 403 / 404", async () => {
+      for (const status of [401, 403, 404]) {
+        mockFetch.mockResolvedValueOnce({ ok: false, status });
+        const result = await service.getAgentMemories("default", "agent-x");
+        expect(result).toEqual({ memories: [], total: 0 });
+      }
+    });
+
+    it("throws on other server errors", async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+      });
+      await expect(
+        service.getAgentMemories("default", "agent-x"),
+      ).rejects.toThrow("Failed to fetch agent memories");
+    });
+  });
 });

--- a/dashboard/src/lib/data/memory-api-service.ts
+++ b/dashboard/src/lib/data/memory-api-service.ts
@@ -122,6 +122,28 @@ export class MemoryApiService {
     }
   }
 
+  async getAgentMemories(
+    workspace: string,
+    agentId: string,
+  ): Promise<MemoryListResponse> {
+    if (!agentId) return { memories: [], total: 0 };
+    const params = new URLSearchParams({ agent: agentId });
+    const response = await fetch(
+      `${MEMORY_API_BASE}/${encodeURIComponent(workspace)}/agent-memories?${params.toString()}`,
+    );
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403 || response.status === 404) {
+        return { memories: [], total: 0 };
+      }
+      throw new Error(`Failed to fetch agent memories: ${response.statusText}`);
+    }
+    const data = await response.json();
+    return {
+      memories: data.memories || [],
+      total: data.total ?? 0,
+    };
+  }
+
   async getMemoryAggregate(
     options: MemoryAggregateOptions & { workspace: string },
   ): Promise<AggregateRow[]> {


### PR DESCRIPTION
## Summary
Adds a Memory tab on the agent detail page that browses the `(workspace, agent)`-scoped memory rows for that specific agent. Closes the visibility gap noted while exercising the demo: agent-tier memory existed in the API and counted in `/memory-analytics`, but couldn't be inspected per-agent without curl.

- New proxy route `GET /api/workspaces/[name]/agent-memories?agent=<uid>` → memory-api `/api/v1/agent-memories` (the endpoint added by #1017).
- New `MemoryApiService.getAgentMemories(workspace, agentId)` and `useAgentMemories({agentId})` hook.
- New `AgentMemoryPanel` component — read-only list with `TierBadge` + `CategoryBadge` + confidence per row; loading / empty / error states.
- New Memory tab on `/agents/[name]`, sitting between Quality and Configuration.

Read-only for v1 — agent-tier rows are operator-curated or runtime-learned; editing them in-dashboard would duplicate the institutional admin shape and isn't needed today.

## Test plan
- [x] `npm --prefix dashboard run typecheck` — passes.
- [x] `npm --prefix dashboard run lint` — passes (only pre-existing warnings).
- [x] `npm --prefix dashboard test` — passes; 9 new tests across the proxy route, service method, hook, and component.

## Notes for reviewers
- The agent_id passed to the API is the AgentRuntime's `metadata.uid` (K8s-assigned UUID), which is what the runtime uses when it writes `(workspace, agent)`-scoped rows. The seed script in `docs/local-backlog/seed-demo-memory.py` uses synthetic agent UUIDs that don't match real agents — the tab will be empty for real agents until the runtime starts learning or an operator seeds against the real UID.
- Consistent with prior PRs, the tab reuses `TierBadge` / `CategoryBadge` so colors line up with `/memory-analytics`'s tri-card.
