### PR TITLE
fix(dashboard/auth): handle Entra groups overage via Microsoft Graph (#855)

### DIFF
--- a/dashboard/src/app/api/auth/callback/route.test.ts
+++ b/dashboard/src/app/api/auth/callback/route.test.ts
@@ -19,7 +19,9 @@ vi.mock("@/lib/auth/oauth", () => ({
     refresh_token: "rt", id_token: "it", expires_at: 999,
   })),
   extractClaims: () => ({ sub: "u1", email: "u1@example", name: "U1", groups: [] }),
-  mapClaimsToUser: () => ({
+  // Async since #855 — the callback now uses mapClaimsToUserAsync to
+  // pick up Entra groups overage from a Graph call.
+  mapClaimsToUserAsync: async () => ({
     id: "u1", username: "u1", email: "u1@example", displayName: "U1",
     groups: [], role: "viewer", provider: "oauth",
   }),

--- a/dashboard/src/app/api/auth/callback/route.ts
+++ b/dashboard/src/app/api/auth/callback/route.ts
@@ -18,7 +18,7 @@ import { getSessionStore } from "@/lib/auth/session-store";
 import {
   exchangeCodeForTokens,
   extractClaims,
-  mapClaimsToUser,
+  mapClaimsToUserAsync,
   getUserInfo,
   validateClaims,
 } from "@/lib/auth/oauth";
@@ -86,7 +86,10 @@ export async function GET(request: NextRequest) {
       return loginRedirect("?error=invalid_claims");
     }
 
-    const user = mapClaimsToUser(claims, config);
+    // mapClaimsToUserAsync resolves Entra groups-overage via Microsoft
+    // Graph when the ID token has _claim_names.groups instead of an
+    // inline list (issue #855). Needs the access_token, NOT the id_token.
+    const user = await mapClaimsToUserAsync(claims, config, tokens.access_token);
     await saveUserToSession(user, {
       refreshToken: tokens.refresh_token,
       idToken: tokens.id_token,

--- a/dashboard/src/app/api/auth/refresh/route.ts
+++ b/dashboard/src/app/api/auth/refresh/route.ts
@@ -11,7 +11,7 @@ import { getSessionRecord, updateSessionOAuth } from "@/lib/auth/session";
 import {
   refreshAccessToken,
   extractClaims,
-  mapClaimsToUser,
+  mapClaimsToUserAsync,
   validateClaims,
 } from "@/lib/auth/oauth";
 
@@ -40,7 +40,10 @@ export async function POST() {
     if (tokens.id_token) {
       const claims = extractClaims(tokens);
       if (validateClaims(claims)) {
-        nextUser = mapClaimsToUser(claims, config);
+        // Re-fetch overage groups on refresh — group memberships can
+        // change between login and refresh, and the new ID token's
+        // claim shape is what dictates whether to call Graph again.
+        nextUser = await mapClaimsToUserAsync(claims, config, tokens.access_token);
       }
     }
 

--- a/dashboard/src/lib/auth/index.ts
+++ b/dashboard/src/lib/auth/index.ts
@@ -157,7 +157,7 @@ async function tryRefreshToken(
 
   try {
     // Lazy-load OAuth module only when token refresh is needed
-    const { refreshAccessToken, extractClaims, mapClaimsToUser, validateClaims } = await import("./oauth");
+    const { refreshAccessToken, extractClaims, mapClaimsToUserAsync, validateClaims } = await import("./oauth");
     const tokens = await refreshAccessToken(currentOAuth.refreshToken);
 
     // Build updated OAuth tokens. Access token is intentionally not
@@ -169,12 +169,13 @@ async function tryRefreshToken(
       expiresAt: typeof tokens.expires_at === "number" ? tokens.expires_at : currentOAuth.expiresAt,
     };
 
-    // Update user from new claims if available
+    // Update user from new claims if available. Use the async path
+    // to pick up Entra groups-overage on refresh (issue #855).
     let updatedUser: User | undefined;
     if (tokens.id_token) {
       const claims = extractClaims(tokens);
       if (validateClaims(claims)) {
-        updatedUser = mapClaimsToUser(claims, config);
+        updatedUser = await mapClaimsToUserAsync(claims, config, tokens.access_token);
       }
     }
 

--- a/dashboard/src/lib/auth/oauth/claims.test.ts
+++ b/dashboard/src/lib/auth/oauth/claims.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from "vitest";
+import { mapClaimsToUserAsync, mapClaimsToUser } from "./claims";
+import type { GraphTransport } from "./groups-overflow";
+import type { AuthConfig } from "../config";
+
+// Minimal AuthConfig for the tests — only the fields mapClaimsToUser
+// actually reads. Casting through `unknown` keeps us decoupled from
+// fields that are required at runtime but irrelevant to claim mapping.
+const baseConfig = {
+  oauth: {
+    claims: {
+      username: "preferred_username",
+      email: "email",
+      displayName: "name",
+      groups: "groups",
+    },
+  },
+  roleMapping: {
+    admin: ["admins"],
+    editor: ["editors"],
+  },
+} as unknown as AuthConfig;
+
+describe("mapClaimsToUser (sync)", () => {
+  it("maps a vanilla token with inline groups", () => {
+    const user = mapClaimsToUser(
+      {
+        sub: "u1",
+        preferred_username: "alice",
+        email: "alice@example.com",
+        name: "Alice",
+        groups: ["editors"],
+      },
+      baseConfig,
+    );
+
+    expect(user).toEqual({
+      id: "u1",
+      username: "alice",
+      email: "alice@example.com",
+      displayName: "Alice",
+      groups: ["editors"],
+      role: "editor",
+      provider: "oauth",
+    });
+  });
+});
+
+describe("mapClaimsToUserAsync — Entra groups overage (issue #855)", () => {
+  it("returns the same shape as the sync mapper when no overage", async () => {
+    const user = await mapClaimsToUserAsync(
+      {
+        sub: "u1",
+        preferred_username: "alice",
+        email: "alice@example.com",
+        name: "Alice",
+        groups: ["admins"],
+      },
+      baseConfig,
+      "irrelevant-access-token",
+    );
+
+    expect(user.role).toBe("admin");
+    expect(user.groups).toEqual(["admins"]);
+  });
+
+  it("resolves overage groups via Graph and recomputes role", async () => {
+    const transport = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ value: ["editors", "other-group"] }),
+    });
+
+    const user = await mapClaimsToUserAsync(
+      {
+        sub: "u1",
+        oid: "abc-oid",
+        preferred_username: "bob",
+        email: "bob@example.com",
+        name: "Bob",
+        // Inline groups missing because of overage; ID token carries
+        // the pointer instead.
+        _claim_names: { groups: "src1" },
+      },
+      baseConfig,
+      "fake-access-token",
+      transport,
+    );
+
+    expect(user.groups).toEqual(["editors", "other-group"]);
+    // Critical: the role MUST be recomputed off the resolved list.
+    // Without that, an admin-overage user would resolve to viewer,
+    // which is the original bug.
+    expect(user.role).toBe("editor");
+  });
+
+  it("falls back to viewer (empty groups) when Graph returns 5xx", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const transport: GraphTransport = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "boom" }),
+    });
+
+    const user = await mapClaimsToUserAsync(
+      {
+        sub: "u1",
+        oid: "abc-oid",
+        preferred_username: "carol",
+        _claim_names: { groups: "src1" },
+      },
+      baseConfig,
+      "fake-access-token",
+      transport,
+    );
+
+    // Graph failure → fail open: keep whatever inline groups the token
+    // had (none, in this case). Operator sees a console.warn.
+    expect(user.role).toBe("viewer");
+    expect(user.groups).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("503"));
+    warn.mockRestore();
+  });
+
+  it("warns and uses inline groups when overage detected without an access token", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const user = await mapClaimsToUserAsync(
+      {
+        sub: "u1",
+        oid: "abc-oid",
+        preferred_username: "dan",
+        _claim_names: { groups: "src1" },
+      },
+      baseConfig,
+      undefined,
+    );
+
+    expect(user.groups).toEqual([]);
+    expect(user.role).toBe("viewer");
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("no access_token"),
+    );
+    warn.mockRestore();
+  });
+});

--- a/dashboard/src/lib/auth/oauth/claims.ts
+++ b/dashboard/src/lib/auth/oauth/claims.ts
@@ -7,6 +7,7 @@
 import type { TokenEndpointResponse, TokenEndpointResponseHelpers } from "openid-client";
 import type { User } from "../types";
 import type { AuthConfig, UserRole } from "../config";
+import { resolveGroupsOverflow, type GraphTransport } from "./groups-overflow";
 
 /**
  * Claims object from ID token or UserInfo.
@@ -19,7 +20,12 @@ type Claims = Record<string, unknown>;
 type TokensWithHelpers = TokenEndpointResponse & TokenEndpointResponseHelpers;
 
 /**
- * Map OIDC claims to User object.
+ * Map OIDC claims to User object. Synchronous; does NOT resolve
+ * Entra `_claim_names.groups` overflow — callers in the OAuth
+ * callback / refresh hot path should use mapClaimsToUserAsync to
+ * pick up overage groups. This sync entry point stays for callers
+ * that genuinely don't have an access token (e.g. tests asserting
+ * pure claim-to-user shape).
  */
 export function mapClaimsToUser(
   claims: Claims,
@@ -46,6 +52,55 @@ export function mapClaimsToUser(
     role,
     provider: "oauth",
   };
+}
+
+/**
+ * mapClaimsToUserAsync is the production entry point. It does
+ * everything mapClaimsToUser does, then resolves Entra's
+ * `_claim_names.groups` overflow (issue #855) when present. accessToken
+ * is the OAuth access token issued alongside the ID token — Microsoft
+ * Graph requires it (NOT the ID token) on the Bearer header.
+ *
+ * Failure modes are absorbed silently (fail-open): if Graph is down /
+ * 5xx / 429 / token has no User.Read scope, we surface a console.warn
+ * with the operator-actionable reason and resolve the user with
+ * `groups: []`. That matches the existing "missing groups → viewer"
+ * behaviour for non-overage tokens — overage users get the same
+ * degraded experience as a misconfigured tenant rather than being
+ * locked out entirely. Operators see the warning in dashboard logs.
+ *
+ * graphTransport is injectable for tests; production callers omit it
+ * to use the global `fetch`.
+ */
+export async function mapClaimsToUserAsync(
+  claims: Claims,
+  config: AuthConfig,
+  accessToken: string | undefined,
+  graphTransport?: GraphTransport,
+): Promise<User> {
+  const user = mapClaimsToUser(claims, config);
+
+  const result = await resolveGroupsOverflow(
+    claims,
+    user.groups,
+    accessToken,
+    graphTransport,
+  );
+
+  if (result.kind === "inline") {
+    return user;
+  }
+
+  if (result.reason) {
+    // eslint-disable-next-line no-console
+    console.warn(`[oauth] ${result.reason}`);
+  }
+
+  // Recompute role with the resolved (or empty-on-failure) group set
+  // — admin/editor mapping must use the same list we surface to the
+  // user object, otherwise audit logs and downstream RBAC drift.
+  const role = resolveRoleFromGroups(result.groups, config.roleMapping);
+  return { ...user, groups: result.groups, role };
 }
 
 /**

--- a/dashboard/src/lib/auth/oauth/groups-overflow.test.ts
+++ b/dashboard/src/lib/auth/oauth/groups-overflow.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveGroupsOverflow, type GraphTransport } from "./groups-overflow";
+
+// Tests for the Entra "groups overage" handler (issue #855).
+//
+// We never hit the real Microsoft Graph from tests; transport is a
+// mock function that asserts on URL/headers and returns canned bodies.
+
+const accessToken = "fake-access-token";
+
+function makeClaims(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    sub: "00000000-0000-0000-0000-000000000001",
+    oid: "11111111-1111-1111-1111-111111111111",
+    ...overrides,
+  };
+}
+
+function overageClaims(): Record<string, unknown> {
+  return makeClaims({
+    _claim_names: { groups: "src1" },
+    _claim_sources: {
+      src1: {
+        endpoint:
+          "https://graph.windows.net/contoso/users/11111111-1111-1111-1111-111111111111/getMemberObjects",
+      },
+    },
+  });
+}
+
+describe("resolveGroupsOverflow", () => {
+  it("returns inline groups when claims have no _claim_names pointer", async () => {
+    const inline = ["g1", "g2"];
+    const transport = vi.fn() as unknown as GraphTransport;
+
+    const result = await resolveGroupsOverflow(makeClaims(), inline, accessToken, transport);
+
+    expect(result).toEqual({ kind: "inline", groups: inline });
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("returns inline groups when _claim_names exists but doesn't point at groups", async () => {
+    const claims = makeClaims({ _claim_names: { other: "src2" } });
+    const transport = vi.fn() as unknown as GraphTransport;
+
+    const result = await resolveGroupsOverflow(claims, ["x"], accessToken, transport);
+
+    expect(result).toEqual({ kind: "inline", groups: ["x"] });
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("returns no_token when overage detected without an access token", async () => {
+    const transport = vi.fn() as unknown as GraphTransport;
+
+    const result = await resolveGroupsOverflow(overageClaims(), [], undefined, transport);
+
+    expect(result.kind).toBe("no_token");
+    expect(result.groups).toEqual([]);
+    expect(result.reason).toContain("no access_token");
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("calls Graph getMemberObjects and returns the resolved groups", async () => {
+    const transport = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ value: ["group-1", "group-2", "group-3"] }),
+    });
+
+    const result = await resolveGroupsOverflow(overageClaims(), [], accessToken, transport);
+
+    expect(result.kind).toBe("resolved");
+    expect(result.groups).toEqual(["group-1", "group-2", "group-3"]);
+    expect(transport).toHaveBeenCalledTimes(1);
+
+    const [url, init] = transport.mock.calls[0];
+    expect(url).toBe(
+      "https://graph.microsoft.com/v1.0/users/11111111-1111-1111-1111-111111111111/getMemberObjects",
+    );
+    expect(init.method).toBe("POST");
+    expect(init.headers.Authorization).toBe(`Bearer ${accessToken}`);
+    expect(init.headers["Content-Type"]).toBe("application/json");
+    // The Graph contract: securityEnabledOnly=false returns ALL groups
+    // (security + Microsoft 365), matching the inline `groups` claim's
+    // default behaviour.
+    expect(JSON.parse(init.body!)).toEqual({ securityEnabledOnly: false });
+  });
+
+  it("follows @odata.nextLink for pagination and de-duplicates", async () => {
+    const transport = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          value: ["g1", "g2", "g3"],
+          "@odata.nextLink":
+            "https://graph.microsoft.com/v1.0/users/.../getMemberObjects?$skiptoken=abc",
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          // g3 is repeated on purpose — must be de-duplicated.
+          value: ["g3", "g4", "g5"],
+        }),
+      });
+
+    const result = await resolveGroupsOverflow(overageClaims(), [], accessToken, transport);
+
+    expect(result.kind).toBe("resolved");
+    expect(result.groups.sort()).toEqual(["g1", "g2", "g3", "g4", "g5"]);
+    expect(transport).toHaveBeenCalledTimes(2);
+
+    // Pagination follow-up uses GET (Graph quirk: getMemberObjects is
+    // POST for the initial call, but @odata.nextLink is GET).
+    expect(transport.mock.calls[1][1].method).toBe("GET");
+    expect(transport.mock.calls[1][1].body).toBeUndefined();
+  });
+
+  it("graceful degrade when Graph returns 5xx", async () => {
+    const transport = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      json: async () => ({ error: "service unavailable" }),
+    });
+
+    const result = await resolveGroupsOverflow(
+      overageClaims(),
+      ["fallback-from-inline-which-was-empty"],
+      accessToken,
+      transport,
+    );
+
+    expect(result.kind).toBe("graph_failed");
+    expect(result.reason).toContain("503");
+    // Returns the inline groups (which the caller passed in) so a
+    // failed Graph call keeps the user at whatever the token's inline
+    // claim said, rather than zeroing them out.
+    expect(result.groups).toEqual(["fallback-from-inline-which-was-empty"]);
+  });
+
+  it("graceful degrade when Graph returns 429", async () => {
+    const transport = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: async () => ({ error: "too many requests" }),
+    });
+
+    const result = await resolveGroupsOverflow(overageClaims(), [], accessToken, transport);
+
+    expect(result.kind).toBe("graph_failed");
+    expect(result.reason).toContain("429");
+  });
+
+  it("graceful degrade when transport throws", async () => {
+    const transport = vi.fn().mockRejectedValue(new Error("ECONNRESET"));
+
+    const result = await resolveGroupsOverflow(overageClaims(), [], accessToken, transport);
+
+    expect(result.kind).toBe("graph_failed");
+    expect(result.reason).toContain("ECONNRESET");
+  });
+
+  it("uses sub when oid is missing", async () => {
+    const claims = makeClaims({
+      _claim_names: { groups: "src1" },
+      oid: undefined,
+    });
+    const transport = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ value: ["g1"] }),
+    });
+
+    const result = await resolveGroupsOverflow(claims, [], accessToken, transport);
+
+    expect(result.kind).toBe("resolved");
+    const [url] = transport.mock.calls[0];
+    expect(url).toContain("/users/00000000-0000-0000-0000-000000000001/");
+  });
+
+  it("returns graph_failed when both oid and sub are missing", async () => {
+    const claims = {
+      _claim_names: { groups: "src1" },
+    };
+    const transport = vi.fn() as unknown as GraphTransport;
+
+    const result = await resolveGroupsOverflow(claims, [], accessToken, transport);
+
+    expect(result.kind).toBe("graph_failed");
+    expect(result.reason).toContain("missing both oid and sub");
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("stops following @odata.nextLink after MAX_PAGES (10)", async () => {
+    // Always return a nextLink — would loop forever without the bound.
+    const transport = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        value: ["g"],
+        "@odata.nextLink": "https://graph.microsoft.com/v1.0/users/.../getMemberObjects?$skiptoken=looping",
+      }),
+    });
+
+    const result = await resolveGroupsOverflow(overageClaims(), [], accessToken, transport);
+
+    expect(result.kind).toBe("resolved");
+    expect(transport).toHaveBeenCalledTimes(10);
+  });
+});

--- a/dashboard/src/lib/auth/oauth/groups-overflow.ts
+++ b/dashboard/src/lib/auth/oauth/groups-overflow.ts
@@ -1,0 +1,232 @@
+/**
+ * Microsoft Entra (Azure AD) "groups overage" claim handler.
+ *
+ * When a user belongs to more than 200 Entra groups, the ID token's
+ * `groups` claim is replaced by a `_claim_names.groups` pointer at a
+ * Microsoft Graph endpoint that lists the full membership. The
+ * out-of-the-box claim parser only reads inline `groups`, so overage
+ * users silently resolve to `groups: []` → viewer role → no workspace
+ * access (issue #855). This module detects the overage shape and
+ * fetches the full list via Microsoft Graph.
+ *
+ * The original `_claim_sources` URL points at the legacy Azure AD
+ * Graph (`graph.windows.net`), which is being deprecated. We hit
+ * Microsoft Graph (`graph.microsoft.com`) instead — same data, current
+ * API, no separate token scope needed when the access token already
+ * has User.Read (which Entra grants by default for openid+profile).
+ *
+ * Returns objectId GUIDs in the same shape Entra puts in the `groups`
+ * claim by default. Tenants that have configured `groups` to emit SAM
+ * names instead would need different code, but those tenants are
+ * almost always using AD groups + `optionalClaims.groupMembershipClaims`,
+ * which has its own size-limit handling and rarely overflows.
+ */
+
+/**
+ * GraphTransport is the minimal contract a `fetch`-like transport
+ * needs to support. Tests inject mocks; production passes the global
+ * `fetch`.
+ */
+export type GraphTransport = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body?: string },
+) => Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }>;
+
+/**
+ * GroupsOverflowResult describes how the resolution went. The caller
+ * uses `resolved` for the group list and `kind` for logging /
+ * telemetry. We never throw on a Graph error — the caller can decide
+ * whether to fail closed (auth rejected) or fail open (empty groups,
+ * viewer role) based on policy. Today the dashboard fails open with
+ * a console.warn, matching the existing "missing groups → viewer"
+ * behaviour for non-overage tokens.
+ */
+export interface GroupsOverflowResult {
+  /** "inline" — no overage; caller should keep using the inline groups claim.
+   *  "resolved" — overage detected, Graph returned full list (in `groups`).
+   *  "graph_failed" — overage detected, Graph call failed (groups is empty).
+   *  "no_token" — overage detected but caller has no access token to resolve. */
+  kind: "inline" | "resolved" | "graph_failed" | "no_token";
+  groups: string[];
+  /** Operator-visible reason / endpoint when something went wrong, for
+   *  console.warn output. */
+  reason?: string;
+}
+
+/**
+ * Maximum number of `@odata.nextLink` follow hops. Entra returns up
+ * to 999 group IDs per page, so 10 hops covers ~10k group memberships
+ * — well past any realistic ceiling. Bounded to prevent a server
+ * sending us into an infinite redirect loop.
+ */
+const MAX_PAGES = 10;
+
+/**
+ * Per-call upper bound on Graph response time. Entra's Graph is
+ * normally <500ms; 10s is generous for slow networks but tight enough
+ * that a stuck call doesn't keep the whole login spinning.
+ */
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * resolveGroupsOverflow detects and resolves Entra's groups-overage
+ * pointer. When the claims do NOT contain `_claim_names.groups`, it
+ * returns `{ kind: "inline", groups: inlineGroups }` and the caller
+ * proceeds with the inline groups unchanged.
+ *
+ * accessToken is the OAuth access token issued alongside the ID token
+ * — Microsoft Graph requires `Bearer <access_token>`, NOT the ID
+ * token. When Entra issues an ID token with the overage pointer it
+ * also issues an access token with the User.Read scope, so the same
+ * token works for the Graph call.
+ */
+export async function resolveGroupsOverflow(
+  claims: Record<string, unknown>,
+  inlineGroups: string[],
+  accessToken: string | undefined,
+  transport: GraphTransport = defaultTransport,
+): Promise<GroupsOverflowResult> {
+  const claimNames = claims._claim_names;
+  if (!claimNames || typeof claimNames !== "object") {
+    return { kind: "inline", groups: inlineGroups };
+  }
+  const groupsPointer = (claimNames as Record<string, unknown>).groups;
+  if (typeof groupsPointer !== "string" || groupsPointer === "") {
+    return { kind: "inline", groups: inlineGroups };
+  }
+
+  if (!accessToken) {
+    return {
+      kind: "no_token",
+      groups: inlineGroups,
+      reason:
+        "Entra groups overage detected but no access_token available — " +
+        "user will resolve to viewer. Token-refresh flow may be missing the User.Read scope.",
+    };
+  }
+
+  // The user's objectId is the `oid` claim, present on every Entra
+  // token. The legacy `_claim_sources` URL embeds the same value, so
+  // we don't strictly need to parse it — going through Graph
+  // directly is cleaner.
+  const oid = typeof claims.oid === "string" ? claims.oid : undefined;
+  const sub = typeof claims.sub === "string" ? claims.sub : undefined;
+  const userKey = oid || sub;
+  if (!userKey) {
+    return {
+      kind: "graph_failed",
+      groups: inlineGroups,
+      reason: "Entra groups overage: claims missing both oid and sub — cannot identify user",
+    };
+  }
+
+  try {
+    const groups = await fetchAllGroupIDs(userKey, accessToken, transport);
+    return { kind: "resolved", groups };
+  } catch (err) {
+    return {
+      kind: "graph_failed",
+      groups: inlineGroups,
+      reason: `Microsoft Graph getMemberObjects failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+}
+
+/**
+ * fetchAllGroupIDs hits `POST /v1.0/users/{oid}/getMemberObjects`,
+ * follows `@odata.nextLink` for pagination, returns the de-duplicated
+ * set of objectIds. `securityEnabledOnly: false` returns ALL groups
+ * (security + Microsoft 365), matching the inline `groups` claim's
+ * default behaviour.
+ *
+ * Throws on transport failure or non-2xx status. The caller catches
+ * and converts to a `graph_failed` result.
+ */
+async function fetchAllGroupIDs(
+  userKey: string,
+  accessToken: string,
+  transport: GraphTransport,
+): Promise<string[]> {
+  const seen = new Set<string>();
+  let url: string | null =
+    `https://graph.microsoft.com/v1.0/users/${encodeURIComponent(userKey)}/getMemberObjects`;
+  let pages = 0;
+  let body: string | undefined = JSON.stringify({ securityEnabledOnly: false });
+  let method = "POST";
+
+  while (url && pages < MAX_PAGES) {
+    pages++;
+    const init: { method: string; headers: Record<string, string>; body?: string } = {
+      method,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        Accept: "application/json",
+      },
+    };
+    if (body !== undefined) {
+      init.headers["Content-Type"] = "application/json";
+      init.body = body;
+    }
+    const resp = await callWithTimeout(transport, url, init, REQUEST_TIMEOUT_MS);
+    if (!resp.ok) {
+      throw new Error(`Graph returned status ${resp.status}`);
+    }
+    const data = (await resp.json()) as {
+      value?: unknown;
+      "@odata.nextLink"?: unknown;
+    };
+    if (Array.isArray(data.value)) {
+      for (const v of data.value) {
+        if (typeof v === "string") {
+          seen.add(v);
+        }
+      }
+    }
+    const next = data["@odata.nextLink"];
+    if (typeof next === "string" && next !== "") {
+      url = next;
+      // Pagination follow-up uses GET (Graph quirk: getMemberObjects
+      // is POST for the initial call but returns GET-style next links).
+      method = "GET";
+      body = undefined;
+    } else {
+      url = null;
+    }
+  }
+  return Array.from(seen);
+}
+
+/**
+ * callWithTimeout adds an AbortController-driven timeout because the
+ * Node fetch implementation does not honour the deprecated `timeout`
+ * option in init. Without this a hung Graph endpoint would stall the
+ * login until the OS-level TCP keepalive triggers (minutes).
+ */
+async function callWithTimeout(
+  transport: GraphTransport,
+  url: string,
+  init: { method: string; headers: Record<string, string>; body?: string },
+  timeoutMs: number,
+): Promise<{ ok: boolean; status: number; json: () => Promise<unknown> }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await transport(url, { ...init, ...{ signal: controller.signal } as object });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * defaultTransport is a thin wrapper around the global `fetch`. Kept
+ * narrow to make the test mocks trivial and prevent accidental
+ * coupling to fetch-specific options.
+ */
+const defaultTransport: GraphTransport = async (url, init) => {
+  const resp = await fetch(url, init as RequestInit);
+  return {
+    ok: resp.ok,
+    status: resp.status,
+    json: () => resp.json(),
+  };
+};

--- a/dashboard/src/lib/auth/oauth/index.ts
+++ b/dashboard/src/lib/auth/oauth/index.ts
@@ -31,7 +31,7 @@ export {
 } from "./client";
 
 // Claim mapping
-export { mapClaimsToUser, extractClaims, validateClaims } from "./claims";
+export { mapClaimsToUser, mapClaimsToUserAsync, extractClaims, validateClaims } from "./claims";
 
 // Provider utilities
 export {


### PR DESCRIPTION
## Summary

Closes #855. Azure AD / Entra caps the \`groups\` claim in ID tokens at 200 entries. Users with more group memberships get \`_claim_names.groups\` pointing at a Microsoft Graph endpoint instead of an inline list. The existing claim parser only reads the inline \`groups\` claim, so **overage users silently resolved to \`groups: []\` → viewer role → no workspace access** with no warning, no log, and no Graph fallback.

### Approach
Detect \`_claim_names.groups\`, call Microsoft Graph \`POST /v1.0/users/{oid}/getMemberObjects\` with the OAuth access token, follow \`@odata.nextLink\` for pagination, return the full group object IDs.

The Graph URL the claim points at is the **legacy graph.windows.net** endpoint; we use the modern **graph.microsoft.com** instead — same data, current API, no extra token scope needed (User.Read is granted by default for openid+profile).

### Files
| File | Change |
|---|---|
| \`oauth/groups-overflow.ts\` | New module. \`GraphTransport\` injectable for tests; pagination bounded to 10 pages (~10k groups); 10s per-call timeout; fail-open semantics. |
| \`oauth/claims.ts\` | New \`mapClaimsToUserAsync\` wraps the sync mapper and calls the overage resolver. **Recomputes role off the resolved group set** so admin-overage users get admin (the original bug). |
| \`api/auth/callback/route.ts\` | Switched to the async path. |
| \`api/auth/refresh/route.ts\` | Same — re-fetches on refresh so group changes propagate. |
| \`lib/auth/index.ts\` (tryRefreshToken) | Same. |
| \`api/auth/callback/route.test.ts\` | Mock updated to the async signature. |

### Failure modes (all fail-open)
| Condition | Behaviour | Operator signal |
|---|---|---|
| Inline groups (no overage) | Use them as-is. | none |
| Overage + Graph 200 | Use Graph response. | none |
| Overage + Graph 5xx / 429 | Empty groups → viewer role. | \`console.warn\` with status code |
| Overage + transport error | Empty groups → viewer role. | \`console.warn\` with error message |
| Overage + no access_token | Empty groups → viewer role. Probably means refresh-flow stripped User.Read scope. | \`console.warn\` with actionable hint |
| Overage + no \`oid\` and no \`sub\` | Empty groups → viewer role. Should never happen on a real Entra token. | \`console.warn\` |

This matches the pre-existing "missing groups → viewer" behaviour for non-overage tokens. Operators see warnings in dashboard logs but nobody is locked out by a Graph outage.

## Test plan
- [x] 11 unit tests on \`resolveGroupsOverflow\` (inline / no-overage / no-token / single-page / paginated+deduped / 5xx / 429 / transport-throw / oid-fallback / no-identifier / MAX_PAGES bound).
- [x] 4 integration tests on \`mapClaimsToUserAsync\` (inline path matches sync, overage resolved + role recomputed, 5xx → viewer + warn, no token → viewer + warn).
- [x] \`tsc --noEmit\` clean.
- [x] \`eslint\` clean (only pre-existing warnings).
- [ ] CI
- [ ] **Manual verification on a real Entra tenant with >200 groups** — that's where this matters. Pre-existing test infrastructure issue (\`@/\` alias resolution) is not affected by this PR.