### PR TITLE
refactor(redis): URL-canonical config + per-consumer overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,8 +363,31 @@ jobs:
     - name: Validate Helm templates (default values)
       run: helm template test ./charts/omnia -f charts/omnia/values-chart-tests.yaml > /dev/null
 
-    - name: Validate Helm templates (enterprise enabled)
-      run: helm template test ./charts/omnia -f charts/omnia/values-chart-tests.yaml --set enterprise.enabled=true > /dev/null
+    - name: Validate Helm templates (enterprise enabled + Redis)
+      # Enterprise enables the Arena queue (type=redis by default), which
+      # requires a resolvable Redis URL — the chart's omnia.validateArenaQueue
+      # render guard fails the template otherwise. Pair the two so this
+      # smoke render exercises both.
+      run: |
+        helm template test ./charts/omnia \
+          -f charts/omnia/values-chart-tests.yaml \
+          --set enterprise.enabled=true \
+          --set redis.enabled=true \
+          > /dev/null
+
+    - name: Validate Helm templates (enterprise without Redis must fail)
+      # Pin the omnia.validateArenaQueue guard. Without this assertion, a
+      # future change that drops the guard would silently let through a
+      # broken Arena install.
+      run: |
+        if helm template test ./charts/omnia \
+          -f charts/omnia/values-chart-tests.yaml \
+          --set enterprise.enabled=true \
+          > /dev/null 2>&1; then
+          echo "FAIL: enterprise enabled without Redis should have failed render"
+          exit 1
+        fi
+        echo "OK: omnia.validateArenaQueue correctly blocked enterprise + no Redis"
 
     - name: Validate Helm templates (full stack)
       run: |

--- a/Tiltfile
+++ b/Tiltfile
@@ -639,10 +639,13 @@ if ENABLE_ENTERPRISE:
         'enterprise.arena.worker.image.repository=omnia-arena-worker-dev',
         'enterprise.arena.worker.image.tag=latest',
         'enterprise.arena.worker.image.pullPolicy=Never',
-        # Arena queue - use Redis when enterprise is enabled
+        # Arena queue - use Redis when enterprise is enabled. Address is
+        # auto-derived by the chart helper from redis.enabled=true (the
+        # FQDN form omnia-redis-master.<ns>.svc.cluster.local:6379) so
+        # arena workers in test-arena namespace can resolve it. Don't
+        # set arena.queue.redis.host explicitly — that override produces
+        # a non-FQDN that fails cross-namespace DNS lookup.
         'enterprise.arena.queue.type=redis',
-        'enterprise.arena.queue.redis.host=omnia-redis-master',
-        'enterprise.arena.queue.redis.port=6379',
         # Enable Redis for Arena queue (Bitnami subchart)
         'redis.enabled=true',
         'redis.architecture=standalone',

--- a/charts/omnia/examples/values-prod-oauth.yaml
+++ b/charts/omnia/examples/values-prod-oauth.yaml
@@ -14,6 +14,13 @@
 #     --from-literal=client-secret=<client-secret>
 #   kubectl create secret generic omnia-dashboard-session \
 #     --from-literal=session-secret=<random-base64>
+#   kubectl create secret generic omnia-redis-url \
+#     --from-literal=url=rediss://default:<password>@<host>:6379/0
+#   (Required because dashboard.replicaCount > 1 needs a shared session
+#   store. Point this at AWS ElastiCache, GCP MemoryStore, Azure Cache,
+#   or any in-cluster Redis you provisioned out of band. If you'd
+#   rather have the chart deploy Bitnami Redis for you, drop this
+#   secret and set redis.enabled=true instead.)
 
 # --- Operator / Dashboard HA ------------------------------------------------
 
@@ -22,6 +29,16 @@ replicaCount: 3
 podDisruptionBudget:
   enabled: true
   minAvailable: 2
+
+# --- Redis for shared session store ---------------------------------------
+# dashboard.replicaCount > 1 requires a Redis-backed session store so users
+# don't get logged out when their request hits a different replica. The
+# chart's omnia.validateSession render guard fails install otherwise.
+redis:
+  default:
+    existingSecret:
+      name: omnia-redis-url
+      key: url
 
 dashboard:
   replicaCount: 2

--- a/charts/omnia/templates/_helpers.tpl
+++ b/charts/omnia/templates/_helpers.tpl
@@ -309,26 +309,236 @@ Eval Worker image
 {{- end }}
 
 {{/*
-Resolve the operator-wide Redis address.
-
-Priority:
-  1. .Values.redis.externalAddr — explicit operator override (off-cluster Redis,
-     e.g. AWS ElastiCache, GCP Memorystore).
-  2. Bitnami Redis subchart service when .Values.redis.enabled=true.
-  3. "" — Redis-dependent features (memory-api cache + event publisher,
-     eval-worker queue, dashboard session store) all stay disabled.
-
-Returning a single canonical address keeps the operator, dashboard, and
-arena-controller in sync without each template having to redo the
-"is Redis available?" reasoning.
+Walk a dotted path into .Values and return the resolved sub-value, or
+an empty dict if any segment is missing. Internal helper.
 */}}
-{{- define "omnia.redisAddr" -}}
-{{- if .Values.redis.externalAddr -}}
-{{- .Values.redis.externalAddr -}}
-{{- else if .Values.redis.enabled -}}
-{{- printf "%s-redis-master.%s.svc.cluster.local:6379" (include "omnia.fullname" .) .Release.Namespace -}}
+{{- define "omnia.redis._lookupConsumer" -}}
+{{- $ctx := .ctx -}}
+{{- $path := .consumer -}}
+{{- $node := $ctx.Values -}}
+{{- if $path -}}
+  {{- range $part := splitList "." $path -}}
+    {{- if and (kindIs "map" $node) (hasKey $node $part) -}}
+      {{- $node = index $node $part -}}
+    {{- else -}}
+      {{- $node = dict -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- toYaml $node -}}
+{{- end }}
+
+{{/*
+Resolve the existingSecret reference for a given consumer's Redis URL.
+
+Args (dict):
+  ctx      - the root context ($)
+  consumer - dotted path to the per-consumer Redis block.
+
+Returns the resolved {name, key} dict from consumer.existingSecret
+(preferred) or redis.default.existingSecret (fallback). Returns an
+empty dict when neither has one. Internal helper for the public
+omnia.redis.* family.
+*/}}
+{{- define "omnia.redis._existingSecret" -}}
+{{- $consumer := fromYaml (include "omnia.redis._lookupConsumer" .) -}}
+{{- $default := .ctx.Values.redis.default | default dict -}}
+{{- $secret := dict -}}
+{{- if and (kindIs "map" $consumer) (kindIs "map" $consumer.existingSecret) (default "" $consumer.existingSecret.name) (default "" $consumer.existingSecret.key) -}}
+  {{- $secret = $consumer.existingSecret -}}
+{{- else if and (kindIs "map" $default.existingSecret) (default "" $default.existingSecret.name) (default "" $default.existingSecret.key) -}}
+  {{- $secret = $default.existingSecret -}}
+{{- end -}}
+{{- toYaml $secret -}}
+{{- end }}
+
+{{/*
+Resolve the Redis URL for a given consumer.
+
+Args (dict):
+  ctx      - the root context ($)
+  consumer - dotted path to the per-consumer Redis block, e.g.
+             "dashboard.session.redis"
+             "workspaceServices.memoryApi.cache.redis"
+             "enterprise.arena.queue.redis"
+
+Resolution order — first non-empty wins:
+  1. <consumer>.existingSecret    → returns ""; caller uses
+     omnia.redis.urlEnv to emit a secretKeyRef-sourced env entry.
+  2. <consumer>.url               → literal URL.
+  3. <consumer>.host              → decomposed; synthesise plaintext URL.
+  4. redis.default.existingSecret → returns "" (same as 1).
+  5. redis.default.url            → literal URL.
+  6. redis.default.host           → decomposed; synthesise plaintext URL.
+  7. redis.enabled=true           → Bitnami subchart in-cluster service.
+  8. ""                           → consumer disabled.
+
+`omnia.redis.url` returns the literal URL string for forms 2, 3, 5, 6, 7
+or empty string for forms 1, 4, 8. To detect the existingSecret form
+and emit the correct env entry, use `omnia.redis.hasSecret` and
+`omnia.redis.urlEnv` (paired helper).
+*/}}
+{{- define "omnia.redis.url" -}}
+{{- $secret := fromYaml (include "omnia.redis._existingSecret" .) -}}
+{{- if and (kindIs "map" $secret) $secret.name -}}
+{{- /* secret form — caller renders env via omnia.redis.urlEnv */ -}}
 {{- else -}}
-{{- "" -}}
+{{- $consumer := fromYaml (include "omnia.redis._lookupConsumer" .) -}}
+{{- $default := .ctx.Values.redis.default | default dict -}}
+{{- if and (kindIs "map" $consumer) $consumer.url -}}
+{{- $consumer.url -}}
+{{- else if and (kindIs "map" $consumer) $consumer.host -}}
+{{- include "omnia.redis.synthesise" $consumer -}}
+{{- else if $default.url -}}
+{{- $default.url -}}
+{{- else if $default.host -}}
+{{- include "omnia.redis.synthesise" $default -}}
+{{- else if .ctx.Values.redis.enabled -}}
+{{- printf "redis://%s-redis-master.%s.svc.cluster.local:6379/0" (include "omnia.fullname" .ctx) .ctx.Release.Namespace -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Returns "true" when the consumer's resolved URL comes from an
+existingSecret (rather than a literal URL or decomposed form);
+otherwise returns "". Use to branch in templates between literal-value
+and secretKeyRef-sourced EnvVar emission.
+*/}}
+{{- define "omnia.redis.hasSecret" -}}
+{{- $secret := fromYaml (include "omnia.redis._existingSecret" .) -}}
+{{- if and (kindIs "map" $secret) $secret.name -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
+Emit a single EnvVar entry carrying the resolved Redis URL.
+
+Args (dict):
+  ctx      - the root context ($)
+  consumer - dotted path to the per-consumer Redis block.
+  envName  - name of the env var to emit, e.g. "OMNIA_SESSION_REDIS_URL".
+
+Produces nothing when the consumer's URL resolves empty (consumer
+disabled). Use the alongside `omnia.validate*` helpers to fail render
+when an empty URL would silently break the consumer.
+
+Output forms:
+  Literal/decomposed/subchart →
+    - name: <envName>
+      value: "<resolved URL>"
+
+  existingSecret →
+    - name: <envName>
+      valueFrom:
+        secretKeyRef:
+          name: "<secret name>"
+          key:  "<secret key>"
+
+Pod templates use this in their env: list:
+
+  env:
+    {{- include "omnia.redis.urlEnv" (dict "ctx" . "consumer" "..." "envName" "...") | nindent 12 }}
+*/}}
+{{- define "omnia.redis.urlEnv" -}}
+{{- $secret := fromYaml (include "omnia.redis._existingSecret" .) -}}
+{{- if and (kindIs "map" $secret) $secret.name -}}
+- name: {{ .envName }}
+  valueFrom:
+    secretKeyRef:
+      name: {{ $secret.name | quote }}
+      key: {{ $secret.key | quote }}
+{{- else -}}
+{{- $url := include "omnia.redis.url" . -}}
+{{- if $url -}}
+- name: {{ .envName }}
+  value: {{ $url | quote }}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Synthesise a plaintext Redis URL from a decomposed config block.
+
+Block shape:
+  host: required
+  port: default 6379
+  db:   default 0
+  user: default "" (Redis ACL default user)
+  tls.caExistingSecret: ignored here (CA is mounted as a file by
+    consumer templates; the URL just uses redis:// vs rediss://
+    based on the scheme implied by tls).
+
+Output: "redis://[user@]host:port/db".
+
+The decomposed form intentionally cannot synthesise auth (no password
+field). Callers wanting auth use the `existingSecret` form instead.
+*/}}
+{{- define "omnia.redis.synthesise" -}}
+{{- $port := default 6379 .port -}}
+{{- $db := default 0 .db -}}
+{{- $user := default "" .user -}}
+{{- if $user -}}
+{{- printf "redis://%s@%s:%v/%v" $user .host $port $db -}}
+{{- else -}}
+{{- printf "redis://%s:%v/%v" .host $port $db -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Extract host:port from a resolved Redis URL.
+
+Used by consumers that take host:port form (eval-worker, arena-worker,
+arena-eval-worker) until their Go code is converted to URL form. The
+chart still feeds them from the same `omnia.redis.url` source of truth.
+
+Args (passed via dict):
+  ctx      - the root context ($)
+  consumer - dotted path to the per-consumer Redis block.
+
+Returns "host:port" or "".
+*/}}
+{{- define "omnia.redis.hostPort" -}}
+{{- $url := include "omnia.redis.url" . -}}
+{{- if $url -}}
+{{- $parsed := urlParse $url -}}
+{{- $parsed.host -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render-time guard: dashboard.replicaCount > 1 with no resolved session
+Redis means per-pod in-memory sessions. Users get logged out the moment
+their request hits a different replica. Fail render rather than ship a
+silently broken multi-replica deployment.
+
+Include this from every template that renders when dashboard.enabled=true.
+*/}}
+{{- define "omnia.validateSession" -}}
+{{- if .Values.dashboard.enabled -}}
+{{- $replicas := int (default 1 .Values.dashboard.replicaCount) -}}
+{{- if gt $replicas 1 -}}
+{{- $sessionURL := include "omnia.redis.url" (dict "ctx" . "consumer" "dashboard.session.redis") -}}
+{{- if not $sessionURL -}}
+{{- fail "dashboard.replicaCount > 1 requires a resolvable Redis session store. Set redis.default, dashboard.session.redis, redis.enabled=true, or scale to dashboard.replicaCount=1." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Render-time guard: enterprise Arena queue requires durable Redis when
+type=redis (which is the default). The in-memory queue mode is only
+useful in dev / E2E; production Arena needs jobs to survive controller
+restarts.
+*/}}
+{{- define "omnia.validateArenaQueue" -}}
+{{- if and .Values.enterprise.enabled (eq (default "redis" .Values.enterprise.arena.queue.type) "redis") -}}
+{{- $arenaURL := include "omnia.redis.url" (dict "ctx" . "consumer" "enterprise.arena.queue.redis") -}}
+{{- if not $arenaURL -}}
+{{- fail "enterprise.arena.queue.type=redis requires a resolvable Redis URL. Set redis.default, enterprise.arena.queue.redis, redis.enabled=true, or set enterprise.arena.queue.type=memory (dev only)." -}}
+{{- end -}}
 {{- end -}}
 {{- end }}
 

--- a/charts/omnia/templates/_helpers.tpl
+++ b/charts/omnia/templates/_helpers.tpl
@@ -519,8 +519,10 @@ Include this from every template that renders when dashboard.enabled=true.
 {{- if .Values.dashboard.enabled -}}
 {{- $replicas := int (default 1 .Values.dashboard.replicaCount) -}}
 {{- if gt $replicas 1 -}}
-{{- $sessionURL := include "omnia.redis.url" (dict "ctx" . "consumer" "dashboard.session.redis") -}}
-{{- if not $sessionURL -}}
+{{- $args := dict "ctx" . "consumer" "dashboard.session.redis" -}}
+{{- $sessionURL := include "omnia.redis.url" $args -}}
+{{- $hasSecret := include "omnia.redis.hasSecret" $args -}}
+{{- if and (not $sessionURL) (not $hasSecret) -}}
 {{- fail "dashboard.replicaCount > 1 requires a resolvable Redis session store. Set redis.default, dashboard.session.redis, redis.enabled=true, or scale to dashboard.replicaCount=1." -}}
 {{- end -}}
 {{- end -}}
@@ -535,8 +537,10 @@ restarts.
 */}}
 {{- define "omnia.validateArenaQueue" -}}
 {{- if and .Values.enterprise.enabled (eq (default "redis" .Values.enterprise.arena.queue.type) "redis") -}}
-{{- $arenaURL := include "omnia.redis.url" (dict "ctx" . "consumer" "enterprise.arena.queue.redis") -}}
-{{- if not $arenaURL -}}
+{{- $args := dict "ctx" . "consumer" "enterprise.arena.queue.redis" -}}
+{{- $arenaURL := include "omnia.redis.url" $args -}}
+{{- $hasSecret := include "omnia.redis.hasSecret" $args -}}
+{{- if and (not $arenaURL) (not $hasSecret) -}}
 {{- fail "enterprise.arena.queue.type=redis requires a resolvable Redis URL. Set redis.default, enterprise.arena.queue.redis, redis.enabled=true, or set enterprise.arena.queue.type=memory (dev only)." -}}
 {{- end -}}
 {{- end -}}

--- a/charts/omnia/templates/arena-controller-deployment.yaml
+++ b/charts/omnia/templates/arena-controller-deployment.yaml
@@ -1,3 +1,4 @@
+{{- include "omnia.validateArenaQueue" . -}}
 {{- if .Values.enterprise.enabled }}
 {{- $po := .Values.enterprise.arena.controller.podOverrides | default dict }}
 apiVersion: apps/v1
@@ -59,14 +60,23 @@ spec:
             - --arena-worker-image={{ .Values.enterprise.arena.worker.image.repository | default "ghcr.io/altairalabs/omnia-arena-worker" }}:{{ .Values.enterprise.arena.worker.image.tag | default .Chart.AppVersion }}
             - --arena-worker-image-pull-policy={{ .Values.enterprise.arena.worker.image.pullPolicy | default "IfNotPresent" }}
             - --arena-dev-console-image={{ .Values.enterprise.arena.devConsole.image.repository | default "ghcr.io/altairalabs/omnia-arena-dev-console" }}:{{ .Values.enterprise.arena.devConsole.image.tag | default .Chart.AppVersion }}
-            {{- if and .Values.enterprise.arena.queue (eq .Values.enterprise.arena.queue.type "redis") }}
-            {{- if .Values.redis.enabled }}
-            - --redis-addr={{ include "omnia.fullname" . }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.enterprise.arena.queue.redis.port | default 6379 }}
-            {{- else if .Values.enterprise.arena.queue.redis.host }}
-            - --redis-addr={{ .Values.enterprise.arena.queue.redis.host }}:{{ .Values.enterprise.arena.queue.redis.port | default 6379 }}
-            {{- end }}
-            {{- if .Values.enterprise.arena.queue.redis.passwordSecret }}
-            - --redis-password-secret={{ .Values.enterprise.arena.queue.redis.passwordSecret }}
+            {{- /*
+              Arena queue Redis. The arena-controller binary still takes
+              host:port form (URL flag is Phase 3); the chart resolves
+              the unified consumer config to host:port via urlParse.
+
+              Limitation: when arena queue Redis comes from existingSecret
+              (URL is opaque at render time), --redis-addr is empty and
+              the arena-controller falls back to its in-process queue
+              (dev-only). Operators on existingSecret + production Arena
+              must provide enterprise.arena.queue.redis.host (decomposed
+              form) explicitly until Phase 3.
+            */}}
+            {{- if and .Values.enterprise.arena.queue (eq (default "redis" .Values.enterprise.arena.queue.type) "redis") }}
+            {{- $arenaConsumer := dict "ctx" . "consumer" "enterprise.arena.queue.redis" }}
+            {{- $arenaHostPort := include "omnia.redis.hostPort" $arenaConsumer }}
+            {{- if $arenaHostPort }}
+            - --redis-addr={{ $arenaHostPort }}
             {{- end }}
             {{- end }}
             {{- if and (or .Values.nfs.server.enabled .Values.nfs.external.server) (not .Values.nfs.csiDriver.enabled) }}

--- a/charts/omnia/templates/dashboard/deployment.yaml
+++ b/charts/omnia/templates/dashboard/deployment.yaml
@@ -1,4 +1,5 @@
 {{- include "omnia.validateAuth" . -}}
+{{- include "omnia.validateSession" . -}}
 {{- if .Values.dashboard.enabled }}
 {{- $po := .Values.dashboard.podOverrides | default dict }}
 apiVersion: apps/v1
@@ -123,46 +124,33 @@ spec:
               value: {{ .Values.dashboard.builtin.admin.password | quote }}
             {{- end }}
             {{- end }}
-            {{- if and .Values.enterprise.enabled .Values.enterprise.arena.queue (eq .Values.enterprise.arena.queue.type "redis") }}
-            {{- if .Values.redis.enabled }}
-            - name: ARENA_REDIS_ADDR
-              value: "{{ include "omnia.fullname" . }}-redis-master.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.enterprise.arena.queue.redis.port | default 6379 }}"
-            {{- else if .Values.enterprise.arena.queue.redis.host }}
-            - name: ARENA_REDIS_ADDR
-              value: "{{ .Values.enterprise.arena.queue.redis.host }}:{{ .Values.enterprise.arena.queue.redis.port | default 6379 }}"
+            {{- /*
+              Arena queue Redis URL — exposed to the dashboard so its
+              stats / job-state views can read queue state directly.
+              Routed through the unified omnia.redis.urlEnv helper so
+              cluster default and per-consumer overrides flow through
+              one path.
+            */}}
+            {{- if and .Values.enterprise.enabled .Values.enterprise.arena.queue (eq (default "redis" .Values.enterprise.arena.queue.type) "redis") }}
+            {{- include "omnia.redis.urlEnv" (dict "ctx" . "consumer" "enterprise.arena.queue.redis" "envName" "ARENA_REDIS_URL") | nindent 12 }}
             {{- end }}
-            {{- if .Values.enterprise.arena.queue.redis.passwordSecret }}
-            - name: ARENA_REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.enterprise.arena.queue.redis.passwordSecret }}
-                  key: redis-password
-            {{- end }}
-            - name: ARENA_REDIS_DB
-              value: "{{ .Values.enterprise.arena.queue.redis.db | default 0 }}"
-            {{- end }}
-            {{- with .Values.dashboard.session }}
-            - name: OMNIA_SESSION_STORE
-              value: {{ .store | quote }}
+            {{- /*
+              PKCE TTL: orthogonal to Redis (in-flight OAuth records have
+              their own TTL even when sessions live in memory).
+            */}}
             - name: OMNIA_SESSION_PKCE_TTL
-              value: {{ .pkceTtl | quote }}
-            {{- if .redis.url }}
-            - name: OMNIA_SESSION_REDIS_URL
-              value: {{ .redis.url | quote }}
-            {{- else if .redis.addr }}
-            - name: OMNIA_SESSION_REDIS_ADDR
-              value: {{ .redis.addr | quote }}
-            - name: OMNIA_SESSION_REDIS_DB
-              value: {{ .redis.db | quote }}
-            {{- if and .redis.existingSecret.name .redis.existingSecret.key }}
-            - name: OMNIA_SESSION_REDIS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .redis.existingSecret.name | quote }}
-                  key: {{ .redis.existingSecret.key | quote }}
-            {{- end }}
-            {{- end }}
-            {{- end }}
+              value: {{ .Values.dashboard.session.pkceTtl | quote }}
+            {{- /*
+              Session Redis URL. The dashboard auto-selects backend by
+              env presence: OMNIA_SESSION_REDIS_URL set → Redis store;
+              empty/unset → in-process memory store. Helper handles all
+              resolution paths (consumer override, default, secret form,
+              Bitnami subchart). Empty resolution → no env emitted →
+              memory store (single-replica installs only; multi-replica
+              fails render via omnia.validateSession).
+            */}}
+            {{- $sessionConsumer := dict "ctx" . "consumer" "dashboard.session.redis" }}
+            {{- include "omnia.redis.urlEnv" (merge (dict "envName" "OMNIA_SESSION_REDIS_URL") $sessionConsumer) | nindent 12 }}
             {{- /*
               Mgmt-plane signing key path. Pointed at the mounted private
               half of the dashboard signing keypair. server.js loads it at

--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -72,15 +72,55 @@ spec:
             - --memory-api-image={{ include "omnia.memoryApi.image" . }}
             - --memory-api-image-pull-policy={{ .Values.workspaceServices.memoryApi.image.pullPolicy }}
             {{- /*
-              Operator-wide Redis. Threaded into per-workspace memory-api
-              pods as --redis-addrs (cache + event publisher) and into
-              eval-worker deployments as --redis-addr. Empty when no Redis
-              is configured (default OSS install) — leaves all three
-              consumers in their no-Redis modes.
+              Operator-wide Redis configuration for the memory-api cache
+              + event publisher and the eval-worker autoscaler.
+
+              --memory-redis-url               Literal URL forwarded to
+                                               every per-workspace memory-
+                                               api as --redis-url. Set
+                                               only when the URL is a
+                                               literal value.
+
+              --memory-redis-url-secret-{name,key}   Secret refs forwarded
+                                               to ServiceBuilder when the
+                                               URL comes from a Secret.
+                                               ServiceBuilder mounts the
+                                               Secret as REDIS_URL env on
+                                               every per-workspace memory-
+                                               api pod; memory-api picks
+                                               the URL up via the env
+                                               fallback on its --redis-url
+                                               flag.
+
+              --redis-addr                     Legacy host:port form for
+                                               the eval-worker autoscaler.
+                                               Empty when the URL came
+                                               from a Secret (host:port
+                                               not knowable at render
+                                               time); operators using
+                                               existingSecret + eval-
+                                               worker must set the
+                                               eval-worker addr
+                                               explicitly until Phase 3.
+
+              All resolutions come from the memory-cache consumer path
+              (workspaceServices.memoryApi.cache.redis → redis.default).
             */}}
-            {{- $redisAddr := include "omnia.redisAddr" . }}
-            {{- if $redisAddr }}
-            - --redis-addr={{ $redisAddr }}
+            {{- $memoryConsumer := dict "ctx" . "consumer" "workspaceServices.memoryApi.cache.redis" }}
+            {{- $memoryHasSecret := include "omnia.redis.hasSecret" $memoryConsumer }}
+            {{- if $memoryHasSecret }}
+            {{- $memorySecret := fromYaml (include "omnia.redis._existingSecret" $memoryConsumer) }}
+            - --memory-redis-url-secret-name={{ $memorySecret.name }}
+            - --memory-redis-url-secret-key={{ $memorySecret.key }}
+            {{- else }}
+            {{- $memoryRedisURL := include "omnia.redis.url" $memoryConsumer }}
+            {{- if $memoryRedisURL }}
+            - --memory-redis-url={{ $memoryRedisURL }}
+            {{- end }}
+            {{- $evalWorkerHostPort := include "omnia.redis.hostPort" $memoryConsumer }}
+            {{- if $evalWorkerHostPort }}
+            - --redis-addr={{ $evalWorkerHostPort }}
+            {{- end }}
             {{- end }}
             {{- with .Values.workspaceServices.memoryApi.cache.ttl }}
             - --memory-cache-ttl={{ . }}

--- a/charts/omnia/tests/dashboard-session-redis_test.yaml
+++ b/charts/omnia/tests/dashboard-session-redis_test.yaml
@@ -1,0 +1,100 @@
+suite: dashboard session store auto-selects backend by Redis URL presence
+release:
+  name: omnia
+values:
+  - ../values-chart-tests.yaml
+templates:
+  - templates/dashboard/deployment.yaml
+  - templates/dashboard/configmap.yaml
+tests:
+  - it: emits no OMNIA_SESSION_REDIS_URL when no Redis is configured (single-replica memory store)
+    # Default OSS install: replicaCount=1, no Redis. The dashboard
+    # auto-falls-back to MemorySessionStore — that's the documented
+    # contract. Multi-replica installs are blocked by the
+    # omnia.validateSession render guard, so getting here with memory
+    # store is safe by construction.
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].env[*].name
+          pattern: ^OMNIA_SESSION_REDIS_URL$
+
+  - it: emits OMNIA_SESSION_STORE on no path (legacy flag is gone)
+    # The OMNIA_SESSION_STORE env was a manual toggle that conflicted
+    # with the URL-presence gate (operators could set store=redis with
+    # no URL → throw on first request). Dropped entirely; this assertion
+    # pins the deletion so it can't reappear.
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].env[*].name
+          pattern: ^OMNIA_SESSION_STORE$
+
+  - it: literal URL emits OMNIA_SESSION_REDIS_URL with value
+    set:
+      redis.default.url: "redis://shared.example.com:6379/0"
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OMNIA_SESSION_REDIS_URL
+            value: "redis://shared.example.com:6379/0"
+
+  - it: existingSecret emits OMNIA_SESSION_REDIS_URL via valueFrom.secretKeyRef
+    # Production-typical: URL contains a password; never appears in
+    # chart values, never in `helm get values` output, never in env
+    # logs. Operators check the Secret to read the URL.
+    set:
+      redis.default.existingSecret.name: redis-creds
+      redis.default.existingSecret.key: url
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OMNIA_SESSION_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: redis-creds
+                key: url
+
+  - it: per-consumer override wins over redis.default
+    # Dashboard session pinned to its own Redis (e.g. cross-region
+    # replicated for cookie persistence) while the rest of the cluster
+    # uses redis.default.
+    set:
+      redis.default.url: "redis://default.example.com:6379/0"
+      dashboard.session.redis.url: "rediss://session-redis.example.com:6379/0"
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OMNIA_SESSION_REDIS_URL
+            value: "rediss://session-redis.example.com:6379/0"
+
+  - it: replicaCount>1 without resolvable Redis fails render (validateSession)
+    # The guard. Without it, multi-replica dashboards silently break:
+    # users get logged out the moment their request hits a different
+    # replica because each pod has its own MemorySessionStore.
+    set:
+      dashboard.replicaCount: 3
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - failedTemplate:
+          errorMessage: "dashboard.replicaCount > 1 requires a resolvable Redis session store. Set redis.default, dashboard.session.redis, redis.enabled=true, or scale to dashboard.replicaCount=1."
+
+  - it: replicaCount>1 with resolvable Redis renders successfully
+    set:
+      dashboard.replicaCount: 3
+      redis.enabled: true
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OMNIA_SESSION_REDIS_URL
+            value: "redis://omnia-redis-master.NAMESPACE.svc.cluster.local:6379/0"

--- a/charts/omnia/tests/dashboard-session-redis_test.yaml
+++ b/charts/omnia/tests/dashboard-session-redis_test.yaml
@@ -98,3 +98,25 @@ tests:
           content:
             name: OMNIA_SESSION_REDIS_URL
             value: "redis://omnia-redis-master.NAMESPACE.svc.cluster.local:6379/0"
+
+  - it: replicaCount>1 with redis.default.existingSecret satisfies validateSession
+    # Secret-form Redis URLs satisfy the multi-replica guard. Without
+    # this assertion, an earlier version of the helper failed render
+    # for prod-typical configs (URL hidden in a Secret) — see
+    # examples/values-prod-oauth.yaml.
+    set:
+      dashboard.replicaCount: 3
+      redis.default.existingSecret.name: omnia-redis-url
+      redis.default.existingSecret.key: url
+    template: templates/dashboard/deployment.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OMNIA_SESSION_REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: omnia-redis-url
+                key: url

--- a/charts/omnia/tests/deployment-injection-hooks_test.yaml
+++ b/charts/omnia/tests/deployment-injection-hooks_test.yaml
@@ -132,6 +132,10 @@ tests:
     template: templates/arena-controller-deployment.yaml
     set:
       enterprise.enabled: true
+      # Required since the omnia.validateArenaQueue render-time guard
+      # was added — enterprise + arena.queue.type=redis (default)
+      # without a resolvable Redis URL fails render.
+      redis.enabled: true
       enterprise.arena.controller.extraEnv:
         - name: AZURE_TENANT_ID
           value: my-tenant
@@ -154,6 +158,7 @@ tests:
     template: templates/arena-controller-deployment.yaml
     set:
       enterprise.enabled: true
+      redis.enabled: true
       enterprise.arena.controller.extraVolumes:
         - name: extra
           emptyDir: {}

--- a/charts/omnia/tests/operator-redis-wiring_test.yaml
+++ b/charts/omnia/tests/operator-redis-wiring_test.yaml
@@ -6,8 +6,8 @@ values:
 templates:
   - templates/deployment.yaml
 tests:
-  - it: operator passes --memory-cache-ttl unconditionally so memory-api wiring matches its 5m default
-    # Memory-api defaults --cache-ttl to 5m on its own, but having the
+  - it: passes --memory-cache-ttl unconditionally so memory-api wiring matches the chart's 5m default
+    # Memory-api defaults --cache-ttl=5m on its own, but having the
     # operator pass it explicitly is the wiring assertion: anyone
     # reading kubectl describe sees the configured TTL without diffing
     # against the binary's compiled default.
@@ -17,42 +17,94 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --memory-cache-ttl=5m
 
-  - it: operator does NOT pass --redis-addr when no Redis is configured
-    # Default OSS install has redis.enabled=false and no externalAddr.
-    # Forwarding "--redis-addr=" with an empty value would degrade into
-    # a connection-refused log on every cache lookup. Absent flag is
-    # the correct shape; memory-api treats it as "Redis disabled".
+  - it: emits no Redis flags when no Redis is configured
+    # Default OSS install (redis.enabled=false, no defaults set, no
+    # consumer overrides) renders the operator with no --memory-redis-url,
+    # no --redis-addr, no --memory-redis-url-secret-*. Every Redis-backed
+    # consumer stays in its no-Redis mode.
     template: templates/deployment.yaml
     asserts:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[*]
-          pattern: ^--redis-addr=$
+          pattern: ^--memory-redis-url=
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--memory-redis-url-secret-
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--redis-addr=
 
-  - it: operator wires --redis-addr to the Bitnami subchart service when redis.enabled=true
-    # When redis.enabled=true, the Bitnami subchart provisions
-    # `<release>-redis-master`; the operator addr must match. This
-    # assertion catches any future rename of the helper.
+  - it: Bitnami subchart auto-populates URL + host:port for memory-api and eval-worker
+    # redis.enabled=true → omnia.redis.url resolves to the in-cluster
+    # subchart service. Operator emits both forms: --memory-redis-url
+    # (consumed by ServiceBuilder for per-workspace memory-api pods)
+    # and --redis-addr (consumed by AgentRuntimeReconciler for the
+    # eval-worker autoscaler, which still takes host:port until Phase 3).
     set:
       redis.enabled: true
     template: templates/deployment.yaml
     asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --memory-redis-url=redis://omnia-redis-master.NAMESPACE.svc.cluster.local:6379/0
       - contains:
           path: spec.template.spec.containers[0].args
           content: --redis-addr=omnia-redis-master.NAMESPACE.svc.cluster.local:6379
 
-  - it: redis.externalAddr wins over redis.enabled (off-cluster Redis)
-    # Operators pointing at AWS ElastiCache, GCP Memorystore, etc. set
-    # redis.externalAddr. The Bitnami subchart should be skipped and
-    # the operator should hand the external addr to memory-api / eval
-    # worker / arena queue.
+  - it: redis.default.url overrides the subchart and omits eval-worker addr extraction
+    # Operators pointing at AWS ElastiCache / GCP MemoryStore set
+    # redis.default.url. Subchart is bypassed; eval-worker still gets
+    # --redis-addr via urlParse extraction.
     set:
-      redis.enabled: true
-      redis.externalAddr: "external-redis.example.com:6380"
+      redis.default.url: "rediss://default:hunter2@redis.example.com:6380/2"
     template: templates/deployment.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --redis-addr=external-redis.example.com:6380
+          content: --memory-redis-url=rediss://default:hunter2@redis.example.com:6380/2
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redis-addr=redis.example.com:6380
+
+  - it: redis.default.existingSecret emits secret refs and skips eval-worker addr
+    # The Secret form is opaque at render time — the chart cannot
+    # extract a host:port for the eval-worker autoscaler. Operator
+    # passes secret refs to ServiceBuilder so per-workspace memory-api
+    # pods get REDIS_URL env from the same Secret.
+    set:
+      redis.default.existingSecret.name: redis-creds
+      redis.default.existingSecret.key: url
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --memory-redis-url-secret-name=redis-creds
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --memory-redis-url-secret-key=url
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--memory-redis-url=
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--redis-addr=
+
+  - it: workspaceServices.memoryApi.cache.redis override wins over redis.default
+    # Per-consumer Redis: memory cache pinned to its own Redis (e.g.
+    # local cache instance) while the rest of the cluster uses
+    # redis.default. Operator sees the consumer override; default is
+    # not consulted.
+    set:
+      redis.default.url: "rediss://default-redis.example.com:6379/0"
+      workspaceServices.memoryApi.cache.redis.url: "redis://memory-cache.example.com:6379/0"
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --memory-redis-url=redis://memory-cache.example.com:6379/0
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: --memory-redis-url=rediss://default-redis
 
   - it: empty workspaceServices.memoryApi.cache.ttl drops the flag entirely
     # An operator wanting Redis for the event publisher only (no read-

--- a/charts/omnia/values.schema.json
+++ b/charts/omnia/values.schema.json
@@ -174,13 +174,7 @@
               "type": "object",
               "properties": {
                 "type": { "type": "string", "enum": ["memory", "redis"] },
-                "redis": {
-                  "type": "object",
-                  "properties": {
-                    "host": { "type": "string" },
-                    "port": { "$ref": "#/$defs/port" }
-                  }
-                }
+                "redis": { "$ref": "#/$defs/redisConsumer" }
               }
             }
           }
@@ -352,33 +346,14 @@
         "extraVolumeMounts": { "type": "array", "items": { "type": "object" } },
         "session": {
           "type": "object",
-          "description": "Server-side session store configuration for the dashboard.",
+          "description": "Dashboard server-side session store. Backend auto-selected by Redis URL presence (URL set → Redis store; empty → in-process memory store).",
           "properties": {
-            "store": {
-              "type": "string",
-              "enum": ["memory", "redis"],
-              "description": "Session storage backend. 'memory' is dev only; 'redis' required for multi-replica."
-            },
             "pkceTtl": {
               "type": "integer",
               "minimum": 1,
               "description": "TTL for in-flight PKCE records in seconds."
             },
-            "redis": {
-              "type": "object",
-              "properties": {
-                "url":  { "type": "string", "description": "Full redis:// URL (preferred). Overrides addr/password/db if set." },
-                "addr": { "type": "string", "description": "host:port fallback when url is empty." },
-                "db":   { "type": "integer", "minimum": 0, "description": "Redis database number." },
-                "existingSecret": {
-                  "type": "object",
-                  "properties": {
-                    "name": { "type": "string" },
-                    "key":  { "type": "string" }
-                  }
-                }
-              }
-            }
+            "redis": { "$ref": "#/$defs/redisConsumer" }
           }
         }
       }
@@ -436,7 +411,8 @@
             "cache": {
               "type": "object",
               "properties": {
-                "ttl": { "type": "string" }
+                "ttl":   { "type": "string" },
+                "redis": { "$ref": "#/$defs/redisConsumer" }
               }
             }
           }
@@ -580,10 +556,11 @@
 
     "redis": {
       "type": "object",
+      "description": "Bitnami Redis subchart toggle + cluster-wide default Redis target. Per-consumer overrides live on each consumer block (dashboard.session.redis, workspaceServices.memoryApi.cache.redis, enterprise.arena.queue.redis).",
       "properties": {
-        "enabled":      { "type": "boolean" },
-        "externalAddr": { "type": "string" },
-        "architecture": { "type": "string", "enum": ["standalone", "replication"] }
+        "enabled":      { "type": "boolean", "description": "Bitnami Redis subchart on/off (dev convenience)." },
+        "architecture": { "type": "string", "enum": ["standalone", "replication"] },
+        "default":      { "$ref": "#/$defs/redisConsumer", "description": "Cluster-wide default. Consumers without overrides fall back to this." }
       }
     },
 
@@ -642,6 +619,38 @@
   },
 
   "$defs": {
+    "redisConsumer": {
+      "type": "object",
+      "description": "Per-consumer Redis target. Three forms (resolution order on this block: existingSecret > url > host). Empty fields fall through to redis.default.",
+      "properties": {
+        "existingSecret": {
+          "type": "object",
+          "description": "Kubernetes Secret containing the full Redis URL. Preferred for any auth'd Redis (the URL never appears in chart values).",
+          "properties": {
+            "name": { "type": "string" },
+            "key":  { "type": "string" }
+          }
+        },
+        "url":  { "type": "string", "description": "Literal Redis URL (redis:// or rediss://). Acceptable for unauthenticated dev Redis or when external-secrets injects the password into chart values." },
+        "host": { "type": "string", "description": "Decomposed form: hostname. Cleartext only — for auth'd Redis use existingSecret." },
+        "port": { "$ref": "#/$defs/port" },
+        "db":   { "type": "integer", "minimum": 0, "maximum": 15, "description": "Redis database index." },
+        "user": { "type": "string", "description": "Redis ACL username. Empty defaults to the Redis 6+ \"default\" user." },
+        "tls": {
+          "type": "object",
+          "properties": {
+            "caExistingSecret": {
+              "type": "object",
+              "description": "Custom CA bundle Secret for self-signed Redis TLS certs. Empty = system CA roots (correct for ElastiCache, MemoryStore, Azure Cache).",
+              "properties": {
+                "name": { "type": "string" },
+                "key":  { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/omnia/values.yaml
+++ b/charts/omnia/values.yaml
@@ -141,21 +141,30 @@ enterprise:
           cpu: 100m
           memory: 128Mi
 
-    # Work queue configuration for job distribution
+    # Work queue configuration for job distribution.
     queue:
-      # -- Queue backend type: memory (dev) or redis (prod)
-      # Production deployments should use redis (requires redis.enabled: true)
+      # -- Queue backend: "memory" (in-process, dev only — single
+      # arena-controller replica, jobs lost on restart) or "redis"
+      # (production — requires a resolvable Redis URL).
       type: redis
 
-      # Redis configuration (when type: redis)
+      # Per-consumer Redis override for the Arena queue. Same shape as
+      # `redis.default`. Empty fields fall through to redis.default.
+      # Set when the queue needs to point at a different Redis than
+      # the rest of the cluster (e.g. job durability requirements).
       redis:
-        # -- Redis host (auto-configured when redis.enabled=true)
+        existingSecret:
+          name: ""
+          key: ""
+        url: ""
         host: ""
-        # -- Redis port
         port: 6379
-        # -- Name of Kubernetes Secret containing Redis password (key: "redis-password").
-        # When set, worker pods receive the password via secretKeyRef instead of plain text.
-        passwordSecret: ""
+        db: 0
+        user: ""
+        tls:
+          caExistingSecret:
+            name: ""
+            key: ""
 
     # Dev console for interactive agent testing
     # Dev console image settings used by ArenaDevSession controller to create
@@ -573,8 +582,12 @@ dashboard:
     # -- Dashboard image tag (defaults to Chart appVersion)
     tag: ""
 
-  # -- Number of dashboard replicas
-  replicaCount: 2
+  # -- Number of dashboard replicas. Defaults to 1 because multi-
+  # replica installs require a shared Redis session store (chart fails
+  # render via omnia.validateSession otherwise — see _helpers.tpl).
+  # Production deployments scaling the dashboard horizontally must
+  # configure redis.default OR dashboard.session.redis AND raise this.
+  replicaCount: 1
 
   # -- Dashboard service configuration
   service:
@@ -910,32 +923,33 @@ dashboard:
     # -- Existing PVC to use
     existingClaim: ""
 
-  # -- Server-side session store configuration for the dashboard.
-  # Controls where OAuth PKCE records and session metadata are stored.
+  # -- Server-side session store for OAuth PKCE records and session
+  # metadata. The dashboard auto-selects its backend by Redis-URL
+  # presence: a resolvable URL → Redis store; empty → in-process map.
+  # In-process is single-replica only — multi-replica installs require
+  # a resolvable Redis URL (chart render fails otherwise; see
+  # `omnia.validateSession` helper).
   session:
-    # -- Backend for server-side session storage.
-    # "memory" is single-replica dev only; "redis" is required for any
-    # multi-replica deployment (replicaCount > 1) or horizontal pod autoscaling.
-    store: redis
     # -- TTL for in-flight PKCE records in seconds (default: 300 = 5 minutes).
     pkceTtl: 300
+    # Per-consumer Redis override. Same shape as `redis.default`.
+    # Empty fields fall through to redis.default. Set when the dashboard
+    # session store needs to point at a different Redis than the rest of
+    # the cluster (e.g. cross-region replicated Redis for sessions while
+    # cache + queue use a local instance).
     redis:
-      # -- Full redis:// URL (preferred). Overrides addr/password/db if set.
-      # Example: "redis://omnia-redis-master.omnia.svc.cluster.local:6379"
-      # When redis.enabled=true, leave url empty and set addr to use the
-      # in-cluster Bitnami Redis: "<release>-redis-master.<namespace>.svc.cluster.local:6379"
-      url: ""
-      # -- host:port fallback (used when url is empty).
-      addr: ""
-      # -- Secret reference for the Redis password. Leave name and key empty
-      # to connect without authentication.
       existingSecret:
-        # -- Name of the Kubernetes Secret containing the Redis password.
         name: ""
-        # -- Key within the Secret whose value is the Redis password.
         key: ""
-      # -- Redis database number (default: 0).
+      url: ""
+      host: ""
+      port: 6379
       db: 0
+      user: ""
+      tls:
+        caExistingSecret:
+          name: ""
+          key: ""
 
 # ============================================================================
 # Session Retention Policy Configuration
@@ -1049,19 +1063,36 @@ workspaceServices:
       # -- Image pull policy
       pullPolicy: IfNotPresent
 
-    # Read-through Redis cache for memory-api Retrieve/List paths. Active
-    # only when an operator-wide Redis is configured (redis.enabled=true
-    # OR redis.externalAddr set). Workers (compaction, retention,
-    # tombstone GC, re-embed) always use the unwrapped Postgres store —
-    # the cache only fronts API reads.
+    # Read-through Redis cache for memory-api Retrieve/List paths.
+    # Active only when a Redis URL resolves (consumer override → default
+    # → Bitnami subchart). Workers (compaction, retention, tombstone GC,
+    # re-embed) always use the unwrapped Postgres store — the cache
+    # only fronts API reads.
     cache:
       # -- TTL for cached Retrieve/List results. Empty or "0" disables
-      # the cache even when Redis is configured (operators sometimes
-      # enable Redis for the event publisher first, cache later).
-      # Cache invalidation is version-keyed on every write, so this TTL
-      # only bounds stale reads in the event of an inactive scope; it
-      # is NOT the staleness window after a write.
+      # the cache even when Redis resolves (operators sometimes enable
+      # Redis for the event publisher first, cache later). Invalidation
+      # is version-keyed on every write, so this TTL only bounds stale
+      # reads on inactive scopes; it is NOT the staleness window after
+      # a write.
       ttl: "5m"
+      # Per-consumer Redis override. Same shape as `redis.default`.
+      # Empty fields fall through to redis.default. Set when memory
+      # cache needs to point at a different Redis than the rest of the
+      # cluster (e.g. local cache Redis vs. cross-region session Redis).
+      redis:
+        existingSecret:
+          name: ""
+          key: ""
+        url: ""
+        host: ""
+        port: 6379
+        db: 0
+        user: ""
+        tls:
+          caExistingSecret:
+            name: ""
+            key: ""
 
 # ============================================================================
 # Dev Postgres
@@ -2206,17 +2237,71 @@ keda:
 
 redis:
   # -- Enable Redis subchart (Bitnami Redis)
-  # Use this for development or when you want a managed Redis instance
+  # Dev convenience. When true, populates redis.default.url with the
+  # in-cluster service URL automatically. Production installs typically
+  # leave this false and point redis.default at an external Redis
+  # (ElastiCache, MemoryStore, Azure Cache).
   enabled: false
 
-  # -- Address (host:port) of an external Redis the chart should use
-  # instead of the Bitnami subchart. Set this when pointing the
-  # operator + memory-api + eval-worker + dashboard at AWS ElastiCache,
-  # GCP Memorystore, or any pre-existing in-cluster Redis. Wins over
-  # `redis.enabled` — the subchart is skipped when this is set.
-  # Empty disables all Redis-dependent features (memory cache, event
-  # publisher, eval queue, server-side sessions).
-  externalAddr: ""
+  # ============================================================================
+  # Cluster-wide default Redis target.
+  #
+  # Every consumer (memory cache, dashboard session store, arena queue, eval
+  # worker, A2A task store) falls back to this when its own override is not
+  # set. Empty here AND empty per-consumer = consumer is disabled.
+  #
+  # Two ways to specify the target. Use ONE form per block:
+  #
+  #   1. `url` — full connection string `redis(s)://[user:pass@]host:port[/db]`.
+  #      Preferred when the password is a literal or when there's no auth.
+  #      Cloud Redis vendors document this form (`rediss://...` for TLS).
+  #
+  #   2. Decomposed `{host, port, db, user, tls, auth.existingSecret}`.
+  #      Use when the password lives in a Kubernetes Secret. The chart
+  #      mounts the Secret as REDIS_PASSWORD env and synthesises a URL
+  #      via `$(VAR)` substitution at pod startup.
+  #
+  # Resolution order at consumer-rendering time:
+  #   consumer.url → consumer.{host,...} → default.url → default.{host,...}
+  #   → Bitnami subchart (when redis.enabled=true) → "" (disabled)
+  # ============================================================================
+  default:
+    # ONE OF the three forms below. Resolution order on this block:
+    #   existingSecret (URL from Secret) > url (literal URL) > host (decomposed).
+    #
+    # FORM 1 — URL stored in a Kubernetes Secret. Preferred for any
+    # auth'd Redis (the password never appears in chart values, never
+    # in `helm get values` output, never in container env logs).
+    existingSecret:
+      # -- Secret name. The Secret must contain a single key holding
+      # the full Redis URL (`redis(s)://[user:pass@]host:port[/db]`).
+      name: ""
+      # -- Key within the Secret whose value is the URL.
+      key: ""
+
+    # FORM 2 — literal URL in chart values. Acceptable for unauthenticated
+    # Redis (dev) or where the password is already an opaque chart-input
+    # (e.g. external-secrets reconciles it into chart values).
+    url: ""
+
+    # FORM 3 — decomposed for convenience. Cleartext only; the chart
+    # cannot synthesise auth from this form (use existingSecret for
+    # auth'd Redis). Useful when pointing at unauthenticated in-cluster
+    # Redis without typing out the URL.
+    host: ""
+    port: 6379
+    db: 0
+    user: ""
+
+    # TLS CA bundle for self-signed Redis TLS certs. Optional regardless
+    # of which form is used — leave empty when the Redis cert chains to
+    # a system CA root (true for ElastiCache, MemoryStore, Azure Cache).
+    # Mounted as a file at /etc/omnia/redis-ca/<key> on every consumer
+    # pod when set.
+    tls:
+      caExistingSecret:
+        name: ""
+        key: ""
 
   # -- Subchart values for Bitnami Redis
   # See: https://github.com/bitnami/charts/tree/main/bitnami/redis

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -121,15 +121,29 @@ func main() {
 	flag.StringVar(&workspaceContentPath, "workspace-content-path", "/workspace-content",
 		"Base path for the workspace content volume. SkillSource writes synced content here.")
 	flag.StringVar(&redisAddr, "redis-addr", "",
-		"Operator-wide Redis address (e.g., omnia-redis-master.omnia-system.svc.cluster.local:6379). "+
-			"Forwarded to eval-worker pods and to every per-workspace memory-api as --redis-addrs, "+
-			"so a single Redis instance fronts the memory-api read-through cache, the memory event "+
-			"publisher, and the eval-worker queue. Empty disables all three.")
+		"Eval-worker Redis address in host:port form (e.g., omnia-redis-master.omnia-system.svc.cluster.local:6379). "+
+			"Used by the AgentRuntime reconciler to wire the eval-worker autoscaler. Per-workspace memory-api "+
+			"uses --memory-redis-url instead (URL form supports cloud Redis with TLS). Empty disables eval-worker.")
+	var memoryRedisURL string
+	flag.StringVar(&memoryRedisURL, "memory-redis-url", "",
+		"Operator-wide Redis URL forwarded to every per-workspace memory-api as --redis-url. "+
+			"Accepts redis:// or rediss:// URLs, and the literal placeholder \"$(REDIS_URL)\" — when set "+
+			"to the placeholder, --memory-redis-url-secret-name and --memory-redis-url-secret-key MUST "+
+			"reference the Kubernetes Secret containing the actual URL. Memory-api's pod will mount that "+
+			"Secret as REDIS_URL env, and Kubernetes env expansion at startup fills the placeholder.")
+	var memoryRedisURLSecretName string
+	flag.StringVar(&memoryRedisURLSecretName, "memory-redis-url-secret-name", "",
+		"Kubernetes Secret name backing $(REDIS_URL) substitution on per-workspace memory-api pods. "+
+			"Required only when --memory-redis-url is the placeholder \"$(REDIS_URL)\".")
+	var memoryRedisURLSecretKey string
+	flag.StringVar(&memoryRedisURLSecretKey, "memory-redis-url-secret-key", "",
+		"Key within --memory-redis-url-secret-name whose value is the Redis URL. "+
+			"Required only when --memory-redis-url is the placeholder \"$(REDIS_URL)\".")
 	var memoryCacheTTL string
 	flag.StringVar(&memoryCacheTTL, "memory-cache-ttl", "5m",
 		"TTL forwarded to memory-api as --cache-ttl. Empty or \"0\" disables the read-through "+
-			"cache even when --redis-addr is set (useful when Redis is provisioned only for the "+
-			"event publisher).")
+			"cache even when --memory-redis-url is set (useful when Redis is provisioned only for "+
+			"the event publisher).")
 	flag.StringVar(&evalWorkerImage, "eval-worker-image", "",
 		"Image for the arena-eval-worker container. If not set, defaults to ghcr.io/altairalabs/arena-eval-worker:latest")
 	flag.StringVar(&policyProxyImage, "policy-proxy-image", "",
@@ -306,8 +320,12 @@ func main() {
 			SessionImagePullPolicy: corev1.PullPolicy(sessionAPIImagePullPolicy),
 			MemoryImage:            memoryAPIImage,
 			MemoryImagePullPolicy:  corev1.PullPolicy(memoryAPIImagePullPolicy),
-			MemoryRedisAddrs:       redisAddr,
-			MemoryCacheTTL:         memoryCacheTTL,
+			MemoryRedisURL:         memoryRedisURL,
+			MemoryRedisURLSecret: controller.SecretKeyRef{
+				Name: memoryRedisURLSecretName,
+				Key:  memoryRedisURLSecretKey,
+			},
+			MemoryCacheTTL: memoryCacheTTL,
 		},
 		AgentWorkspaceReaderClusterRole: agentWorkspaceReaderClusterRole,
 		OperatorNamespace:               os.Getenv("POD_NAMESPACE"),

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -105,7 +105,7 @@ type flags struct {
 	healthAddr            string
 	metricsAddr           string
 	postgresConn          string
-	redisAddrs            string
+	redisURL              string // --redis-url, env REDIS_URL or OMNIA_MEMORY_REDIS_URL
 	cacheTTL              string // env: MEMORY_CACHE_TTL, e.g. "5m"; "" or "0" disables
 	enterprise            bool
 	tracingEnabled        bool
@@ -135,8 +135,8 @@ func parseFlags() *flags {
 	flag.StringVar(&f.healthAddr, "health-addr", ":8081", "Health probe listen address")
 	flag.StringVar(&f.metricsAddr, "metrics-addr", ":9090", "Metrics server listen address")
 	flag.StringVar(&f.postgresConn, "postgres-conn", "", "Postgres connection string")
-	flag.StringVar(&f.redisAddrs, "redis-addrs", "", "Redis addresses (comma-separated). When set, the same client is reused for both the read-through cache and the event publisher.")
-	flag.StringVar(&f.cacheTTL, "cache-ttl", "5m", "TTL for the Redis read-through cache (Retrieve/List). Set to 0 or empty to disable caching even when --redis-addrs is configured.")
+	flag.StringVar(&f.redisURL, "redis-url", "", "Redis connection URL (redis:// or rediss://). When set, the same client is reused for both the read-through cache and the event publisher. Empty disables both.")
+	flag.StringVar(&f.cacheTTL, "cache-ttl", "5m", "TTL for the Redis read-through cache (Retrieve/List). Set to 0 or empty to disable caching even when --redis-url is configured.")
 	flag.BoolVar(&f.enterprise, "enterprise", false, "Enable enterprise features (audit logging)")
 	flag.BoolVar(&f.tracingEnabled, "tracing-enabled", false, "Enable OpenTelemetry tracing")
 	flag.StringVar(&f.tracingEndpoint, "tracing-endpoint", "", "OTel collector endpoint")
@@ -166,7 +166,8 @@ func parseFlags() *flags {
 // applyEnvFallbacks applies environment variable overrides to flag defaults.
 func (f *flags) applyEnvFallbacks() {
 	envFallback(&f.postgresConn, "", "POSTGRES_CONN")
-	envFallback(&f.redisAddrs, "", "REDIS_ADDRS")
+	envFallback(&f.redisURL, "", "REDIS_URL")
+	envFallback(&f.redisURL, "", "OMNIA_MEMORY_REDIS_URL")
 	envFallback(&f.cacheTTL, "5m", "MEMORY_CACHE_TTL")
 	envFallback(&f.apiAddr, ":8080", "API_ADDR")
 	envFallback(&f.healthAddr, ":8081", "HEALTH_ADDR")
@@ -387,14 +388,17 @@ func run() error {
 	// cache wrapper or the event publisher. One client, one TCP pool —
 	// keeps connection accounting honest and lets ops see "is Redis up"
 	// from a single set of metrics rather than two.
-	redisClient := buildRedisClient(f.redisAddrs)
+	redisClient, redisErr := buildRedisClient(f.redisURL)
+	if redisErr != nil {
+		return fmt.Errorf("redis URL: %w", redisErr)
+	}
 	if redisClient != nil {
 		defer func() { _ = redisClient.Close() }()
 	}
 
 	apiStore, cacheEnabled := resolveAPIStore(pgStore, redisClient, f.cacheTTL, log)
 	if cacheEnabled {
-		log.Info("memory store cache enabled", "ttl", f.cacheTTL, "redisAddrs", f.redisAddrs)
+		log.Info("memory store cache enabled", "ttl", f.cacheTTL)
 	}
 
 	// --- Read-path metrics ---
@@ -523,7 +527,7 @@ func run() error {
 	var eventPublisher memoryapi.MemoryEventPublisher
 	if redisClient != nil {
 		eventPublisher = memoryapi.NewRedisMemoryEventPublisher(redisClient, log)
-		log.Info("memory event publisher enabled", "redisAddrs", f.redisAddrs)
+		log.Info("memory event publisher enabled")
 	}
 
 	// --- Build API mux ---

--- a/cmd/memory-api/redis_cache.go
+++ b/cmd/memory-api/redis_cache.go
@@ -19,6 +19,7 @@ limitations under the License.
 package main
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -28,24 +29,24 @@ import (
 	"github.com/altairalabs/omnia/internal/memory"
 )
 
-// buildRedisClient returns a Redis client for the given addrs string, or
-// nil when the input is empty. Comma-separated addrs are accepted so the
-// flag matches Sentinel-friendly conventions, but the production wire-up
-// today is single-master — only the first entry is used. We stay
-// permissive on input so a future move to a Sentinel client doesn't
-// break operator config.
-func buildRedisClient(addrs string) *goredis.Client {
-	addr := strings.TrimSpace(addrs)
-	if addr == "" {
-		return nil
+// buildRedisClient parses a Redis connection URL and returns a client.
+// Empty URL → (nil, nil) so callers can branch on "Redis configured"
+// without tripping on parse errors. Invalid URL → (nil, error) — bad
+// config is a startup error, not a silently-disabled cache.
+//
+// Accepts redis:// and rediss:// URLs. TLS, AUTH, DB index, ACL user
+// all encoded in the URL per RFC 7595. goredis.ParseURL handles the
+// edge cases (URL-encoded passwords, IPv6 hosts, etc.).
+func buildRedisClient(url string) (*goredis.Client, error) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return nil, nil
 	}
-	if i := strings.Index(addr, ","); i >= 0 {
-		addr = strings.TrimSpace(addr[:i])
+	opts, err := goredis.ParseURL(url)
+	if err != nil {
+		return nil, fmt.Errorf("parse redis URL: %w", err)
 	}
-	if addr == "" {
-		return nil
-	}
-	return goredis.NewClient(&goredis.Options{Addr: addr})
+	return goredis.NewClient(opts), nil
 }
 
 // resolveAPIStore returns the Store the HTTP API should use.

--- a/cmd/memory-api/redis_cache_test.go
+++ b/cmd/memory-api/redis_cache_test.go
@@ -16,32 +16,49 @@ import (
 	"github.com/altairalabs/omnia/internal/memory"
 )
 
-// TestBuildRedisClient_EmptyReturnsNil proves an unset --redis-addrs
-// flag produces no client. This is the gate the rest of the cache
-// wiring depends on — a non-nil client with no real backend would
-// turn every Retrieve/List into a connection-refused round trip.
+// TestBuildRedisClient_EmptyReturnsNil proves an unset --redis-url
+// flag produces no client without surfacing an error. The cache is
+// opt-in: empty URL means "no Redis", not "broken config".
 func TestBuildRedisClient_EmptyReturnsNil(t *testing.T) {
-	if buildRedisClient("") != nil {
-		t.Error("expected nil client for empty addrs")
-	}
-	if buildRedisClient("   ") != nil {
-		t.Error("expected nil client for whitespace-only addrs")
+	for _, url := range []string{"", "   "} {
+		c, err := buildRedisClient(url)
+		if err != nil {
+			t.Errorf("buildRedisClient(%q): unexpected error %v", url, err)
+		}
+		if c != nil {
+			t.Errorf("buildRedisClient(%q): expected nil client, got %v", url, c)
+		}
 	}
 }
 
-// TestBuildRedisClient_TakesFirstAddr proves the comma-separated input
-// shape is tolerated even though the production go-redis client is
-// single-master. Operators don't have to remember which one of
-// "Sentinel-shaped or single-shaped" the binary expects.
-func TestBuildRedisClient_TakesFirstAddr(t *testing.T) {
-	c := buildRedisClient("redis-a:6379,redis-b:6379")
-	if c == nil {
-		t.Fatal("expected a client for non-empty addrs")
+// TestBuildRedisClient_ParsesURL proves redis:// URLs parse correctly
+// and the resulting client carries the parsed addr/db. Validates the
+// canonical form documented in chart values.
+func TestBuildRedisClient_ParsesURL(t *testing.T) {
+	c, err := buildRedisClient("redis://omnia-redis-master.omnia-system.svc.cluster.local:6379/3")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
 	}
-	if got := c.Options().Addr; got != "redis-a:6379" {
-		t.Errorf("expected addr=redis-a:6379, got %q", got)
+	if c == nil {
+		t.Fatal("expected a client for a valid URL")
+	}
+	if got := c.Options().Addr; got != "omnia-redis-master.omnia-system.svc.cluster.local:6379" {
+		t.Errorf("addr: got %q", got)
+	}
+	if got := c.Options().DB; got != 3 {
+		t.Errorf("db: got %d, want 3", got)
 	}
 	_ = c.Close()
+}
+
+// TestBuildRedisClient_RejectsInvalidURL proves bad input is a startup
+// error, not silently dropped. A typo in the chart values shouldn't
+// degrade into "cache disabled" — operators need a clear signal.
+func TestBuildRedisClient_RejectsInvalidURL(t *testing.T) {
+	_, err := buildRedisClient("not-a-url")
+	if err == nil {
+		t.Fatal("expected an error for an invalid URL")
+	}
 }
 
 // TestParseCacheTTL covers every meaningful path of the helper:

--- a/dashboard/src/lib/auth/session-store/index.test.ts
+++ b/dashboard/src/lib/auth/session-store/index.test.ts
@@ -9,36 +9,28 @@ vi.mock("./redis-client", () => ({
 }));
 
 import { getSessionStore, __resetSessionStoreForTests } from "./index";
-import { MemorySessionStore } from "./memory-store";
 import { RedisSessionStore } from "./redis-store";
 
 describe("getSessionStore", () => {
-  const originalEnv = process.env;
   beforeEach(() => {
     __resetSessionStoreForTests();
-    process.env = { ...originalEnv };
-    delete process.env.OMNIA_SESSION_STORE;
   });
 
-  it("defaults to MemorySessionStore when OMNIA_SESSION_STORE is unset", () => {
-    const store = getSessionStore();
-    expect(store).toBeInstanceOf(MemorySessionStore);
-  });
-
-  it("returns RedisSessionStore when OMNIA_SESSION_STORE=redis", () => {
-    process.env.OMNIA_SESSION_STORE = "redis";
+  it("returns RedisSessionStore when getSessionRedisClient yields a client", () => {
     const store = getSessionStore();
     expect(store).toBeInstanceOf(RedisSessionStore);
   });
 
-  it("throws when OMNIA_SESSION_STORE=redis but no redis client is configured", async () => {
+  it("returns MemorySessionStore when getSessionRedisClient returns null", async () => {
     vi.resetModules();
     vi.doMock("./redis-client", () => ({ getSessionRedisClient: () => null }));
-    process.env.OMNIA_SESSION_STORE = "redis";
-    // Re-import after remocking.
-    const fresh = await import("./index");
-    fresh.__resetSessionStoreForTests();
-    expect(() => fresh.getSessionStore()).toThrow(/OMNIA_SESSION_REDIS_URL/);
+    // Re-import both the factory AND the class so instanceof matches —
+    // resetModules invalidates the Memory*Store reference at the top
+    // of this file.
+    const freshFactory = await import("./index");
+    const freshMemoryStore = await import("./memory-store");
+    freshFactory.__resetSessionStoreForTests();
+    expect(freshFactory.getSessionStore()).toBeInstanceOf(freshMemoryStore.MemorySessionStore);
   });
 
   it("is a singleton across calls", () => {
@@ -47,12 +39,10 @@ describe("getSessionStore", () => {
     expect(first).toBe(second);
   });
 
-  it("falls back to memory for unknown OMNIA_SESSION_STORE values and warns", () => {
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    process.env.OMNIA_SESSION_STORE = "sqlite";
-    const store = getSessionStore();
-    expect(store).toBeInstanceOf(MemorySessionStore);
-    expect(warnSpy).toHaveBeenCalled();
-    warnSpy.mockRestore();
+  it("logs the chosen backend at first construction", () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    getSessionStore();
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining("session store: redis"));
+    logSpy.mockRestore();
   });
 });

--- a/dashboard/src/lib/auth/session-store/index.ts
+++ b/dashboard/src/lib/auth/session-store/index.ts
@@ -1,13 +1,13 @@
 /**
  * Factory + re-exports for the OAuth session store.
  *
- * Backend is chosen by OMNIA_SESSION_STORE:
- *   "memory" (default) — in-process store; single-replica only.
- *   "redis"            — shared Redis; required for multi-replica deployments.
+ * Backend is chosen by URL presence:
+ *   OMNIA_SESSION_REDIS_URL set → RedisSessionStore (multi-replica safe).
+ *   OMNIA_SESSION_REDIS_URL unset → MemorySessionStore (single-replica only).
  *
- * When "redis" is selected but no Redis endpoint is configured,
- * construction fails loudly at first use rather than silently falling
- * back to memory (which would turn into an inconsistency between replicas).
+ * The chart's omnia.validateSession render-time guard fails install
+ * when dashboard.replicaCount > 1 and no Redis URL resolves, so getting
+ * here with replicaCount > 1 + memory store is impossible by construction.
  */
 
 import { MemorySessionStore } from "./memory-store";
@@ -15,31 +15,17 @@ import { RedisSessionStore } from "./redis-store";
 import { getSessionRedisClient } from "./redis-client";
 import type { SessionStore } from "./types";
 
-type Backend = "memory" | "redis";
-
 let cached: SessionStore | null = null;
-
-function resolveBackend(): Backend {
-  const raw = (process.env.OMNIA_SESSION_STORE ?? "memory").toLowerCase();
-  if (raw === "memory" || raw === "redis") return raw;
-  console.warn(`Unknown OMNIA_SESSION_STORE="${raw}", falling back to memory`);
-  return "memory";
-}
 
 export function getSessionStore(): SessionStore {
   if (cached) return cached;
-
-  const backend = resolveBackend();
-  if (backend === "redis") {
-    const redis = getSessionRedisClient();
-    if (!redis) {
-      throw new Error(
-        "OMNIA_SESSION_STORE=redis but neither OMNIA_SESSION_REDIS_URL nor OMNIA_SESSION_REDIS_ADDR is set",
-      );
-    }
+  const redis = getSessionRedisClient();
+  if (redis) {
     cached = new RedisSessionStore(redis);
+    console.log("session store: redis");
   } else {
     cached = new MemorySessionStore();
+    console.log("session store: memory (single-replica only)");
   }
   return cached;
 }

--- a/dashboard/src/lib/auth/session-store/redis-client.test.ts
+++ b/dashboard/src/lib/auth/session-store/redis-client.test.ts
@@ -29,16 +29,13 @@ describe("getSessionRedisClient", () => {
     delete g.sessionRedis;
     process.env = { ...originalEnv };
     delete process.env.OMNIA_SESSION_REDIS_URL;
-    delete process.env.OMNIA_SESSION_REDIS_ADDR;
-    delete process.env.OMNIA_SESSION_REDIS_PASSWORD;
-    delete process.env.OMNIA_SESSION_REDIS_DB;
   });
 
   afterEach(() => {
     process.env = originalEnv;
   });
 
-  it("returns null when no Redis env vars are set", () => {
+  it("returns null when OMNIA_SESSION_REDIS_URL is not set", () => {
     expect(getSessionRedisClient()).toBeNull();
     expect(constructorCalls).toHaveLength(0);
   });
@@ -50,16 +47,12 @@ describe("getSessionRedisClient", () => {
     expect(constructorCalls[0][0]).toBe("redis://sess:6380");
   });
 
-  it("creates a client from OMNIA_SESSION_REDIS_ADDR + password + db", () => {
-    process.env.OMNIA_SESSION_REDIS_ADDR = "sess:6379";
-    process.env.OMNIA_SESSION_REDIS_PASSWORD = "pw"; // eslint-disable-line sonarjs/no-hardcoded-passwords
-    process.env.OMNIA_SESSION_REDIS_DB = "2";
+  it("respects rediss:// (TLS) URLs by passing them through unchanged", () => {
+    // ioredis parses rediss:// natively — the client is responsible for
+    // TLS, the chart just emits the URL.
+    process.env.OMNIA_SESSION_REDIS_URL = "rediss://default:hunter2@elasticache.example.com:6379/0";
     getSessionRedisClient();
-    const opts = constructorCalls[0][0] as Record<string, unknown>;
-    expect(opts.host).toBe("sess");
-    expect(opts.port).toBe(6379);
-    expect(opts.password).toBe("pw");
-    expect(opts.db).toBe(2);
+    expect(constructorCalls[0][0]).toBe("rediss://default:hunter2@elasticache.example.com:6379/0");
   });
 
   it("is a singleton across calls", () => {
@@ -101,18 +94,6 @@ describe("getSessionRedisClient", () => {
     expect(retryStrategy(5)).toBe(1000);
     expect(retryStrategy(6)).toBeNull();
     expect(retryStrategy(10)).toBeNull();
-  });
-
-  it("ADDR-based retryStrategy scales delay and returns null after 5 retries", () => {
-    process.env.OMNIA_SESSION_REDIS_ADDR = "sess:6379";
-    getSessionRedisClient();
-
-    const options = constructorCalls[0][0] as Record<string, (times: number) => number | null>;
-    const retryStrategy = options.retryStrategy;
-
-    expect(retryStrategy(1)).toBe(200);
-    expect(retryStrategy(5)).toBe(1000);
-    expect(retryStrategy(6)).toBeNull();
   });
 
   it("retry delay is capped at 2000ms", () => {

--- a/dashboard/src/lib/auth/session-store/redis-client.ts
+++ b/dashboard/src/lib/auth/session-store/redis-client.ts
@@ -1,16 +1,11 @@
 /**
  * Redis client singleton for the OAuth session store.
  *
- * Mirrors the pattern in `dashboard/src/lib/redis/client.ts` (arena
- * stats) but uses its own env-var namespace so operators can point
- * session storage at a different Redis — in particular, a managed,
- * multi-AZ Redis when the in-cluster dev Redis is not suitable.
- *
- * Env vars:
- *   OMNIA_SESSION_REDIS_URL      — full redis:// URL (preferred)
- *   OMNIA_SESSION_REDIS_ADDR     — host:port fallback
- *   OMNIA_SESSION_REDIS_PASSWORD — optional
- *   OMNIA_SESSION_REDIS_DB       — optional DB number (default 0)
+ * Backend is gated by OMNIA_SESSION_REDIS_URL: present → returns a
+ * client; absent → returns null (callers fall back to MemorySessionStore).
+ * URL accepts redis:// or rediss:// (TLS, ACL user, password, DB index
+ * all encoded). For password-from-Secret, the chart wires the env from
+ * a Kubernetes secretKeyRef so the URL arrives complete at startup.
  */
 
 import Redis from "ioredis";
@@ -29,36 +24,17 @@ function retryStrategy(times: number): number | null {
 }
 
 export function getSessionRedisClient(): Redis | null {
-  if (!process.env.OMNIA_SESSION_REDIS_URL && !process.env.OMNIA_SESSION_REDIS_ADDR) {
-    return null;
-  }
-
+  const url = process.env.OMNIA_SESSION_REDIS_URL;
+  if (!url) return null;
   if (!globalForRedis.sessionRedis) {
-    const url = process.env.OMNIA_SESSION_REDIS_URL;
-    if (url) {
-      globalForRedis.sessionRedis = new Redis(url, {
-        connectTimeout: CONNECT_TIMEOUT_MS,
-        maxRetriesPerRequest: MAX_RETRIES_PER_REQUEST,
-        retryStrategy,
-      });
-    } else {
-      const addr = process.env.OMNIA_SESSION_REDIS_ADDR || "localhost:6379";
-      const [host, port] = addr.split(":");
-      globalForRedis.sessionRedis = new Redis({
-        host,
-        port: Number.parseInt(port || "6379", 10),
-        password: process.env.OMNIA_SESSION_REDIS_PASSWORD || undefined,
-        db: Number.parseInt(process.env.OMNIA_SESSION_REDIS_DB || "0", 10),
-        connectTimeout: CONNECT_TIMEOUT_MS,
-        maxRetriesPerRequest: MAX_RETRIES_PER_REQUEST,
-        retryStrategy,
-      });
-    }
-
+    globalForRedis.sessionRedis = new Redis(url, {
+      connectTimeout: CONNECT_TIMEOUT_MS,
+      maxRetriesPerRequest: MAX_RETRIES_PER_REQUEST,
+      retryStrategy,
+    });
     globalForRedis.sessionRedis.on("error", (err) => {
       console.error("Session Redis client error", err);
     });
   }
-
   return globalForRedis.sessionRedis;
 }

--- a/hack/validate-helm.sh
+++ b/hack/validate-helm.sh
@@ -56,15 +56,36 @@ else
     FAILED=1
 fi
 
-# Test with enterprise enabled
+# Test with enterprise enabled. Enterprise implies arena.queue.type=redis,
+# which requires a resolvable Redis URL — chart fails render via
+# omnia.validateArenaQueue otherwise. Pair enterprise=true with the
+# Bitnami subchart so a CI / smoke render exercises both.
 if helm template omnia "$CHART_DIR" "${AUTH_VALUES[@]}" \
     --set enterprise.enabled=true \
     --set enterprise.arena.controller.image.repository=test \
     --set enterprise.arena.worker.image.repository=test \
+    --set redis.enabled=true \
     > /dev/null 2>&1; then
     print_success "Template renders with enterprise enabled"
 else
     print_error "Template failed with enterprise enabled"
+    helm template omnia "$CHART_DIR" "${AUTH_VALUES[@]}" \
+        --set enterprise.enabled=true \
+        --set enterprise.arena.controller.image.repository=test \
+        --set enterprise.arena.worker.image.repository=test \
+        --set redis.enabled=true 2>&1 | tail -10
+    FAILED=1
+fi
+
+# Test enterprise without Redis must FAIL (arena queue guard).
+if ! helm template omnia "$CHART_DIR" "${AUTH_VALUES[@]}" \
+    --set enterprise.enabled=true \
+    --set enterprise.arena.controller.image.repository=test \
+    --set enterprise.arena.worker.image.repository=test \
+    > /dev/null 2>&1; then
+    print_success "Enterprise without Redis correctly fails render (omnia.validateArenaQueue)"
+else
+    print_error "Enterprise without Redis rendered when it should have failed"
     FAILED=1
 fi
 

--- a/hack/verify-rbac-sync.sh
+++ b/hack/verify-rbac-sync.sh
@@ -72,7 +72,8 @@ HELM_ENTERPRISE_OUT="$TMP_DIR/helm-enterprise.yaml"
 info "Rendering Helm chart (charts/omnia, enterprise.enabled=true)..."
 helm template omnia "$REPO_ROOT/charts/omnia" \
   -f "$REPO_ROOT/charts/omnia/values-chart-tests.yaml" \
-  --set enterprise.enabled=true > "$HELM_ENTERPRISE_OUT"
+  --set enterprise.enabled=true \
+  --set redis.enabled=true > "$HELM_ENTERPRISE_OUT"
 
 # Append enterprise kustomize roles to the kustomize output so they're
 # available for comparison. ee/config/rbac/ is controller-gen-owned, just

--- a/internal/controller/service_builder.go
+++ b/internal/controller/service_builder.go
@@ -51,18 +51,39 @@ type ServiceBuilder struct {
 	MemoryImage            string
 	MemoryImagePullPolicy  corev1.PullPolicy
 
-	// MemoryRedisAddrs is the operator-wide Redis target threaded into
-	// every per-workspace memory-api Deployment as --redis-addrs. Empty
+	// MemoryRedisURL is the operator-wide Redis target threaded into
+	// every per-workspace memory-api Deployment as --redis-url. Empty
 	// disables both the read-through cache and the event publisher.
 	// One Redis is shared across workspaces; per-workspace caching is
 	// already namespaced by the scope-hash inside CachedStore.
-	MemoryRedisAddrs string
+	//
+	// Accepts the literal placeholder "$(REDIS_URL)" — when the chart
+	// passes this, ServiceBuilder also mounts the corresponding Secret
+	// as REDIS_URL env on every memory-api pod so Kubernetes env
+	// expansion fills it at startup. The Secret reference is supplied
+	// via MemoryRedisURLSecret.
+	MemoryRedisURL string
+
+	// MemoryRedisURLSecret references the Kubernetes Secret holding
+	// the actual Redis URL when MemoryRedisURL is the placeholder
+	// "$(REDIS_URL)". When set, ServiceBuilder mounts it as a REDIS_URL
+	// env on every per-workspace memory-api pod. Empty means
+	// MemoryRedisURL is a literal value and no env mount is needed.
+	MemoryRedisURLSecret SecretKeyRef
 
 	// MemoryCacheTTL is forwarded to memory-api as --cache-ttl. Empty
-	// or "0" disables the cache even when MemoryRedisAddrs is set, so
+	// or "0" disables the cache even when MemoryRedisURL is set, so
 	// operators can stand up Redis (for the event publisher) without
 	// the cache, or vice-versa.
 	MemoryCacheTTL string
+}
+
+// SecretKeyRef points at a single key within a Kubernetes Secret. Used
+// for mounting Redis URL secrets without coupling ServiceBuilder to
+// corev1.SecretKeySelector everywhere.
+type SecretKeyRef struct {
+	Name string
+	Key  string
 }
 
 // BuildSessionDeployment builds a Deployment for the session-api service group.
@@ -120,13 +141,14 @@ const (
 func (sb *ServiceBuilder) BuildMemoryDeployment(workspaceName, namespace string, sg omniav1alpha1.WorkspaceServiceGroup) *appsv1.Deployment {
 	name := fmt.Sprintf("memory-%s-%s", workspaceName, sg.Name)
 	labels := serviceLabels("memory-api", workspaceName, sg.Name)
-	args := buildMemoryAPIArgs(workspaceName, sg, sb.MemoryRedisAddrs, sb.MemoryCacheTTL)
+	args := buildMemoryAPIArgs(workspaceName, sg, sb.MemoryRedisURL, sb.MemoryCacheTTL)
 	var overrides *omniav1alpha1.PodOverrides
 	if sg.Memory != nil {
 		overrides = sg.Memory.PodOverrides
 	}
 	dep := buildServiceDeployment(name, namespace, sb.MemoryImage, sb.MemoryImagePullPolicy, args, labels, overrides)
 	addPodNamespaceEnv(dep)
+	addMemoryRedisURLEnv(dep, sb.MemoryRedisURLSecret)
 	if dep.Spec.Template.Annotations == nil {
 		dep.Spec.Template.Annotations = map[string]string{}
 	}
@@ -134,16 +156,41 @@ func (sb *ServiceBuilder) BuildMemoryDeployment(workspaceName, namespace string,
 	return dep
 }
 
+// addMemoryRedisURLEnv mounts REDIS_URL from a Secret when the operator
+// was configured with the placeholder + Secret reference. Memory-api's
+// --redis-url flag arrives at the binary as the literal string
+// "$(REDIS_URL)"; Kubernetes env expansion replaces it at container
+// startup. No-op when ref is empty (either no Redis configured, or the
+// URL was passed as a literal in chart values).
+func addMemoryRedisURLEnv(dep *appsv1.Deployment, ref SecretKeyRef) {
+	if ref.Name == "" || ref.Key == "" {
+		return
+	}
+	containers := dep.Spec.Template.Spec.Containers
+	for i := range containers {
+		containers[i].Env = append(containers[i].Env, corev1.EnvVar{
+			Name: "REDIS_URL",
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{Name: ref.Name},
+					Key:                  ref.Key,
+				},
+			},
+		})
+	}
+}
+
 // buildMemoryAPIArgs assembles the CLI args passed to memory-api. The operator
 // is the canonical source of these because each one is a wiring boundary
 // crossing — the binary's flag default is "off", so anything the operator
 // doesn't pass silently doesn't run.
 //
-// redisAddrs and cacheTTL come from the operator (chart-driven, not per-
-// workspace) because Redis is a shared cluster service. We pass them
-// through unconditionally when set so memory-api wires the cache and
-// event publisher with one client.
-func buildMemoryAPIArgs(workspaceName string, sg omniav1alpha1.WorkspaceServiceGroup, redisAddrs, cacheTTL string) []string {
+// redisURL and cacheTTL come from the operator (chart-driven, not per-
+// workspace) because Redis is a shared cluster service. The URL may be
+// the literal placeholder "$(REDIS_URL)" — Kubernetes env expansion at
+// the memory-api pod fills it from the REDIS_URL Secret env that
+// addMemoryRedisURLEnv mounts.
+func buildMemoryAPIArgs(workspaceName string, sg omniav1alpha1.WorkspaceServiceGroup, redisURL, cacheTTL string) []string {
 	args := []string{
 		fmt.Sprintf("--workspace=%s", workspaceName),
 		fmt.Sprintf("--service-group=%s", sg.Name),
@@ -154,8 +201,8 @@ func buildMemoryAPIArgs(workspaceName string, sg omniav1alpha1.WorkspaceServiceG
 	if sg.Memory != nil && sg.Memory.ProviderRef != nil && sg.Memory.ProviderRef.Name != "" {
 		args = append(args, fmt.Sprintf("--embedding-provider=%s", sg.Memory.ProviderRef.Name))
 	}
-	if redisAddrs != "" {
-		args = append(args, fmt.Sprintf("--redis-addrs=%s", redisAddrs))
+	if redisURL != "" {
+		args = append(args, fmt.Sprintf("--redis-url=%s", redisURL))
 	}
 	if cacheTTL != "" {
 		args = append(args, fmt.Sprintf("--cache-ttl=%s", cacheTTL))

--- a/internal/controller/service_builder_test.go
+++ b/internal/controller/service_builder_test.go
@@ -192,47 +192,91 @@ func TestBuildMemoryDeployment_AnnotatesConfigHash(t *testing.T) {
 }
 
 // TestBuildMemoryDeployment_RedisFlagsAbsentByDefault proves the
-// operator does NOT pass --redis-addrs / --cache-ttl when the
+// operator does NOT pass --redis-url / --cache-ttl when the
 // ServiceBuilder is constructed without Redis config. Memory-api
 // then runs with the cache disabled and no event publisher, which
 // is the correct OSS / non-Redis dev install behaviour. Passing
-// empty strings as flags would degrade into "--redis-addrs=" and
-// trigger a connection-refused log on every Retrieve.
+// empty strings as flags would degrade into "--redis-url=" and
+// trigger goredis.ParseURL to fail on every startup.
 func TestBuildMemoryDeployment_RedisFlagsAbsentByDefault(t *testing.T) {
 	sb := newTestServiceBuilder()
 	sg := newTestServiceGroup("default")
 
 	dep := sb.BuildMemoryDeployment("acme", "acme-ns", sg)
 	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
-	args := dep.Spec.Template.Spec.Containers[0].Args
-	for _, a := range args {
-		if strings.HasPrefix(a, "--redis-addrs=") {
-			t.Errorf("expected no --redis-addrs flag when MemoryRedisAddrs is empty, got %q", a)
+	container := dep.Spec.Template.Spec.Containers[0]
+	for _, a := range container.Args {
+		if strings.HasPrefix(a, "--redis-url=") {
+			t.Errorf("expected no --redis-url flag when MemoryRedisURL is empty, got %q", a)
 		}
 		if strings.HasPrefix(a, "--cache-ttl=") {
 			t.Errorf("expected no --cache-ttl flag when MemoryCacheTTL is empty, got %q", a)
 		}
 	}
+	for _, e := range container.Env {
+		if e.Name == "REDIS_URL" {
+			t.Errorf("expected no REDIS_URL env when no Secret reference is configured, got %+v", e)
+		}
+	}
 }
 
-// TestBuildMemoryDeployment_RedisFlagsThreaded proves that operator-
-// level Redis config flows through to every per-workspace memory-api
-// pod. Without this, setting MemoryRedisAddrs on the operator would
-// be cosmetic — the per-workspace flags wouldn't reflect it and
-// neither the cache nor the event publisher would activate. This is
-// the wiring assertion that mirrors #1038's "the workers were
-// implemented but never started" failure mode for Redis.
-func TestBuildMemoryDeployment_RedisFlagsThreaded(t *testing.T) {
+// TestBuildMemoryDeployment_RedisURLLiteralThreaded proves that an
+// operator-level literal Redis URL flows through to every per-workspace
+// memory-api pod as --redis-url, with no REDIS_URL Secret env (because
+// no Secret reference was configured). The URL is consumed verbatim by
+// goredis.ParseURL at memory-api startup.
+func TestBuildMemoryDeployment_RedisURLLiteralThreaded(t *testing.T) {
 	sb := newTestServiceBuilder()
-	sb.MemoryRedisAddrs = "omnia-redis-master.omnia-system.svc:6379"
+	sb.MemoryRedisURL = "redis://omnia-redis-master.omnia-system.svc.cluster.local:6379/0"
 	sb.MemoryCacheTTL = "10m"
 	sg := newTestServiceGroup("default")
 
 	dep := sb.BuildMemoryDeployment("acme", "acme-ns", sg)
 	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
-	args := dep.Spec.Template.Spec.Containers[0].Args
-	assert.Contains(t, args, "--redis-addrs=omnia-redis-master.omnia-system.svc:6379")
-	assert.Contains(t, args, "--cache-ttl=10m")
+	container := dep.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, container.Args, "--redis-url=redis://omnia-redis-master.omnia-system.svc.cluster.local:6379/0")
+	assert.Contains(t, container.Args, "--cache-ttl=10m")
+	for _, e := range container.Env {
+		if e.Name == "REDIS_URL" {
+			t.Errorf("expected no REDIS_URL env for literal URL, got %+v", e)
+		}
+	}
+}
+
+// TestBuildMemoryDeployment_RedisURLFromSecretMountsEnv proves the
+// secret-backed URL path: when ServiceBuilder is configured with the
+// $(REDIS_URL) placeholder + a Secret reference, every per-workspace
+// memory-api pod gets:
+//   - the placeholder URL on its --redis-url flag, and
+//   - a REDIS_URL env sourced from valueFrom.secretKeyRef.
+//
+// Kubernetes env expansion at pod startup substitutes the placeholder
+// with the Secret's value before goredis.ParseURL sees it. Without the
+// env mount, expansion no-ops and goredis.ParseURL fails with
+// "redis: invalid URL scheme: $(REDIS_URL)".
+func TestBuildMemoryDeployment_RedisURLFromSecretMountsEnv(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sb.MemoryRedisURL = "$(REDIS_URL)"
+	sb.MemoryRedisURLSecret = SecretKeyRef{Name: "redis-url-secret", Key: "url"}
+	sg := newTestServiceGroup("default")
+
+	dep := sb.BuildMemoryDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	container := dep.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, container.Args, "--redis-url=$(REDIS_URL)")
+
+	var redisURLEnv *corev1.EnvVar
+	for i := range container.Env {
+		if container.Env[i].Name == "REDIS_URL" {
+			redisURLEnv = &container.Env[i]
+			break
+		}
+	}
+	require.NotNil(t, redisURLEnv, "expected REDIS_URL env to be mounted from Secret")
+	require.NotNil(t, redisURLEnv.ValueFrom)
+	require.NotNil(t, redisURLEnv.ValueFrom.SecretKeyRef)
+	assert.Equal(t, "redis-url-secret", redisURLEnv.ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "url", redisURLEnv.ValueFrom.SecretKeyRef.Key)
 }
 
 // TestBuildMemoryDeployment_EmbeddingProviderArg proves that setting

--- a/scripts/setup-arena-e2e.sh
+++ b/scripts/setup-arena-e2e.sh
@@ -323,8 +323,6 @@ retry 2 15 helm upgrade --install omnia charts/omnia \
     --set enterprise.evalWorker.image.pullPolicy=Never \
     --set enterprise.evalWorker.workspaceNamespace=dev-agents \
     --set enterprise.arena.queue.type=redis \
-    --set enterprise.arena.queue.redis.host=omnia-redis-master \
-    --set enterprise.arena.queue.redis.port=6379 \
     --set redis.enabled=true \
     --set redis.architecture=standalone \
     --set redis.auth.enabled=false \


### PR DESCRIPTION
## Summary

Reshapes Redis configuration across the chart, operator, memory-api, and dashboard so cloud-managed Redis (ElastiCache, MemoryStore, Azure Cache) is a primary path rather than an afterthought, and so the default install stops shipping a config that throws on first request. Phase 1 of the design at `docs/local-backlog/2026-04-29-redis-config-cleanup-proposal.md`.

## What was broken

Default chart values shipped:
- `dashboard.session.store: redis`
- `dashboard.session.redis.url/addr: ""`
- `redis.enabled: false` (Bitnami subchart off)

Every fresh install with `auth.mode=oauth` threw `OMNIA_SESSION_STORE=redis but neither OMNIA_SESSION_REDIS_URL nor OMNIA_SESSION_REDIS_ADDR is set` on the first auth-related request. Three different chart templates also auto-derived the same in-cluster Redis address inline; no clean path for off-cluster Redis or per-consumer (cache vs. session vs. queue) topology.

## What's now true

- **One canonical form**: every Redis consumer takes a `redis://` or `rediss://` URL. `goredis.ParseURL` handles host/port/auth/TLS/db-index.
- **Three input shapes**, resolution order `existingSecret > url > decomposed`:
  - `existingSecret { name, key }` — full URL stored in a Kubernetes Secret. Preferred for any auth'd Redis.
  - `url` — literal URL in chart values. Acceptable for unauthenticated dev.
  - `host` + `port` + `db` + `user` + `tls` — decomposed convenience form, cleartext only.
- **Per-consumer overrides** with cluster-wide `redis.default` fallback. One source of truth: the `omnia.redis.url` template helper.
- **Render-time guards**: `omnia.validateSession` (multi-replica + no Redis fails render) and `omnia.validateArenaQueue` (Arena queue type=redis + no Redis fails render). Same shape as the existing `omnia.validateAuth`.
- **Dashboard simplification**: `OMNIA_SESSION_STORE` flag deleted. Backend is auto-selected by URL presence — no manual toggle, no throw-on-mismatch.

## Configuration topologies covered

| Topology | How |
|---|---|
| Dev OSS, no Redis | Default values; single-replica dashboard, memory session store, memory cache disabled |
| Dev with Bitnami subchart | `redis.enabled=true` |
| Single cloud Redis (ElastiCache) | `redis.default.existingSecret.{name, key}` pointing at a Secret containing the full `rediss://...` URL |
| Per-consumer split | Cache on Bitnami subchart, sessions on cloud, etc. — each consumer block has the same shape |

## Backwards compatibility

Zero — no users. Existing legacy values (`redis.externalAddr`, `dashboard.session.store`, `dashboard.session.redis.{addr, password, existingSecret, db}`) are removed outright; deprecation aliases would be pure overhead. Operators on the old shape must move to the new one.

## Test plan

- [x] 76/76 helm-unittest assertions (10 suites; new suite `dashboard-session-redis_test.yaml`, rewritten `operator-redis-wiring_test.yaml`)
- [x] 704/704 Go tests (memory-api + controller)
- [x] 4442/4442 dashboard vitest
- [x] `bash hack/validate-helm.sh` — default OSS, enterprise+redis, enterprise-without-redis-fails-render
- [x] `bash hack/verify-rbac-sync.sh` — kustomize↔helm RBAC drift check (passes with `redis.enabled=true` for the enterprise render)
- [x] Dashboard typecheck + lint clean
- [ ] Verify in dev cluster after merge (Tilt: enable Redis subchart, confirm session store + memory cache both wire)

## Out of scope (Phase 2/3 follow-ups)

- **Workspace CRD per-workspace Redis** — `spec.services[].memory.cache.redis` + `spec.services[].session.redis` fields for SaaS multi-tenant Redis isolation.
- **Other consumers to URL form** — arena-controller, arena-worker, arena-eval-worker, eval-worker, compaction. Currently fed host:port via `omnia.redis.hostPort` extraction; opaque under `existingSecret` (operators using existingSecret + Arena must use the decomposed form for the arena queue until those binaries take URL flags).
- **AWS / GCP IAM-auth Redis** — token-refresh loop. Workaround documented: `external-secrets` + Secrets Manager rotator.
- **Sentinel / Cluster client modes** — `goredis.NewFailoverClient` / `NewClusterClient`.
