### PR TITLE
feat(controller): detect placeholder credentials in Provider secrets (#1037 part 1)

### DIFF
--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -281,10 +281,15 @@ func (r *ProviderReconciler) validateCredentialSecretRef(ctx context.Context, pr
 		return fmt.Errorf("%s", msg)
 	}
 
-	// Check for expected key if specified
+	// Check for expected key if specified, capturing the value so we
+	// can also check for placeholders (issue #1037: dev-sample
+	// secrets like "sk-demo-key-replace-with-real-key" pass the
+	// presence check but break at chat-time with INVALID_API_KEY).
+	var matchedValue []byte
 	if ref.Key != nil {
 		expectedKey := *ref.Key
-		if _, exists := secret.Data[expectedKey]; !exists {
+		v, exists := secret.Data[expectedKey]
+		if !exists {
 			msg := fmt.Sprintf(errFmtSecretMissingKey, key.Name, expectedKey)
 			SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeSecretFound, metav1.ConditionFalse,
 				"SecretKeyMissing", msg)
@@ -293,17 +298,17 @@ func (r *ProviderReconciler) validateCredentialSecretRef(ctx context.Context, pr
 			provider.Status.Phase = omniav1alpha1.ProviderPhaseError
 			return fmt.Errorf("%s", msg)
 		}
+		matchedValue = v
 	} else {
 		// Check for provider-appropriate key
 		expectedKeys := getExpectedKeysForProvider(provider.Spec.Type)
-		found := false
 		for _, k := range expectedKeys {
-			if _, exists := secret.Data[k]; exists {
-				found = true
+			if v, exists := secret.Data[k]; exists {
+				matchedValue = v
 				break
 			}
 		}
-		if !found {
+		if matchedValue == nil {
 			msg := fmt.Sprintf(errFmtSecretMissingAnyKey, key.Name, expectedKeys)
 			SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeSecretFound, metav1.ConditionFalse,
 				"SecretKeyMissing", msg)
@@ -316,6 +321,24 @@ func (r *ProviderReconciler) validateCredentialSecretRef(ctx context.Context, pr
 
 	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeSecretFound, metav1.ConditionTrue,
 		"SecretFound", "Referenced secret exists")
+
+	// Placeholder detection: catch dev-sample values that pass the
+	// presence check but would fail at chat-time. Phase stays Ready
+	// — the secret IS configured, just with a value the operator
+	// almost certainly forgot to replace. CredentialConfigured flips
+	// False so the dashboard can surface "key looks like a placeholder"
+	// instead of waiting for INVALID_API_KEY at the first message.
+	if IsPlaceholderCredential(string(matchedValue)) {
+		msg := fmt.Sprintf("secret %s contains a placeholder value (matches dev-sample marker like 'replace-with-real-key'); replace with a real key", key.Name)
+		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionFalse,
+			"PlaceholderCredential", msg)
+		r.emitWarningEvent(provider, EventReasonCredentialInvalid, msg)
+		// Don't return an error — the Provider is still considered
+		// usable for reconciliation purposes (referenced secret
+		// exists). Operators see the condition + event and fix it.
+		return nil
+	}
+
 	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionTrue,
 		"SecretFound", "Credential configured via secret reference")
 	return nil

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -883,6 +883,85 @@ var _ = Describe("Provider Controller", func() {
 			Expect(credCondition.Reason).To(Equal("SecretKeyMissing"))
 		})
 
+		It("should detect placeholder secret value and flip CredentialConfigured False (#1037)", func() {
+			// Issue #1037: a Secret containing a dev-sample placeholder
+			// (the "replace-with-real-key" suffix) used to pass the
+			// presence check and let CredentialConfigured go True. The
+			// agent then failed at chat-time with INVALID_API_KEY, often
+			// disguised as a 429. The controller now flags the
+			// placeholder explicitly so operators see the problem at
+			// reconcile time. SecretFound stays True (the secret IS
+			// present) — this regression test asserts both halves of
+			// that contract.
+			placeholderSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "placeholder-secret",
+					Namespace: providerNamespace,
+				},
+				Data: map[string][]byte{
+					"ANTHROPIC_API_KEY": []byte("sk-ant-demo-key-replace-with-real-key"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, placeholderSecret)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, placeholderSecret) }()
+
+			provider = &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cred-placeholder",
+					Namespace: providerNamespace,
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:  omniav1alpha1.ProviderTypeClaude,
+					Model: "claude-sonnet-4-20250514",
+					Credential: &omniav1alpha1.CredentialConfig{
+						SecretRef: &omniav1alpha1.SecretKeyRef{
+							Name: "placeholder-secret",
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+
+			reconciler := &ProviderReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				HTTPClient: alwaysHealthyClient(),
+			}
+
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      provider.Name,
+					Namespace: providerNamespace,
+				},
+			})
+			// Reconciliation should NOT error — the secret IS configured,
+			// just with a placeholder. Operators see the condition + event
+			// and fix it; we don't want to spam the requeue queue.
+			Expect(err).NotTo(HaveOccurred())
+
+			var updated omniav1alpha1.Provider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: providerNamespace}, &updated)).To(Succeed())
+
+			var secretFound, credConfigured *metav1.Condition
+			for i := range updated.Status.Conditions {
+				switch updated.Status.Conditions[i].Type {
+				case ProviderConditionTypeSecretFound:
+					secretFound = &updated.Status.Conditions[i]
+				case ProviderConditionTypeCredentialConfigured:
+					credConfigured = &updated.Status.Conditions[i]
+				}
+			}
+			Expect(secretFound).NotTo(BeNil(), "SecretFound condition missing")
+			Expect(secretFound.Status).To(Equal(metav1.ConditionTrue),
+				"SecretFound should be True — the secret is present, just placeholder-valued")
+
+			Expect(credConfigured).NotTo(BeNil(), "CredentialConfigured condition missing")
+			Expect(credConfigured.Status).To(Equal(metav1.ConditionFalse),
+				"CredentialConfigured should be False — the value matches a known placeholder")
+			Expect(credConfigured.Reason).To(Equal("PlaceholderCredential"))
+			Expect(credConfigured.Message).To(ContainSubstring("placeholder"))
+		})
+
 		It("should succeed with credential.envVar set to valid name", func() {
 			provider = &omniav1alpha1.Provider{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/controller/provider_credential_placeholder.go
+++ b/internal/controller/provider_credential_placeholder.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+)
+
+// IsPlaceholderCredential reports whether the given secret value is one
+// of the well-known placeholder strings that ship with the dev samples
+// (config/samples/dev/samples.yaml). Operators are expected to replace
+// these with real keys; surfacing the placeholder via a Provider
+// condition catches the "I forgot to set my key" failure mode at
+// reconcile time instead of at chat time (issue #1037).
+//
+// The matcher is conservative — it only flags strings that are
+// clearly placeholders (the "replace-with-real-key" suffix is the
+// canonical marker, plus a few well-known dev-sample variants).
+// A real Anthropic key happens to start with "sk-ant-" but won't
+// contain "replace-with-real-key", so false positives are minimal.
+//
+// Empty values return false — that's a "missing key" condition and
+// the existing key-presence check handles it.
+func IsPlaceholderCredential(value string) bool {
+	if value == "" {
+		return false
+	}
+	v := strings.ToLower(value)
+	for _, marker := range placeholderMarkers {
+		if strings.Contains(v, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// placeholderMarkers are substrings that, if present, confirm the
+// value is a dev-sample placeholder. The strings live in
+// config/samples/dev/samples.yaml — keep this list in sync if more
+// placeholder shapes appear there.
+var placeholderMarkers = []string{
+	"replace-with-real-key",
+	"replace-me",
+	"your-api-key-here",
+	"changeme",
+}

--- a/internal/controller/provider_credential_placeholder_test.go
+++ b/internal/controller/provider_credential_placeholder_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import "testing"
+
+func TestIsPlaceholderCredential(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		// Real placeholders that ship in config/samples/dev/samples.yaml —
+		// these are the actual strings that bit us in issue #1037.
+		{"anthropic placeholder", "sk-ant-demo-key-replace-with-real-key", true},
+		{"openai placeholder", "sk-demo-key-replace-with-real-key", true},
+		{"gemini placeholder", "ya29-demo-key-replace-with-real-key", true},
+
+		// Common variants seen in other Helm-chart-style samples.
+		{"REPLACE-ME shouty", "REPLACE-ME", true},
+		{"your-api-key-here", "your-api-key-here", true},
+		{"changeme", "changeme", true},
+		{"changeme suffix", "supersecret-CHANGEME", true},
+
+		// Real-shaped keys that should NOT match. Values below are
+		// SYNTHETIC — never paste a real API key into a test case,
+		// even one you intend to rotate. If a real key ever starts
+		// containing "replace-with-real-key" we have bigger problems;
+		// the marker is intentionally distinctive.
+		{"anthropic shape", "sk-ant-api03-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", false},
+		{"openai shape", "sk-proj-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", false},
+		{"gemini shape", "AIzaSyXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX", false},
+
+		// Edge cases — empty / whitespace are missing-key, not placeholder.
+		{"empty", "", false},
+		{"whitespace only", "   ", false},
+		{"single space", " ", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsPlaceholderCredential(tt.value); got != tt.want {
+				t.Errorf("IsPlaceholderCredential(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Item 1 from issue #1037's prevention plan. Provider secrets shipped with `config/samples/dev/` (strings like `sk-ant-demo-key-replace-with-real-key`) currently pass the existing presence check and let `CredentialConfigured` go True, even though the value will fail at chat-time with `INVALID_API_KEY`. The audit during PR #1035 hit this twice; the diagnostic was painful because Google sometimes returns 429 instead of 401 for invalid keys, sending us down a quota-exhaustion rabbit hole.

## Change

`internal/controller/provider_credential_placeholder.go`: new helper `IsPlaceholderCredential` does a conservative substring check against well-known dev-sample markers (`replace-with-real-key`, `replace-me`, `your-api-key-here`, `changeme`).

`internal/controller/provider_controller.go::validateCredentialSecret`:
- Captures the matched secret value (was `_, exists := ...`)
- Runs it through `IsPlaceholderCredential`
- On match: `SecretFound=True` (the secret IS there), `CredentialConfigured=False` with reason `PlaceholderCredential`, Warning event `EventReasonCredentialInvalid`
- Reconciliation does NOT fail — operators see the condition + event and fix it

The matcher is deliberately substring-only so a real key that happens to start with `sk-ant-` won't trip — false positives would be more annoying than the bug.

## Tests

13 cases in `provider_credential_placeholder_test.go` covering all three dev-sample variants, real-shaped keys (Anthropic, OpenAI, Gemini), and edge cases (empty, whitespace).

## Test plan
- [x] `go test ./internal/controller/... -count=1` — 633 tests pass
- [x] `go build ./...` clean
- [x] Per-file coverage `provider_credential_placeholder.go: 100%`, `provider_controller.go: 86.6%`
- [ ] Verify on cluster: `kubectl describe provider gemini-provider -n dev-agents` after applying placeholder secret should show `Type: CredentialConfigured Status: False Reason: PlaceholderCredential`

## Out of scope

Items 2 and 3 from #1037 (dashboard structured auth-error banner, active credential validation via models.list) ship separately. This PR catches the dev-loop case at reconcile time; those PRs catch real-world rotations and runtime errors.
