### PR TITLE
refactor(memory): share recall filter primitives across single-tier and multi-tier (#1038-E)

### DIFF
--- a/internal/memory/retrieve_multi_tier.go
+++ b/internal/memory/retrieve_multi_tier.go
@@ -25,11 +25,11 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/altairalabs/omnia/internal/pgutil"
 )
 
 // Tier identifies which scope layer a memory belongs to in a multi-tier
@@ -249,84 +249,62 @@ func classifyTierFromScope(scope map[string]string) Tier {
 // multi-tier retrieval. It returns an error when WorkspaceID is empty; the
 // candidate LIMIT is a constant (multiTierCandidatePool) independent of the
 // caller's Limit.
+//
+// The query shares filter primitives (type/confidence/FTS/purpose) with
+// single-tier Retrieve via internal/memory/store.go's helpers — a feature
+// added to one path lands in both. Tier-specific NULL-anchoring on
+// virtual_user_id / agent_id stays here because that semantics genuinely
+// differs from single-tier (multi-tier wants institutional rows merged
+// in, single-tier wants strict scope match).
 func buildMultiTierQuery(req MultiTierRequest) (string, []any, error) {
 	if req.WorkspaceID == "" {
 		return "", nil, errors.New(errWorkspaceRequired)
 	}
 
-	args := make([]any, 0, 6)
-	args = append(args, req.WorkspaceID)
-	clauses := []string{
-		"e.workspace_id=$" + strconv.Itoa(len(args)),
-		colEntityForgot,
-	}
+	var qb pgutil.QueryBuilder
+	qb.Add("e.workspace_id=$?", req.WorkspaceID)
+	qb.AddRaw(colEntityForgot)
+	addUserTierClause(&qb, req.UserID)
+	addAgentTierClause(&qb, req.AgentID)
+	addTypeFilters(&qb, req.Types)
+	addConfidenceFilter(&qb, req.MinConfidence)
+	addFTSPredicate(&qb, req.Query)
+	addPurposeFilters(&qb, req.Purposes)
 
-	clauses = append(clauses, userTierClause(req.UserID, &args))
-	clauses = append(clauses, agentTierClause(req.AgentID, &args))
+	sql := fmt.Sprintf(
+		"SELECT DISTINCT ON (e.id) %s, %s, %s "+
+			"FROM memory_entities %s%s "+
+			"WHERE %s%s "+
+			"ORDER BY e.id, o.observed_at DESC LIMIT %d",
+		selectEntityCols, selectEntityScopeCols, selectObserveColsMulti,
+		entityTableAlias, observationJoin,
+		colEntityForgot, qb.Where(),
+		multiTierCandidatePool,
+	)
 
-	if len(req.Types) == 1 {
-		args = append(args, req.Types[0])
-		clauses = append(clauses, "e.kind=$"+strconv.Itoa(len(args)))
-	} else if len(req.Types) > 1 {
-		args = append(args, req.Types)
-		clauses = append(clauses, "e.kind = ANY($"+strconv.Itoa(len(args))+")")
-	}
-
-	if req.MinConfidence > 0 {
-		args = append(args, req.MinConfidence)
-		clauses = append(clauses, "o.confidence >= $"+strconv.Itoa(len(args)))
-	}
-
-	if req.Query != "" {
-		// Tokenized FTS match against the stored tsvector (mirrors the
-		// single-tier path in store.go). ILIKE was a literal-substring
-		// filter — "when I was in Morocco" against "User was in Morocco"
-		// returned zero rows. websearch_to_tsquery handles stopwords and
-		// word boundaries the way the agent expects.
-		args = append(args, req.Query)
-		clauses = append(clauses, "o.search_vector @@ websearch_to_tsquery('english', $"+strconv.Itoa(len(args))+")")
-	}
-
-	if len(req.Purposes) == 1 {
-		args = append(args, req.Purposes[0])
-		clauses = append(clauses, "e.purpose=$"+strconv.Itoa(len(args)))
-	} else if len(req.Purposes) > 1 {
-		args = append(args, req.Purposes)
-		clauses = append(clauses, "e.purpose = ANY($"+strconv.Itoa(len(args))+")")
-	}
-
-	sql := fmt.Sprintf(`SELECT DISTINCT ON (e.id) e.id, e.kind, e.metadata, e.created_at, e.expires_at, e.title, e.virtual_user_id, e.agent_id, o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at, o.access_count, o.summary, o.body_size_bytes FROM memory_entities e JOIN memory_observations o ON o.entity_id = e.id AND o.superseded_by IS NULL AND (o.valid_until IS NULL OR o.valid_until > now()) WHERE %s ORDER BY e.id, o.observed_at DESC LIMIT %d`,
-		joinAnd(clauses), multiTierCandidatePool)
-
-	return sql, args, nil
+	return sql, qb.Args(), nil
 }
 
-// userTierClause returns the user-scope predicate for the multi-tier query.
-// When userID is empty the predicate anchors to NULL so institutional-only
-// retrievals do not bleed through other users' memories. The column is
-// unqualified because memory_observations does not share it, avoiding an
-// alias prefix keeps the emitted SQL aligned with the agreed contract.
-func userTierClause(userID string, args *[]any) string {
+// addUserTierClause appends the user-scope predicate. Empty userID
+// anchors strictly to NULL (so institutional-only retrievals don't
+// bleed through other users' memories); a populated userID widens to
+// "NULL OR matches". The columns are unqualified to keep emitted SQL
+// aligned with the existing contract observers expect.
+func addUserTierClause(qb *pgutil.QueryBuilder, userID string) {
 	if userID == "" {
-		return "virtual_user_id IS NULL"
+		qb.AddRaw("virtual_user_id IS NULL")
+		return
 	}
-	*args = append(*args, userID)
-	return "(virtual_user_id IS NULL OR virtual_user_id=$" + strconv.Itoa(len(*args)) + ")"
+	qb.Add("(virtual_user_id IS NULL OR virtual_user_id=$?)", userID)
 }
 
-// agentTierClause returns the agent-scope predicate. Same NULL-anchoring
-// behaviour as userTierClause.
-func agentTierClause(agentID string, args *[]any) string {
+// addAgentTierClause mirrors addUserTierClause for agent scope.
+func addAgentTierClause(qb *pgutil.QueryBuilder, agentID string) {
 	if agentID == "" {
-		return "agent_id IS NULL"
+		qb.AddRaw("agent_id IS NULL")
+		return
 	}
-	*args = append(*args, agentID)
-	return "(agent_id IS NULL OR agent_id=$" + strconv.Itoa(len(*args)) + ")"
-}
-
-// joinAnd joins SQL WHERE fragments with " AND ".
-func joinAnd(parts []string) string {
-	return strings.Join(parts, " AND ")
+	qb.Add("(agent_id IS NULL OR agent_id=$?)", agentID)
 }
 
 // scanMultiTierRows reads multi-tier query rows into MultiTierMemory values.

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -75,6 +75,17 @@ const (
 	entityTableAlias  = "e"
 	selectEntityCols  = "e.id, e.kind, e.metadata, e.created_at, e.expires_at, e.title"
 	selectObserveCols = "o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at, o.summary, o.body_size_bytes"
+	// Multi-tier SELECT extras — extracted so the column list is named
+	// once. Multi-tier needs the per-row scope columns to classify the
+	// result into a Tier and the access count for the Go-side ranker;
+	// single-tier doesn't surface either, which is why these aren't
+	// folded into selectEntityCols / selectObserveCols.
+	selectEntityScopeCols = "e.virtual_user_id, e.agent_id"
+	// selectObserveColsMulti is selectObserveCols with access_count
+	// inserted before the large-payload columns, matching the order
+	// scanMultiTierRow expects. Kept adjacent to selectObserveCols
+	// so a future change to either list is hard to make in only one.
+	selectObserveColsMulti = "o.content, o.confidence, o.session_id, o.turn_range, o.observed_at, o.accessed_at, o.access_count, o.summary, o.body_size_bytes"
 )
 
 // PostgresMemoryStore implements Store against the memory_entities / memory_observations
@@ -563,21 +574,12 @@ func (s *PostgresMemoryStore) Retrieve(ctx context.Context, scope map[string]str
 // returns the standard recency-ordered query.
 func buildRetrieveQuery(scope map[string]string, query string, opts RetrieveOptions) (string, *pgutil.QueryBuilder) {
 	qb := buildBaseMemoryQuery(scope, opts.Types, "")
+	addConfidenceFilter(qb, opts.MinConfidence)
 
-	if opts.MinConfidence > 0 {
-		qb.Add(confidenceFilter, opts.MinConfidence)
-	}
-
-	if query == "" {
+	queryArgIdx := addFTSPredicate(qb, query)
+	if queryArgIdx == 0 {
 		return formatMemorySQL(qb, opts.Limit, 0), qb
 	}
-
-	// FTS path: filter observations by tsquery match, pick the highest-
-	// ranked observation per entity, then sort entities by that rank.
-	// The query argument is referenced twice (WHERE + ORDER BY rank); we
-	// capture its placeholder index so both spots see the same parameter.
-	queryArgIdx := len(qb.Args()) + 1
-	qb.Add("o.search_vector @@ websearch_to_tsquery('english', $?)", query)
 	return formatMemoryFTSSQL(qb, queryArgIdx, opts.Limit, 0), qb
 }
 
@@ -1691,6 +1693,62 @@ func addTypeFilters(qb *pgutil.QueryBuilder, types []string) {
 	default:
 		qb.Add("e.kind = ANY($?)", types)
 	}
+}
+
+// addPurposeFilters appends a purpose-equals or purpose=ANY filter. Empty
+// list is a no-op so callers can pass req.Purposes without conditional
+// scaffolding. Shared between Retrieve and RetrieveMultiTier so future
+// purpose-related work (e.g. SUPPORT_CONTINUITY scoring) lands in both.
+func addPurposeFilters(qb *pgutil.QueryBuilder, purposes []string) {
+	switch len(purposes) {
+	case 0:
+		return
+	case 1:
+		qb.Add("e.purpose=$?", purposes[0])
+	default:
+		qb.Add("e.purpose = ANY($?)", purposes)
+	}
+}
+
+// addConfidenceFilter appends an "o.confidence >= $?" predicate when min > 0.
+// Both single-tier Retrieve and multi-tier RetrieveMultiTier filter on this
+// — extracting the helper means a future tweak (e.g. switching to a fused
+// confidence × source-type score) can't drift between paths.
+func addConfidenceFilter(qb *pgutil.QueryBuilder, min float64) {
+	if min > 0 {
+		qb.Add(confidenceFilter, min)
+	}
+}
+
+// joinAnd joins SQL WHERE fragments with " AND ". Used by the
+// non-QueryBuilder structured-lookup path; QueryBuilder users don't
+// need it because Where() handles the join.
+func joinAnd(parts []string) string {
+	return strings.Join(parts, " AND ")
+}
+
+// addFTSPredicate appends a websearch_to_tsquery match against the
+// observation's stored search_vector and returns the 1-based positional
+// index of the bound query string. The caller can re-use that index to
+// reference the same parameter in a scoring expression (e.g. ts_rank_cd
+// in the single-tier FTS path) without binding the query twice.
+//
+// This is the single-source-of-truth for "how do we match the user's
+// query against the FTS index". The April ILIKE→FTS migration only
+// touched the single-tier path, leaving the multi-tier path on
+// literal-substring matching for two months until #1038 surfaced it
+// (the agent answered "I don't recall Morocco" two sentences after
+// storing three Morocco memories). Sharing the predicate keeps that
+// kind of drift impossible by construction.
+//
+// Returns 0 when query is empty (no clause appended). Callers needing
+// the index unconditionally should branch on that themselves.
+func addFTSPredicate(qb *pgutil.QueryBuilder, query string) int {
+	if query == "" {
+		return 0
+	}
+	qb.Add("o.search_vector @@ websearch_to_tsquery('english', $?)", query)
+	return len(qb.Args())
 }
 
 // scanMemories collects Memory structs from query rows.

--- a/internal/memory/store_unit_test.go
+++ b/internal/memory/store_unit_test.go
@@ -112,6 +112,91 @@ func TestAddTypeFilters(t *testing.T) {
 	}
 }
 
+func TestAddPurposeFilters(t *testing.T) {
+	tests := []struct {
+		name     string
+		purposes []string
+		wantArgs int
+	}{
+		{"no purposes", nil, 0},
+		{"empty slice", []string{}, 0},
+		{"single purpose", []string{"support_continuity"}, 1},
+		{"multiple purposes", []string{"support_continuity", "personalisation"}, 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var qb pgutil.QueryBuilder
+			addPurposeFilters(&qb, tt.purposes)
+			assert.Len(t, qb.Args(), tt.wantArgs)
+		})
+	}
+}
+
+func TestAddConfidenceFilter(t *testing.T) {
+	t.Run("zero is no-op", func(t *testing.T) {
+		var qb pgutil.QueryBuilder
+		addConfidenceFilter(&qb, 0)
+		assert.Empty(t, qb.Args())
+	})
+	t.Run("negative is no-op", func(t *testing.T) {
+		var qb pgutil.QueryBuilder
+		addConfidenceFilter(&qb, -0.1)
+		assert.Empty(t, qb.Args())
+	})
+	t.Run("positive binds threshold", func(t *testing.T) {
+		var qb pgutil.QueryBuilder
+		addConfidenceFilter(&qb, 0.7)
+		require.Len(t, qb.Args(), 1)
+		assert.InDelta(t, 0.7, qb.Args()[0], 1e-9)
+		assert.Contains(t, qb.Where(), "o.confidence")
+	})
+}
+
+func TestAddFTSPredicate(t *testing.T) {
+	t.Run("empty query is no-op", func(t *testing.T) {
+		var qb pgutil.QueryBuilder
+		idx := addFTSPredicate(&qb, "")
+		assert.Equal(t, 0, idx)
+		assert.Empty(t, qb.Args())
+	})
+	t.Run("non-empty query binds and reports placeholder index", func(t *testing.T) {
+		var qb pgutil.QueryBuilder
+		idx := addFTSPredicate(&qb, "Morocco")
+		assert.Equal(t, 1, idx)
+		require.Len(t, qb.Args(), 1)
+		assert.Equal(t, "Morocco", qb.Args()[0])
+		assert.Contains(t, qb.Where(), "websearch_to_tsquery")
+		assert.NotContains(t, qb.Where(), "ILIKE", "FTS predicate must never be ILIKE — that was the bug #1038-A surfaced")
+	})
+	t.Run("placeholder index respects pre-existing args", func(t *testing.T) {
+		var qb pgutil.QueryBuilder
+		qb.Add("a=$?", 1)
+		qb.Add("b=$?", 2)
+		idx := addFTSPredicate(&qb, "Morocco")
+		assert.Equal(t, 3, idx, "FTS bind index must equal len(args) so callers can re-use it in the scoring expression")
+	})
+}
+
+// TestSharedFTSHelper_BothPathsUse asserts that single-tier and multi-tier
+// build their FTS predicate via the same helper. This is the regression
+// guard for #1038-E: the original ILIKE-vs-FTS drift was possible because
+// each path had its own inline predicate. Now that addFTSPredicate is the
+// single source of truth, this test fails loudly if anyone reverts either
+// path to a bespoke predicate.
+func TestSharedFTSHelper_BothPathsUse(t *testing.T) {
+	scope := map[string]string{ScopeWorkspaceID: "ws-1"}
+	singleSQL, _ := buildRetrieveQuery(scope, "Morocco trip", RetrieveOptions{})
+	multiSQL, _, err := buildMultiTierQuery(MultiTierRequest{WorkspaceID: "ws-1", Query: "Morocco trip"})
+	require.NoError(t, err)
+
+	const ftsClause = "o.search_vector @@ websearch_to_tsquery('english', $"
+	assert.Contains(t, singleSQL, ftsClause, "single-tier must use the FTS predicate")
+	assert.Contains(t, multiSQL, ftsClause, "multi-tier must use the same FTS predicate (#1038-E)")
+	assert.NotContains(t, singleSQL, "ILIKE")
+	assert.NotContains(t, multiSQL, "ILIKE")
+}
+
 // --- validation tests (nil pool is fine since errors happen before DB call) ---
 
 func TestSave_MissingWorkspace(t *testing.T) {

--- a/internal/pgutil/querybuilder.go
+++ b/internal/pgutil/querybuilder.go
@@ -52,6 +52,18 @@ func (qb *QueryBuilder) Add(clause string, arg any) {
 	qb.clauses = append(qb.clauses, strings.ReplaceAll(clause, "$?", "$"+strconv.Itoa(len(qb.args))))
 }
 
+// AddRaw appends a clause that takes no positional argument (e.g. an
+// IS NULL predicate or a constant filter). The clause is added verbatim
+// so callers must already have substituted any placeholders themselves
+// — Add is the right entry point for clauses that need parameter
+// numbering. AddRaw exists because some shared filters (NULL-anchoring
+// for tier-aware queries, e.g. "virtual_user_id IS NULL") have no
+// argument to bind, and forcing callers to fall back to manual SQL
+// concatenation would defeat the point of QueryBuilder.
+func (qb *QueryBuilder) AddRaw(clause string) {
+	qb.clauses = append(qb.clauses, clause)
+}
+
 // Where returns the accumulated clauses joined with " AND " and prefixed
 // with " AND ". If no clauses have been added, it returns an empty string.
 // The caller is expected to include "WHERE 1=1" (or equivalent) before the

--- a/internal/pgutil/querybuilder_test.go
+++ b/internal/pgutil/querybuilder_test.go
@@ -55,6 +55,34 @@ func TestQueryBuilder_Where_MultipleClauses(t *testing.T) {
 	}
 }
 
+func TestQueryBuilder_AddRaw_NoArg(t *testing.T) {
+	qb := &QueryBuilder{}
+	qb.AddRaw("forgotten = false")
+	qb.Add("workspace_id=$?", "ws-1")
+
+	want := " AND forgotten = false AND workspace_id=$1"
+	if got := qb.Where(); got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+	if len(qb.Args()) != 1 {
+		t.Fatalf("expected 1 arg (AddRaw must not consume a position), got %d", len(qb.Args()))
+	}
+	if qb.Args()[0] != "ws-1" {
+		t.Errorf("expected first arg to be the Add call's binding, got %v", qb.Args()[0])
+	}
+}
+
+func TestQueryBuilder_AddRaw_VerbatimClause(t *testing.T) {
+	// AddRaw is for fully-formed clauses including any IS NULL / IS NOT NULL
+	// predicates. The clause is appended verbatim — no $? substitution.
+	qb := &QueryBuilder{}
+	qb.AddRaw("(virtual_user_id IS NULL OR agent_id IS NULL)")
+	want := " AND (virtual_user_id IS NULL OR agent_id IS NULL)"
+	if got := qb.Where(); got != want {
+		t.Errorf("expected %q, got %q", want, got)
+	}
+}
+
 func TestQueryBuilder_SetArgs(t *testing.T) {
 	qb := &QueryBuilder{}
 	existing := []any{"pre-existing"}


### PR DESCRIPTION
## Summary

Closes the architectural prevention from #1038-E. The ILIKE→FTS drift was possible because each recall path reinvented its WHERE clause; this consolidates the shared predicates so a feature added to one lands in both by construction.

### Shared helpers (used by both `Retrieve` and `RetrieveMultiTier`)
- \`addFTSPredicate\` — \`websearch_to_tsquery\` match; returns the bound placeholder index so the single-tier scoring expression can re-use the same parameter
- \`addConfidenceFilter\` — \`o.confidence >= \$?\`
- \`addPurposeFilters\` — \`e.purpose=\$?\` / \`= ANY(\$?)\`
- \`addTypeFilters\` — already shared; multi-tier was reinventing it inline, now uses the helper

### Structural changes
- \`buildMultiTierQuery\` migrated from manual \`[]any\` + string concat to \`pgutil.QueryBuilder\`
- Multi-tier's \`SELECT\` now uses the same \`selectEntityCols\` / \`observationJoin\` / \`entityTableAlias\` constants as single-tier; multi-tier-only columns extracted into \`selectEntityScopeCols\` and \`selectObserveColsMulti\`
- Tier-specific NULL-anchoring (\`virtual_user_id IS NULL\` etc.) stays in \`retrieve_multi_tier.go\` — that semantics genuinely differs from single-tier (multi-tier merges institutional rows in, single-tier wants strict scope match) — but now uses the new \`pgutil.QueryBuilder.AddRaw\` API rather than manual string concat
- \`pgutil.QueryBuilder.AddRaw(clause)\` added for zero-arg predicates (with own unit tests)

### Regression guard
\`TestSharedFTSHelper_BothPathsUse\` builds the SQL for both paths from a single query and asserts the FTS predicate is present in both and ILIKE is absent in both. Reverting either path to a bespoke clause now fails CI loudly instead of silently 8 weeks later.

### What this is *not*
Not a "delete one path" refactor. Single-tier (\`Retrieve\`) is still used by:
- \`/api/v1/memories/search\` and the hybrid RRF path that wraps it
- Doctor smoke checks
- The HTTP-client fallback when the scope has no \`agent_id\`

Multi-tier (\`RetrieveMultiTier\`) is the agent's recall path. Unifying the *response shape* would require porting the SQL-side FTS scoring / hybrid RRF onto multi-tier; that's a follow-up.

## Test plan
- [x] \`go test ./internal/memory/... -count=1\` (656 passed)
- [x] \`go test ./internal/pgutil/... -count=1\` (24 passed)
- [x] \`golangci-lint run ./internal/memory/... ./internal/pgutil/...\` (clean)
- [x] \`go build ./...\` (full repo)
- [ ] CI