### PR TITLE
feat(controller): active credential validation (#1037 part 3)

### DIFF
--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -44,6 +45,7 @@ import (
 const (
 	ProviderConditionTypeSecretFound          = "SecretFound"
 	ProviderConditionTypeCredentialConfigured = "CredentialConfigured"
+	ProviderConditionTypeCredentialValid      = "CredentialValid"
 	ProviderConditionTypeAuthConfigured       = "AuthConfigured"
 	ProviderConditionTypeEndpointReachable    = "EndpointReachable"
 	// secretKeyAPIKey is the common secret key name for API keys.
@@ -77,6 +79,12 @@ type ProviderReconciler struct {
 	Scheme     *runtime.Scheme
 	Recorder   record.EventRecorder
 	HTTPClient *http.Client // used for provider health checks; defaults to a 5s-timeout client
+	// CredentialValidatorFactory builds a Validator for a given Provider.
+	// Default is validatorForProvider; tests override it to inject a fake.
+	// Returning nil means "validation not supported for this provider type".
+	CredentialValidatorFactory func(*omniav1alpha1.Provider, *http.Client) CredentialValidator
+	// validationCache memoises Validate results across reconciles.
+	validationCache *credentialValidationCache
 }
 
 // +kubebuilder:rbac:groups=omnia.altairalabs.ai,resources=providers,verbs=get;list;watch;create;update;patch;delete
@@ -281,54 +289,32 @@ func (r *ProviderReconciler) validateCredentialSecretRef(ctx context.Context, pr
 		return fmt.Errorf("%s", msg)
 	}
 
-	// Check for expected key if specified, capturing the value so we
-	// can also check for placeholders (issue #1037: dev-sample
-	// secrets like "sk-demo-key-replace-with-real-key" pass the
-	// presence check but break at chat-time with INVALID_API_KEY).
-	var matchedValue []byte
-	if ref.Key != nil {
-		expectedKey := *ref.Key
-		v, exists := secret.Data[expectedKey]
-		if !exists {
-			msg := fmt.Sprintf(errFmtSecretMissingKey, key.Name, expectedKey)
-			SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeSecretFound, metav1.ConditionFalse,
-				"SecretKeyMissing", msg)
-			SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionFalse,
-				"SecretKeyMissing", msg)
-			provider.Status.Phase = omniav1alpha1.ProviderPhaseError
-			return fmt.Errorf("%s", msg)
-		}
-		matchedValue = v
-	} else {
-		// Check for provider-appropriate key
-		expectedKeys := getExpectedKeysForProvider(provider.Spec.Type)
-		for _, k := range expectedKeys {
-			if v, exists := secret.Data[k]; exists {
-				matchedValue = v
-				break
-			}
-		}
-		if matchedValue == nil {
-			msg := fmt.Sprintf(errFmtSecretMissingAnyKey, key.Name, expectedKeys)
-			SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeSecretFound, metav1.ConditionFalse,
-				"SecretKeyMissing", msg)
-			SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionFalse,
-				"SecretKeyMissing", msg)
-			provider.Status.Phase = omniav1alpha1.ProviderPhaseError
-			return fmt.Errorf("%s", msg)
-		}
+	// Locate the credential value within the secret. Either the explicit key
+	// (when ref.Key is set) or the first matching provider-default key.
+	credValue, foundKey, err := extractCredentialFromSecret(secret, ref, provider.Spec.Type)
+	if err != nil {
+		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeSecretFound, metav1.ConditionFalse,
+			"SecretKeyMissing", err.Error())
+		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionFalse,
+			"SecretKeyMissing", err.Error())
+		provider.Status.Phase = omniav1alpha1.ProviderPhaseError
+		return err
 	}
 
 	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeSecretFound, metav1.ConditionTrue,
 		"SecretFound", "Referenced secret exists")
 
-	// Placeholder detection: catch dev-sample values that pass the
-	// presence check but would fail at chat-time. Phase stays Ready
-	// — the secret IS configured, just with a value the operator
+	// Placeholder detection (#1037 part 1): catch dev-sample values that
+	// pass the presence check but would fail at chat-time. Phase stays
+	// Ready — the secret IS configured, just with a value the operator
 	// almost certainly forgot to replace. CredentialConfigured flips
 	// False so the dashboard can surface "key looks like a placeholder"
 	// instead of waiting for INVALID_API_KEY at the first message.
-	if IsPlaceholderCredential(string(matchedValue)) {
+	// We short-circuit before runCredentialValidation: a placeholder
+	// can't be valid, and we'd rather not spend a probe round-trip
+	// (and a CredentialRejected condition that masks the real reason)
+	// on a string we already know is a stub.
+	if IsPlaceholderCredential(string(credValue)) {
 		msg := fmt.Sprintf("secret %s contains a placeholder value (matches dev-sample marker like 'replace-with-real-key'); replace with a real key", key.Name)
 		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionFalse,
 			"PlaceholderCredential", msg)
@@ -341,7 +327,88 @@ func (r *ProviderReconciler) validateCredentialSecretRef(ctx context.Context, pr
 
 	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionTrue,
 		"SecretFound", "Credential configured via secret reference")
+
+	r.runCredentialValidation(ctx, provider, secret, foundKey, credValue)
 	return nil
+}
+
+// extractCredentialFromSecret returns the credential value bytes from the
+// secret, the key it was found under, or an error suitable for use as a
+// SecretKeyMissing condition message.
+func extractCredentialFromSecret(secret *corev1.Secret, ref *omniav1alpha1.SecretKeyRef, providerType omniav1alpha1.ProviderType) ([]byte, string, error) {
+	if ref.Key != nil {
+		expectedKey := *ref.Key
+		v, exists := secret.Data[expectedKey]
+		if !exists {
+			return nil, "", fmt.Errorf(errFmtSecretMissingKey, ref.Name, expectedKey)
+		}
+		return v, expectedKey, nil
+	}
+	expectedKeys := getExpectedKeysForProvider(providerType)
+	for _, k := range expectedKeys {
+		if v, exists := secret.Data[k]; exists {
+			return v, k, nil
+		}
+	}
+	return nil, "", fmt.Errorf(errFmtSecretMissingAnyKey, ref.Name, expectedKeys)
+}
+
+// runCredentialValidation hits the provider with the supplied credential and
+// records the outcome on CredentialValid. Errors are non-fatal — a network
+// failure or 5xx leaves the condition Unknown so we don't trip False on a
+// transient problem (false positives are worse than no signal).
+func (r *ProviderReconciler) runCredentialValidation(ctx context.Context, provider *omniav1alpha1.Provider, secret *corev1.Secret, secretKey string, credValue []byte) {
+	log := logf.FromContext(ctx)
+	factory := r.CredentialValidatorFactory
+	if factory == nil {
+		factory = validatorForProvider
+	}
+	validator := factory(provider, r.HTTPClient)
+	if validator == nil {
+		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialValid, metav1.ConditionUnknown,
+			"ValidationNotSupported",
+			"No probe defined for this provider type — credential cannot be pre-flight validated")
+		return
+	}
+
+	if r.validationCache == nil {
+		r.validationCache = newCredentialValidationCache()
+	}
+	cacheKey := validationCacheKey(provider.Namespace, provider.Name, secret.Name, secret.ResourceVersion)
+	if cachedErr, hit := r.validationCache.get(cacheKey); hit {
+		applyCredentialValidationResult(provider, cachedErr, "cached")
+		return
+	}
+
+	probeErr := validator.Validate(ctx, string(credValue))
+	r.validationCache.put(cacheKey, probeErr)
+	applyCredentialValidationResult(provider, probeErr, "probe")
+	if probeErr != nil {
+		log.V(1).Info("credential validation outcome",
+			"provider", provider.Name,
+			"namespace", provider.Namespace,
+			"secretKey", secretKey,
+			"err", probeErr.Error())
+	}
+}
+
+// applyCredentialValidationResult sets CredentialValid based on the probe outcome.
+// nil → True, ErrCredentialInvalid → False, anything else → Unknown.
+func applyCredentialValidationResult(provider *omniav1alpha1.Provider, probeErr error, source string) {
+	switch {
+	case probeErr == nil:
+		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialValid, metav1.ConditionTrue,
+			"CredentialAccepted",
+			fmt.Sprintf("Provider accepted the credential (%s)", source))
+	case errors.Is(probeErr, ErrCredentialInvalid):
+		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialValid, metav1.ConditionFalse,
+			"CredentialRejected",
+			fmt.Sprintf("Provider rejected the credential (%s) — rotate or replace the secret", source))
+	default:
+		SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialValid, metav1.ConditionUnknown,
+			"CredentialValidationError",
+			fmt.Sprintf("Could not validate credential (%s): %s", source, probeErr.Error()))
+	}
 }
 
 // validateCredentialEnvVar validates an environment variable name.
@@ -359,6 +426,9 @@ func (r *ProviderReconciler) validateCredentialEnvVar(provider *omniav1alpha1.Pr
 		"NoSecretRequired", "Credential uses environment variable, no secret required")
 	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionTrue,
 		"EnvVarConfigured", fmt.Sprintf("Credential configured via environment variable %q", envVar))
+	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialValid, metav1.ConditionUnknown,
+		"ValidationNotSupported",
+		"Credential supplied via env var — value is not visible to the operator and cannot be pre-flight validated")
 	return nil
 }
 
@@ -387,6 +457,9 @@ func (r *ProviderReconciler) validateCredentialFilePath(provider *omniav1alpha1.
 		"NoSecretRequired", "Credential uses file path, no secret required")
 	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialConfigured, metav1.ConditionTrue,
 		"FilePathConfigured", fmt.Sprintf("Credential configured via file path %q", path))
+	SetCondition(&provider.Status.Conditions, provider.Generation, ProviderConditionTypeCredentialValid, metav1.ConditionUnknown,
+		"ValidationNotSupported",
+		"Credential supplied via file path — value is not visible to the operator and cannot be pre-flight validated")
 	return nil
 }
 

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -36,6 +37,20 @@ import (
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// fakeCredentialValidator lets tests inject deterministic Validate outcomes.
+// onValidate runs first when set; otherwise the static err is returned.
+type fakeCredentialValidator struct {
+	err        error
+	onValidate func() error
+}
+
+func (f fakeCredentialValidator) Validate(_ context.Context, _ string) error {
+	if f.onValidate != nil {
+		return f.onValidate()
+	}
+	return f.err
+}
 
 // alwaysHealthyClient returns an HTTP client that responds 200 to every request.
 // This prevents envtest reconciler tests from hitting real provider endpoints.
@@ -1596,6 +1611,140 @@ var _ = Describe("Provider Controller", func() {
 			Expect(credCondition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(credCondition.Reason).To(Equal("SecretKeyMissing"))
 			Expect(provider.Status.Phase).To(Equal(omniav1alpha1.ProviderPhaseError))
+		})
+	})
+
+	Context("credential validation outcome", func() {
+		var (
+			ctx    context.Context
+			secret *corev1.Secret
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "validate-creds-secret",
+					Namespace: "default",
+				},
+				Data: map[string][]byte{
+					"ANTHROPIC_API_KEY": []byte("probe-credential"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, secret)
+		})
+
+		newProvider := func(name string) *omniav1alpha1.Provider {
+			return &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:  omniav1alpha1.ProviderTypeClaude,
+					Model: "claude-sonnet-4-20250514",
+				},
+			}
+		}
+
+		findValidCondition := func(p *omniav1alpha1.Provider) *metav1.Condition {
+			for i := range p.Status.Conditions {
+				if p.Status.Conditions[i].Type == ProviderConditionTypeCredentialValid {
+					return &p.Status.Conditions[i]
+				}
+			}
+			return nil
+		}
+
+		It("sets CredentialValid=True when validator returns nil", func() {
+			provider := newProvider("cred-valid-true")
+			reconciler := &ProviderReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				CredentialValidatorFactory: func(_ *omniav1alpha1.Provider, _ *http.Client) CredentialValidator {
+					return fakeCredentialValidator{err: nil}
+				},
+			}
+			ref := &omniav1alpha1.SecretKeyRef{Name: "validate-creds-secret"}
+			Expect(reconciler.validateCredentialSecretRef(ctx, provider, ref)).To(Succeed())
+
+			cond := findValidCondition(provider)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal("CredentialAccepted"))
+		})
+
+		It("sets CredentialValid=False when validator returns ErrCredentialInvalid", func() {
+			provider := newProvider("cred-valid-false")
+			reconciler := &ProviderReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				CredentialValidatorFactory: func(_ *omniav1alpha1.Provider, _ *http.Client) CredentialValidator {
+					return fakeCredentialValidator{err: ErrCredentialInvalid}
+				},
+			}
+			ref := &omniav1alpha1.SecretKeyRef{Name: "validate-creds-secret"}
+			Expect(reconciler.validateCredentialSecretRef(ctx, provider, ref)).To(Succeed())
+
+			cond := findValidCondition(provider)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(cond.Reason).To(Equal("CredentialRejected"))
+		})
+
+		It("sets CredentialValid=Unknown when validator returns a non-sentinel error", func() {
+			provider := newProvider("cred-valid-unknown")
+			reconciler := &ProviderReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				CredentialValidatorFactory: func(_ *omniav1alpha1.Provider, _ *http.Client) CredentialValidator {
+					return fakeCredentialValidator{err: errors.New("connection refused")}
+				},
+			}
+			ref := &omniav1alpha1.SecretKeyRef{Name: "validate-creds-secret"}
+			Expect(reconciler.validateCredentialSecretRef(ctx, provider, ref)).To(Succeed())
+
+			cond := findValidCondition(provider)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal("CredentialValidationError"))
+		})
+
+		It("sets CredentialValid=Unknown when no validator exists for the provider type", func() {
+			provider := newProvider("cred-valid-none")
+			reconciler := &ProviderReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				CredentialValidatorFactory: func(_ *omniav1alpha1.Provider, _ *http.Client) CredentialValidator {
+					return nil
+				},
+			}
+			ref := &omniav1alpha1.SecretKeyRef{Name: "validate-creds-secret"}
+			Expect(reconciler.validateCredentialSecretRef(ctx, provider, ref)).To(Succeed())
+
+			cond := findValidCondition(provider)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionUnknown))
+			Expect(cond.Reason).To(Equal("ValidationNotSupported"))
+		})
+
+		It("reuses cached results across reconciles for the same secret resourceVersion", func() {
+			provider := newProvider("cred-valid-cached")
+			calls := 0
+			reconciler := &ProviderReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+				CredentialValidatorFactory: func(_ *omniav1alpha1.Provider, _ *http.Client) CredentialValidator {
+					return fakeCredentialValidator{
+						onValidate: func() error { calls++; return nil },
+					}
+				},
+			}
+			ref := &omniav1alpha1.SecretKeyRef{Name: "validate-creds-secret"}
+			Expect(reconciler.validateCredentialSecretRef(ctx, provider, ref)).To(Succeed())
+			Expect(reconciler.validateCredentialSecretRef(ctx, provider, ref)).To(Succeed())
+			Expect(calls).To(Equal(1), "second reconcile should hit cache")
 		})
 	})
 

--- a/internal/controller/provider_credential_validation.go
+++ b/internal/controller/provider_credential_validation.go
@@ -1,0 +1,287 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+// CredentialValidator runs an authenticated probe against a provider
+// to verify that a credential is actually accepted, not just present.
+//
+// Issue #1037 part 3. The CredentialConfigured condition only proves
+// "we found a value in the secret"; #1037 part 1 added the
+// PlaceholderCredential check for known dev-sample markers, but a
+// typo, a revoked key, or a key for the wrong account still slips
+// through. The validator hits the cheapest authenticated endpoint each
+// provider exposes (typically a models-list call) and surfaces the
+// outcome via the CredentialValid Provider status condition. Pre-flight
+// surfaces "your key is wrong" instead of "the agent crashed
+// mid-conversation with INVALID_API_KEY."
+//
+// Implementations MUST be safe to call concurrently — the controller
+// reconciles Providers in parallel and may probe several at once.
+type CredentialValidator interface {
+	// Validate returns nil when the credential is accepted by the
+	// provider. ErrCredentialInvalid wraps "the provider rejected
+	// this key" (401/403/400-with-API_KEY_INVALID-shaped); other
+	// errors mean we couldn't tell (network, 5xx, timeout) and the
+	// caller leaves CredentialValid as Unknown rather than False —
+	// false positives are worse than no signal.
+	Validate(ctx context.Context, credential string) error
+}
+
+// ErrCredentialInvalid sentinels a "provider rejected this credential"
+// outcome. Other errors from a Validator mean "we couldn't tell" and
+// the controller leaves the condition Unknown rather than False.
+var ErrCredentialInvalid = errors.New("credential rejected by provider")
+
+// validatorTimeout caps the per-probe HTTP call. The validator runs
+// during Provider reconcile so a hung provider should not block the
+// reconciler indefinitely.
+const validatorTimeout = 10 * time.Second
+
+// validatorCacheTTL bounds how long a validation result is reused.
+// Cache keys include the Secret resourceVersion so a key rotation
+// invalidates immediately; the TTL only matters for "the provider
+// changed its mind" (key revoked outside k8s, account suspended).
+const validatorCacheTTL = 30 * time.Minute
+
+// httpCredentialValidator probes a provider via an HTTP GET.
+// addAuth prepares the request — different providers carry the
+// credential in different headers.
+type httpCredentialValidator struct {
+	url     string
+	addAuth func(req *http.Request, credential string)
+	client  *http.Client
+}
+
+// Validate sends the probe and classifies the response. 401/403 → invalid;
+// 200 → valid; everything else → "couldn't tell" so we don't trip
+// CredentialValid=False on a transient 5xx.
+func (v *httpCredentialValidator) Validate(ctx context.Context, credential string) error {
+	if credential == "" {
+		return ErrCredentialInvalid
+	}
+	probeCtx, cancel := context.WithTimeout(ctx, validatorTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(probeCtx, http.MethodGet, v.url, nil)
+	if err != nil {
+		return fmt.Errorf("build credential-validation request: %w", err)
+	}
+	v.addAuth(req, credential)
+
+	client := v.client
+	if client == nil {
+		client = &http.Client{Timeout: validatorTimeout}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("credential-validation HTTP error: %w", err)
+	}
+	defer func() {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	switch {
+	case resp.StatusCode >= 200 && resp.StatusCode < 300:
+		return nil
+	case resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden:
+		return ErrCredentialInvalid
+	case resp.StatusCode == http.StatusBadRequest:
+		// Some providers (Gemini in particular) return 400 with an
+		// API_KEY_INVALID body for bad keys instead of 401. Read a
+		// bounded amount of the body and look for the marker; if
+		// it's absent we treat the 400 as "something else went
+		// wrong" and leave the condition Unknown.
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4*1024))
+		if containsAuthFailureMarker(body) {
+			return ErrCredentialInvalid
+		}
+		return fmt.Errorf("credential-validation 400 from provider: %s", truncate(string(body), 200))
+	default:
+		return fmt.Errorf("credential-validation unexpected status %d", resp.StatusCode)
+	}
+}
+
+// authFailureMarkers are body substrings that confirm a non-2xx is an
+// auth failure rather than something else.
+var authFailureMarkers = [][]byte{
+	[]byte("API_KEY_INVALID"),
+	[]byte("api key not valid"),
+	[]byte("invalid_api_key"),
+	[]byte("authentication_error"),
+}
+
+func containsAuthFailureMarker(body []byte) bool {
+	for _, m := range authFailureMarkers {
+		if containsCaseInsensitive(body, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// truncate caps a string at n runes, appending "…" when cut.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+// containsCaseInsensitive does a case-insensitive substring scan
+// without allocating a fresh lowercased copy of the body — bytes.Contains
+// is case-sensitive, and providers don't agree on case.
+func containsCaseInsensitive(haystack, needle []byte) bool {
+	if len(needle) == 0 || len(haystack) < len(needle) {
+		return len(needle) == 0
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		match := true
+		for j := 0; j < len(needle); j++ {
+			h, n := haystack[i+j], needle[j]
+			if h >= 'A' && h <= 'Z' {
+				h += 'a' - 'A'
+			}
+			if n >= 'A' && n <= 'Z' {
+				n += 'a' - 'A'
+			}
+			if h != n {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// validatorForProvider returns a Validator for the given provider type
+// or nil when validation isn't supported (mock, platform-hosted via
+// cloud SDK auth, ollama with no auth, vllm self-hosted).
+//
+// Returning nil is the documented "skip" signal — the controller
+// leaves CredentialValid as Unknown when no validator exists.
+func validatorForProvider(p *omniav1alpha1.Provider, client *http.Client) CredentialValidator {
+	if isPlatformHosted(p) {
+		// Platform-hosted (vertex, bedrock, azure) authenticate via
+		// the cloud SDK's credential chain — no API-key probe applies.
+		return nil
+	}
+	switch p.Spec.Type {
+	case omniav1alpha1.ProviderTypeOpenAI:
+		return &httpCredentialValidator{
+			url:     resolveProviderBaseURL(p) + "/v1/models",
+			addAuth: func(req *http.Request, c string) { req.Header.Set("Authorization", "Bearer "+c) },
+			client:  client,
+		}
+	case omniav1alpha1.ProviderTypeClaude:
+		return &httpCredentialValidator{
+			url: resolveProviderBaseURL(p) + "/v1/models",
+			addAuth: func(req *http.Request, c string) {
+				req.Header.Set("x-api-key", c)
+				req.Header.Set("anthropic-version", "2023-06-01")
+			},
+			client: client,
+		}
+	case omniav1alpha1.ProviderTypeGemini:
+		return &httpCredentialValidator{
+			url:     resolveProviderBaseURL(p) + "/v1beta/models",
+			addAuth: func(req *http.Request, c string) { req.Header.Set("x-goog-api-key", c) },
+			client:  client,
+		}
+	default:
+		return nil
+	}
+}
+
+// resolveProviderBaseURL returns the base URL the validator should
+// hit. Honors Provider.spec.baseURL (for proxies / OpenRouter) and
+// falls back to the well-known endpoint for the type.
+func resolveProviderBaseURL(p *omniav1alpha1.Provider) string {
+	if p.Spec.BaseURL != "" {
+		return p.Spec.BaseURL
+	}
+	return defaultProviderEndpoints[p.Spec.Type]
+}
+
+// credentialValidationCache memoises Validate results keyed by
+// (provider namespace, provider name, secret name, secret
+// resourceVersion). Entries expire after validatorCacheTTL; rotating
+// the Secret invalidates immediately because the resourceVersion
+// changes. Concurrent reconciles hit the same cache.
+type credentialValidationCache struct {
+	mu      sync.Mutex
+	entries map[string]credentialValidationEntry
+}
+
+type credentialValidationEntry struct {
+	err      error
+	cachedAt time.Time
+}
+
+// newCredentialValidationCache constructs an empty cache. Tests
+// inject their own; production wires one per ProviderReconciler.
+func newCredentialValidationCache() *credentialValidationCache {
+	return &credentialValidationCache{entries: map[string]credentialValidationEntry{}}
+}
+
+// get returns the cached validation result for the given key when
+// it's still within the TTL window. The bool indicates a hit; the
+// error mirrors what Validate returned (nil for "valid").
+func (c *credentialValidationCache) get(key string) (error, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	e, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if time.Since(e.cachedAt) > validatorCacheTTL {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return e.err, true
+}
+
+// put records the result for the given key with the current time.
+func (c *credentialValidationCache) put(key string, result error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = credentialValidationEntry{err: result, cachedAt: time.Now()}
+}
+
+// validationCacheKey assembles the cache key for a Provider + Secret.
+// Includes the Secret's resourceVersion so any modification (rotation,
+// re-paste, label change) invalidates immediately.
+func validationCacheKey(providerNS, providerName, secretName, secretResourceVersion string) string {
+	return providerNS + "/" + providerName + "|" + secretName + "@" + secretResourceVersion
+}

--- a/internal/controller/provider_credential_validation_test.go
+++ b/internal/controller/provider_credential_validation_test.go
@@ -1,0 +1,409 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+func TestHTTPCredentialValidator_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer good-key" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":[]}`))
+	}))
+	defer srv.Close()
+
+	v := &httpCredentialValidator{
+		url:     srv.URL,
+		addAuth: func(req *http.Request, c string) { req.Header.Set("Authorization", "Bearer "+c) },
+		client:  srv.Client(),
+	}
+	if err := v.Validate(context.Background(), "good-key"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	v := &httpCredentialValidator{
+		url:     srv.URL,
+		addAuth: func(req *http.Request, c string) { req.Header.Set("Authorization", "Bearer "+c) },
+		client:  srv.Client(),
+	}
+	err := v.Validate(context.Background(), "bad-key")
+	if !errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("expected ErrCredentialInvalid, got %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_Forbidden(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "nope", http.StatusForbidden)
+	}))
+	defer srv.Close()
+
+	v := &httpCredentialValidator{
+		url:     srv.URL,
+		addAuth: func(req *http.Request, c string) { req.Header.Set("x-api-key", c) },
+		client:  srv.Client(),
+	}
+	err := v.Validate(context.Background(), "bad-key")
+	if !errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("expected ErrCredentialInvalid, got %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_Gemini400WithMarker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":{"code":400,"message":"API key not valid","status":"INVALID_ARGUMENT","details":[{"reason":"API_KEY_INVALID"}]}}`))
+	}))
+	defer srv.Close()
+
+	v := &httpCredentialValidator{
+		url:     srv.URL,
+		addAuth: func(req *http.Request, c string) { req.Header.Set("x-goog-api-key", c) },
+		client:  srv.Client(),
+	}
+	err := v.Validate(context.Background(), "bad-key")
+	if !errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("expected ErrCredentialInvalid, got %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_400WithoutMarker(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"missing required parameter"}`))
+	}))
+	defer srv.Close()
+
+	v := &httpCredentialValidator{
+		url:     srv.URL,
+		addAuth: func(req *http.Request, c string) { req.Header.Set("x-goog-api-key", c) },
+		client:  srv.Client(),
+	}
+	err := v.Validate(context.Background(), "any-key")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("400 without auth marker must NOT be classified as invalid: %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_500NotInvalid(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	v := &httpCredentialValidator{
+		url:     srv.URL,
+		addAuth: func(req *http.Request, c string) { req.Header.Set("Authorization", "Bearer "+c) },
+		client:  srv.Client(),
+	}
+	err := v.Validate(context.Background(), "key")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("5xx must NOT be classified as invalid: %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_EmptyCredential(t *testing.T) {
+	v := &httpCredentialValidator{
+		url:     "http://unused",
+		addAuth: func(_ *http.Request, _ string) {},
+	}
+	err := v.Validate(context.Background(), "")
+	if !errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("expected ErrCredentialInvalid for empty credential, got %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_NetworkError(t *testing.T) {
+	v := &httpCredentialValidator{
+		url:     "http://127.0.0.1:1", // port 1 reliably refuses connections
+		addAuth: func(req *http.Request, c string) { req.Header.Set("Authorization", "Bearer "+c) },
+		client:  &http.Client{Timeout: 2 * time.Second},
+	}
+	err := v.Validate(context.Background(), "key")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("network error must NOT be classified as invalid: %v", err)
+	}
+}
+
+func TestHTTPCredentialValidator_ContextCancel(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	v := &httpCredentialValidator{
+		url:     srv.URL,
+		addAuth: func(req *http.Request, c string) { req.Header.Set("Authorization", "Bearer "+c) },
+		client:  srv.Client(),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	err := v.Validate(ctx, "key")
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if errors.Is(err, ErrCredentialInvalid) {
+		t.Fatalf("context cancel must NOT be classified as invalid: %v", err)
+	}
+}
+
+func TestValidatorForProvider(t *testing.T) {
+	tests := []struct {
+		name       string
+		provider   *omniav1alpha1.Provider
+		wantNil    bool
+		wantPath   string
+		wantHeader string
+	}{
+		{
+			name: "openai with default base url",
+			provider: &omniav1alpha1.Provider{
+				Spec: omniav1alpha1.ProviderSpec{Type: omniav1alpha1.ProviderTypeOpenAI},
+			},
+			wantPath:   "https://api.openai.com/v1/models",
+			wantHeader: "Authorization",
+		},
+		{
+			name: "claude with default base url",
+			provider: &omniav1alpha1.Provider{
+				Spec: omniav1alpha1.ProviderSpec{Type: omniav1alpha1.ProviderTypeClaude},
+			},
+			wantPath:   "https://api.anthropic.com/v1/models",
+			wantHeader: "x-api-key",
+		},
+		{
+			name: "gemini with default base url",
+			provider: &omniav1alpha1.Provider{
+				Spec: omniav1alpha1.ProviderSpec{Type: omniav1alpha1.ProviderTypeGemini},
+			},
+			wantPath:   "https://generativelanguage.googleapis.com/v1beta/models",
+			wantHeader: "x-goog-api-key",
+		},
+		{
+			name: "openai with custom base url",
+			provider: &omniav1alpha1.Provider{
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:    omniav1alpha1.ProviderTypeOpenAI,
+					BaseURL: "https://openrouter.ai/api",
+				},
+			},
+			wantPath:   "https://openrouter.ai/api/v1/models",
+			wantHeader: "Authorization",
+		},
+		{
+			name: "ollama returns nil (no auth)",
+			provider: &omniav1alpha1.Provider{
+				Spec: omniav1alpha1.ProviderSpec{Type: omniav1alpha1.ProviderTypeOllama},
+			},
+			wantNil: true,
+		},
+		{
+			name: "mock returns nil",
+			provider: &omniav1alpha1.Provider{
+				Spec: omniav1alpha1.ProviderSpec{Type: omniav1alpha1.ProviderTypeMock},
+			},
+			wantNil: true,
+		},
+		{
+			name: "platform-hosted returns nil",
+			provider: &omniav1alpha1.Provider{
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:     omniav1alpha1.ProviderTypeClaude,
+					Platform: &omniav1alpha1.PlatformConfig{Type: omniav1alpha1.PlatformTypeBedrock},
+				},
+			},
+			wantNil: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := validatorForProvider(tt.provider, nil)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("expected nil, got %#v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("expected non-nil validator")
+			}
+			httpV, ok := got.(*httpCredentialValidator)
+			if !ok {
+				t.Fatalf("expected *httpCredentialValidator, got %T", got)
+			}
+			if httpV.url != tt.wantPath {
+				t.Errorf("url: want %q, got %q", tt.wantPath, httpV.url)
+			}
+			req, _ := http.NewRequestWithContext(context.Background(), http.MethodGet, "http://x", nil)
+			httpV.addAuth(req, "test-cred")
+			if req.Header.Get(tt.wantHeader) == "" {
+				t.Errorf("expected %q header to be set", tt.wantHeader)
+			}
+		})
+	}
+}
+
+func TestCredentialValidationCache_HitAndMiss(t *testing.T) {
+	c := newCredentialValidationCache()
+	key := validationCacheKey("ns", "p", "s", "rv1")
+
+	if _, ok := c.get(key); ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	c.put(key, nil)
+	got, ok := c.get(key)
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if got != nil {
+		t.Fatalf("expected nil error, got %v", got)
+	}
+
+	c.put(key, ErrCredentialInvalid)
+	got, ok = c.get(key)
+	if !ok {
+		t.Fatal("expected hit")
+	}
+	if !errors.Is(got, ErrCredentialInvalid) {
+		t.Fatalf("expected ErrCredentialInvalid, got %v", got)
+	}
+}
+
+func TestCredentialValidationCache_Expiry(t *testing.T) {
+	c := newCredentialValidationCache()
+	key := validationCacheKey("ns", "p", "s", "rv1")
+	c.entries[key] = credentialValidationEntry{
+		err:      nil,
+		cachedAt: time.Now().Add(-2 * validatorCacheTTL),
+	}
+	if _, ok := c.get(key); ok {
+		t.Fatal("expected expired entry to miss")
+	}
+	if _, present := c.entries[key]; present {
+		t.Fatal("expected expired entry to be evicted")
+	}
+}
+
+func TestCredentialValidationCache_KeyIncludesResourceVersion(t *testing.T) {
+	k1 := validationCacheKey("ns", "p", "s", "rv1")
+	k2 := validationCacheKey("ns", "p", "s", "rv2")
+	if k1 == k2 {
+		t.Fatal("cache keys must differ when resourceVersion changes")
+	}
+}
+
+func TestContainsAuthFailureMarker(t *testing.T) {
+	cases := []struct {
+		body string
+		want bool
+	}{
+		{`{"error":{"details":[{"reason":"API_KEY_INVALID"}]}}`, true},
+		{`api key not valid. Please pass a valid API key.`, true},
+		{`{"error":{"type":"authentication_error"}}`, true},
+		{`{"error":{"code":"invalid_api_key"}}`, true},
+		{`{"ERROR":"INVALID_API_KEY"}`, true}, // case-insensitive
+		{`{"error":"missing required parameter"}`, false},
+		{`{}`, false},
+		{``, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.body, func(t *testing.T) {
+			got := containsAuthFailureMarker([]byte(tc.body))
+			if got != tc.want {
+				t.Errorf("containsAuthFailureMarker(%q) = %v, want %v", tc.body, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestContainsCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		hay, needle string
+		want        bool
+	}{
+		{"hello world", "WORLD", true},
+		{"HELLO WORLD", "world", true},
+		{"hello", "hello", true},
+		{"hello", "h", true},
+		{"hello", "x", false},
+		{"hi", "hello", false},
+		{"", "x", false},
+		{"x", "", true},
+	}
+	for _, tc := range cases {
+		got := containsCaseInsensitive([]byte(tc.hay), []byte(tc.needle))
+		if got != tc.want {
+			t.Errorf("containsCaseInsensitive(%q,%q) = %v, want %v", tc.hay, tc.needle, got, tc.want)
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	if got := truncate("short", 100); got != "short" {
+		t.Errorf("truncate short: got %q", got)
+	}
+	got := truncate(strings.Repeat("x", 50), 10)
+	if !strings.HasSuffix(got, "…") {
+		t.Errorf("truncate long: missing ellipsis: %q", got)
+	}
+	if len(got) <= 10 {
+		// "…" is 3 bytes in UTF-8 so total > 10 bytes is fine; just sanity check
+		t.Errorf("truncate long: too short %q", got)
+	}
+}
+
+func TestValidationCacheKey_Format(t *testing.T) {
+	got := validationCacheKey("ns", "prov", "sec", "12345")
+	want := "ns/prov|sec@12345"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the third part of #1037: a Provider whose credential is *present* but *wrong* now surfaces that as a status condition instead of crashing the agent mid-conversation with `INVALID_API_KEY`.

- New `CredentialValid` Provider status condition, set by an HTTP probe against the cheapest authenticated endpoint each provider exposes:
  - **OpenAI** — `GET /v1/models` with `Authorization: Bearer …`
  - **Claude** — `GET /v1/models` with `x-api-key` + `anthropic-version`
  - **Gemini** — `GET /v1beta/models` with `x-goog-api-key` (also detects 400 + `API_KEY_INVALID` body)
- Outcome classification:
  - `True` — provider accepted the credential
  - `False` (`CredentialRejected`) — provider rejected it; rotate the key
  - `Unknown` — couldn't tell (network, 5xx, env-var/file-path credentials, ollama/mock/platform-hosted providers)
- **False positives are worse than no signal**: a transient 5xx leaves the condition `Unknown`, never `False`.
- Results cached per `(provider, secret, secret resourceVersion)` for 30 min; rotating the Secret invalidates immediately because the resourceVersion changes.
- Tests inject a fake validator factory through the new `ProviderReconciler.CredentialValidatorFactory` field — five integration specs cover True / False / Unknown-error / Unknown-no-validator / cache-reuse.

This combines with #1037 part 1 (placeholder detection, #1044) and part 2 (dashboard error banner, #1047) to give end-to-end credential failure visibility from CRD → operator → API → dashboard.

Coverage on new code: `provider_credential_validation.go` 97.4%, `provider_controller.go` 88.8%.

## Test plan

- [x] `go test ./internal/controller/... -count=1` (332 ginkgo specs + 32 unit tests)
- [x] `golangci-lint run ./internal/controller/...`
- [x] Pre-commit hook: build, vet, lint, coverage, generated-code sync
- [ ] CI: full Go test suite + sonar
- [ ] Operator E2E