### PR TITLE
feat(hack): wiring-test enforcement lint (#1038-C)

### DIFF
--- a/hack/check-wiring-tests.sh
+++ b/hack/check-wiring-tests.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# check-wiring-tests.sh
+#
+# Enforces the "every service binary has a wiring test" contract from
+# CLAUDE.md (Testing Standards section). For every `cmd/*/main.go` (and
+# `ee/cmd/*/main.go`) the directory must contain at least one `_test.go`
+# file. Without a test in the same dir, an assembled-binary regression
+# (missing route registration, missing worker start, missing interceptor)
+# only surfaces as a smoke-test failure in-cluster — exactly the failure
+# class that gave us issue #1038's wiring audit.
+#
+# A test file matches if its name ends in `_test.go`. The lint does NOT
+# attempt to verify what the test actually asserts on — content-level
+# enforcement is the human reviewer's job. The shape "is there a test"
+# is the cheap signal that catches binaries with zero coverage.
+#
+# Exit codes:
+#   0  every cmd/main.go has a sibling _test.go
+#   1  one or more main.go files lack a sibling test
+#
+# Usage:
+#   bash hack/check-wiring-tests.sh
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+# Portable across bash 3.2 (macOS default) and bash 4+ — uses temp
+# files + line-comparison instead of associative arrays.
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+# Pre-existing gaps that this lint deliberately accepts. The list
+# pins the current state so NEW binaries without wiring tests fail,
+# while existing gaps are tracked as separate tickets rather than
+# blocking unrelated PRs. Removing a gap (by adding a wiring test)
+# requires deleting the line below — the lint will tell you to.
+#
+# To add a wiring test for one of these and remove it from the list:
+# see CLAUDE.md → Testing Standards → 'Wiring tests'.
+allowlist_file="hack/wiring-tests.allowlist"
+
+# Build the allowlist (sorted, comments + blanks stripped) into a tmp
+# file so we can compare it to the current set with `comm`. Plain
+# files + sort + comm are portable across bash 3.2 (macOS) and bash
+# 4+ (Linux CI) — declare -A is bash-4-only.
+allowlist="$tmp/allowed"
+if [ -f "$allowlist_file" ]; then
+    sed -e 's/#.*//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$allowlist_file" \
+        | grep -v '^$' \
+        | LC_ALL=C sort -u >"$allowlist"
+else
+    : >"$allowlist"
+fi
+
+# Build the current set of cmd/*/main.go that lack a sibling _test.go.
+current="$tmp/current"
+: >"$current"
+shopt -s nullglob
+for main_path in cmd/*/main.go ee/cmd/*/main.go; do
+    dir="$(dirname "$main_path")"
+    if ! compgen -G "$dir/*_test.go" >/dev/null; then
+        echo "$main_path" >>"$current"
+    fi
+done
+shopt -u nullglob
+LC_ALL=C sort -o "$current" "$current"
+
+# Set differences. comm -23: lines only in current. comm -13: only in allowlist.
+new_gaps="$(comm -23 "$current" "$allowlist")"
+stale_allowlist="$(comm -13 "$current" "$allowlist")"
+
+fail=0
+if [ -n "$new_gaps" ]; then
+    fail=1
+    echo "✗ new wiring-test gap (not in $allowlist_file):"
+    while IFS= read -r m; do
+        echo "  - $m"
+    done <<<"$new_gaps"
+    echo ""
+    echo "Add a wiring test (cmd/<name>/wiring_test.go or main_test.go) that exercises the assembled binary's"
+    echo "cross-service contracts: registered routes, started workers, configured providers, etc."
+    echo "See CLAUDE.md → Testing Standards → 'Wiring tests (service startup verification)'."
+    echo ""
+    echo "Why this matters: see issue #1038. Workers wired in main.go that silently never run because the"
+    echo "operator doesn't pass the enabling flag pass unit tests — only an assembled-binary test catches them."
+fi
+
+if [ -n "$stale_allowlist" ]; then
+    fail=1
+    echo "✗ stale entries in $allowlist_file (these binaries now have a wiring test — remove them):"
+    while IFS= read -r m; do
+        echo "  - $m"
+    done <<<"$stale_allowlist"
+fi
+
+if [ $fail -eq 0 ]; then
+    current_count=$(wc -l <"$current" | tr -d '[:space:]')
+    if [ "$current_count" = "0" ]; then
+        echo "✓ all cmd/*/main.go binaries have a sibling _test.go"
+    else
+        echo "✓ no new wiring-test gaps ($current_count pre-existing, all allowlisted)"
+    fi
+    exit 0
+fi
+
+exit 1

--- a/hack/wiring-tests.allowlist
+++ b/hack/wiring-tests.allowlist
@@ -1,0 +1,15 @@
+# Pre-existing wiring-test gaps. The lint at hack/check-wiring-tests.sh
+# fails when a NEW cmd/*/main.go appears without a sibling _test.go.
+# Lines below pin the gaps that existed when the lint shipped so
+# unrelated PRs don't get blocked. Tracked work to close them lives
+# in their respective issues.
+#
+# To remove a line below: add a wiring test to the named cmd/<name>/
+# directory (CLAUDE.md → Testing Standards → 'Wiring tests'). The
+# lint will tell you the line is stale once the test exists.
+
+cmd/doctor/main.go
+ee/cmd/arena-dev-console/main.go
+ee/cmd/omnia-arena-controller/main.go
+ee/cmd/policy-proxy/main.go
+ee/cmd/promptkit-lsp/main.go


### PR DESCRIPTION
## Summary

Item C from issue #1038's prevention plan. Issue #1038 surfaced 5 wiring failures where workers were wired in `cmd/*/main.go` but silently never ran because the operator didn't pass the enabling flags. Unit tests were green; only assembled-binary tests catch that class of bug. CLAUDE.md mandates a wiring test per service binary; nothing enforced it.

## Change

`hack/check-wiring-tests.sh`: for every `cmd/*/main.go` and `ee/cmd/*/main.go`, assert at least one `*_test.go` in the same directory.

- **New gap → fail.** A future `cmd/<name>/main.go` without a sibling test breaks the build with the "add a wiring test" guidance.
- **Closed gap → "stale allowlist" fail.** When someone adds a wiring test for a previously-allowlisted binary, the lint forces them to remove the line — keeps the allowlist accurate.

`hack/wiring-tests.allowlist`: pins the 5 pre-existing gaps so unrelated PRs don't get blocked while those tickets are worked separately.

```
cmd/doctor/main.go
ee/cmd/arena-dev-console/main.go
ee/cmd/omnia-arena-controller/main.go
ee/cmd/policy-proxy/main.go
ee/cmd/promptkit-lsp/main.go
```

## Implementation note

File-based set comparison via `sort` + `comm` so the script runs on bash 3.2 (macOS default) as well as bash 4+ (Linux CI). An earlier draft used `declare -A` and crashed on macOS pre-commit.

## Verified

- Clean run returns exit 0 with the allowlist (5 pre-existing, all allowlisted)
- Synthetic `cmd/newbie/main.go` (no test) → exit 1 with "add a wiring test" guidance
- Allowlist entry referencing a non-gap → exit 1 with "remove the stale entry" guidance

## Out of scope

Pre-commit + CI wiring deliberately ships in a follow-up so reviewers can read this PR and the new check before it starts blocking unrelated PRs. The lint can be invoked manually today via `bash hack/check-wiring-tests.sh`.

## Test plan
- [x] Lint passes against current main
- [x] Both failure modes return exit 1 with actionable messages
- [x] Portable across bash 3.2 / 4+
