### PR TITLE
ci: retry cert-manager / gateway-api yaml fetches against GitHub CDN flake

### DIFF
--- a/.github/workflows/test-agent-e2e-llm.yml
+++ b/.github/workflows/test-agent-e2e-llm.yml
@@ -129,14 +129,14 @@ jobs:
 
       - name: Install cert-manager
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml | kubectl apply -f -
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
 
       - name: Install Gateway API CRDs
         run: |
-          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml | kubectl apply -f -
 
       - name: Build chart dependencies
         run: |
@@ -339,7 +339,7 @@ jobs:
       - name: Install cert-manager
         if: steps.gate.outputs.skip != 'true'
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml | kubectl apply -f -
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
@@ -347,7 +347,7 @@ jobs:
       - name: Install Gateway API CRDs
         if: steps.gate.outputs.skip != 'true'
         run: |
-          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml | kubectl apply -f -
 
       - name: Build chart dependencies
         if: steps.gate.outputs.skip != 'true'

--- a/.github/workflows/test-agent-e2e.yml
+++ b/.github/workflows/test-agent-e2e.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Install cert-manager
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml | kubectl apply -f -
           echo "Waiting for cert-manager to be ready..."
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
@@ -135,7 +135,7 @@ jobs:
 
       - name: Install Gateway API CRDs
         run: |
-          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml | kubectl apply -f -
 
       - name: Add Helm repositories
         run: |

--- a/.github/workflows/test-helm-e2e.yml
+++ b/.github/workflows/test-helm-e2e.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Install cert-manager
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml | kubectl apply -f -
           echo "Waiting for cert-manager to be ready..."
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install Gateway API CRDs
         run: |
-          kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.0/standard-install.yaml | kubectl apply -f -
 
       - name: Add Helm repositories
         run: |
@@ -175,7 +175,7 @@ jobs:
         run: |
           kind delete cluster --name $KIND_CLUSTER
           kind create cluster --name $KIND_CLUSTER --wait 60s
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml | kubectl apply -f -
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
@@ -266,7 +266,7 @@ jobs:
         run: |
           kind delete cluster --name $KIND_CLUSTER
           kind create cluster --name $KIND_CLUSTER --wait 60s
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml | kubectl apply -f -
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s
@@ -322,7 +322,7 @@ jobs:
         run: |
           kind delete cluster --name $KIND_CLUSTER
           kind create cluster --name $KIND_CLUSTER --wait 60s
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+          curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL https://github.com/cert-manager/cert-manager/releases/download/v1.14.4/cert-manager.yaml | kubectl apply -f -
           kubectl wait --for=condition=Available deployment/cert-manager -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-webhook -n cert-manager --timeout=120s
           kubectl wait --for=condition=Available deployment/cert-manager-cainjector -n cert-manager --timeout=120s


### PR DESCRIPTION
## Summary

The first scheduled run of the real-LLM workflow ([run 25098479576](https://github.com/AltairaLabs/Omnia/actions/runs/25098479576)) failed in the **Install cert-manager** step with \`HTTP 502\` fetching \`cert-manager.yaml\` from \`github.com/cert-manager/.../releases\`. Pure transient CDN issue — same vulnerability lives in every workflow that does \`kubectl apply -f <github-url>\`:

| File | cert-manager.yaml | gateway-api/standard-install.yaml |
|---|---|---|
| \`test-agent-e2e.yml\` | 1 | 1 |
| \`test-agent-e2e-llm.yml\` | 2 | 2 |
| \`test-helm-e2e.yml\` | 4 | 1 |
| **Total** | **7** | **4** |

### Change
Switch to:
```bash
curl --retry 5 --retry-delay 5 --retry-all-errors --fail -sL <url> | kubectl apply -f -
```

\`--retry-all-errors\` (curl 7.71+, available on \`ubuntu-latest\`) retries on 4xx/5xx too — not just transport errors — so today's 502 gets retried automatically. Max wait on a sustained outage is 5 × 5s = 25s, which keeps the failure loud rather than running for the full 35-min job timeout.

Same treatment applied to the Gateway API CRD URL — same \`github.com/.../releases\` pattern, same flake risk.

## Test plan
- [x] \`actionlint\` clean (no new issues; pre-existing info-level shellcheck warnings unchanged).
- [ ] CI green on this PR.
- [ ] Tonight's scheduled real-LLM workflow run survives any CDN flake.