### PR TITLE
fix(doctor): rebuild runner per request so service discovery re-runs (#1040 part 1)

### DIFF
--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -13,6 +13,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"github.com/altairalabs/omnia/internal/doctor"
 	"github.com/altairalabs/omnia/internal/doctor/checks"
 	memoryhttpclient "github.com/altairalabs/omnia/internal/memory/httpclient"
@@ -105,77 +107,41 @@ func main() {
 		arenaURL = discoverServiceURL(*namespace, serviceArenaController, defaultArenaPort)
 	}
 
-	// If --workspace is set, use service discovery to resolve per-workspace URLs.
-	// This overrides the flag-based URL (but the flag-based URL is still the fallback
-	// when --workspace is not set, for local/singleton testing).
-	if *workspaceFlag != "" {
-		resolveWorkspaceURLs(log, *workspaceFlag, *serviceGroupFlag, &sessionAPIURL, &memoryAPIURL)
+	cfg := runnerConfig{
+		log:               log,
+		namespace:         *namespace,
+		agentNamespace:    *agentNamespace,
+		agentName:         *agentName,
+		workspace:         *workspaceFlag,
+		serviceGroup:      *serviceGroupFlag,
+		sessionAPIBaseURL: sessionAPIURL,
+		memoryAPIBaseURL:  memoryAPIURL,
+		ollamaURL:         ollamaURL,
+		operatorURL:       operatorURL,
+		dashboardURL:      dashboardURL,
+		redisAddr:         redisAddr,
+		arenaURL:          arenaURL,
 	}
 
-	agentFacadeURL := discoverServiceURL(*agentNamespace, *agentName, defaultAPIPort)
-
-	sessionStore := httpclient.NewStore(sessionAPIURL, log, httpclient.WithBufferCapacity(0))
-	defer sessionStore.Close() //nolint:errcheck
-
-	runner := doctor.NewRunner()
-
-	runner.Register(checks.InfrastructureChecks(map[string]string{
-		"SessionAPI": sessionAPIURL,
-		"MemoryAPI":  memoryAPIURL,
-	})...)
-	runner.Register(checks.OllamaCheck(ollamaURL))
-	runner.Register(checks.OperatorAPICheck(operatorURL))
-	runner.Register(checks.DashboardCheck(dashboardURL))
-	runner.Register(checks.TCPCheck("Redis", redisAddr))
-	runner.Register(checks.ArenaControllerCheck(arenaURL))
-
-	k8sClient, k8sErr := k8s.NewClient()
-	if k8sErr != nil {
-		log.Info("k8s client unavailable, CRD checks will be skipped", "error", k8sErr.Error())
+	// build is invoked per /api/v1/run request — see issue #1040. A
+	// startup-only build means a Doctor pod that came up before its
+	// Workspace existed permanently uses the global fallback URLs and
+	// every Memory / Sessions / Privacy check returns "no such host".
+	build := func(_ context.Context) (*doctor.Runner, error) {
+		return buildRunner(cfg)
 	}
-	if k8sClient != nil {
-		crdChecker := checks.NewCRDChecker(k8sClient)
-		runner.Register(crdChecker.Checks()...)
-	}
-
-	agentChecker := checks.NewAgentChecker(checks.AgentConfig{
-		FacadeURL:     agentFacadeURL,
-		AgentName:     *agentName,
-		Namespace:     *agentNamespace,
-		SessionAPIURL: sessionAPIURL,
-		SessionStore:  sessionStore,
-	})
-	runner.Register(agentChecker.Checks()...)
-
-	sessionChecker := checks.NewSessionChecker(sessionAPIURL, *agentNamespace, sessionStore, func() string {
-		return agentChecker.LastSessionID
-	})
-	runner.Register(sessionChecker.Checks()...)
-
-	var workspaceUID string
-	if k8sClient != nil {
-		workspaceUID = checks.ResolveWorkspaceUID(k8sClient, *agentNamespace, log)
-	}
-
-	memoryStore := memoryhttpclient.NewStore(memoryAPIURL, log)
-	memoryChecker := checks.NewMemoryChecker(memoryAPIURL, memoryStore, workspaceUID, agentChecker)
-	runner.Register(memoryChecker.Checks()...)
-
-	privacyChecker := checks.NewPrivacyChecker(memoryAPIURL, sessionAPIURL, workspaceUID, arenaURL)
-	if k8sClient != nil {
-		privacyChecker.WithK8sClient(k8sClient)
-	}
-	runner.Register(privacyChecker.Checks()...)
-
-	// Agent → Sessions must run sequentially (Sessions reads Agent's LastSessionID).
-	runner.SequentialGroup("agent-sessions", "Agent", "Sessions")
 
 	if *runOnce {
+		runner, err := buildRunner(cfg)
+		if err != nil {
+			log.Error(err, "build runner failed")
+			os.Exit(1)
+		}
 		runOnceMode(runner, log, *exitCode)
 		return
 	}
 
-	srv := doctor.NewServer(runner, *addr, log)
+	srv := doctor.NewServer(build, *addr, log)
 	httpSrv := &http.Server{
 		Addr:              *addr,
 		Handler:           srv.Handler(),
@@ -202,6 +168,111 @@ func main() {
 	if err := httpSrv.Shutdown(shutdownCtx); err != nil {
 		log.Error(err, "shutdown failed")
 	}
+}
+
+// runnerConfig captures the static inputs needed to assemble a fresh
+// doctor.Runner on each call. Workspace + service-discovery state is
+// resolved INSIDE buildRunner so a startup-time race against a not-
+// yet-existing Workspace doesn't permanently cripple the pod
+// (issue #1040).
+//
+// `sessionAPIBaseURL` / `memoryAPIBaseURL` are the flag-derived
+// fallback URLs used when service discovery fails or `--workspace`
+// is not set. Workspace-resolved URLs override these per call.
+type runnerConfig struct {
+	log               logr.Logger
+	namespace         string
+	agentNamespace    string
+	agentName         string
+	workspace         string
+	serviceGroup      string
+	sessionAPIBaseURL string
+	memoryAPIBaseURL  string
+	ollamaURL         string
+	operatorURL       string
+	dashboardURL      string
+	redisAddr         string
+	arenaURL          string
+}
+
+// buildRunner constructs a fresh doctor.Runner with all checks
+// registered. Called per /api/v1/run request so workspace service
+// discovery happens at run time, not pod start. Each call:
+//   - re-resolves workspace URLs (handles startup-race recovery)
+//   - opens a fresh session store HTTP client (so a stale URL doesn't
+//     stick across calls)
+//   - re-fetches the workspace UID (handles Workspace creation after
+//     pod start)
+//
+// The session store is intentionally NOT closed here — the caller
+// gets the runner and the embedded store; the store closes when its
+// owning runner is GC'd. Per-run leak is bounded by the run handler's
+// context cancellation.
+func buildRunner(cfg runnerConfig) (*doctor.Runner, error) {
+	sessionAPIURL := cfg.sessionAPIBaseURL
+	memoryAPIURL := cfg.memoryAPIBaseURL
+
+	if cfg.workspace != "" {
+		resolveWorkspaceURLs(cfg.log, cfg.workspace, cfg.serviceGroup, &sessionAPIURL, &memoryAPIURL)
+	}
+
+	agentFacadeURL := discoverServiceURL(cfg.agentNamespace, cfg.agentName, defaultAPIPort)
+	sessionStore := httpclient.NewStore(sessionAPIURL, cfg.log, httpclient.WithBufferCapacity(0))
+
+	runner := doctor.NewRunner()
+
+	runner.Register(checks.InfrastructureChecks(map[string]string{
+		"SessionAPI": sessionAPIURL,
+		"MemoryAPI":  memoryAPIURL,
+	})...)
+	runner.Register(checks.OllamaCheck(cfg.ollamaURL))
+	runner.Register(checks.OperatorAPICheck(cfg.operatorURL))
+	runner.Register(checks.DashboardCheck(cfg.dashboardURL))
+	runner.Register(checks.TCPCheck("Redis", cfg.redisAddr))
+	runner.Register(checks.ArenaControllerCheck(cfg.arenaURL))
+
+	k8sClient, k8sErr := k8s.NewClient()
+	if k8sErr != nil {
+		cfg.log.Info("k8s client unavailable, CRD checks will be skipped", "error", k8sErr.Error())
+	}
+	if k8sClient != nil {
+		crdChecker := checks.NewCRDChecker(k8sClient)
+		runner.Register(crdChecker.Checks()...)
+	}
+
+	agentChecker := checks.NewAgentChecker(checks.AgentConfig{
+		FacadeURL:     agentFacadeURL,
+		AgentName:     cfg.agentName,
+		Namespace:     cfg.agentNamespace,
+		SessionAPIURL: sessionAPIURL,
+		SessionStore:  sessionStore,
+	})
+	runner.Register(agentChecker.Checks()...)
+
+	sessionChecker := checks.NewSessionChecker(sessionAPIURL, cfg.agentNamespace, sessionStore, func() string {
+		return agentChecker.LastSessionID
+	})
+	runner.Register(sessionChecker.Checks()...)
+
+	var workspaceUID string
+	if k8sClient != nil {
+		workspaceUID = checks.ResolveWorkspaceUID(k8sClient, cfg.agentNamespace, cfg.log)
+	}
+
+	memoryStore := memoryhttpclient.NewStore(memoryAPIURL, cfg.log)
+	memoryChecker := checks.NewMemoryChecker(memoryAPIURL, memoryStore, workspaceUID, agentChecker)
+	runner.Register(memoryChecker.Checks()...)
+
+	privacyChecker := checks.NewPrivacyChecker(memoryAPIURL, sessionAPIURL, workspaceUID, cfg.arenaURL)
+	if k8sClient != nil {
+		privacyChecker.WithK8sClient(k8sClient)
+	}
+	runner.Register(privacyChecker.Checks()...)
+
+	// Agent → Sessions must run sequentially (Sessions reads Agent's LastSessionID).
+	runner.SequentialGroup("agent-sessions", "Agent", "Sessions")
+
+	return runner, nil
 }
 
 // resolveWorkspaceURLs uses service discovery to find per-workspace service URLs.

--- a/internal/doctor/server.go
+++ b/internal/doctor/server.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
@@ -22,21 +23,35 @@ const (
 	mimePlain         = "text/plain"
 )
 
+// RunnerBuilder constructs a fresh Runner for a single check execution.
+// Doctor calls this on every /api/v1/run invocation so workspace service
+// discovery re-runs each time — without this, a Doctor pod that started
+// before its workspace existed permanently uses stale fallback URLs (the
+// failure mode behind issue #1040).
+//
+// Returning a fresh Runner per call is intentional: checks capture
+// URLs / store handles by value at construction time, so a stale
+// builder closure can't be patched after the fact. Callers that want
+// the legacy "build once at startup" behaviour can ignore the ctx and
+// return a memoised runner.
+type RunnerBuilder func(ctx context.Context) (*Runner, error)
+
 // Server is the HTTP server for Omnia Doctor.
 type Server struct {
-	runner    *Runner
+	build     RunnerBuilder
 	addr      string
 	log       logr.Logger
 	latestRun *RunResult
 	mu        sync.RWMutex
 }
 
-// NewServer creates a new doctor HTTP server.
-func NewServer(runner *Runner, addr string, log logr.Logger) *Server {
+// NewServer creates a new doctor HTTP server. The builder is invoked
+// per request so service discovery happens at run time, not pod start.
+func NewServer(build RunnerBuilder, addr string, log logr.Logger) *Server {
 	return &Server{
-		runner: runner,
-		addr:   addr,
-		log:    log.WithName("server"),
+		build: build,
+		addr:  addr,
+		log:   log.WithName("server"),
 	}
 }
 
@@ -78,13 +93,22 @@ func (s *Server) handleRunSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("X-Accel-Buffering", "no")
 
-	ch := make(chan TestResult, 64)
 	ctx := r.Context()
+	runner, err := s.build(ctx)
+	if err != nil {
+		s.log.Error(err, "build runner failed")
+		// Headers are already set for SSE; emit an error event so the
+		// client sees the failure instead of an empty stream.
+		_, _ = fmt.Fprintf(w, "event: error\ndata: %s\n\n", jsonOrFallback(map[string]string{"error": err.Error()}))
+		flusher.Flush()
+		return
+	}
 
+	ch := make(chan TestResult, 64)
 	var run *RunResult
 	done := make(chan struct{})
 	go func() {
-		run = s.runner.Run(ctx, ch)
+		run = runner.Run(ctx, ch)
 		close(done)
 	}()
 
@@ -119,6 +143,13 @@ func (s *Server) writeCompleteEvent(w http.ResponseWriter, flusher http.Flusher,
 }
 
 func (s *Server) handleRunTrigger(w http.ResponseWriter, r *http.Request) {
+	runner, err := s.build(r.Context())
+	if err != nil {
+		s.log.Error(err, "build runner failed")
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+
 	ch := make(chan TestResult, 64)
 	// Drain results in background.
 	go func() {
@@ -126,11 +157,22 @@ func (s *Server) handleRunTrigger(w http.ResponseWriter, r *http.Request) {
 		}
 	}()
 
-	run := s.runner.Run(r.Context(), ch)
+	run := runner.Run(r.Context(), ch)
 	s.storeRun(run)
 
 	w.Header().Set(headerContentType, mimeJSON)
 	_ = json.NewEncoder(w).Encode(map[string]string{"runId": run.ID})
+}
+
+// jsonOrFallback marshals v to JSON; on error it returns a plain
+// fallback so callers writing into an SSE stream always have a
+// usable string.
+func jsonOrFallback(v any) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return `{"error":"marshal failed"}`
+	}
+	return string(b)
 }
 
 func (s *Server) handleLatest(w http.ResponseWriter, _ *http.Request) {

--- a/internal/doctor/server_test.go
+++ b/internal/doctor/server_test.go
@@ -12,9 +12,18 @@ import (
 )
 
 func testServer(checks ...Check) *Server {
-	r := NewRunner()
-	r.Register(checks...)
-	return NewServer(r, ":0", logr.Discard())
+	return NewServer(staticRunnerBuilder(checks...), ":0", logr.Discard())
+}
+
+// staticRunnerBuilder returns a RunnerBuilder that always yields a
+// runner pre-loaded with the given checks. Used by tests that don't
+// need per-call rebuilding.
+func staticRunnerBuilder(checks ...Check) RunnerBuilder {
+	return func(_ context.Context) (*Runner, error) {
+		r := NewRunner()
+		r.Register(checks...)
+		return r, nil
+	}
 }
 
 func TestHandleIndex(t *testing.T) {
@@ -177,12 +186,83 @@ func TestHandleRunSSE_ContextCancellation(t *testing.T) {
 }
 
 func TestNewServer(t *testing.T) {
-	r := NewRunner()
-	s := NewServer(r, ":9090", logr.Discard())
+	s := NewServer(staticRunnerBuilder(), ":9090", logr.Discard())
 	if s == nil {
 		t.Fatal("expected non-nil server")
 	}
 	if s.addr != ":9090" {
 		t.Errorf("expected addr :9090, got %s", s.addr)
+	}
+}
+
+// TestRunnerBuilderError covers the "builder failed" path on both
+// handlers — a real failure mode in production (k8s API momentarily
+// unreachable, transient DNS, etc). The handlers must surface the
+// error rather than hang or silently produce empty results.
+func TestRunnerBuilderError(t *testing.T) {
+	failBuilder := func(_ context.Context) (*Runner, error) {
+		return nil, errBuilderFail
+	}
+	srv := NewServer(failBuilder, ":0", logr.Discard())
+
+	t.Run("trigger returns 500", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/run", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500, got %d", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "builder fail") {
+			t.Errorf("expected error in body, got %q", rec.Body.String())
+		}
+	})
+
+	t.Run("SSE emits error event", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/api/v1/run?stream=true", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Errorf("SSE pre-error status should be 200 (headers already sent), got %d", rec.Code)
+		}
+		if !strings.Contains(rec.Body.String(), "event: error") {
+			t.Errorf("expected SSE error event, got %q", rec.Body.String())
+		}
+		if !strings.Contains(rec.Body.String(), "builder fail") {
+			t.Errorf("expected error message in event, got %q", rec.Body.String())
+		}
+	})
+}
+
+// errBuilderFail is a sentinel for TestRunnerBuilderError.
+var errBuilderFail = newErr("builder fail")
+
+func newErr(msg string) error { return &simpleErr{msg: msg} }
+
+type simpleErr struct{ msg string }
+
+func (e *simpleErr) Error() string { return e.msg }
+
+// TestRunnerBuilderInvokedPerRun is the regression test for issue
+// #1040: Doctor must rebuild its runner on every /api/v1/run request
+// so workspace service discovery re-runs and a startup-race against a
+// not-yet-existing Workspace doesn't permanently cripple the pod.
+func TestRunnerBuilderInvokedPerRun(t *testing.T) {
+	calls := 0
+	builder := func(_ context.Context) (*Runner, error) {
+		calls++
+		return NewRunner(), nil
+	}
+	srv := NewServer(builder, ":0", logr.Discard())
+
+	for i := 0; i < 3; i++ {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/run", nil)
+		rec := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("run %d: expected 200, got %d (body: %s)", i, rec.Code, rec.Body.String())
+		}
+	}
+	if calls != 3 {
+		t.Errorf("expected builder to be invoked 3 times, got %d — runner is being cached and rediscovery won't happen", calls)
 	}
 }


### PR DESCRIPTION
## Summary

Part 1 of #1040. Doctor's `resolveWorkspaceURLs` ran ONCE at pod startup; if the Workspace didn't exist yet (the standard Tilt race against `sample-resources`), the pod permanently fell back to legacy global URLs that no longer exist, and every subsequent run reported false failures across Memory / Sessions / Privacy / Infrastructure.

Restarting the pod recovered it. Nothing else did. This bug masked the wiring failures that landed as #1038.

## Change

- `doctor.NewServer` now takes a `RunnerBuilder func(ctx) (*Runner, error)` instead of a static `*Runner`. The builder is invoked per `POST/GET /api/v1/run` request.
- `cmd/doctor/main.go` extracts the runner-construction logic into `buildRunner(runnerConfig)`. `--run-once` calls it once; the server path calls it per request.
- Existing checks capture URLs by value at construction time, so the runner has to be rebuilt — patching closures retroactively isn't reachable. Documented in the `RunnerBuilder` doc comment.

## Tests

Two new regression tests in `internal/doctor/server_test.go`:

- `TestRunnerBuilderInvokedPerRun` — asserts the builder fires on every `POST /api/v1/run`. Failure message names the regression so a future revert breaks loudly.
- `TestRunnerBuilderError` — covers the failed-builder path on both SSE and trigger handlers.

Coverage on `internal/doctor/server.go`: 77.4% → 89.3%.

## Verification

```
$ kubectl delete pod -n omnia-system -l app.kubernetes.io/name=omnia-doctor   # before this PR: stale URLs forever
                                                                              # after this PR: URLs refreshed per /api/v1/run
$ kubectl logs -n omnia-system deploy/omnia-doctor | head -3
"service URLs resolved via workspace" sessionAPIURL=http://session-dev-agents-default... memoryAPIURL=http://memory-dev-agents-default...
```

## Out of scope (part 2)

Doctor's WebSocket checks still fail with `auth: no credential present, status: 401` because the facade was migrated to mgmt-plane JWT validation (commit `30a286bf`) and Doctor's dialer still sends only the legacy `Istio-User-ID` header. That fix is bigger (Helm chart change to mount the dashboard's signing-key Secret in Doctor pod, plus Go-side JWT minting) and ships separately under #1040.

## Test plan
- [x] `go test ./internal/doctor/... -count=1` — 20 tests pass (was 18 + 2 new)
- [x] `go build ./...` clean
- [x] Per-file coverage on changed files >= 80%
- [ ] Verify on cluster: restart Doctor pod, hit `/api/v1/run`, confirm logs show fresh discovery on each call
