### PR TITLE
feat(memory): wire CachedStore into memory-api

### DIFF
--- a/charts/omnia/templates/_helpers.tpl
+++ b/charts/omnia/templates/_helpers.tpl
@@ -309,6 +309,30 @@ Eval Worker image
 {{- end }}
 
 {{/*
+Resolve the operator-wide Redis address.
+
+Priority:
+  1. .Values.redis.externalAddr — explicit operator override (off-cluster Redis,
+     e.g. AWS ElastiCache, GCP Memorystore).
+  2. Bitnami Redis subchart service when .Values.redis.enabled=true.
+  3. "" — Redis-dependent features (memory-api cache + event publisher,
+     eval-worker queue, dashboard session store) all stay disabled.
+
+Returning a single canonical address keeps the operator, dashboard, and
+arena-controller in sync without each template having to redo the
+"is Redis available?" reasoning.
+*/}}
+{{- define "omnia.redisAddr" -}}
+{{- if .Values.redis.externalAddr -}}
+{{- .Values.redis.externalAddr -}}
+{{- else if .Values.redis.enabled -}}
+{{- printf "%s-redis-master.%s.svc.cluster.local:6379" (include "omnia.fullname" .) .Release.Namespace -}}
+{{- else -}}
+{{- "" -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Resolve OTLP tracing endpoint for runtime/facade containers.
 Priority:
 1. .Values.tracing.endpoint (explicit override)

--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -71,6 +71,20 @@ spec:
             - --session-api-image-pull-policy={{ .Values.workspaceServices.sessionApi.image.pullPolicy }}
             - --memory-api-image={{ include "omnia.memoryApi.image" . }}
             - --memory-api-image-pull-policy={{ .Values.workspaceServices.memoryApi.image.pullPolicy }}
+            {{- /*
+              Operator-wide Redis. Threaded into per-workspace memory-api
+              pods as --redis-addrs (cache + event publisher) and into
+              eval-worker deployments as --redis-addr. Empty when no Redis
+              is configured (default OSS install) — leaves all three
+              consumers in their no-Redis modes.
+            */}}
+            {{- $redisAddr := include "omnia.redisAddr" . }}
+            {{- if $redisAddr }}
+            - --redis-addr={{ $redisAddr }}
+            {{- end }}
+            {{- with .Values.workspaceServices.memoryApi.cache.ttl }}
+            - --memory-cache-ttl={{ . }}
+            {{- end }}
             - --agent-workspace-reader-clusterrole={{ include "omnia.fullname" . }}-agent-workspace-reader
             {{- if .Values.dashboard.enabled }}
             {{- /*

--- a/charts/omnia/tests/operator-redis-wiring_test.yaml
+++ b/charts/omnia/tests/operator-redis-wiring_test.yaml
@@ -1,0 +1,69 @@
+suite: operator forwards Redis config to memory-api + eval-worker
+release:
+  name: omnia
+values:
+  - ../values-chart-tests.yaml
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: operator passes --memory-cache-ttl unconditionally so memory-api wiring matches its 5m default
+    # Memory-api defaults --cache-ttl to 5m on its own, but having the
+    # operator pass it explicitly is the wiring assertion: anyone
+    # reading kubectl describe sees the configured TTL without diffing
+    # against the binary's compiled default.
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --memory-cache-ttl=5m
+
+  - it: operator does NOT pass --redis-addr when no Redis is configured
+    # Default OSS install has redis.enabled=false and no externalAddr.
+    # Forwarding "--redis-addr=" with an empty value would degrade into
+    # a connection-refused log on every cache lookup. Absent flag is
+    # the correct shape; memory-api treats it as "Redis disabled".
+    template: templates/deployment.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--redis-addr=$
+
+  - it: operator wires --redis-addr to the Bitnami subchart service when redis.enabled=true
+    # When redis.enabled=true, the Bitnami subchart provisions
+    # `<release>-redis-master`; the operator addr must match. This
+    # assertion catches any future rename of the helper.
+    set:
+      redis.enabled: true
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redis-addr=omnia-redis-master.NAMESPACE.svc.cluster.local:6379
+
+  - it: redis.externalAddr wins over redis.enabled (off-cluster Redis)
+    # Operators pointing at AWS ElastiCache, GCP Memorystore, etc. set
+    # redis.externalAddr. The Bitnami subchart should be skipped and
+    # the operator should hand the external addr to memory-api / eval
+    # worker / arena queue.
+    set:
+      redis.enabled: true
+      redis.externalAddr: "external-redis.example.com:6380"
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redis-addr=external-redis.example.com:6380
+
+  - it: empty workspaceServices.memoryApi.cache.ttl drops the flag entirely
+    # An operator wanting Redis for the event publisher only (no read-
+    # through cache) sets ttl="". The flag must be omitted, not passed
+    # as "--memory-cache-ttl=", which would arrive at memory-api as a
+    # bad duration and silently disable the cache anyway — but the
+    # confused log line is worse than absent config.
+    set:
+      workspaceServices.memoryApi.cache.ttl: ""
+    template: templates/deployment.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--memory-cache-ttl(=.*)?$

--- a/charts/omnia/values.schema.json
+++ b/charts/omnia/values.schema.json
@@ -432,7 +432,13 @@
           "type": "object",
           "properties": {
             "image":     { "$ref": "#/$defs/image" },
-            "resources": { "$ref": "#/$defs/resources" }
+            "resources": { "$ref": "#/$defs/resources" },
+            "cache": {
+              "type": "object",
+              "properties": {
+                "ttl": { "type": "string" }
+              }
+            }
           }
         }
       }
@@ -576,6 +582,7 @@
       "type": "object",
       "properties": {
         "enabled":      { "type": "boolean" },
+        "externalAddr": { "type": "string" },
         "architecture": { "type": "string", "enum": ["standalone", "replication"] }
       }
     },

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -1049,6 +1049,20 @@ workspaceServices:
       # -- Image pull policy
       pullPolicy: IfNotPresent
 
+    # Read-through Redis cache for memory-api Retrieve/List paths. Active
+    # only when an operator-wide Redis is configured (redis.enabled=true
+    # OR redis.externalAddr set). Workers (compaction, retention,
+    # tombstone GC, re-embed) always use the unwrapped Postgres store —
+    # the cache only fronts API reads.
+    cache:
+      # -- TTL for cached Retrieve/List results. Empty or "0" disables
+      # the cache even when Redis is configured (operators sometimes
+      # enable Redis for the event publisher first, cache later).
+      # Cache invalidation is version-keyed on every write, so this TTL
+      # only bounds stale reads in the event of an inactive scope; it
+      # is NOT the staleness window after a write.
+      ttl: "5m"
+
 # ============================================================================
 # Dev Postgres
 # ============================================================================
@@ -2194,6 +2208,15 @@ redis:
   # -- Enable Redis subchart (Bitnami Redis)
   # Use this for development or when you want a managed Redis instance
   enabled: false
+
+  # -- Address (host:port) of an external Redis the chart should use
+  # instead of the Bitnami subchart. Set this when pointing the
+  # operator + memory-api + eval-worker + dashboard at AWS ElastiCache,
+  # GCP Memorystore, or any pre-existing in-cluster Redis. Wins over
+  # `redis.enabled` — the subchart is skipped when this is set.
+  # Empty disables all Redis-dependent features (memory cache, event
+  # publisher, eval queue, server-side sessions).
+  externalAddr: ""
 
   # -- Subchart values for Bitnami Redis
   # See: https://github.com/bitnami/charts/tree/main/bitnami/redis

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,7 +121,15 @@ func main() {
 	flag.StringVar(&workspaceContentPath, "workspace-content-path", "/workspace-content",
 		"Base path for the workspace content volume. SkillSource writes synced content here.")
 	flag.StringVar(&redisAddr, "redis-addr", "",
-		"Redis address for eval worker deployments (e.g., redis.omnia-system.svc.cluster.local:6379)")
+		"Operator-wide Redis address (e.g., omnia-redis-master.omnia-system.svc.cluster.local:6379). "+
+			"Forwarded to eval-worker pods and to every per-workspace memory-api as --redis-addrs, "+
+			"so a single Redis instance fronts the memory-api read-through cache, the memory event "+
+			"publisher, and the eval-worker queue. Empty disables all three.")
+	var memoryCacheTTL string
+	flag.StringVar(&memoryCacheTTL, "memory-cache-ttl", "5m",
+		"TTL forwarded to memory-api as --cache-ttl. Empty or \"0\" disables the read-through "+
+			"cache even when --redis-addr is set (useful when Redis is provisioned only for the "+
+			"event publisher).")
 	flag.StringVar(&evalWorkerImage, "eval-worker-image", "",
 		"Image for the arena-eval-worker container. If not set, defaults to ghcr.io/altairalabs/arena-eval-worker:latest")
 	flag.StringVar(&policyProxyImage, "policy-proxy-image", "",
@@ -298,6 +306,8 @@ func main() {
 			SessionImagePullPolicy: corev1.PullPolicy(sessionAPIImagePullPolicy),
 			MemoryImage:            memoryAPIImage,
 			MemoryImagePullPolicy:  corev1.PullPolicy(memoryAPIImagePullPolicy),
+			MemoryRedisAddrs:       redisAddr,
+			MemoryCacheTTL:         memoryCacheTTL,
 		},
 		AgentWorkspaceReaderClusterRole: agentWorkspaceReaderClusterRole,
 		OperatorNamespace:               os.Getenv("POD_NAMESPACE"),

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -34,7 +34,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	goredis "github.com/redis/go-redis/v9"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -107,6 +106,7 @@ type flags struct {
 	metricsAddr           string
 	postgresConn          string
 	redisAddrs            string
+	cacheTTL              string // env: MEMORY_CACHE_TTL, e.g. "5m"; "" or "0" disables
 	enterprise            bool
 	tracingEnabled        bool
 	tracingEndpoint       string
@@ -135,7 +135,8 @@ func parseFlags() *flags {
 	flag.StringVar(&f.healthAddr, "health-addr", ":8081", "Health probe listen address")
 	flag.StringVar(&f.metricsAddr, "metrics-addr", ":9090", "Metrics server listen address")
 	flag.StringVar(&f.postgresConn, "postgres-conn", "", "Postgres connection string")
-	flag.StringVar(&f.redisAddrs, "redis-addrs", "", "Redis addresses (comma-separated)")
+	flag.StringVar(&f.redisAddrs, "redis-addrs", "", "Redis addresses (comma-separated). When set, the same client is reused for both the read-through cache and the event publisher.")
+	flag.StringVar(&f.cacheTTL, "cache-ttl", "5m", "TTL for the Redis read-through cache (Retrieve/List). Set to 0 or empty to disable caching even when --redis-addrs is configured.")
 	flag.BoolVar(&f.enterprise, "enterprise", false, "Enable enterprise features (audit logging)")
 	flag.BoolVar(&f.tracingEnabled, "tracing-enabled", false, "Enable OpenTelemetry tracing")
 	flag.StringVar(&f.tracingEndpoint, "tracing-endpoint", "", "OTel collector endpoint")
@@ -166,6 +167,7 @@ func parseFlags() *flags {
 func (f *flags) applyEnvFallbacks() {
 	envFallback(&f.postgresConn, "", "POSTGRES_CONN")
 	envFallback(&f.redisAddrs, "", "REDIS_ADDRS")
+	envFallback(&f.cacheTTL, "5m", "MEMORY_CACHE_TTL")
 	envFallback(&f.apiAddr, ":8080", "API_ADDR")
 	envFallback(&f.healthAddr, ":8081", "HEALTH_ADDR")
 	envFallback(&f.metricsAddr, ":9090", "METRICS_ADDR")
@@ -373,8 +375,27 @@ func run() error {
 	log.V(1).Info("migrations complete")
 
 	// --- Memory store ---
-	store := memory.NewPostgresMemoryStore(pool)
-	defer store.Close()
+	// pgStore is the raw Postgres-backed store. Workers (compaction,
+	// retention, tombstone GC, re-embed) call concrete methods on this
+	// type, so they keep using the unwrapped value. The HTTP API gets
+	// the (possibly cache-fronted) Store interface — see resolveAPIStore
+	// below.
+	pgStore := memory.NewPostgresMemoryStore(pool)
+	defer pgStore.Close()
+
+	// Build the shared Redis client (if configured) before either the
+	// cache wrapper or the event publisher. One client, one TCP pool —
+	// keeps connection accounting honest and lets ops see "is Redis up"
+	// from a single set of metrics rather than two.
+	redisClient := buildRedisClient(f.redisAddrs)
+	if redisClient != nil {
+		defer func() { _ = redisClient.Close() }()
+	}
+
+	apiStore, cacheEnabled := resolveAPIStore(pgStore, redisClient, f.cacheTTL, log)
+	if cacheEnabled {
+		log.Info("memory store cache enabled", "ttl", f.cacheTTL, "redisAddrs", f.redisAddrs)
+	}
 
 	// --- Read-path metrics ---
 	// accessed_at / access_count are bumped asynchronously on every
@@ -404,7 +425,7 @@ func run() error {
 	policyLoader := buildRetentionPolicyLoader(f.retentionInterval, f.workspace, f.serviceGroup, log)
 
 	// --- Retention worker ---
-	startRetentionWorkerWithLoader(ctx, store, policyLoader, log)
+	startRetentionWorkerWithLoader(ctx, pgStore, policyLoader, log)
 
 	// --- Analytics opt-in metric + worker ---
 	// Computes the fraction of users who have granted the
@@ -426,8 +447,8 @@ func run() error {
 	// Temporal summarization of old memories. Uses NoopSummarizer by default —
 	// memory growth is still bounded because the worker supersedes originals,
 	// but summaries aren't informative until a real LLM summarizer is wired.
-	if compactionOpts, enabled := f.compactionWorkerOptions(log, store); enabled {
-		worker := memory.NewCompactionWorker(store, memory.NoopSummarizer{}, compactionOpts, log)
+	if compactionOpts, enabled := f.compactionWorkerOptions(log, pgStore); enabled {
+		worker := memory.NewCompactionWorker(pgStore, memory.NoopSummarizer{}, compactionOpts, log)
 		go worker.Run(ctx)
 		log.Info("compaction worker started",
 			"interval", compactionOpts.Interval,
@@ -439,7 +460,7 @@ func run() error {
 	// --- Embedding service ---
 	var embeddingSvc *memory.EmbeddingService
 	if f.embeddingProviderName != "" {
-		embeddingSvc = createEmbeddingService(ctx, f.embeddingProviderName, store, log)
+		embeddingSvc = createEmbeddingService(ctx, f.embeddingProviderName, pgStore, log)
 	}
 
 	// --- Tombstone GC worker ---
@@ -447,8 +468,8 @@ func run() error {
 	// chains, keeping the most recent K per chain for audit. Bounds
 	// storage growth without losing the agent-visible "this got
 	// updated" history.
-	if tombstoneOpts, enabled := f.tombstoneWorkerOptions(log, store); enabled {
-		worker := memory.NewTombstoneWorker(store, tombstoneOpts, log)
+	if tombstoneOpts, enabled := f.tombstoneWorkerOptions(log, pgStore); enabled {
+		worker := memory.NewTombstoneWorker(pgStore, tombstoneOpts, log)
 		go worker.Run(ctx)
 		log.Info("tombstone worker started",
 			"interval", tombstoneOpts.Interval,
@@ -464,7 +485,7 @@ func run() error {
 	// recall path doesn't silently miss them. Requires both an
 	// embedding service AND a configured interval.
 	if reembedOpts, enabled := f.reembedWorkerOptions(embeddingSvc); enabled {
-		worker := memory.NewReembedWorker(store, embeddingSvc.Provider(), reembedOpts, log)
+		worker := memory.NewReembedWorker(pgStore, embeddingSvc.Provider(), reembedOpts, log)
 		go worker.Run(ctx)
 		log.Info("reembed worker started",
 			"interval", reembedOpts.Interval,
@@ -497,15 +518,16 @@ func run() error {
 	}
 
 	// --- Event publisher (optional) ---
+	// Reuses the shared Redis client built above so we don't create a
+	// second TCP pool against the same target.
 	var eventPublisher memoryapi.MemoryEventPublisher
-	if f.redisAddrs != "" {
-		redisClient := goredis.NewClient(&goredis.Options{Addr: f.redisAddrs})
+	if redisClient != nil {
 		eventPublisher = memoryapi.NewRedisMemoryEventPublisher(redisClient, log)
 		log.Info("memory event publisher enabled", "redisAddrs", f.redisAddrs)
 	}
 
 	// --- Build API mux ---
-	apiMux, cleanup := buildAPIMux(ctx, store, embeddingSvc, svcCfg, eventPublisher, f.enterprise, pool, policyLoader, log)
+	apiMux, cleanup := buildAPIMux(ctx, apiStore, embeddingSvc, svcCfg, eventPublisher, f.enterprise, pool, policyLoader, log)
 	defer cleanup()
 
 	// --- Servers ---

--- a/cmd/memory-api/redis_cache.go
+++ b/cmd/memory-api/redis_cache.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// buildRedisClient returns a Redis client for the given addrs string, or
+// nil when the input is empty. Comma-separated addrs are accepted so the
+// flag matches Sentinel-friendly conventions, but the production wire-up
+// today is single-master — only the first entry is used. We stay
+// permissive on input so a future move to a Sentinel client doesn't
+// break operator config.
+func buildRedisClient(addrs string) *goredis.Client {
+	addr := strings.TrimSpace(addrs)
+	if addr == "" {
+		return nil
+	}
+	if i := strings.Index(addr, ","); i >= 0 {
+		addr = strings.TrimSpace(addr[:i])
+	}
+	if addr == "" {
+		return nil
+	}
+	return goredis.NewClient(&goredis.Options{Addr: addr})
+}
+
+// resolveAPIStore returns the Store the HTTP API should use.
+//
+// Workers (compaction, retention, tombstone, re-embed) take the raw
+// *PostgresMemoryStore directly — they need concrete-type methods like
+// ListWorkspaceIDs and they always want live data. The HTTP API
+// benefits from a Redis read-through cache on Retrieve/List, so when a
+// Redis client and a positive TTL are both available we wrap inner in
+// a CachedStore.
+//
+// The bool return is purely informational (so the caller can log
+// "cache enabled" once at startup); the wrap decision itself is fully
+// reflected in the returned Store.
+//
+// Failure modes:
+//   - rdb == nil → no cache, return inner
+//   - cacheTTLRaw empty / "0" / unparseable / non-positive → no cache,
+//     return inner. Bad input is treated like "off"; we log later in
+//     run() that the cache is enabled, so a missing log line is a
+//     readable signal that the operator's configured TTL didn't parse.
+func resolveAPIStore(inner memory.Store, rdb *goredis.Client, cacheTTLRaw string, log logr.Logger) (memory.Store, bool) {
+	if rdb == nil {
+		return inner, false
+	}
+	ttl, ok := parseCacheTTL(cacheTTLRaw)
+	if !ok {
+		return inner, false
+	}
+	return memory.NewCachedStore(inner, rdb, ttl, log), true
+}
+
+// parseCacheTTL accepts the raw flag/env value and returns (duration,
+// enabled). "" and "0" are explicitly off; anything that fails to
+// parse is also off (callers don't get a half-configured cache from a
+// typo). Negative durations are rejected.
+func parseCacheTTL(raw string) (time.Duration, bool) {
+	s := strings.TrimSpace(raw)
+	if s == "" || s == "0" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d <= 0 {
+		return 0, false
+	}
+	return d, true
+}

--- a/cmd/memory-api/redis_cache_test.go
+++ b/cmd/memory-api/redis_cache_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	goredis "github.com/redis/go-redis/v9"
+
+	"github.com/altairalabs/omnia/internal/memory"
+)
+
+// TestBuildRedisClient_EmptyReturnsNil proves an unset --redis-addrs
+// flag produces no client. This is the gate the rest of the cache
+// wiring depends on — a non-nil client with no real backend would
+// turn every Retrieve/List into a connection-refused round trip.
+func TestBuildRedisClient_EmptyReturnsNil(t *testing.T) {
+	if buildRedisClient("") != nil {
+		t.Error("expected nil client for empty addrs")
+	}
+	if buildRedisClient("   ") != nil {
+		t.Error("expected nil client for whitespace-only addrs")
+	}
+}
+
+// TestBuildRedisClient_TakesFirstAddr proves the comma-separated input
+// shape is tolerated even though the production go-redis client is
+// single-master. Operators don't have to remember which one of
+// "Sentinel-shaped or single-shaped" the binary expects.
+func TestBuildRedisClient_TakesFirstAddr(t *testing.T) {
+	c := buildRedisClient("redis-a:6379,redis-b:6379")
+	if c == nil {
+		t.Fatal("expected a client for non-empty addrs")
+	}
+	if got := c.Options().Addr; got != "redis-a:6379" {
+		t.Errorf("expected addr=redis-a:6379, got %q", got)
+	}
+	_ = c.Close()
+}
+
+// TestParseCacheTTL covers every meaningful path of the helper:
+// the explicit-off values ("" and "0"), parse failures, non-positive
+// durations, and the happy path. Each case has its own table row so a
+// regression points at exactly which input class broke.
+func TestParseCacheTTL(t *testing.T) {
+	cases := []struct {
+		raw     string
+		wantDur time.Duration
+		wantOK  bool
+	}{
+		{"", 0, false},
+		{"   ", 0, false},
+		{"0", 0, false},
+		{"-5m", 0, false},
+		{"not-a-duration", 0, false},
+		{"5m", 5 * time.Minute, true},
+		{"30s", 30 * time.Second, true},
+		{"  10m  ", 10 * time.Minute, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.raw, func(t *testing.T) {
+			d, ok := parseCacheTTL(tc.raw)
+			if ok != tc.wantOK {
+				t.Errorf("parseCacheTTL(%q): ok=%v, want %v", tc.raw, ok, tc.wantOK)
+			}
+			if d != tc.wantDur {
+				t.Errorf("parseCacheTTL(%q): dur=%v, want %v", tc.raw, d, tc.wantDur)
+			}
+		})
+	}
+}
+
+// TestResolveAPIStore_NoRedisReturnsInner proves that without a Redis
+// client the API store is the unwrapped inner Store — the cache must
+// be opt-in. A wrapper here would mean every Retrieve/List goes
+// through cache code paths that would NPE on the missing client.
+func TestResolveAPIStore_NoRedisReturnsInner(t *testing.T) {
+	inner := fakeMemoryStore{}
+	got, enabled := resolveAPIStore(inner, nil, "5m", logr.Discard())
+	if enabled {
+		t.Error("expected cache disabled when redis client is nil")
+	}
+	if _, ok := got.(*memory.CachedStore); ok {
+		t.Error("expected unwrapped inner Store, got *memory.CachedStore")
+	}
+}
+
+// TestResolveAPIStore_NoTTLReturnsInner proves the TTL gate: a
+// configured Redis client with no/zero/invalid TTL leaves the store
+// uncached. Operators sometimes provision Redis ahead of enabling the
+// cache; this gate keeps that intermediate state correct.
+func TestResolveAPIStore_NoTTLReturnsInner(t *testing.T) {
+	rdb := goredis.NewClient(&goredis.Options{Addr: "localhost:0"})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	for _, ttl := range []string{"", "0", "garbage"} {
+		t.Run("ttl="+ttl, func(t *testing.T) {
+			got, enabled := resolveAPIStore(fakeMemoryStore{}, rdb, ttl, logr.Discard())
+			if enabled {
+				t.Errorf("expected cache disabled for ttl=%q", ttl)
+			}
+			if _, ok := got.(*memory.CachedStore); ok {
+				t.Errorf("expected unwrapped Store for ttl=%q", ttl)
+			}
+		})
+	}
+}
+
+// TestResolveAPIStore_WrapsWhenConfigured proves the happy path: a
+// client + valid TTL produces a *memory.CachedStore. This is the
+// wiring assertion that #692 (Phase 3) was missing — the cache
+// implementation existed and was tested, but no cmd/* binary actually
+// constructed one.
+func TestResolveAPIStore_WrapsWhenConfigured(t *testing.T) {
+	rdb := goredis.NewClient(&goredis.Options{Addr: "localhost:0"})
+	t.Cleanup(func() { _ = rdb.Close() })
+
+	got, enabled := resolveAPIStore(fakeMemoryStore{}, rdb, "5m", logr.Discard())
+	if !enabled {
+		t.Fatal("expected cache enabled with rdb + valid TTL")
+	}
+	if _, ok := got.(*memory.CachedStore); !ok {
+		t.Errorf("expected *memory.CachedStore, got %T", got)
+	}
+}

--- a/internal/controller/service_builder.go
+++ b/internal/controller/service_builder.go
@@ -50,6 +50,19 @@ type ServiceBuilder struct {
 	SessionImagePullPolicy corev1.PullPolicy
 	MemoryImage            string
 	MemoryImagePullPolicy  corev1.PullPolicy
+
+	// MemoryRedisAddrs is the operator-wide Redis target threaded into
+	// every per-workspace memory-api Deployment as --redis-addrs. Empty
+	// disables both the read-through cache and the event publisher.
+	// One Redis is shared across workspaces; per-workspace caching is
+	// already namespaced by the scope-hash inside CachedStore.
+	MemoryRedisAddrs string
+
+	// MemoryCacheTTL is forwarded to memory-api as --cache-ttl. Empty
+	// or "0" disables the cache even when MemoryRedisAddrs is set, so
+	// operators can stand up Redis (for the event publisher) without
+	// the cache, or vice-versa.
+	MemoryCacheTTL string
 }
 
 // BuildSessionDeployment builds a Deployment for the session-api service group.
@@ -107,7 +120,7 @@ const (
 func (sb *ServiceBuilder) BuildMemoryDeployment(workspaceName, namespace string, sg omniav1alpha1.WorkspaceServiceGroup) *appsv1.Deployment {
 	name := fmt.Sprintf("memory-%s-%s", workspaceName, sg.Name)
 	labels := serviceLabels("memory-api", workspaceName, sg.Name)
-	args := buildMemoryAPIArgs(workspaceName, sg)
+	args := buildMemoryAPIArgs(workspaceName, sg, sb.MemoryRedisAddrs, sb.MemoryCacheTTL)
 	var overrides *omniav1alpha1.PodOverrides
 	if sg.Memory != nil {
 		overrides = sg.Memory.PodOverrides
@@ -125,7 +138,12 @@ func (sb *ServiceBuilder) BuildMemoryDeployment(workspaceName, namespace string,
 // is the canonical source of these because each one is a wiring boundary
 // crossing — the binary's flag default is "off", so anything the operator
 // doesn't pass silently doesn't run.
-func buildMemoryAPIArgs(workspaceName string, sg omniav1alpha1.WorkspaceServiceGroup) []string {
+//
+// redisAddrs and cacheTTL come from the operator (chart-driven, not per-
+// workspace) because Redis is a shared cluster service. We pass them
+// through unconditionally when set so memory-api wires the cache and
+// event publisher with one client.
+func buildMemoryAPIArgs(workspaceName string, sg omniav1alpha1.WorkspaceServiceGroup, redisAddrs, cacheTTL string) []string {
 	args := []string{
 		fmt.Sprintf("--workspace=%s", workspaceName),
 		fmt.Sprintf("--service-group=%s", sg.Name),
@@ -135,6 +153,12 @@ func buildMemoryAPIArgs(workspaceName string, sg omniav1alpha1.WorkspaceServiceG
 	}
 	if sg.Memory != nil && sg.Memory.ProviderRef != nil && sg.Memory.ProviderRef.Name != "" {
 		args = append(args, fmt.Sprintf("--embedding-provider=%s", sg.Memory.ProviderRef.Name))
+	}
+	if redisAddrs != "" {
+		args = append(args, fmt.Sprintf("--redis-addrs=%s", redisAddrs))
+	}
+	if cacheTTL != "" {
+		args = append(args, fmt.Sprintf("--cache-ttl=%s", cacheTTL))
 	}
 	return args
 }

--- a/internal/controller/service_builder_test.go
+++ b/internal/controller/service_builder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -188,6 +189,50 @@ func TestBuildMemoryDeployment_AnnotatesConfigHash(t *testing.T) {
 	require.NotEmpty(t, annoB)
 	assert.NotEqual(t, annoA, annoB,
 		"providerRef change must alter the configHash so the pod rolls")
+}
+
+// TestBuildMemoryDeployment_RedisFlagsAbsentByDefault proves the
+// operator does NOT pass --redis-addrs / --cache-ttl when the
+// ServiceBuilder is constructed without Redis config. Memory-api
+// then runs with the cache disabled and no event publisher, which
+// is the correct OSS / non-Redis dev install behaviour. Passing
+// empty strings as flags would degrade into "--redis-addrs=" and
+// trigger a connection-refused log on every Retrieve.
+func TestBuildMemoryDeployment_RedisFlagsAbsentByDefault(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sg := newTestServiceGroup("default")
+
+	dep := sb.BuildMemoryDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	args := dep.Spec.Template.Spec.Containers[0].Args
+	for _, a := range args {
+		if strings.HasPrefix(a, "--redis-addrs=") {
+			t.Errorf("expected no --redis-addrs flag when MemoryRedisAddrs is empty, got %q", a)
+		}
+		if strings.HasPrefix(a, "--cache-ttl=") {
+			t.Errorf("expected no --cache-ttl flag when MemoryCacheTTL is empty, got %q", a)
+		}
+	}
+}
+
+// TestBuildMemoryDeployment_RedisFlagsThreaded proves that operator-
+// level Redis config flows through to every per-workspace memory-api
+// pod. Without this, setting MemoryRedisAddrs on the operator would
+// be cosmetic — the per-workspace flags wouldn't reflect it and
+// neither the cache nor the event publisher would activate. This is
+// the wiring assertion that mirrors #1038's "the workers were
+// implemented but never started" failure mode for Redis.
+func TestBuildMemoryDeployment_RedisFlagsThreaded(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sb.MemoryRedisAddrs = "omnia-redis-master.omnia-system.svc:6379"
+	sb.MemoryCacheTTL = "10m"
+	sg := newTestServiceGroup("default")
+
+	dep := sb.BuildMemoryDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	args := dep.Spec.Template.Spec.Containers[0].Args
+	assert.Contains(t, args, "--redis-addrs=omnia-redis-master.omnia-system.svc:6379")
+	assert.Contains(t, args, "--cache-ttl=10m")
 }
 
 // TestBuildMemoryDeployment_EmbeddingProviderArg proves that setting


### PR DESCRIPTION
## Summary

Wires `internal/memory.CachedStore` (Redis-backed read-through cache for memory-api Retrieve/List with version-keyed invalidation) into the actual memory-api binary. The implementation, unit tests, metrics, and Grafana dashboard shipped with #692 (memory-api Phase 3) but no `cmd/*` binary ever called `NewCachedStore` — production memory recall has been an uncached Postgres round-trip ever since.

## What changed

- **memory-api binary** — new `--cache-ttl` flag (env `MEMORY_CACHE_TTL`, default `5m`); one shared Redis client for both the cache and the event publisher; workers continue to use the unwrapped `*PostgresMemoryStore`.
- **operator → memory-api wiring** — `ServiceBuilder` grows `MemoryRedisAddrs` + `MemoryCacheTTL`; `buildMemoryAPIArgs` forwards them as `--redis-addrs` / `--cache-ttl` per workspace.
- **chart** — new `omnia.redisAddr` helper resolves a single canonical address (priority: `redis.externalAddr` → Bitnami subchart → `""`); new `redis.externalAddr` value for off-cluster Redis (ElastiCache/Memorystore); new `workspaceServices.memoryApi.cache.ttl` value (default `5m`); operator Deployment now passes `--redis-addr` (when resolved) and `--memory-cache-ttl`.

## Test coverage

- 17 new Go assertions on `buildRedisClient` / `parseCacheTTL` / `resolveAPIStore` (every input class has its own row, including the empty/whitespace/zero/garbage TTL paths and the no-Redis short-circuit).
- 2 new controller assertions on `buildMemoryAPIArgs` (flags absent by default, threaded when set).
- 5 new helm-unittest cases covering every Redis config branch the operator deployment can render.

## Backwards compatibility

Default OSS install (`redis.enabled=false`, no `externalAddr`) renders identically to before — no flag emitted, memory-api stays in no-Redis mode. Operators wanting the cache flip `redis.enabled=true` (or set `redis.externalAddr`) and everything wires through.

## Test plan

- [x] `env GOWORK=off go test ./cmd/memory-api/... ./internal/controller/...` — 892 assertions pass
- [x] `helm unittest charts/omnia` — 67 assertions pass
- [x] `bash hack/validate-helm.sh` — lint + render-default + render-enterprise pass
- [ ] Verify in dev cluster: enable Redis via Tilt, confirm `cache hit/miss` metrics appear on a memory recall

## Out of scope (follow-ups)

- Tiltfile: enable Bitnami Redis unconditionally for dev (separate PR)
- Doctor: skip `RedisReachable` when `omnia.redisAddr` resolves empty (separate PR)
- Dashboard `OMNIA_SESSION_STORE` default flip + auto-wire (separate PR — surfaced in the broader Redis cleanup discussion)
