### PR TITLE
fix(dev): always-on Redis subchart + Doctor skips check when none

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -625,6 +625,20 @@ helm_set = [
     'dashboard.livenessProbe.failureThreshold=6',
 ]
 
+# Bitnami Redis subchart — enabled unconditionally for dev so the
+# memory-api read-through cache, the dashboard session store, the
+# memory event publisher, and (in enterprise mode) the Arena queue
+# all get a working backend out of the box. Footprint is tiny:
+# standalone, no auth, no persistence, ~50MB. Without this, Doctor's
+# RedisReachable check fails on every dev run and any consumer that
+# reaches for Redis crashloops on connect.
+helm_set.extend([
+    'redis.enabled=true',
+    'redis.architecture=standalone',
+    'redis.auth.enabled=false',
+    'redis.master.persistence.enabled=false',
+])
+
 # Enterprise features configuration
 if ENABLE_ENTERPRISE:
     helm_set.extend([
@@ -639,18 +653,14 @@ if ENABLE_ENTERPRISE:
         'enterprise.arena.worker.image.repository=omnia-arena-worker-dev',
         'enterprise.arena.worker.image.tag=latest',
         'enterprise.arena.worker.image.pullPolicy=Never',
-        # Arena queue - use Redis when enterprise is enabled. Address is
-        # auto-derived by the chart helper from redis.enabled=true (the
-        # FQDN form omnia-redis-master.<ns>.svc.cluster.local:6379) so
-        # arena workers in test-arena namespace can resolve it. Don't
-        # set arena.queue.redis.host explicitly — that override produces
-        # a non-FQDN that fails cross-namespace DNS lookup.
+        # Arena queue uses Redis. The Bitnami subchart is already
+        # enabled unconditionally above; address auto-derives via the
+        # chart helper to FQDN form (omnia-redis-master.<ns>.svc.
+        # cluster.local:6379). Don't set arena.queue.redis.host
+        # explicitly — that override produces a non-FQDN that fails
+        # cross-namespace DNS lookup from arena workers in
+        # dev-agents/test-arena namespaces.
         'enterprise.arena.queue.type=redis',
-        # Enable Redis for Arena queue (Bitnami subchart)
-        'redis.enabled=true',
-        'redis.architecture=standalone',
-        'redis.auth.enabled=false',
-        'redis.master.persistence.enabled=false',
         # PromptKit LSP server for YAML validation
         'enterprise.promptkitLsp.enabled=true',
         'enterprise.promptkitLsp.image.repository=omnia-promptkit-lsp-dev',
@@ -675,7 +685,6 @@ else:
     # Disable enterprise features
     helm_set.extend([
         'enterprise.enabled=false',
-        'redis.enabled=false',
     ])
 
 if ENABLE_OBSERVABILITY:
@@ -1007,16 +1016,18 @@ if ENABLE_OBSERVABILITY:
     )
 
 # ============================================================================
-# Redis for Arena Queue (Enterprise only)
+# Redis (always-on for dev)
 # ============================================================================
+# Bitnami Redis subchart is enabled unconditionally so memory cache,
+# session store, event publisher, and (in enterprise mode) Arena queue
+# all have a working backend in dev. Resource label "infra" rather
+# than "enterprise" because it serves OSS consumers too.
 
-if ENABLE_ENTERPRISE:
-    # Redis master (Bitnami standalone mode) - required for Arena queue
-    k8s_resource(
-        'omnia-redis-master',
-        labels=['enterprise'],
-        port_forwards=['6379:6379'],  # Redis port for local debugging
-    )
+k8s_resource(
+    'omnia-redis-master',
+    labels=['infra'],
+    port_forwards=['6379:6379'],  # Redis port for local debugging
+)
 
 # ============================================================================
 # Enterprise Storage - NFS Server and CSI Driver

--- a/charts/omnia/templates/doctor/deployment.yaml
+++ b/charts/omnia/templates/doctor/deployment.yaml
@@ -80,10 +80,15 @@ spec:
             Pass --redis-addr only when a Redis target resolves. Doctor
             skips the RedisReachable check when this flag is empty —
             no false-positive failures on OSS installs without Redis.
-            Sourced from the same omnia.redisAddr helper as the
-            operator so both Doctor and memory-api see the same Redis.
+            Sourced from the same omnia.redis.hostPort helper as the
+            operator (memory-cache consumer path), so Doctor and memory-
+            api see the same Redis. Returns "" for the existingSecret
+            URL form (urlParse can't extract host:port from a Secret
+            reference); operators on the secret form must set --redis-
+            addr explicitly via doctor.* podOverrides until Doctor
+            takes URL form (Phase 3).
           */}}
-          {{- $redisAddr := include "omnia.redisAddr" . }}
+          {{- $redisAddr := include "omnia.redis.hostPort" (dict "ctx" . "consumer" "workspaceServices.memoryApi.cache.redis") }}
           {{- if $redisAddr }}
           {{- $args = append $args (printf "--redis-addr=%s" $redisAddr) }}
           {{- end }}

--- a/charts/omnia/templates/doctor/deployment.yaml
+++ b/charts/omnia/templates/doctor/deployment.yaml
@@ -76,6 +76,17 @@ spec:
           {{- if .Values.doctor.ollamaService }}
           {{- $args = append $args (printf "--ollama-url=http://%s.%s.svc.cluster.local:%d" .Values.doctor.ollamaService .Values.doctor.agentNamespace 11434) }}
           {{- end }}
+          {{- /*
+            Pass --redis-addr only when a Redis target resolves. Doctor
+            skips the RedisReachable check when this flag is empty —
+            no false-positive failures on OSS installs without Redis.
+            Sourced from the same omnia.redisAddr helper as the
+            operator so both Doctor and memory-api see the same Redis.
+          */}}
+          {{- $redisAddr := include "omnia.redisAddr" . }}
+          {{- if $redisAddr }}
+          {{- $args = append $args (printf "--redis-addr=%s" $redisAddr) }}
+          {{- end }}
           {{- if $args }}
           args:
             {{- range $args }}

--- a/charts/omnia/tests/doctor-redis-skip_test.yaml
+++ b/charts/omnia/tests/doctor-redis-skip_test.yaml
@@ -1,0 +1,40 @@
+suite: doctor skips RedisReachable when no Redis is expected
+release:
+  name: omnia
+values:
+  - ../values-chart-tests.yaml
+templates:
+  - templates/doctor/deployment.yaml
+tests:
+  - it: passes no --redis-addr when no Redis is configured
+    # Default OSS install has redis.enabled=false and no externalAddr.
+    # Without this gate, Doctor's TCPCheck("Redis", ...) registered
+    # unconditionally and surfaced a fake "RedisReachable: unreachable"
+    # failure on every run — masking real issues among the noise.
+    set:
+      doctor.enabled: true
+    template: templates/doctor/deployment.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--redis-addr=
+
+  - it: passes --redis-addr from the Bitnami subchart when redis.enabled=true
+    set:
+      doctor.enabled: true
+      redis.enabled: true
+    template: templates/doctor/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redis-addr=omnia-redis-master.NAMESPACE.svc.cluster.local:6379
+
+  - it: passes --redis-addr from redis.externalAddr when set
+    set:
+      doctor.enabled: true
+      redis.externalAddr: "elasticache.example.com:6379"
+    template: templates/doctor/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --redis-addr=elasticache.example.com:6379

--- a/charts/omnia/tests/doctor-redis-skip_test.yaml
+++ b/charts/omnia/tests/doctor-redis-skip_test.yaml
@@ -7,7 +7,7 @@ templates:
   - templates/doctor/deployment.yaml
 tests:
   - it: passes no --redis-addr when no Redis is configured
-    # Default OSS install has redis.enabled=false and no externalAddr.
+    # Default OSS install has redis.enabled=false and no redis.default.url.
     # Without this gate, Doctor's TCPCheck("Redis", ...) registered
     # unconditionally and surfaced a fake "RedisReachable: unreachable"
     # failure on every run — masking real issues among the noise.
@@ -29,12 +29,29 @@ tests:
           path: spec.template.spec.containers[0].args
           content: --redis-addr=omnia-redis-master.NAMESPACE.svc.cluster.local:6379
 
-  - it: passes --redis-addr from redis.externalAddr when set
+  - it: passes --redis-addr from redis.default.host when set
     set:
       doctor.enabled: true
-      redis.externalAddr: "elasticache.example.com:6379"
+      redis.default.host: elasticache.example.com
+      redis.default.port: 6379
     template: templates/doctor/deployment.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
           content: --redis-addr=elasticache.example.com:6379
+
+  - it: skips --redis-addr for the existingSecret form (host:port not knowable)
+    # When the URL is sourced from a Secret, urlParse can't extract a
+    # host:port. Doctor's check is registered host:port-only today
+    # (Phase 3 will move it to URL form). Until then, operators on the
+    # secret form get the check skipped — and can override via
+    # doctor.* podOverrides if they want it back.
+    set:
+      doctor.enabled: true
+      redis.default.existingSecret.name: redis-creds
+      redis.default.existingSecret.key: url
+    template: templates/doctor/deployment.yaml
+    asserts:
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].args[*]
+          pattern: ^--redis-addr=

--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -35,12 +35,10 @@ const (
 	serviceOllama          = "ollama"
 	serviceOperator        = "omnia-operator"
 	serviceDashboard       = "omnia-dashboard"
-	serviceRedis           = "omnia-redis-master"
 	serviceArenaController = "omnia-arena-controller"
 	defaultOllamaPort      = 11434
 	defaultOperatorPort    = 8083
 	defaultDashboardPort   = 3000
-	defaultRedisPort       = 6379
 	defaultArenaPort       = 8082
 )
 
@@ -60,7 +58,12 @@ func main() {
 	ollamaURLFlag := flag.String("ollama-url", "", "override Ollama URL")
 	operatorURLFlag := flag.String("operator-url", "", "override operator API URL")
 	dashboardURLFlag := flag.String("dashboard-url", "", "override dashboard URL")
-	redisAddrFlag := flag.String("redis-addr", "", "override Redis address (host:port)")
+	redisAddrFlag := flag.String("redis-addr", "",
+		"Redis address (host:port). When unset, the Redis reachability check is "+
+			"skipped — installs without Redis (no memory cache, no session store, "+
+			"no Arena queue) are a valid OSS configuration. Chart wires this from "+
+			"omnia.redis.hostPort when a Redis target resolves; operators can also "+
+			"set it explicitly to point Doctor at an out-of-band Redis.")
 	arenaURLFlag := flag.String("arena-url", "", "override arena controller URL")
 	workspaceFlag := flag.String("workspace", "", "workspace name for per-workspace service discovery (optional)")
 	serviceGroupFlag := flag.String("service-group", "default", "service group to resolve within the workspace")
@@ -106,10 +109,11 @@ func main() {
 		dashboardURL = discoverServiceURL(*namespace, serviceDashboard, defaultDashboardPort)
 	}
 
+	// No auto-derivation — Redis is consumer-optional. The check is
+	// registered only when a non-empty addr arrives via the flag, so a
+	// fresh OSS install (no Redis) doesn't surface a fake "Redis
+	// unreachable" failure.
 	redisAddr := *redisAddrFlag
-	if redisAddr == "" {
-		redisAddr = fmt.Sprintf("%s.%s.svc.cluster.local:%d", serviceRedis, *namespace, defaultRedisPort)
-	}
 
 	arenaURL := *arenaURLFlag
 	if arenaURL == "" {
@@ -269,7 +273,12 @@ func buildRunner(cfg runnerConfig) (*doctor.Runner, error) {
 	runner.Register(checks.OllamaCheck(cfg.ollamaURL))
 	runner.Register(checks.OperatorAPICheck(cfg.operatorURL))
 	runner.Register(checks.DashboardCheck(cfg.dashboardURL))
-	runner.Register(checks.TCPCheck("Redis", cfg.redisAddr))
+	// Redis is optional. Skip registration when no addr was provided —
+	// otherwise OSS installs (no Redis configured) would surface a
+	// noisy false-positive "RedisReachable: unreachable" on every run.
+	if cfg.redisAddr != "" {
+		runner.Register(checks.TCPCheck("Redis", cfg.redisAddr))
+	}
 	runner.Register(checks.ArenaControllerCheck(cfg.arenaURL))
 
 	k8sClient, k8sErr := k8s.NewClient()


### PR DESCRIPTION
## Summary

Closes the dev-cluster Redis gap and stops Doctor's noisy `RedisReachable: unreachable` false positive for OSS installs.

**Tiltfile**: Bitnami Redis subchart now enabled unconditionally for dev (was gated behind `ENABLE_ENTERPRISE`). Tiny footprint (standalone, no auth, no persistence, ~50MB) — gives memory-api cache, dashboard session store, memory event publisher, and (in enterprise) Arena queue a working backend out of the box. Without it, the most common dev configuration crashlooped or silently disabled every Redis-using consumer.

**Doctor**: drops the auto-derivation that defaulted `--redis-addr` to `omnia-redis-master.<ns>:6379` even when no Redis was deployed. The TCP check is now registered only when `--redis-addr` is non-empty. Chart wires it from `omnia.redisAddr` so OSS installs without Redis get the check skipped (no fake failure), Bitnami-subchart installs get the FQDN, and operators with `redis.externalAddr` get that.

## Test plan

- [x] `helm unittest charts/omnia` — 70/70 pass (3 new doctor-redis-skip cases)
- [x] `validate-helm.sh` — default + enterprise-enabled both pass
- [x] `go test ./cmd/doctor/...` — 10 pass
- [x] Verify in dev cluster after merge (Tilt up, confirm Doctor's `RedisReachable` is `pass`, not `fail`)

## Notes

Builds on top of #1059 (memory-api `CachedStore` wiring shipped 2 PRs ago). Will need a small rebase if/when #1060 (URL-canonical Redis config) merges first — the doctor chart template references `omnia.redisAddr` which #1060 renames to `omnia.redis.hostPort`.
