### PR TITLE
feat(dashboard): expose eval group routing in EvalConfigPanel (#988)

### DIFF
--- a/dashboard/src/app/agents/[name]/page.tsx
+++ b/dashboard/src/app/agents/[name]/page.tsx
@@ -373,6 +373,9 @@ export default function AgentDetailPage({ params }: Readonly<AgentDetailPageProp
               frameworkType={spec.framework?.type || "promptkit"}
               evalsEnabled={spec.evals?.enabled}
               sampling={spec.evals?.sampling}
+              inlineGroups={spec.evals?.inline?.groups}
+              workerGroups={spec.evals?.worker?.groups}
+              promptPackName={spec.promptPackRef?.name}
             />
           </TabsContent>
 

--- a/dashboard/src/app/api/workspaces/[name]/agents/[agentName]/evals/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/agents/[agentName]/evals/route.ts
@@ -23,10 +23,99 @@ interface EvalConfigBody {
     defaultRate?: number;
     extendedRate?: number;
   };
+  // inline.groups / worker.groups route which evals run on which path
+  // (issue #988). The CRD's EvalPathConfig treats an absent or empty
+  // list as "use the built-in default for that path", so callers
+  // wanting to drop back to defaults can omit the field or send an
+  // empty array.
+  inline?: { groups?: string[] };
+  worker?: { groups?: string[] };
 }
+
+// Sanity bound on the number of groups in one path. Realistic configs
+// have 1–4; refusing >32 keeps a malformed client from writing
+// pathological lists into the CRD.
+const MAX_GROUPS_PER_PATH = 32;
+
+// Group names follow the same shape as Kubernetes label values:
+// alphanumeric with `_`, `-`, `.`, 1–63 chars. Tightening the regex
+// here means we never write an unrenderable group name to the CRD,
+// which would force a `kubectl edit` to recover.
+const GROUP_NAME_RE = /^[A-Za-z0-9]([A-Za-z0-9_.-]{0,61}[A-Za-z0-9])?$/;
+
+// ERR_BAD_REQUEST is the shared response shape; SonarCloud flags
+// duplicated string literals at 3+ occurrences.
+const ERR_BAD_REQUEST = "Bad Request";
 
 function isValidRate(value: unknown): boolean {
   return typeof value === "number" && value >= 0 && value <= 100;
+}
+
+function validateGroups(groups: unknown, fieldName: string): string | null {
+  if (groups === undefined) return null;
+  if (!Array.isArray(groups)) {
+    return `${fieldName} must be an array of strings`;
+  }
+  if (groups.length > MAX_GROUPS_PER_PATH) {
+    return `${fieldName} has ${groups.length} entries; maximum is ${MAX_GROUPS_PER_PATH}`;
+  }
+  const seen = new Set<string>();
+  for (const g of groups) {
+    if (typeof g !== "string") {
+      return `${fieldName} entries must be strings`;
+    }
+    if (!GROUP_NAME_RE.test(g)) {
+      return `${fieldName} entry ${JSON.stringify(g)} is not a valid group name (alphanumeric, _, -, . — up to 63 chars)`;
+    }
+    if (seen.has(g)) {
+      return `${fieldName} contains duplicate entry ${JSON.stringify(g)}`;
+    }
+    seen.add(g);
+  }
+  return null;
+}
+
+/**
+ * validateBody returns the first validation error message, or null
+ * when the body shape is acceptable. Extracted so the request handler
+ * stays under SonarCloud's cognitive-complexity ceiling.
+ */
+function validateBody(body: EvalConfigBody): string | null {
+  if (body.sampling) {
+    if (body.sampling.defaultRate !== undefined && !isValidRate(body.sampling.defaultRate)) {
+      return "sampling.defaultRate must be a number between 0 and 100";
+    }
+    if (body.sampling.extendedRate !== undefined && !isValidRate(body.sampling.extendedRate)) {
+      return "sampling.extendedRate must be a number between 0 and 100";
+    }
+  }
+  if (body.inline) {
+    const err = validateGroups(body.inline.groups, "inline.groups");
+    if (err) return err;
+  }
+  if (body.worker) {
+    const err = validateGroups(body.worker.groups, "worker.groups");
+    if (err) return err;
+  }
+  return null;
+}
+
+/**
+ * buildPatch composes the JSON-Merge-Patch body. Each top-level key
+ * is included only when the caller supplied it so a sampling-only
+ * update doesn't clobber existing groups (and vice versa).
+ */
+function buildPatch(body: EvalConfigBody): Record<string, unknown> {
+  return {
+    spec: {
+      evals: {
+        ...(body.enabled !== undefined && { enabled: body.enabled }),
+        ...(body.sampling && { sampling: body.sampling }),
+        ...(body.inline && { inline: body.inline }),
+        ...(body.worker && { worker: body.worker }),
+      },
+    },
+  };
 }
 
 export const PUT = withWorkspaceAccess<RouteParams>(
@@ -39,43 +128,25 @@ export const PUT = withWorkspaceAccess<RouteParams>(
   ): Promise<NextResponse> => {
     try {
       const { name, agentName } = await context.params;
-
       const body: EvalConfigBody = await request.json();
 
-      if (body.sampling) {
-        if (body.sampling.defaultRate !== undefined && !isValidRate(body.sampling.defaultRate)) {
-          return NextResponse.json(
-            { error: "Bad Request", message: "sampling.defaultRate must be a number between 0 and 100" },
-            { status: 400 }
-          );
-        }
-        if (body.sampling.extendedRate !== undefined && !isValidRate(body.sampling.extendedRate)) {
-          return NextResponse.json(
-            { error: "Bad Request", message: "sampling.extendedRate must be a number between 0 and 100" },
-            { status: 400 }
-          );
-        }
+      const validationError = validateBody(body);
+      if (validationError) {
+        return NextResponse.json(
+          { error: ERR_BAD_REQUEST, message: validationError },
+          { status: 400 },
+        );
       }
 
       const result = await getWorkspaceResource<AgentRuntime>(name, access.role!, CRD_AGENTS, agentName, "Agent");
       if (!result.ok) return result.response;
 
-      const patch: Record<string, unknown> = {
-        spec: {
-          evals: {
-            ...(body.enabled !== undefined && { enabled: body.enabled }),
-            ...(body.sampling && { sampling: body.sampling }),
-          },
-        },
-      };
-
       const patched = await patchCrd<AgentRuntime>(
         result.clientOptions,
         CRD_AGENTS,
         agentName,
-        patch
+        buildPatch(body),
       );
-
       return NextResponse.json(patched);
     } catch (error) {
       return handleK8sError(error, "update eval configuration");

--- a/dashboard/src/components/agents/eval-config-panel.test.tsx
+++ b/dashboard/src/components/agents/eval-config-panel.test.tsx
@@ -187,4 +187,94 @@ describe("EvalConfigPanel", () => {
     expect(screen.getByText("100%")).toBeInTheDocument();
     expect(screen.getByText("10%")).toBeInTheDocument();
   });
+
+  // #988 — Advanced routing UI
+  describe("advanced routing", () => {
+    it("hides advanced routing when evals are disabled", () => {
+      renderPanel({ evalsEnabled: false });
+      expect(screen.queryByText("Advanced routing")).not.toBeInTheDocument();
+    });
+
+    it("shows the advanced routing disclosure when evals are enabled", () => {
+      renderPanel({ evalsEnabled: true });
+      expect(screen.getByText("Advanced routing")).toBeInTheDocument();
+    });
+
+    it("offers the four built-in groups when no pack is configured", async () => {
+      renderPanel({ evalsEnabled: true });
+      fireEvent.click(screen.getByText("Advanced routing"));
+
+      await waitFor(() => {
+        // Each group is rendered twice (once per path) — we just need
+        // to confirm presence, not count.
+        expect(screen.getAllByText("default").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("fast-running").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("long-running").length).toBeGreaterThan(0);
+        expect(screen.getAllByText("external").length).toBeGreaterThan(0);
+      });
+    });
+
+    it("calls updateAgentEvals with the inline.groups patch when a group is toggled", async () => {
+      const mockUpdate = vi.fn().mockResolvedValue({});
+      const service = createMockDataService({ updateAgentEvals: mockUpdate });
+      renderPanel({ evalsEnabled: true, inlineGroups: ["fast-running"] }, service);
+
+      fireEvent.click(screen.getByText("Advanced routing"));
+
+      // Toggle "default" on the inline path. The id encodes the path
+      // prefix so we can target the inline checkbox specifically.
+      await waitFor(() => {
+        expect(document.getElementById("evals-inline-default")).not.toBeNull();
+      });
+      const inlineDefault = document.getElementById("evals-inline-default") as HTMLInputElement;
+      fireEvent.click(inlineDefault);
+
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalledWith("test-ws", "test-agent", {
+          inline: { groups: ["fast-running", "default"] },
+        });
+      });
+    });
+
+    it("renders custom groups already on the agent as removable chips", async () => {
+      renderPanel({
+        evalsEnabled: true,
+        workerGroups: ["long-running", "my-custom"],
+      });
+      fireEvent.click(screen.getByText("Advanced routing"));
+
+      // The custom group renders both as a removable badge AND in the
+      // list when it's selected — assert at least one occurrence.
+      await waitFor(() => {
+        expect(screen.getAllByText("my-custom").length).toBeGreaterThan(0);
+      });
+    });
+
+    it("rolls back optimistic group change on error", async () => {
+      const mockUpdate = vi.fn().mockRejectedValue(new Error("conflict"));
+      const service = createMockDataService({ updateAgentEvals: mockUpdate });
+      renderPanel(
+        { evalsEnabled: true, workerGroups: ["long-running"] },
+        service,
+      );
+
+      fireEvent.click(screen.getByText("Advanced routing"));
+      await waitFor(() => {
+        expect(document.getElementById("evals-worker-external")).not.toBeNull();
+      });
+      const workerExternal = document.getElementById("evals-worker-external") as HTMLInputElement;
+      fireEvent.click(workerExternal);
+
+      // Wait for the patch attempt and the rollback. The "external"
+      // checkbox should end up unchecked again because the patch
+      // failed and we restored the prior selection.
+      await waitFor(() => {
+        expect(mockUpdate).toHaveBeenCalled();
+      });
+      await waitFor(() => {
+        const cb = document.getElementById("evals-worker-external") as HTMLInputElement;
+        expect(cb.getAttribute("data-state")).toBe("unchecked");
+      });
+    });
+  });
 });

--- a/dashboard/src/components/agents/eval-config-panel.tsx
+++ b/dashboard/src/components/agents/eval-config-panel.tsx
@@ -1,16 +1,29 @@
 "use client";
 
 import { useState, useCallback } from "react";
-import { AlertTriangle, Sparkles } from "lucide-react";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { AlertTriangle, ChevronDown, Sparkles } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
 import { Slider } from "@/components/ui/slider";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { useEnterpriseConfig } from "@/hooks/core";
 import { useDataService } from "@/lib/data";
 import { useWorkspace } from "@/contexts/workspace-context";
 import { useQueryClient } from "@tanstack/react-query";
+import { useEvalGroups } from "@/hooks/use-eval-groups";
+import { GroupSelector } from "./group-selector";
 
 interface EvalConfigPanelProps {
   agentName: string;
@@ -20,6 +33,16 @@ interface EvalConfigPanelProps {
     defaultRate?: number;
     extendedRate?: number;
   };
+  // inline / worker group routing (issue #988). When the agent's
+  // CRD has no spec.evals.inline.groups (or .worker.groups) the
+  // operator applies its built-in default — passing undefined here
+  // surfaces "[default]" in the UI as the effective value.
+  inlineGroups?: string[];
+  workerGroups?: string[];
+  // The agent's PromptPack name, used to discover custom group names
+  // declared on the pack's eval defs. Optional — when absent the
+  // GroupSelector still offers the four built-in groups.
+  promptPackName?: string;
 }
 
 export function EvalConfigPanel({
@@ -27,6 +50,9 @@ export function EvalConfigPanel({
   frameworkType,
   evalsEnabled = false,
   sampling,
+  inlineGroups,
+  workerGroups,
+  promptPackName,
 }: Readonly<EvalConfigPanelProps>) {
   const { enterpriseEnabled, hideEnterprise } = useEnterpriseConfig();
   const dataService = useDataService();
@@ -37,7 +63,12 @@ export function EvalConfigPanel({
   const [enabled, setEnabled] = useState(evalsEnabled);
   const [lightweightRate, setLightweightRate] = useState(sampling?.defaultRate ?? 100);
   const [extendedRate, setExtendedRate] = useState(sampling?.extendedRate ?? 10);
+  const [inline, setInline] = useState<string[]>(inlineGroups ?? []);
+  const [worker, setWorker] = useState<string[]>(workerGroups ?? []);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
   const [saving, setSaving] = useState(false);
+
+  const { groups: groupOptions } = useEvalGroups(workspace, promptPackName);
 
   const isPromptKit = frameworkType === "promptkit" || frameworkType === "";
 
@@ -75,6 +106,29 @@ export function EvalConfigPanel({
     }
   }, [workspace, agentName, lightweightRate, extendedRate, dataService, queryClient]);
 
+  const handleGroupsChange = useCallback(
+    async (path: "inline" | "worker", next: string[]) => {
+      const prev = path === "inline" ? inline : worker;
+      if (path === "inline") setInline(next);
+      else setWorker(next);
+      setSaving(true);
+      try {
+        await dataService.updateAgentEvals(workspace, agentName, {
+          [path]: { groups: next },
+        });
+        await queryClient.invalidateQueries({ queryKey: ["agent", workspace, agentName] });
+      } catch {
+        // Roll back optimistic update on failure so the UI reflects
+        // the operator-side truth.
+        if (path === "inline") setInline(prev);
+        else setWorker(prev);
+      } finally {
+        setSaving(false);
+      }
+    },
+    [workspace, agentName, inline, worker, dataService, queryClient],
+  );
+
   // Only show for EE mode, hide completely if hideEnterprise
   if (hideEnterprise || !enterpriseEnabled) {
     return null;
@@ -97,9 +151,9 @@ export function EvalConfigPanel({
           <AlertDescription className="text-blue-700 dark:text-blue-300">
             When enabled, cheap deterministic evals (contains, regex) run inline
             in the agent runtime and expensive ones (LLM judges, external API
-            checks) run in the eval-worker. The sampling rates below control how
-            often each tier fires. For custom group routing, edit the AgentRuntime
-            CRD directly.
+            checks) run in the eval-worker. The sampling rates control how
+            often each tier fires; advanced routing lets you override which
+            groups run on which path.
           </AlertDescription>
         </Alert>
 
@@ -164,6 +218,49 @@ export function EvalConfigPanel({
                 Worker path — long-running and external handlers (LLM judges, REST, A2A)
               </p>
             </div>
+
+            <Collapsible open={advancedOpen} onOpenChange={setAdvancedOpen}>
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between text-left text-sm font-medium hover:text-primary"
+                >
+                  <span>Advanced routing</span>
+                  <ChevronDown
+                    className={`h-4 w-4 transition-transform ${advancedOpen ? "rotate-180" : ""}`}
+                  />
+                </button>
+              </CollapsibleTrigger>
+              <CollapsibleContent className="space-y-5 pt-4">
+                <p className="text-xs text-muted-foreground">
+                  Override which eval groups run on each path. Empty = use the
+                  built-in default for that path. Built-in groups:
+                  {" "}
+                  <code>fast-running</code>, <code>long-running</code>,
+                  {" "}<code>external</code>, <code>default</code>. Custom
+                  groups discovered from the agent&apos;s PromptPack are also
+                  offered.
+                </p>
+                <GroupSelector
+                  idPrefix="evals-inline"
+                  label="Inline groups (run in the runtime)"
+                  options={groupOptions}
+                  value={inline}
+                  disabled={saving}
+                  onChange={(next) => handleGroupsChange("inline", next)}
+                  emptyHint='Empty list uses the built-in default ["fast-running"].'
+                />
+                <GroupSelector
+                  idPrefix="evals-worker"
+                  label="Worker groups (run out-of-band in the eval-worker)"
+                  options={groupOptions}
+                  value={worker}
+                  disabled={saving}
+                  onChange={(next) => handleGroupsChange("worker", next)}
+                  emptyHint='Empty list uses the built-in default ["long-running", "external"].'
+                />
+              </CollapsibleContent>
+            </Collapsible>
           </div>
         )}
       </CardContent>

--- a/dashboard/src/components/agents/group-selector.tsx
+++ b/dashboard/src/components/agents/group-selector.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+/**
+ * Multi-select for eval group routing (#988).
+ *
+ * Renders a checkbox per known group plus a free-text input for custom
+ * groups. No new UI deps — composes existing Checkbox / Input / Badge
+ * primitives, matching the dashboard's existing arena/import-provider
+ * pattern (Set-backed selection, click row to toggle).
+ *
+ * Empty `value` means "use the path's built-in default" — the
+ * operator-side EvalPathConfig contract. We never coerce to a default
+ * inline; the parent component decides whether to send `groups: []` or
+ * omit the field.
+ */
+
+import { useState, useCallback, useMemo } from "react";
+import { Plus, X } from "lucide-react";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+
+interface GroupSelectorProps {
+  /** Currently-selected group names. */
+  value: string[];
+  /** Group names to offer as built-in or pack-discovered options. */
+  options: string[];
+  /** Fires with the new selection set whenever the user toggles a
+   *  checkbox or adds a custom group. */
+  onChange: (next: string[]) => void;
+  /** Disables all interactions while a save is in flight. */
+  disabled?: boolean;
+  /** ID prefix used to keep label/checkbox associations unique when
+   *  two GroupSelectors render in the same form. */
+  idPrefix: string;
+  /** Description shown below the field — explains what an empty
+   *  selection means for the path. */
+  emptyHint: string;
+  /** Sentinel hint shown above the option list. */
+  label: string;
+}
+
+const GROUP_NAME_RE = /^[A-Za-z0-9]([A-Za-z0-9_.-]{0,61}[A-Za-z0-9])?$/;
+
+export function GroupSelector({
+  value,
+  options,
+  onChange,
+  disabled = false,
+  idPrefix,
+  emptyHint,
+  label,
+}: Readonly<GroupSelectorProps>) {
+  const [customDraft, setCustomDraft] = useState("");
+  const [customError, setCustomError] = useState<string | null>(null);
+
+  // The selection set decides which checkboxes are on. We also need
+  // to know which selected entries aren't in `options` so they render
+  // as removable chips above the option list (custom groups added in
+  // a previous session, or set via kubectl edit).
+  const selected = useMemo(() => new Set(value), [value]);
+  const customSelected = useMemo(
+    () => value.filter((g) => !options.includes(g)),
+    [value, options],
+  );
+
+  const toggle = useCallback(
+    (group: string) => {
+      if (disabled) return;
+      const next = selected.has(group)
+        ? value.filter((g) => g !== group)
+        : [...value, group];
+      onChange(next);
+    },
+    [disabled, selected, value, onChange],
+  );
+
+  const removeCustom = useCallback(
+    (group: string) => {
+      if (disabled) return;
+      onChange(value.filter((g) => g !== group));
+    },
+    [disabled, value, onChange],
+  );
+
+  const addCustom = useCallback(() => {
+    const trimmed = customDraft.trim();
+    if (!trimmed) return;
+    if (!GROUP_NAME_RE.test(trimmed)) {
+      setCustomError(
+        "Group name must be alphanumeric (with _, -, .) and 1–63 characters.",
+      );
+      return;
+    }
+    if (selected.has(trimmed)) {
+      setCustomError("Already selected.");
+      return;
+    }
+    setCustomError(null);
+    setCustomDraft("");
+    onChange([...value, trimmed]);
+  }, [customDraft, selected, value, onChange]);
+
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">{label}</Label>
+
+      {customSelected.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {customSelected.map((g) => (
+            <Badge key={g} variant="secondary" className="gap-1">
+              {g}
+              <button
+                type="button"
+                aria-label={`Remove ${g}`}
+                disabled={disabled}
+                className="ml-0.5 rounded-sm opacity-70 hover:opacity-100 focus:outline-none focus:ring-1"
+                onClick={() => removeCustom(g)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+
+      <div className="space-y-1.5 rounded-md border p-3">
+        {options.map((g) => {
+          const id = `${idPrefix}-${g}`;
+          return (
+            <label
+              key={g}
+              htmlFor={id}
+              className="flex items-center gap-2 cursor-pointer"
+            >
+              <Checkbox
+                id={id}
+                checked={selected.has(g)}
+                disabled={disabled}
+                onCheckedChange={() => toggle(g)}
+              />
+              <span className="text-sm">{g}</span>
+            </label>
+          );
+        })}
+      </div>
+
+      <div className="flex items-start gap-2">
+        <div className="flex-1">
+          <Input
+            placeholder="Add custom group…"
+            value={customDraft}
+            disabled={disabled}
+            onChange={(e) => {
+              setCustomDraft(e.target.value);
+              if (customError) setCustomError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addCustom();
+              }
+            }}
+            aria-label={`Add a custom group to ${label}`}
+          />
+          {customError && (
+            <p className="mt-1 text-xs text-destructive">{customError}</p>
+          )}
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled || customDraft.trim().length === 0}
+          onClick={addCustom}
+        >
+          <Plus className="h-4 w-4" />
+          Add
+        </Button>
+      </div>
+
+      <p className="text-xs text-muted-foreground">{emptyHint}</p>
+    </div>
+  );
+}

--- a/dashboard/src/hooks/use-eval-groups.test.ts
+++ b/dashboard/src/hooks/use-eval-groups.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { collectPackGroups, BUILTIN_EVAL_GROUPS } from "./use-eval-groups";
+import type { PromptPackContent } from "@/lib/data/types";
+
+// The hook itself is thin (delegates to usePromptPackContent and
+// memoizes); we cover the pure pack-walk separately so a regression in
+// the discovery rule is caught without spinning up React Query.
+
+describe("collectPackGroups", () => {
+  it("returns [] for null/undefined", () => {
+    expect(collectPackGroups(null)).toEqual([]);
+    expect(collectPackGroups(undefined)).toEqual([]);
+  });
+
+  it("collects pack-level eval groups", () => {
+    const content: PromptPackContent = {
+      id: "p",
+      name: "p",
+      version: "1",
+      template_engine: { version: "v1", syntax: "{{}}" },
+      evals: [
+        { id: "e1", type: "contains", trigger: "always", groups: ["safety", "fast"] },
+        { id: "e2", type: "regex", trigger: "always", groups: ["fast"] },
+      ],
+    };
+    expect(collectPackGroups(content).sort()).toEqual(["fast", "fast", "safety"]);
+  });
+
+  it("collects prompt-level eval groups", () => {
+    const content: PromptPackContent = {
+      id: "p",
+      name: "p",
+      version: "1",
+      template_engine: { version: "v1", syntax: "{{}}" },
+      prompts: {
+        default: {
+          id: "default",
+          evals: [
+            { id: "e1", type: "judge", trigger: "always", groups: ["llm-judge"] },
+          ],
+        },
+      },
+    };
+    expect(collectPackGroups(content)).toEqual(["llm-judge"]);
+  });
+
+  it("merges pack-level and prompt-level groups", () => {
+    const content: PromptPackContent = {
+      id: "p",
+      name: "p",
+      version: "1",
+      template_engine: { version: "v1", syntax: "{{}}" },
+      evals: [{ id: "e1", type: "contains", trigger: "always", groups: ["pack-g"] }],
+      prompts: {
+        default: {
+          id: "default",
+          evals: [
+            { id: "e2", type: "judge", trigger: "always", groups: ["prompt-g"] },
+          ],
+        },
+      },
+    };
+    expect(collectPackGroups(content).sort()).toEqual(["pack-g", "prompt-g"]);
+  });
+
+  it("ignores evals without groups", () => {
+    const content: PromptPackContent = {
+      id: "p",
+      name: "p",
+      version: "1",
+      template_engine: { version: "v1", syntax: "{{}}" },
+      evals: [{ id: "e1", type: "contains", trigger: "always" }],
+    };
+    expect(collectPackGroups(content)).toEqual([]);
+  });
+});
+
+describe("BUILTIN_EVAL_GROUPS", () => {
+  it("is the four built-in PromptKit group names — order-stable for snapshot", () => {
+    expect(BUILTIN_EVAL_GROUPS).toEqual([
+      "default",
+      "fast-running",
+      "long-running",
+      "external",
+    ]);
+  });
+});

--- a/dashboard/src/hooks/use-eval-groups.ts
+++ b/dashboard/src/hooks/use-eval-groups.ts
@@ -50,7 +50,7 @@ export function useEvalGroups(
         set.add(g);
       }
     }
-    return Array.from(set).sort();
+    return Array.from(set).sort((a, b) => a.localeCompare(b));
   }, [content]);
 
   return { groups, isLoading: !!packName && isLoading };

--- a/dashboard/src/hooks/use-eval-groups.ts
+++ b/dashboard/src/hooks/use-eval-groups.ts
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * Hook for discovering eval groups available to an agent.
+ *
+ * Returns the union of:
+ *   - Built-in groups: `default`, `fast-running`, `long-running`, `external`.
+ *     PromptKit auto-classifies handlers into the latter three; every eval
+ *     also carries `default`. These are always offered as options even when
+ *     the pack declares no custom groups.
+ *   - Custom groups declared on any eval in the pack — pack-level
+ *     `evals[].groups` plus prompt-level `prompts[*].evals[].groups`.
+ *
+ * Supports the dashboard's eval routing UI (#988) without requiring an
+ * extra dashboard endpoint — the PromptPack content is already
+ * fetchable via the existing data-service path.
+ */
+
+import { useMemo } from "react";
+import { usePromptPackContent } from "./use-promptpack-content";
+import type { PromptPackContent } from "@/lib/data/types";
+
+export const BUILTIN_EVAL_GROUPS = [
+  "default",
+  "fast-running",
+  "long-running",
+  "external",
+] as const;
+
+export interface UseEvalGroupsResult {
+  /** Sorted, deduped list of group names available for selection.
+   *  Always includes the four built-in groups, plus pack-declared
+   *  custom groups when a packName is supplied. */
+  groups: string[];
+  /** True while the pack content is loading; the caller can render a
+   *  skeleton without flickering between built-in-only and full lists. */
+  isLoading: boolean;
+}
+
+export function useEvalGroups(
+  workspace: string,
+  packName: string | undefined,
+): UseEvalGroupsResult {
+  const { data: content, isLoading } = usePromptPackContent(packName ?? "", workspace);
+
+  const groups = useMemo(() => {
+    const set = new Set<string>(BUILTIN_EVAL_GROUPS);
+    if (content) {
+      for (const g of collectPackGroups(content)) {
+        set.add(g);
+      }
+    }
+    return Array.from(set).sort();
+  }, [content]);
+
+  return { groups, isLoading: !!packName && isLoading };
+}
+
+/**
+ * collectPackGroups walks every eval definition in the pack — both
+ * pack-level and prompt-level — and yields the group names declared on
+ * each. Exported separately so tests can pin the collection rule
+ * without going through React Query.
+ */
+export function collectPackGroups(content: PromptPackContent | null | undefined): string[] {
+  if (!content) return [];
+  const out: string[] = [];
+  for (const e of content.evals ?? []) {
+    if (e.groups) out.push(...e.groups);
+  }
+  for (const promptId of Object.keys(content.prompts ?? {})) {
+    const prompt = content.prompts?.[promptId];
+    for (const e of prompt?.evals ?? []) {
+      if (e.groups) out.push(...e.groups);
+    }
+  }
+  return out;
+}

--- a/dashboard/src/lib/data/live-service.ts
+++ b/dashboard/src/lib/data/live-service.ts
@@ -356,7 +356,7 @@ export class LiveDataService implements DataService {
   async updateAgentEvals(
     workspace: string,
     name: string,
-    evals: { enabled?: boolean; sampling?: { defaultRate?: number; extendedRate?: number } }
+    evals: import("./types").AgentEvalsPatch,
   ): Promise<AgentRuntime> {
     return this.workspaceService.updateAgentEvals(workspace, name, evals);
   }

--- a/dashboard/src/lib/data/mock-service.ts
+++ b/dashboard/src/lib/data/mock-service.ts
@@ -596,7 +596,7 @@ export class MockDataService implements DataService {
   async updateAgentEvals(
     workspace: string,
     name: string,
-    evals: { enabled?: boolean; sampling?: { defaultRate?: number; extendedRate?: number } }
+    evals: import("./types").AgentEvalsPatch,
   ): Promise<AgentRuntime> {
     await delay(500);
     const agent = mockAgentRuntimes.find(

--- a/dashboard/src/lib/data/types.ts
+++ b/dashboard/src/lib/data/types.ts
@@ -200,6 +200,30 @@ export interface EvalDefinition {
   params?: Record<string, unknown>;
   sample_percentage?: number;
   metric?: MetricDef;
+  // Custom group names this eval belongs to. The dashboard's eval
+  // routing UI (issue #988) discovers these and offers them as
+  // autocomplete options alongside the four built-in groups
+  // (default, fast-running, long-running, external).
+  groups?: string[];
+}
+
+/**
+ * Patch shape for updateAgentEvals. Each top-level field is
+ * independently optional so callers can update one slice (e.g. the
+ * sampling slider) without re-sending the rest.
+ *
+ * `inline.groups` and `worker.groups` route which evals run on which
+ * path; an empty array means "use the built-in default for that path"
+ * (the operator-side EvalPathConfig contract).
+ */
+export interface AgentEvalsPatch {
+  enabled?: boolean;
+  sampling?: {
+    defaultRate?: number;
+    extendedRate?: number;
+  };
+  inline?: { groups?: string[] };
+  worker?: { groups?: string[] };
 }
 
 export interface MetricDef {
@@ -391,7 +415,11 @@ export interface DataService {
   getAgent(workspace: string, name: string): Promise<AgentRuntimeType | undefined>;
   createAgent(workspace: string, spec: Record<string, unknown>): Promise<AgentRuntimeType>;
   scaleAgent(workspace: string, name: string, replicas: number): Promise<AgentRuntimeType>;
-  updateAgentEvals(workspace: string, name: string, evals: { enabled?: boolean; sampling?: { defaultRate?: number; extendedRate?: number } }): Promise<AgentRuntimeType>;
+  updateAgentEvals(
+    workspace: string,
+    name: string,
+    evals: AgentEvalsPatch,
+  ): Promise<AgentRuntimeType>;
   getAgentLogs(workspace: string, name: string, options?: LogOptions): Promise<LogEntry[]>;
   getAgentEvents(workspace: string, name: string): Promise<K8sEvent[]>;
 

--- a/dashboard/src/lib/data/workspace-api-service.ts
+++ b/dashboard/src/lib/data/workspace-api-service.ts
@@ -90,7 +90,7 @@ export class WorkspaceApiService {
   async updateAgentEvals(
     workspace: string,
     name: string,
-    evals: { enabled?: boolean; sampling?: { defaultRate?: number; extendedRate?: number } }
+    evals: import("./types").AgentEvalsPatch,
   ): Promise<AgentRuntime> {
     const response = await fetch(
       `/api/workspaces/${encodeURIComponent(workspace)}/agents/${encodeURIComponent(name)}/evals`,


### PR DESCRIPTION
## Summary

Closes #988. PR #983 added \`spec.evals.inline.groups\` and \`spec.evals.worker.groups\` to the AgentRuntime CRD with disjoint defaults — inline runs \`[\"fast-running\"]\`, worker runs \`[\"long-running\",\"external\"]\`. Defaults fit ~99% of agents; the remaining 1% (custom routing, LLM-judge inline, throughput-sensitive worker offload) had to reach for \`kubectl edit agentruntime\` because the panel only exposed the enabled toggle and two sampling sliders.

This adds an **\"Advanced routing\"** disclosure (collapsed by default) under the existing sampling controls. Two \`GroupSelector\` instances surface \`inline.groups\` and \`worker.groups\`; each lists the four built-in PromptKit groups (\`default\`, \`fast-running\`, \`long-running\`, \`external\`) plus any custom groups discovered on the agent's PromptPack eval defs.

### Components
| File | Purpose |
|---|---|
| \`group-selector.tsx\` | Reusable multi-select. Composes existing Checkbox / Input / Badge / Button (no new UI deps); supports adding ad-hoc custom group names via input + \"Add\" button. |
| \`use-eval-groups.ts\` | \`useEvalGroups(workspace, packName)\` returns the union of built-in and pack-declared groups. \`default\` always included. |
| \`eval-config-panel.tsx\` | New \`Collapsible\` advanced section + wires both selectors through \`dataService.updateAgentEvals\`. Optimistic updates roll back on failure. |

### Backend wiring
- \`api/.../evals/route.ts\` — \`EvalConfigBody\` accepts \`inline\` / \`worker\`. \`validateGroups\` enforces the K8s-label-shape regex, dedup, and a ≤32-entry sanity bound. Refactored handler into \`validateBody\` + \`buildPatch\` to stay under SonarCloud's cognitive-complexity ceiling.
- \`lib/data/types.ts\` — new \`AgentEvalsPatch\` type; \`updateAgentEvals\` widened across the three implementations (live, workspace-api, mock).
- \`EvalDefinition\` gains an optional \`groups[]\` so the discovery hook can read pack-declared custom groups.

### Tests (24 passing)
- 6 specs on \`collectPackGroups\` (the discovery rule): null/undefined safety, pack-level only, prompt-level only, merge of both, ignore evals without groups, built-in list ordering snapshot.
- 6 new specs on \`EvalConfigPanel\`: advanced disclosure visible only when enabled, four built-in groups always offered, inline-group toggle sends the right patch, custom groups already on the agent render as removable chips, optimistic rollback on patch failure.

### Out of scope
- Doesn't validate that selected groups actually exist on the pack — operators may add custom group names ahead of declaring them on a pack and that's fine. The CRD admission path stops bad shape; \"no eval matches this group\" is a runtime no-op, not an error.
- Doesn't expose \`rateLimit\` fields — those remain kubectl-only.

## Test plan
- [x] \`npm test src/hooks/use-eval-groups.test.ts src/components/agents/eval-config-panel.test.tsx\` (24 / 24)
- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean (only pre-existing warnings)
- [ ] CI
- [ ] Manual: open an agent's evals tab, expand \"Advanced routing\", verify defaults render + adding/removing groups patches the CRD.