### PR TITLE
ci(dashboard): bump vitest testTimeout from 5s to 15s

### DIFF
--- a/dashboard/vitest.config.ts
+++ b/dashboard/vitest.config.ts
@@ -7,6 +7,12 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     globals: true,
+    // Default is 5000ms. CI runners under high load occasionally
+    // exceed that on tests with heavy mock setup (the arena versions
+    // route test stacks ~20 fs mocks per spec). 15s is plenty
+    // headroom for those without slowing local dev — local runs
+    // complete sub-second per spec regardless.
+    testTimeout: 15_000,
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}", "lib/**/*.test.{js,mjs,cjs,ts}"],
     exclude: [


### PR DESCRIPTION
## Summary

Main CI failed after #1054 merged because one dashboard test (the arena versions route handler) hit the 5000ms vitest default. The test passes sub-second locally and on every other CI run — runtime variance on GitHub-hosted runners under high load occasionally pushes tests with heavy mock setup (~20 fs mocks per spec) past 5s.

15s is plenty of headroom without slowing local dev: local runs complete sub-second per spec regardless of timeout. A genuinely-hung test still fails — just in 15s instead of 5s.

The rerun of the failed CI on main is queued separately; this is the durable fix.

## Test plan
- [x] \`npm test src/app/api/workspaces/[name]/arena/sources/[sourceName]/versions\` passes locally (15 / 15, 1.06s).
- [ ] CI green on this PR.
- [ ] Failing main CI run cleared by the manual rerun.