### PR TITLE
feat(dashboard): structured agent error banner (#1037 part 2)

### DIFF
--- a/dashboard/src/components/console/agent-console.tsx
+++ b/dashboard/src/components/console/agent-console.tsx
@@ -11,6 +11,7 @@ import { useAgentConsole, useConsoleConfig } from "@/hooks/console";
 import { ConsoleMessage } from "./console-message";
 import { AttachmentPreview } from "./attachment-preview";
 import { ImageCropDialog } from "./image-crop-dialog";
+import { AgentErrorBanner } from "./agent-error-banner";
 import { isAllowedType, formatFileSize, needsResize } from "./attachment-utils";
 import { blobToDataUrl, getImageDimensions } from "@/lib/image-processor";
 import { getClientToolHandler, isAutoApproved, setAutoApproved } from "@/lib/client-tools";
@@ -502,12 +503,14 @@ export function AgentConsole({ agentName, namespace, sessionId, className }: Rea
         onClose={() => setMemorySidebarOpen(false)}
       />
 
-      {/* Error display */}
-      {error && (
-        <div className="px-4 py-2 bg-red-500/10 border-b border-red-500/20 text-red-600 dark:text-red-400 text-sm">
-          {error}
-        </div>
-      )}
+      {/* Error display — AgentErrorBanner classifies the raw runtime
+          error into invalid_credential / rate_limited / provider_unavailable
+          / unknown and renders an actionable headline + optional link
+          to the provider page (issue #1037 part 2). When the
+          classifier returns "unknown" the banner falls back to the
+          legacy raw-text display, so existing error paths don't
+          regress. */}
+      {error && <AgentErrorBanner error={error} workspace={namespace} />}
 
       {/* File rejection feedback */}
       {rejections.length > 0 && (

--- a/dashboard/src/components/console/agent-error-banner.test.tsx
+++ b/dashboard/src/components/console/agent-error-banner.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AgentErrorBanner } from "./agent-error-banner";
+
+describe("AgentErrorBanner", () => {
+  it("renders the legacy raw-text banner for unknown errors", () => {
+    // Regression guard: the issue #1037 banner must NOT swallow
+    // unrecognised errors. Anything the classifier doesn't match
+    // falls through to the original plain-text display so debugging
+    // surface doesn't shrink.
+    const raw = "something completely random in the runtime";
+    render(<AgentErrorBanner error={raw} />);
+    expect(screen.getByText(raw)).toBeInTheDocument();
+    // Structured banner affordances should be absent.
+    expect(screen.queryByText(/show details/i)).not.toBeInTheDocument();
+  });
+
+  it("renders an invalid-credential headline + check-provider link with workspace", () => {
+    const raw = "API_KEY_INVALID for generativelanguage.googleapis.com";
+    render(<AgentErrorBanner error={raw} workspace="dev-agents" />);
+
+    // Headline mentions auth + provider name.
+    expect(screen.getByText(/authentication failed/i)).toBeInTheDocument();
+    expect(screen.getByText(/gemini/i)).toBeInTheDocument();
+
+    // Action link goes to the right provider page.
+    const link = screen.getByRole("link", { name: /check provider/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "/providers/gemini-provider?namespace=dev-agents",
+    );
+  });
+
+  it("falls back to /providers when provider can't be detected", () => {
+    // No provider URL or name in the message, but still an
+    // identifiable invalid-credential.
+    const raw = "Authentication failed: invalid token (placeholder)";
+    render(<AgentErrorBanner error={raw} workspace="dev-agents" />);
+    const link = screen.getByRole("link", { name: /check providers/i });
+    expect(link).toHaveAttribute("href", "/providers");
+  });
+
+  it("toggles raw-text disclosure", () => {
+    const raw = "openai 401 unauthorized invalid_api_key";
+    render(<AgentErrorBanner error={raw} workspace="dev-agents" />);
+
+    // Raw text hidden by default — the headline is enough.
+    expect(screen.queryByText(raw)).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/show details/i));
+    // Now visible (rendered in a <pre>).
+    expect(screen.getByText(raw)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText(/hide details/i));
+    expect(screen.queryByText(raw)).not.toBeInTheDocument();
+  });
+
+  it("handles rate_limited errors with neutral guidance instead of a link", () => {
+    const raw = "status 429: rate limited, retry after 30s";
+    render(<AgentErrorBanner error={raw} workspace="dev-agents" />);
+    expect(screen.getByText(/rate limit hit/i)).toBeInTheDocument();
+    // No "check provider" link — there's nothing to fix on the
+    // provider page for a quota issue.
+    expect(
+      screen.queryByRole("link", { name: /check provider/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("handles provider_unavailable errors with retry guidance", () => {
+    const raw = "dial tcp: lookup api.openai.com on 10.96.0.10:53: no such host";
+    render(<AgentErrorBanner error={raw} workspace="dev-agents" />);
+    expect(screen.getByText(/unreachable/i)).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /check provider/i })).not.toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/console/agent-error-banner.tsx
+++ b/dashboard/src/components/console/agent-error-banner.tsx
@@ -1,0 +1,139 @@
+"use client";
+
+import Link from "next/link";
+import { AlertCircle, ChevronDown } from "lucide-react";
+import { useState } from "react";
+import {
+  classifyAgentError,
+  summariseAgentError,
+  type AgentErrorKind,
+} from "@/lib/agent-errors/classify";
+
+interface AgentErrorBannerProps {
+  /**
+   * Raw error string from the agent runtime. Pass it through unchanged
+   * — the classifier handles "is this auth?" / "is this a rate limit?"
+   * / "is this network?" detection internally.
+   */
+  error: string;
+  /**
+   * Workspace name for the "Check provider" link target. When omitted
+   * the banner still renders but the action button doesn't link to a
+   * specific provider page.
+   */
+  workspace?: string;
+}
+
+/**
+ * Issue #1037 part 2. Pre-this, the agent console rendered every
+ * runtime error as a single 400-line stack trace. Operators couldn't
+ * tell "your API key is invalid" apart from "the network blipped"
+ * apart from "the LLM provider is down" — we lost an hour during the
+ * #1035 audit chasing a quota-exhaustion red herring when Gemini was
+ * actually returning 429 for an INVALID_API_KEY.
+ *
+ * The banner classifies the error and surfaces an actionable
+ * headline + optional link to the provider page. The raw text stays
+ * available in a "Show details" disclosure so the existing diagnostic
+ * path isn't worse.
+ *
+ * When the classifier returns "unknown" we render the plain banner
+ * the dashboard had before — no regression for unknown errors.
+ */
+export function AgentErrorBanner({ error, workspace }: AgentErrorBannerProps) {
+  const [showDetails, setShowDetails] = useState(false);
+  const info = classifyAgentError(error);
+
+  // Unknown class → preserve the legacy plain-text banner. Avoids
+  // over-fitting: if the classifier doesn't recognise the error, the
+  // user still sees the raw text exactly like before.
+  if (info.kind === "unknown") {
+    return (
+      <div className="px-4 py-2 bg-red-500/10 border-b border-red-500/20 text-red-600 dark:text-red-400 text-sm">
+        {error}
+      </div>
+    );
+  }
+
+  const headline = summariseAgentError(info);
+  const action = renderAction(info.kind, info.provider, workspace);
+
+  return (
+    <div className="px-4 py-2 bg-red-500/10 border-b border-red-500/20 text-red-600 dark:text-red-400 text-sm">
+      <div className="flex items-start gap-2">
+        <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-3">
+            <span className="font-medium">{headline}</span>
+            {action}
+          </div>
+          <button
+            type="button"
+            className="mt-1 inline-flex items-center gap-1 text-xs underline-offset-2 hover:underline opacity-80"
+            onClick={() => setShowDetails((v) => !v)}
+            aria-expanded={showDetails}
+          >
+            <ChevronDown
+              className={`h-3 w-3 transition-transform ${showDetails ? "rotate-180" : ""}`}
+            />
+            {showDetails ? "Hide details" : "Show details"}
+          </button>
+          {showDetails && (
+            <pre className="mt-2 p-2 rounded bg-red-500/5 text-xs overflow-x-auto whitespace-pre-wrap break-words">
+              {info.raw}
+            </pre>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Renders an action affordance for each error class. invalid_credential
+ * deep-links to the provider page when both workspace and provider
+ * name are known; rate_limited and provider_unavailable get neutral
+ * guidance because there's nothing to click.
+ */
+function renderAction(
+  kind: AgentErrorKind,
+  provider?: string,
+  workspace?: string,
+): React.ReactNode {
+  if (kind === "invalid_credential" && provider && workspace) {
+    return (
+      <Link
+        href={`/providers/${provider}-provider?namespace=${workspace}`}
+        className="text-xs underline underline-offset-2 hover:opacity-80"
+      >
+        Check provider →
+      </Link>
+    );
+  }
+  if (kind === "invalid_credential") {
+    // Provider unknown — give the operator the next-best landing page.
+    return (
+      <Link
+        href="/providers"
+        className="text-xs underline underline-offset-2 hover:opacity-80"
+      >
+        Check providers →
+      </Link>
+    );
+  }
+  if (kind === "rate_limited") {
+    return (
+      <span className="text-xs opacity-80">
+        Wait a moment, then retry. If this persists, check the provider&apos;s quota dashboard.
+      </span>
+    );
+  }
+  if (kind === "provider_unavailable") {
+    return (
+      <span className="text-xs opacity-80">
+        Network or upstream issue — retry shortly. If it persists, check the provider&apos;s status page.
+      </span>
+    );
+  }
+  return null;
+}

--- a/dashboard/src/lib/agent-errors/classify.test.ts
+++ b/dashboard/src/lib/agent-errors/classify.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyAgentError,
+  summariseAgentError,
+} from "./classify";
+
+describe("classifyAgentError", () => {
+  describe("invalid_credential", () => {
+    it("identifies Gemini API_KEY_INVALID even when wrapped in 429 RESOURCE_EXHAUSTED", () => {
+      // Real string from the issue #1037 audit. Gemini sometimes
+      // returns 429 RESOURCE_EXHAUSTED for invalid keys; the auth
+      // marker MUST win or the user is told "wait for quota".
+      const raw = `provider stream failed: failed to send request: API request to generativelanguage.googleapis.com failed with status 429: [{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED","details":[{"reason":"API_KEY_INVALID"}]}}]`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("invalid_credential");
+      expect(info.provider).toBe("gemini");
+    });
+
+    it("identifies Gemini status 400 + API key not valid", () => {
+      const raw = `API request to generativelanguage.googleapis.com failed with status 400: API key not valid. Please pass a valid API key.`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("invalid_credential");
+      expect(info.provider).toBe("gemini");
+    });
+
+    it("identifies OpenAI invalid_api_key", () => {
+      const raw = `openai 401 unauthorized: {"error":{"message":"Incorrect API key provided","type":"invalid_request_error","code":"invalid_api_key"}}`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("invalid_credential");
+      expect(info.provider).toBe("openai");
+    });
+
+    it("identifies Anthropic authentication_error", () => {
+      const raw = `anthropic api error: {"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("invalid_credential");
+      expect(info.provider).toBe("claude");
+    });
+
+    it("identifies the operator's PlaceholderCredential marker", () => {
+      // From #1037 part 1 — operator surfaces this as a Provider
+      // condition, but it can also reach the runtime when the
+      // pre-flight check is skipped. The classifier picks it up.
+      const raw = `secret gemini-credentials contains a placeholder value (matches dev-sample marker like 'replace-with-real-key'); replace with a real key`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("invalid_credential");
+    });
+
+    it("treats bare 401/403 as invalid_credential when an API URL is in the message", () => {
+      const raw = `request to https://api.openai.com/v1/chat/completions returned status: 401`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("invalid_credential");
+      expect(info.provider).toBe("openai");
+    });
+  });
+
+  describe("rate_limited", () => {
+    it("identifies a generic 429 rate-limit", () => {
+      // Plain rate limit, no INVALID_API_KEY marker.
+      const raw = `provider stream failed: status 429: rate limited, retry after 30s`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("rate_limited");
+    });
+
+    it("identifies 'too many requests'", () => {
+      const raw = `429 Too Many Requests`;
+      expect(classifyAgentError(raw).kind).toBe("rate_limited");
+    });
+  });
+
+  describe("provider_unavailable", () => {
+    it("identifies DNS failures", () => {
+      const raw = `dial tcp: lookup api.openai.com on 10.96.0.10:53: no such host`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("provider_unavailable");
+      expect(info.provider).toBe("openai");
+    });
+
+    it("identifies connection-refused", () => {
+      const raw = `dial tcp 1.2.3.4:443: connection refused`;
+      expect(classifyAgentError(raw).kind).toBe("provider_unavailable");
+    });
+
+    it("identifies provider 5xx", () => {
+      const raw = `api.anthropic.com returned status: 503 service unavailable`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("provider_unavailable");
+      expect(info.provider).toBe("claude");
+    });
+  });
+
+  describe("unknown", () => {
+    it("falls through for messages without known markers", () => {
+      const raw = `something completely random happened in the runtime`;
+      const info = classifyAgentError(raw);
+      expect(info.kind).toBe("unknown");
+      expect(info.raw).toBe(raw);
+    });
+
+    it("returns unknown with empty raw for empty input", () => {
+      expect(classifyAgentError("").kind).toBe("unknown");
+    });
+  });
+});
+
+describe("summariseAgentError", () => {
+  it("includes provider label when known", () => {
+    const summary = summariseAgentError({
+      kind: "invalid_credential",
+      provider: "gemini",
+      raw: "...",
+    });
+    expect(summary).toContain("(gemini)");
+    expect(summary).toContain("authentication failed");
+  });
+
+  it("omits provider label when unknown", () => {
+    const summary = summariseAgentError({
+      kind: "invalid_credential",
+      raw: "...",
+    });
+    expect(summary).not.toContain("()");
+    expect(summary).toContain("authentication failed");
+  });
+
+  it("returns raw text for kind=unknown", () => {
+    const raw = "weird unparseable error";
+    const summary = summariseAgentError({ kind: "unknown", raw });
+    expect(summary).toBe(raw);
+  });
+});

--- a/dashboard/src/lib/agent-errors/classify.ts
+++ b/dashboard/src/lib/agent-errors/classify.ts
@@ -1,0 +1,148 @@
+/**
+ * Classifies error strings emitted by the agent runtime into structured
+ * categories the UI can render actionably.
+ *
+ * Issue #1037 part 2. Pre-this, an authentication failure surfaced as a
+ * raw stack trace in the chat banner — operators saw 400 lines of Go
+ * runtime detail and had no signal pointing them at "your API key is
+ * invalid; check the provider." Even worse, Google's Gemini API
+ * returns 429 for some invalid-key scenarios, sending diagnostics down
+ * a quota-exhaustion rabbit hole.
+ *
+ * The classifier is INTENTIONALLY conservative — when a string doesn't
+ * match a known pattern it falls through to "unknown" and the existing
+ * raw-text banner renders. False positives (claiming "auth failed"
+ * when it's really a network blip) are worse than false negatives.
+ */
+
+/** Structured error classification. */
+export interface AgentErrorInfo {
+  /** The error category. "unknown" preserves existing raw-text behaviour. */
+  kind: AgentErrorKind;
+  /** Best-guess provider name when identifiable from the error text. */
+  provider?: KnownProvider;
+  /**
+   * The raw error string that was classified. Always the input, returned
+   * verbatim so the UI can show it in a "details" disclosure even when
+   * a structured banner is shown above.
+   */
+  raw: string;
+}
+
+export type AgentErrorKind =
+  | "invalid_credential"
+  | "rate_limited"
+  | "provider_unavailable"
+  | "unknown";
+
+export type KnownProvider = "gemini" | "openai" | "claude";
+
+/**
+ * Provider markers — substrings that identify which LLM provider the
+ * error came from. Order matters when multiple could match (we hit
+ * the first); each provider's string is distinctive enough that
+ * collisions don't happen in practice.
+ */
+const providerMarkers: ReadonlyArray<{ marker: RegExp; provider: KnownProvider }> = [
+  { marker: /generativelanguage\.googleapis\.com|gemini/i, provider: "gemini" },
+  { marker: /api\.openai\.com|openai/i, provider: "openai" },
+  { marker: /api\.anthropic\.com|anthropic|claude/i, provider: "claude" },
+];
+
+/**
+ * Auth-class markers — patterns that identify "this is a credential
+ * problem, not a transient network issue." Drawn from the actual
+ * provider error strings hit during the issue #1037 audit:
+ *   Gemini: "API_KEY_INVALID", "API key not valid"
+ *   OpenAI: "invalid_api_key", "Incorrect API key"
+ *   Anthropic: "authentication_error", "invalid x-api-key"
+ *   Generic HTTP: "401" / "403" with an API URL nearby
+ */
+const invalidCredentialMarkers: RegExp[] = [
+  /API_KEY_INVALID/,
+  /api key not valid/i,
+  /invalid_api_key/,
+  /incorrect api key/i,
+  /authentication_error/,
+  /invalid x-api-key/i,
+  /\bunauthorized\b/i,
+  /\bforbidden\b/i,
+  /status\s*[:=]\s*401\b/i,
+  /status\s*[:=]\s*403\b/i,
+  /\bplaceholder\b/i, // operator's PlaceholderCredential condition (#1037 part 1)
+];
+
+const rateLimitMarkers: RegExp[] = [
+  /\brate.?limit/i,
+  /resource_exhausted/i,
+  /\btoo many requests\b/i,
+  /status\s*[:=]\s*429\b/i,
+  // Note: Gemini returns 429 RESOURCE_EXHAUSTED for SOME invalid-key
+  // cases, so we leave a guard in classifyAgentError to demote
+  // RESOURCE_EXHAUSTED to invalid_credential when an INVALID_API_KEY
+  // marker also appears in the same string.
+];
+
+const providerUnavailableMarkers: RegExp[] = [
+  /no such host/i,
+  /connection refused/i,
+  /context deadline exceeded/i,
+  /timeout/i,
+  /status\s*[:=]\s*5\d{2}\b/i,
+];
+
+/**
+ * Classifies an error string from the agent. Returns "unknown" for
+ * strings that don't match any known pattern — callers should keep
+ * showing the raw message in that case.
+ */
+export function classifyAgentError(raw: string): AgentErrorInfo {
+  if (!raw) {
+    return { kind: "unknown", raw: "" };
+  }
+
+  const provider = detectProvider(raw);
+
+  // Invalid-credential check FIRST: a string that mentions both
+  // INVALID_API_KEY and 429 RESOURCE_EXHAUSTED is the Gemini "I
+  // returned 429 for an invalid key" failure mode — don't classify
+  // it as rate-limited.
+  if (invalidCredentialMarkers.some((re) => re.test(raw))) {
+    return { kind: "invalid_credential", provider, raw };
+  }
+
+  if (rateLimitMarkers.some((re) => re.test(raw))) {
+    return { kind: "rate_limited", provider, raw };
+  }
+
+  if (providerUnavailableMarkers.some((re) => re.test(raw))) {
+    return { kind: "provider_unavailable", provider, raw };
+  }
+
+  return { kind: "unknown", provider, raw };
+}
+
+function detectProvider(raw: string): KnownProvider | undefined {
+  for (const { marker, provider } of providerMarkers) {
+    if (marker.test(raw)) return provider;
+  }
+  return undefined;
+}
+
+/**
+ * Human-readable summary line for a classified error. Used as the
+ * banner headline; the raw text remains available below in details.
+ */
+export function summariseAgentError(info: AgentErrorInfo): string {
+  const providerLabel = info.provider ? ` (${info.provider})` : "";
+  switch (info.kind) {
+    case "invalid_credential":
+      return `Provider authentication failed${providerLabel}. The API key looks invalid or expired.`;
+    case "rate_limited":
+      return `Provider rate limit hit${providerLabel}. Wait a moment or check the quota.`;
+    case "provider_unavailable":
+      return `Provider unreachable${providerLabel}. Network error or service outage.`;
+    case "unknown":
+      return info.raw;
+  }
+}


### PR DESCRIPTION
## Summary

Item 2 from issue #1037's prevention plan. Pre-this, the agent console rendered every runtime error as a single plain-text red bar. Operators couldn't tell **"your API key is invalid"** apart from **"the network blipped"** apart from **"the LLM provider is down"** — we lost an hour during the #1035 audit chasing a quota-exhaustion red herring when Gemini was actually returning 429 for an `INVALID_API_KEY`.

## Three pieces

### 1. `dashboard/src/lib/agent-errors/classify.ts`

`classifyAgentError(raw)` returns:
```ts
{
  kind: "invalid_credential" | "rate_limited" | "provider_unavailable" | "unknown",
  provider?: "gemini" | "openai" | "claude",
  raw: string,
}
```

Conservative substring/regex matchers; `"unknown"` preserves the legacy plain-text path. **Critically:** when both `INVALID_API_KEY` and `429 RESOURCE_EXHAUSTED` appear in the same string (Gemini's misleading auth-failure mode), the auth marker wins.

### 2. `dashboard/src/components/console/agent-error-banner.tsx`

`AgentErrorBanner` renders a structured headline + action affordance:

| Kind | Action |
|---|---|
| `invalid_credential` | "Check provider →" link to `/providers/<provider>-provider?namespace=<ws>` (or `/providers` when provider unknown) |
| `rate_limited` | Neutral guidance text |
| `provider_unavailable` | Retry guidance text |
| `unknown` | Falls back to the legacy raw-text bar |

Raw error text remains available behind a "Show details" disclosure so the diagnostic surface doesn't shrink.

### 3. `dashboard/src/components/console/agent-console.tsx`

Replaces the inline `{error && <div>{error}</div>}` block with `<AgentErrorBanner error={error} workspace={namespace} />`.

## Tests

- 16 cases for `classifyAgentError` covering every documented failure mode from the issue, including the Gemini 429-for-invalid-key edge case
- 6 cases for the banner component covering legacy fallback, provider-link routing, `/providers` fallback when provider unknown, raw-text disclosure toggle, and the neutral-guidance paths

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (warnings only, all pre-existing)
- [x] `npx vitest run src/lib/agent-errors src/components/console/agent-error-banner` — 22 tests pass
- [x] Per-file coverage `src/lib/agent-errors/classify.ts: 100%`

## Related

- #1037 part 1 (controller-side placeholder detection) ships as **#1044**
- #1037 part 3 (active credential validation via `models.list`) ships separately
