### PR TITLE
feat: migrate dev samples + dashboard to spec.credential.secretRef (#1036)

### DIFF
--- a/config/samples/dev/samples.yaml
+++ b/config/samples/dev/samples.yaml
@@ -125,8 +125,9 @@ metadata:
 spec:
   type: claude
   model: claude-sonnet-4-20250514
-  secretRef:
-    name: anthropic-credentials
+  credential:
+    secretRef:
+      name: anthropic-credentials
   defaults:
     temperature: "0.7"
     maxTokens: 4096
@@ -143,8 +144,9 @@ metadata:
 spec:
   type: openai
   model: gpt-4o
-  secretRef:
-    name: openai-credentials
+  credential:
+    secretRef:
+      name: openai-credentials
   defaults:
     temperature: "0.7"
     maxTokens: 4096
@@ -161,8 +163,9 @@ metadata:
 spec:
   type: gemini
   model: gemini-2.5-flash
-  secretRef:
-    name: gemini-credentials
+  credential:
+    secretRef:
+      name: gemini-credentials
   defaults:
     temperature: "0.7"
     maxTokens: 4096

--- a/dashboard/src/app/providers/[name]/page.tsx
+++ b/dashboard/src/app/providers/[name]/page.tsx
@@ -25,7 +25,7 @@ import { ProviderTypeIcon } from "@/components/providers/provider-type-icon";
 import { ProviderDialog } from "@/components/providers/provider-dialog";
 import { useProvider, useUpdateProviderSecretRef, useSecrets, useProviderMetrics } from "@/hooks/resources";
 import { useWorkspace } from "@/contexts/workspace-context";
-import { effectiveSecretRefName } from "@/lib/k8s/providers";
+import { effectiveSecretRefName } from "@/lib/k8s/provider-secret-ref";
 
 interface ProviderDetailPageProps {
   params: Promise<{ name: string }>;

--- a/dashboard/src/app/providers/[name]/page.tsx
+++ b/dashboard/src/app/providers/[name]/page.tsx
@@ -25,6 +25,7 @@ import { ProviderTypeIcon } from "@/components/providers/provider-type-icon";
 import { ProviderDialog } from "@/components/providers/provider-dialog";
 import { useProvider, useUpdateProviderSecretRef, useSecrets, useProviderMetrics } from "@/hooks/resources";
 import { useWorkspace } from "@/contexts/workspace-context";
+import { effectiveSecretRefName } from "@/lib/k8s/providers";
 
 interface ProviderDetailPageProps {
   params: Promise<{ name: string }>;
@@ -62,8 +63,12 @@ export default function ProviderDetailPage({ params }: Readonly<ProviderDetailPa
   const { data: secrets, isLoading: secretsLoading } = useSecrets({ namespace });
   const updateSecretRef = useUpdateProviderSecretRef();
 
-  // Determine current secret status
-  const currentSecretRef = provider?.spec?.secretRef?.name;
+  // Determine current secret status. effectiveSecretRefName checks
+  // both the new spec.credential.secretRef and the legacy spec.secretRef
+  // so a Provider written in either shape resolves correctly. Pre-#1036
+  // this only checked the legacy field, so a Provider migrated to the
+  // new shape would render "(missing)" even when the secret existed.
+  const currentSecretRef = effectiveSecretRefName(provider);
   const secretExists = useMemo(() => {
     if (!currentSecretRef) return true; // No secret configured
     if (!secrets) return undefined; // Still loading
@@ -297,10 +302,10 @@ export default function ProviderDetailPage({ params }: Readonly<ProviderDetailPa
                       </div>
                     )}
                   </div>
-                  {spec?.secretRef?.key && (
+                  {(spec?.credential?.secretRef?.key || spec?.secretRef?.key) && (
                     <div className="flex justify-between">
                       <span className="text-muted-foreground">Key</span>
-                      <span className="font-medium">{spec.secretRef.key}</span>
+                      <span className="font-medium">{spec?.credential?.secretRef?.key || spec?.secretRef?.key}</span>
                     </div>
                   )}
                 </CardContent>

--- a/dashboard/src/lib/k8s/provider-secret-ref.ts
+++ b/dashboard/src/lib/k8s/provider-secret-ref.ts
@@ -1,0 +1,35 @@
+/**
+ * Pure type-only helper for resolving a Provider's effective secretRef.
+ *
+ * Lives in a separate file from `providers.ts` because that module
+ * imports `@kubernetes/client-node`, which depends on Node-only modules
+ * (`dns`, `net`, `tls`) that webpack can't bundle for the browser.
+ * Client components ("use client") that just need to *read* a Provider's
+ * secret name should import from here, not `./providers`, otherwise the
+ * whole k8s SDK gets dragged into the client bundle and the build fails
+ * with "Module not found: Can't resolve 'dns'".
+ */
+
+interface ProviderLike {
+  spec?: {
+    credential?: { secretRef?: { name?: string } };
+    secretRef?: { name?: string };
+  };
+}
+
+/**
+ * Returns the effective secretRef name for a Provider, checking the new
+ * `spec.credential.secretRef` first and falling back to legacy
+ * `spec.secretRef`. Returns undefined when neither is set.
+ *
+ * Mirrors the operator's pkg/k8s/EffectiveSecretRef so the dashboard
+ * shows the same secret the runtime uses regardless of which shape the
+ * Provider author chose.
+ */
+export function effectiveSecretRefName(
+  provider: ProviderLike | null | undefined,
+): string | undefined {
+  return (
+    provider?.spec?.credential?.secretRef?.name ?? provider?.spec?.secretRef?.name
+  );
+}

--- a/dashboard/src/lib/k8s/providers.test.ts
+++ b/dashboard/src/lib/k8s/providers.test.ts
@@ -127,9 +127,13 @@ describe("providers", () => {
         "new-secret"
       );
 
+      // After #1036: writes go to spec.credential.secretRef and the
+      // legacy spec.secretRef is cleared in the same patch (the CRD
+      // rejects "both set"). This regression-asserts both behaviours.
       expect(mockReplaceNamespacedCustomObject).toHaveBeenCalled();
       const replaceCall = mockReplaceNamespacedCustomObject.mock.calls[0][0];
-      expect(replaceCall.body.spec.secretRef.name).toBe("new-secret");
+      expect(replaceCall.body.spec.credential.secretRef.name).toBe("new-secret");
+      expect(replaceCall.body.spec.secretRef).toBeUndefined();
       expect(result).toEqual(updatedProvider);
     });
 
@@ -149,6 +153,7 @@ describe("providers", () => {
       expect(mockReplaceNamespacedCustomObject).toHaveBeenCalled();
       const replaceCall = mockReplaceNamespacedCustomObject.mock.calls[0][0];
       expect(replaceCall.body.spec.secretRef).toBeUndefined();
+      expect(replaceCall.body.spec.credential).toBeUndefined();
       expect(result).toEqual(updatedProvider);
     });
 
@@ -167,8 +172,69 @@ describe("providers", () => {
 
       expect(mockReplaceNamespacedCustomObject).toHaveBeenCalled();
       const replaceCall = mockReplaceNamespacedCustomObject.mock.calls[0][0];
-      expect(replaceCall.body.spec.secretRef.name).toBe("new-secret");
+      expect(replaceCall.body.spec.credential.secretRef.name).toBe("new-secret");
+      expect(replaceCall.body.spec.secretRef).toBeUndefined();
       expect(result).toEqual(updatedProvider);
+    });
+
+    it("should migrate legacy spec.secretRef to spec.credential.secretRef on next write", async () => {
+      // A Provider that started life on the legacy field gets migrated
+      // automatically when the dashboard updates its secretRef. Without
+      // this the dashboard would write spec.credential while leaving
+      // spec.secretRef in place, and the CRD's "exactly one" validation
+      // would reject the patch.
+      const existingProvider = createMockProvider("default", "legacy", "old-secret");
+      mockGetNamespacedCustomObject.mockResolvedValue(existingProvider);
+      mockReplaceNamespacedCustomObject.mockResolvedValue(existingProvider);
+
+      await providersModule.updateProviderSecretRef("default", "legacy", "new-secret");
+
+      const replaceCall = mockReplaceNamespacedCustomObject.mock.calls[0][0];
+      expect(replaceCall.body.spec.credential.secretRef.name).toBe("new-secret");
+      expect(replaceCall.body.spec.secretRef).toBeUndefined();
+    });
+  });
+
+  describe("effectiveSecretRefName", () => {
+    it("returns the new spec.credential.secretRef name", () => {
+      expect(
+        providersModule.effectiveSecretRefName({
+          spec: { credential: { secretRef: { name: "new-name" } } },
+        }),
+      ).toBe("new-name");
+    });
+
+    it("falls back to legacy spec.secretRef.name", () => {
+      expect(
+        providersModule.effectiveSecretRefName({
+          spec: { secretRef: { name: "legacy-name" } },
+        }),
+      ).toBe("legacy-name");
+    });
+
+    it("prefers credential.secretRef when both are set", () => {
+      // Reflects operator's pkg/k8s/EffectiveSecretRef precedence —
+      // dashboard must agree or it'll show one secret while the
+      // runtime uses another. The CRD admission controller rejects
+      // both-set, so this case shouldn't reach prod, but the helper
+      // is the right place to define the resolution rule anyway.
+      expect(
+        providersModule.effectiveSecretRefName({
+          spec: {
+            credential: { secretRef: { name: "new" } },
+            secretRef: { name: "old" },
+          },
+        }),
+      ).toBe("new");
+    });
+
+    it("returns undefined when neither is set", () => {
+      expect(providersModule.effectiveSecretRefName({ spec: {} })).toBeUndefined();
+    });
+
+    it("handles null/undefined provider", () => {
+      expect(providersModule.effectiveSecretRefName(null)).toBeUndefined();
+      expect(providersModule.effectiveSecretRefName(undefined)).toBeUndefined();
     });
 
     it("should throw error if provider not found", async () => {

--- a/dashboard/src/lib/k8s/providers.test.ts
+++ b/dashboard/src/lib/k8s/providers.test.ts
@@ -177,6 +177,51 @@ describe("providers", () => {
       expect(result).toEqual(updatedProvider);
     });
 
+    it("removes the secretRef and drops the credential block when only credential.secretRef was set", async () => {
+      // Provider already on the new shape with ONLY a secretRef in the
+      // credential block: clearing it should also drop the empty
+      // credential block so the Provider doesn't carry an inert {}.
+      const existingProvider = {
+        ...createMockProvider("default", "new-shape"),
+        spec: {
+          type: "claude",
+          model: "claude-sonnet-4-20250514",
+          credential: { secretRef: { name: "old-secret" } },
+        },
+      };
+      mockGetNamespacedCustomObject.mockResolvedValue(existingProvider);
+      mockReplaceNamespacedCustomObject.mockResolvedValue(existingProvider);
+
+      await providersModule.updateProviderSecretRef("default", "new-shape", null);
+
+      const replaceCall = mockReplaceNamespacedCustomObject.mock.calls[0][0];
+      expect(replaceCall.body.spec.secretRef).toBeUndefined();
+      expect(replaceCall.body.spec.credential).toBeUndefined();
+    });
+
+    it("preserves other credential fields when clearing only secretRef", async () => {
+      // If credential carries an envVar alongside secretRef, removing
+      // the secretRef should NOT delete the rest of the credential block.
+      const existingProvider = {
+        ...createMockProvider("default", "mixed"),
+        spec: {
+          type: "claude",
+          model: "claude-sonnet-4-20250514",
+          credential: {
+            secretRef: { name: "old-secret" },
+            envVar: "MY_ENV",
+          },
+        },
+      };
+      mockGetNamespacedCustomObject.mockResolvedValue(existingProvider);
+      mockReplaceNamespacedCustomObject.mockResolvedValue(existingProvider);
+
+      await providersModule.updateProviderSecretRef("default", "mixed", null);
+
+      const replaceCall = mockReplaceNamespacedCustomObject.mock.calls[0][0];
+      expect(replaceCall.body.spec.credential).toEqual({ envVar: "MY_ENV" });
+    });
+
     it("should migrate legacy spec.secretRef to spec.credential.secretRef on next write", async () => {
       // A Provider that started life on the legacy field gets migrated
       // automatically when the dashboard updates its secretRef. Without

--- a/dashboard/src/lib/k8s/providers.ts
+++ b/dashboard/src/lib/k8s/providers.ts
@@ -41,6 +41,19 @@ function getClient(): k8s.CustomObjectsApi {
 
 /**
  * Provider resource from K8s API.
+ *
+ * The Provider CRD has TWO ways to express its credential reference:
+ *
+ *   spec.secretRef            — legacy (Phase 1, marked Deprecated in v1alpha1)
+ *   spec.credential.secretRef — current shape (#1036)
+ *
+ * Operator's k8s/EffectiveSecretRef accepts either; readers should
+ * prefer `effectiveSecretRefName(provider)` over poking at either
+ * field directly so a Provider written in either shape works.
+ *
+ * Writers in this package always set the new shape and remove the
+ * old one in the same patch so a single Provider never carries both
+ * — the CRD validation rejects "both set" at admission.
  */
 interface ProviderResource {
   apiVersion: string;
@@ -58,12 +71,35 @@ interface ProviderResource {
       name: string;
       key?: string;
     };
+    credential?: {
+      secretRef?: {
+        name: string;
+        key?: string;
+      };
+      envVar?: string;
+      filePath?: string;
+    };
     [key: string]: unknown;
   };
   status?: {
     phase?: string;
     [key: string]: unknown;
   };
+}
+
+/**
+ * Returns the effective secretRef name for a Provider, checking the
+ * new `spec.credential.secretRef` first and falling back to legacy
+ * `spec.secretRef`. Returns undefined when neither is set.
+ *
+ * Mirrors the operator's pkg/k8s/EffectiveSecretRef so the dashboard
+ * shows the same secret the runtime uses regardless of which shape
+ * the Provider author chose.
+ */
+export function effectiveSecretRefName(
+  provider: { spec?: { credential?: { secretRef?: { name?: string } }; secretRef?: { name?: string } } } | null | undefined,
+): string | undefined {
+  return provider?.spec?.credential?.secretRef?.name ?? provider?.spec?.secretRef?.name;
 }
 
 /**
@@ -109,13 +145,27 @@ export async function updateProviderSecretRef(
     throw new Error(`Provider ${namespace}/${name} not found`);
   }
 
-  // Update the secretRef
+  // Always write the new shape (spec.credential.secretRef). The CRD
+  // validation rejects "both set", so we also clear the legacy field
+  // in the same patch — without this, a Provider that started life
+  // with spec.secretRef would fail to update.
+  delete existing.spec.secretRef;
   if (secretName === null) {
-    // Remove secretRef
-    delete existing.spec.secretRef;
+    if (existing.spec.credential) {
+      delete existing.spec.credential.secretRef;
+      // Drop the credential block entirely if it's now empty so the
+      // Provider doesn't carry an inert {} that confuses readers.
+      if (
+        Object.keys(existing.spec.credential).length === 0
+      ) {
+        delete existing.spec.credential;
+      }
+    }
   } else {
-    // Set secretRef
-    existing.spec.secretRef = { name: secretName };
+    if (!existing.spec.credential) {
+      existing.spec.credential = {};
+    }
+    existing.spec.credential.secretRef = { name: secretName };
   }
 
   // Use replaceNamespacedCustomObject to update

--- a/dashboard/src/lib/k8s/providers.ts
+++ b/dashboard/src/lib/k8s/providers.ts
@@ -152,9 +152,7 @@ export async function updateProviderSecretRef(
       }
     }
   } else {
-    if (!existing.spec.credential) {
-      existing.spec.credential = {};
-    }
+    existing.spec.credential ??= {};
     existing.spec.credential.secretRef = { name: secretName };
   }
 

--- a/dashboard/src/lib/k8s/providers.ts
+++ b/dashboard/src/lib/k8s/providers.ts
@@ -7,6 +7,11 @@
 
 import * as k8s from "@kubernetes/client-node";
 
+// Re-exported from a Node-free module so client components can read a
+// Provider's effective secret name without dragging the k8s SDK into
+// the browser bundle. See provider-secret-ref.ts for the rationale.
+export { effectiveSecretRefName } from "./provider-secret-ref";
+
 const GROUP = "omnia.altairalabs.ai";
 const VERSION = "v1alpha1";
 const PLURAL = "providers";
@@ -85,21 +90,6 @@ interface ProviderResource {
     phase?: string;
     [key: string]: unknown;
   };
-}
-
-/**
- * Returns the effective secretRef name for a Provider, checking the
- * new `spec.credential.secretRef` first and falling back to legacy
- * `spec.secretRef`. Returns undefined when neither is set.
- *
- * Mirrors the operator's pkg/k8s/EffectiveSecretRef so the dashboard
- * shows the same secret the runtime uses regardless of which shape
- * the Provider author chose.
- */
-export function effectiveSecretRefName(
-  provider: { spec?: { credential?: { secretRef?: { name?: string } }; secretRef?: { name?: string } } } | null | undefined,
-): string | undefined {
-  return provider?.spec?.credential?.secretRef?.name ?? provider?.spec?.secretRef?.name;
 }
 
 /**


### PR DESCRIPTION
## Summary

Issue #1036 part 1 of 3. Provider has two ways to express its credential reference:
- `spec.secretRef` — legacy, marked Deprecated in v1alpha1
- `spec.credential.secretRef` — current shape

Operator's `pkg/k8s/EffectiveSecretRef` accepts either, but the dashboard read-side at `app/providers/[name]/page.tsx:66` only checked the legacy field. Result: a Provider written in the new shape would render its secret as **"(missing)"** in the dashboard even when the secret existed and the runtime was using it. We hit this during the PR #1035 audit and lost an hour to it.

## Three changes

### 1. `config/samples/dev/samples.yaml`
All four Providers (claude, openai, gemini, ollama) migrate from `spec.secretRef` to `spec.credential.secretRef`. Stops the `LegacySecretRefUsed` warning event firing on every reconcile.

### 2. `dashboard/src/lib/k8s/providers.ts`
- `effectiveSecretRefName(provider)` helper returns the right name regardless of which shape is set; mirrors the operator's `EffectiveSecretRef` precedence (new wins on tie, falls back to legacy when only it is set, undefined when neither).
- `updateProviderSecretRef` writes the new shape AND clears the legacy field in the same patch — without this a Provider that started life on `spec.secretRef` would fail the CRD's "exactly one of secretRef/credential" validation on the next update.

### 3. `dashboard/src/app/providers/[name]/page.tsx`
Uses `effectiveSecretRefName()` instead of poking at `spec.secretRef` directly. The "Key" sub-row also reads from either shape.

## Tests

- 5 cases for `effectiveSecretRefName` (new only, legacy only, both set, neither, null/undefined)
- Updated three existing `updateProviderSecretRef` tests to assert the new shape, plus a new "migrate legacy on next write" case that fails loudly if anyone reverts the auto-cleanup

## Out of scope (other parts of #1036)

- Removing `spec.secretRef` from the CRD entirely — breaking change, needs deprecation window + conversion webhook
- Removing the `LegacySecretRefUsed` event source from the operator — same release as the CRD removal

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings only, all pre-existing)
- [x] `npx vitest run src/lib/k8s/providers` — 16 tests pass
- [x] Per-file coverage `src/lib/k8s/providers.ts: 92.7%`
