### PR TITLE
feat(redis): per-workspace session-api Redis + Doctor URL form (Phase 4)

### DIFF
--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -632,6 +632,8 @@ type MemoryServiceConfig struct {
 }
 
 // SessionServiceConfig defines the configuration for a managed session-api instance.
+//
+// +kubebuilder:validation:XValidation:rule="!has(self.redis) || [has(self.redis.existingSecret), has(self.redis.url) && size(self.redis.url) > 0, has(self.redis.host) && size(self.redis.host) > 0].exists_one(b, b)",message="session.redis must use exactly one of existingSecret, url, or host"
 type SessionServiceConfig struct {
 	// database configures the PostgreSQL database for this session service.
 	// +kubebuilder:validation:Required
@@ -643,6 +645,15 @@ type SessionServiceConfig struct {
 	// falls back to its baked-in defaults.
 	// +optional
 	PolicyRef *corev1.LocalObjectReference `json:"policyRef,omitempty"`
+
+	// redis pins this workspace's session-api hot cache to a specific
+	// Redis instance, overriding the operator-wide default. Use for
+	// SaaS multi-tenancy where each customer's session data must live
+	// on physically separate Redis (data residency, blast-radius
+	// isolation), or per-workspace durability tier choices. Unset =
+	// inherit the operator-wide --session-redis-url passed by the chart.
+	// +optional
+	Redis *RedisConfig `json:"redis,omitempty"`
 
 	// podOverrides customizes the managed session-api Pod (SA, scheduling,
 	// CSI secret-stores, etc.).

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -4061,6 +4061,11 @@ func (in *SessionServiceConfig) DeepCopyInto(out *SessionServiceConfig) {
 		*out = new(corev1.LocalObjectReference)
 		**out = **in
 	}
+	if in.Redis != nil {
+		in, out := &in.Redis, &out.Redis
+		*out = new(RedisConfig)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.PodOverrides != nil {
 		in, out := &in.PodOverrides, &out.PodOverrides
 		*out = new(PodOverrides)

--- a/charts/omnia/crds/omnia.altairalabs.ai_workspaces.yaml
+++ b/charts/omnia/crds/omnia.altairalabs.ai_workspaces.yaml
@@ -7529,9 +7529,78 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        redis:
+                          description: |-
+                            redis pins this workspace's session-api hot cache to a specific
+                            Redis instance, overriding the operator-wide default. Use for
+                            SaaS multi-tenancy where each customer's session data must live
+                            on physically separate Redis (data residency, blast-radius
+                            isolation), or per-workspace durability tier choices. Unset =
+                            inherit the operator-wide --session-redis-url passed by the chart.
+                          properties:
+                            db:
+                              description: db is the Redis database index. Defaults
+                                to 0.
+                              format: int32
+                              maximum: 15
+                              minimum: 0
+                              type: integer
+                            existingSecret:
+                              description: |-
+                                existingSecret references a Kubernetes Secret containing the
+                                full Redis URL. The Secret must hold a single key with a
+                                complete `redis(s)://...` connection string.
+                              properties:
+                                key:
+                                  description: key within the Secret whose value is
+                                    the Redis URL.
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: |-
+                                    name of the Secret in the same namespace as the workspace's
+                                    service Deployment.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            host:
+                              description: |-
+                                host is the Redis hostname for the decomposed form. Combined
+                                with port, db, and user to synthesise an unauthenticated URL.
+                                For any auth'd Redis, use existingSecret.
+                              type: string
+                            port:
+                              description: port is the Redis TCP port. Defaults to
+                                6379 when host is set.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            url:
+                              description: |-
+                                url is a literal Redis connection string. Use only when the URL
+                                either contains no password or carries a password injected via
+                                external-secrets / KV-CSI rather than typed into chart values.
+                              pattern: ^rediss?://
+                              type: string
+                            user:
+                              description: |-
+                                user is the Redis ACL username. Empty defaults to "default"
+                                (the built-in Redis 6+ user).
+                              type: string
+                          type: object
                       required:
                       - database
                       type: object
+                      x-kubernetes-validations:
+                      - message: session.redis must use exactly one of existingSecret,
+                          url, or host
+                        rule: '!has(self.redis) || [has(self.redis.existingSecret),
+                          has(self.redis.url) && size(self.redis.url) > 0, has(self.redis.host)
+                          && size(self.redis.host) > 0].exists_one(b, b)'
                   required:
                   - name
                   type: object

--- a/charts/omnia/templates/_helpers.tpl
+++ b/charts/omnia/templates/_helpers.tpl
@@ -487,27 +487,6 @@ field). Callers wanting auth use the `existingSecret` form instead.
 {{- end }}
 
 {{/*
-Extract host:port from a resolved Redis URL.
-
-Used by consumers that take host:port form (eval-worker, arena-worker,
-arena-eval-worker) until their Go code is converted to URL form. The
-chart still feeds them from the same `omnia.redis.url` source of truth.
-
-Args (passed via dict):
-  ctx      - the root context ($)
-  consumer - dotted path to the per-consumer Redis block.
-
-Returns "host:port" or "".
-*/}}
-{{- define "omnia.redis.hostPort" -}}
-{{- $url := include "omnia.redis.url" . -}}
-{{- if $url -}}
-{{- $parsed := urlParse $url -}}
-{{- $parsed.host -}}
-{{- end -}}
-{{- end }}
-
-{{/*
 Render-time guard: dashboard.replicaCount > 1 with no resolved session
 Redis means per-pod in-memory sessions. Users get logged out the moment
 their request hits a different replica. Fail render rather than ship a

--- a/charts/omnia/templates/deployment.yaml
+++ b/charts/omnia/templates/deployment.yaml
@@ -125,6 +125,27 @@ spec:
             {{- with .Values.workspaceServices.memoryApi.cache.ttl }}
             - --memory-cache-ttl={{ . }}
             {{- end }}
+            {{- /*
+              Session-api hot-cache Redis. Routes through dashboard.
+              session.redis (the same consumer block the dashboard
+              session store uses, since they share Redis topology by
+              default) → redis.default → Bitnami subchart. Operators
+              wanting to split session-api hot-cache Redis from
+              dashboard session-store Redis can set per-workspace
+              overrides via Workspace.spec.services[].session.redis.
+            */}}
+            {{- $sessionConsumer := dict "ctx" . "consumer" "dashboard.session.redis" }}
+            {{- $sessionHasSecret := include "omnia.redis.hasSecret" $sessionConsumer }}
+            {{- if $sessionHasSecret }}
+            {{- $sessionSecret := fromYaml (include "omnia.redis._existingSecret" $sessionConsumer) }}
+            - --session-redis-url-secret-name={{ $sessionSecret.name }}
+            - --session-redis-url-secret-key={{ $sessionSecret.key }}
+            {{- else }}
+            {{- $sessionRedisURL := include "omnia.redis.url" $sessionConsumer }}
+            {{- if $sessionRedisURL }}
+            - --session-redis-url={{ $sessionRedisURL }}
+            {{- end }}
+            {{- end }}
             - --agent-workspace-reader-clusterrole={{ include "omnia.fullname" . }}-agent-workspace-reader
             {{- if .Values.dashboard.enabled }}
             {{- /*

--- a/charts/omnia/templates/doctor/deployment.yaml
+++ b/charts/omnia/templates/doctor/deployment.yaml
@@ -77,20 +77,22 @@ spec:
           {{- $args = append $args (printf "--ollama-url=http://%s.%s.svc.cluster.local:%d" .Values.doctor.ollamaService .Values.doctor.agentNamespace 11434) }}
           {{- end }}
           {{- /*
-            Pass --redis-addr only when a Redis target resolves. Doctor
-            skips the RedisReachable check when this flag is empty —
-            no false-positive failures on OSS installs without Redis.
-            Sourced from the same omnia.redis.hostPort helper as the
-            operator (memory-cache consumer path), so Doctor and memory-
-            api see the same Redis. Returns "" for the existingSecret
-            URL form (urlParse can't extract host:port from a Secret
-            reference); operators on the secret form must set --redis-
-            addr explicitly via doctor.* podOverrides until Doctor
-            takes URL form (Phase 3).
+            Doctor takes --redis-url. Resolved from the same memory-
+            cache consumer path as the operator's --memory-redis-url
+            so Doctor's TCPCheck dials the same Redis the rest of the
+            cluster talks to. The literal-URL and decomposed forms
+            pass through as --redis-url=<url>. The existingSecret form
+            mounts REDIS_URL env from the Secret on the Doctor pod;
+            the binary's --redis-url flag falls back to the env. Empty
+            resolution → check skipped (OSS/no-Redis).
           */}}
-          {{- $redisAddr := include "omnia.redis.hostPort" (dict "ctx" . "consumer" "workspaceServices.memoryApi.cache.redis") }}
-          {{- if $redisAddr }}
-          {{- $args = append $args (printf "--redis-addr=%s" $redisAddr) }}
+          {{- $redisConsumer := dict "ctx" . "consumer" "workspaceServices.memoryApi.cache.redis" }}
+          {{- $redisHasSecret := include "omnia.redis.hasSecret" $redisConsumer }}
+          {{- if not $redisHasSecret }}
+          {{- $redisURL := include "omnia.redis.url" $redisConsumer }}
+          {{- if $redisURL }}
+          {{- $args = append $args (printf "--redis-url=%s" $redisURL) }}
+          {{- end }}
           {{- end }}
           {{- if $args }}
           args:
@@ -124,11 +126,22 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.doctor.resources | nindent 12 }}
-          {{- if or $tokenEnabled $po.extraEnv }}
+          {{- /*
+            Mount REDIS_URL on the Doctor pod when the consumer is on
+            the existingSecret form. Doctor's --redis-url flag falls
+            back to REDIS_URL env, so the binary parses the resolved
+            URL at startup. When the consumer is literal/decomposed,
+            the URL is passed via --redis-url (above) and no env mount
+            is needed.
+          */}}
+          {{- if or $tokenEnabled $redisHasSecret $po.extraEnv }}
           env:
             {{- if $tokenEnabled }}
             - name: OMNIA_MGMT_PLANE_TOKEN_URL
               value: {{ $tokenURL | quote }}
+            {{- end }}
+            {{- if $redisHasSecret }}
+            {{- include "omnia.redis.urlEnv" (merge (dict "envName" "REDIS_URL") $redisConsumer) | nindent 12 }}
             {{- end }}
             {{- with $po.extraEnv }}
             {{- toYaml . | nindent 12 }}

--- a/charts/omnia/tests/doctor-redis-skip_test.yaml
+++ b/charts/omnia/tests/doctor-redis-skip_test.yaml
@@ -1,4 +1,4 @@
-suite: doctor skips RedisReachable when no Redis is expected
+suite: doctor URL-canonical Redis wiring
 release:
   name: omnia
 values:
@@ -6,10 +6,9 @@ values:
 templates:
   - templates/doctor/deployment.yaml
 tests:
-  - it: passes no --redis-addr when no Redis is configured
-    # Default OSS install has redis.enabled=false and no redis.default.url.
-    # Without this gate, Doctor's TCPCheck("Redis", ...) registered
-    # unconditionally and surfaced a fake "RedisReachable: unreachable"
+  - it: passes no --redis-url when no Redis is configured
+    # Default OSS install has no Redis. Without this gate Doctor's
+    # TCPCheck would surface a fake "RedisReachable: unreachable"
     # failure on every run — masking real issues among the noise.
     set:
       doctor.enabled: true
@@ -17,9 +16,9 @@ tests:
     asserts:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[*]
-          pattern: ^--redis-addr=
+          pattern: ^--redis-url=
 
-  - it: passes --redis-addr from the Bitnami subchart when redis.enabled=true
+  - it: passes --redis-url from the Bitnami subchart when redis.enabled=true
     set:
       doctor.enabled: true
       redis.enabled: true
@@ -27,25 +26,23 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --redis-addr=omnia-redis-master.NAMESPACE.svc.cluster.local:6379
+          content: --redis-url=redis://omnia-redis-master.NAMESPACE.svc.cluster.local:6379/0
 
-  - it: passes --redis-addr from redis.default.host when set
+  - it: passes --redis-url from redis.default.url when set
     set:
       doctor.enabled: true
-      redis.default.host: elasticache.example.com
-      redis.default.port: 6379
+      redis.default.url: rediss://elasticache.example.com:6379/0
     template: templates/doctor/deployment.yaml
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: --redis-addr=elasticache.example.com:6379
+          content: --redis-url=rediss://elasticache.example.com:6379/0
 
-  - it: skips --redis-addr for the existingSecret form (host:port not knowable)
-    # When the URL is sourced from a Secret, urlParse can't extract a
-    # host:port. Doctor's check is registered host:port-only today
-    # (Phase 3 will move it to URL form). Until then, operators on the
-    # secret form get the check skipped — and can override via
-    # doctor.* podOverrides if they want it back.
+  - it: existingSecret form mounts REDIS_URL env instead of passing --redis-url flag
+    # Secret-form: the URL is opaque at render time. Doctor's
+    # --redis-url flag falls back to REDIS_URL env, so the chart
+    # mounts the env from the Secret. Without this Doctor would
+    # try to dial "$(REDIS_URL)" literal as a host:port.
     set:
       doctor.enabled: true
       redis.default.existingSecret.name: redis-creds
@@ -54,4 +51,12 @@ tests:
     asserts:
       - notMatchRegex:
           path: spec.template.spec.containers[0].args[*]
-          pattern: ^--redis-addr=
+          pattern: ^--redis-url=
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: REDIS_URL
+            valueFrom:
+              secretKeyRef:
+                name: redis-creds
+                key: url

--- a/cmd/doctor/main.go
+++ b/cmd/doctor/main.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	goredis "github.com/redis/go-redis/v9"
 
 	"github.com/altairalabs/omnia/internal/doctor"
 	"github.com/altairalabs/omnia/internal/doctor/checks"
@@ -58,12 +59,13 @@ func main() {
 	ollamaURLFlag := flag.String("ollama-url", "", "override Ollama URL")
 	operatorURLFlag := flag.String("operator-url", "", "override operator API URL")
 	dashboardURLFlag := flag.String("dashboard-url", "", "override dashboard URL")
-	redisAddrFlag := flag.String("redis-addr", "",
-		"Redis address (host:port). When unset, the Redis reachability check is "+
-			"skipped — installs without Redis (no memory cache, no session store, "+
-			"no Arena queue) are a valid OSS configuration. Chart wires this from "+
-			"omnia.redis.hostPort when a Redis target resolves; operators can also "+
-			"set it explicitly to point Doctor at an out-of-band Redis.")
+	redisURLFlag := flag.String("redis-url", os.Getenv("REDIS_URL"),
+		"Redis URL (redis:// or rediss://). When unset, the Redis reachability "+
+			"check is skipped — installs without Redis (no memory cache, no session "+
+			"store, no Arena queue) are a valid OSS configuration. Chart wires this "+
+			"from omnia.redis.url when a Redis target resolves; operators can also "+
+			"set it explicitly. The TCPCheck dials host:port extracted from the URL "+
+			"via goredis.ParseURL; the Doctor doesn't authenticate.")
 	arenaURLFlag := flag.String("arena-url", "", "override arena controller URL")
 	workspaceFlag := flag.String("workspace", "", "workspace name for per-workspace service discovery (optional)")
 	serviceGroupFlag := flag.String("service-group", "default", "service group to resolve within the workspace")
@@ -110,10 +112,20 @@ func main() {
 	}
 
 	// No auto-derivation — Redis is consumer-optional. The check is
-	// registered only when a non-empty addr arrives via the flag, so a
+	// registered only when a non-empty URL arrives via the flag, so a
 	// fresh OSS install (no Redis) doesn't surface a fake "Redis
-	// unreachable" failure.
-	redisAddr := *redisAddrFlag
+	// unreachable" failure. URL → host:port via ParseURL because the
+	// TCPCheck takes a dial address (auth is irrelevant for a TCP
+	// reachability probe).
+	redisAddr := ""
+	if *redisURLFlag != "" {
+		opts, parseErr := goredis.ParseURL(*redisURLFlag)
+		if parseErr != nil {
+			log.Error(parseErr, "invalid --redis-url", "value", *redisURLFlag)
+			os.Exit(1)
+		}
+		redisAddr = opts.Addr
+	}
 
 	arenaURL := *arenaURLFlag
 	if arenaURL == "" {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -145,6 +145,17 @@ func main() {
 		"TTL forwarded to memory-api as --cache-ttl. Empty or \"0\" disables the read-through "+
 			"cache even when --memory-redis-url is set (useful when Redis is provisioned only for "+
 			"the event publisher).")
+	var sessionRedisURL string
+	flag.StringVar(&sessionRedisURL, "session-redis-url", "",
+		"Operator-wide Redis URL forwarded to every per-workspace session-api as --redis-url for "+
+			"the hot-cache layer. Same shape as --memory-redis-url: literal URL, or \"$(REDIS_URL)\" "+
+			"placeholder paired with --session-redis-url-secret-{name,key}.")
+	var sessionRedisURLSecretName string
+	flag.StringVar(&sessionRedisURLSecretName, "session-redis-url-secret-name", "",
+		"Kubernetes Secret name backing $(REDIS_URL) substitution on per-workspace session-api pods.")
+	var sessionRedisURLSecretKey string
+	flag.StringVar(&sessionRedisURLSecretKey, "session-redis-url-secret-key", "",
+		"Key within --session-redis-url-secret-name whose value is the Redis URL.")
 	flag.StringVar(&evalWorkerImage, "eval-worker-image", "",
 		"Image for the arena-eval-worker container. If not set, defaults to ghcr.io/altairalabs/arena-eval-worker:latest")
 	flag.StringVar(&policyProxyImage, "policy-proxy-image", "",
@@ -326,7 +337,12 @@ func main() {
 				Name: memoryRedisURLSecretName,
 				Key:  memoryRedisURLSecretKey,
 			},
-			MemoryCacheTTL: memoryCacheTTL,
+			MemoryCacheTTL:  memoryCacheTTL,
+			SessionRedisURL: sessionRedisURL,
+			SessionRedisURLSecret: controller.SecretKeyRef{
+				Name: sessionRedisURLSecretName,
+				Key:  sessionRedisURLSecretKey,
+			},
 		},
 		AgentWorkspaceReaderClusterRole: agentWorkspaceReaderClusterRole,
 		OperatorNamespace:               os.Getenv("POD_NAMESPACE"),

--- a/config/crd/bases/omnia.altairalabs.ai_workspaces.yaml
+++ b/config/crd/bases/omnia.altairalabs.ai_workspaces.yaml
@@ -7529,9 +7529,78 @@ spec:
                               type: string
                           type: object
                           x-kubernetes-map-type: atomic
+                        redis:
+                          description: |-
+                            redis pins this workspace's session-api hot cache to a specific
+                            Redis instance, overriding the operator-wide default. Use for
+                            SaaS multi-tenancy where each customer's session data must live
+                            on physically separate Redis (data residency, blast-radius
+                            isolation), or per-workspace durability tier choices. Unset =
+                            inherit the operator-wide --session-redis-url passed by the chart.
+                          properties:
+                            db:
+                              description: db is the Redis database index. Defaults
+                                to 0.
+                              format: int32
+                              maximum: 15
+                              minimum: 0
+                              type: integer
+                            existingSecret:
+                              description: |-
+                                existingSecret references a Kubernetes Secret containing the
+                                full Redis URL. The Secret must hold a single key with a
+                                complete `redis(s)://...` connection string.
+                              properties:
+                                key:
+                                  description: key within the Secret whose value is
+                                    the Redis URL.
+                                  minLength: 1
+                                  type: string
+                                name:
+                                  description: |-
+                                    name of the Secret in the same namespace as the workspace's
+                                    service Deployment.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - key
+                              - name
+                              type: object
+                            host:
+                              description: |-
+                                host is the Redis hostname for the decomposed form. Combined
+                                with port, db, and user to synthesise an unauthenticated URL.
+                                For any auth'd Redis, use existingSecret.
+                              type: string
+                            port:
+                              description: port is the Redis TCP port. Defaults to
+                                6379 when host is set.
+                              format: int32
+                              maximum: 65535
+                              minimum: 1
+                              type: integer
+                            url:
+                              description: |-
+                                url is a literal Redis connection string. Use only when the URL
+                                either contains no password or carries a password injected via
+                                external-secrets / KV-CSI rather than typed into chart values.
+                              pattern: ^rediss?://
+                              type: string
+                            user:
+                              description: |-
+                                user is the Redis ACL username. Empty defaults to "default"
+                                (the built-in Redis 6+ user).
+                              type: string
+                          type: object
                       required:
                       - database
                       type: object
+                      x-kubernetes-validations:
+                      - message: session.redis must use exactly one of existingSecret,
+                          url, or host
+                        rule: '!has(self.redis) || [has(self.redis.existingSecret),
+                          has(self.redis.url) && size(self.redis.url) > 0, has(self.redis.host)
+                          && size(self.redis.host) > 0].exists_one(b, b)'
                   required:
                   - name
                   type: object

--- a/internal/controller/service_builder.go
+++ b/internal/controller/service_builder.go
@@ -76,6 +76,19 @@ type ServiceBuilder struct {
 	// operators can stand up Redis (for the event publisher) without
 	// the cache, or vice-versa.
 	MemoryCacheTTL string
+
+	// SessionRedisURL is the operator-wide Redis target threaded into
+	// every per-workspace session-api Deployment as --redis-url for
+	// the hot-cache layer (warm-tier sessions live in Postgres; the
+	// hot tier accelerates active-session reads). Same shape as
+	// MemoryRedisURL: literal value or "$(REDIS_URL)" placeholder
+	// when SessionRedisURLSecret is set. Empty disables the hot cache.
+	SessionRedisURL string
+
+	// SessionRedisURLSecret references the Kubernetes Secret holding
+	// the actual Redis URL when SessionRedisURL is the placeholder
+	// "$(REDIS_URL)". Mirrors MemoryRedisURLSecret.
+	SessionRedisURLSecret SecretKeyRef
 }
 
 // SecretKeyRef points at a single key within a Kubernetes Secret. Used
@@ -87,18 +100,78 @@ type SecretKeyRef struct {
 }
 
 // BuildSessionDeployment builds a Deployment for the session-api service group.
+//
+// Per-workspace Redis (sg.Session.Redis) wins over the operator-wide
+// SessionRedisURL. Either form may be empty (session-api then runs
+// without the hot cache; warm-tier Postgres still serves all reads,
+// just slower for active sessions).
 func (sb *ServiceBuilder) BuildSessionDeployment(workspaceName, namespace string, sg omniav1alpha1.WorkspaceServiceGroup) *appsv1.Deployment {
 	name := fmt.Sprintf("session-%s-%s", workspaceName, sg.Name)
 	labels := serviceLabels("session-api", workspaceName, sg.Name)
+	redisURL, redisSecret := resolveSessionRedis(sg, sb.SessionRedisURL, sb.SessionRedisURLSecret)
 	args := []string{
 		fmt.Sprintf("--workspace=%s", workspaceName),
 		fmt.Sprintf("--service-group=%s", sg.Name),
+	}
+	if redisURL != "" {
+		args = append(args, fmt.Sprintf("--redis-url=%s", redisURL))
 	}
 	var overrides *omniav1alpha1.PodOverrides
 	if sg.Session != nil {
 		overrides = sg.Session.PodOverrides
 	}
-	return buildServiceDeployment(name, namespace, sb.SessionImage, sb.SessionImagePullPolicy, args, labels, overrides)
+	dep := buildServiceDeployment(name, namespace, sb.SessionImage, sb.SessionImagePullPolicy, args, labels, overrides)
+	addMemoryRedisURLEnv(dep, redisSecret)
+	if dep.Spec.Template.Annotations == nil {
+		dep.Spec.Template.Annotations = map[string]string{}
+	}
+	dep.Spec.Template.Annotations[annotationConfigHash] = sessionConfigHash(sg)
+	return dep
+}
+
+// resolveSessionRedis mirrors resolveMemoryRedis for the session-api
+// hot cache. Per-workspace override > operator-wide default. Same
+// three input forms (existingSecret/url/host) and same
+// "$(REDIS_URL)" placeholder convention for the Secret form.
+func resolveSessionRedis(sg omniav1alpha1.WorkspaceServiceGroup, defaultURL string, defaultSecret SecretKeyRef) (string, SecretKeyRef) {
+	if sg.Session == nil || sg.Session.Redis == nil {
+		return defaultURL, defaultSecret
+	}
+	r := sg.Session.Redis
+	if r.ExistingSecret != nil && r.ExistingSecret.Name != "" && r.ExistingSecret.Key != "" {
+		return "$(REDIS_URL)", SecretKeyRef{Name: r.ExistingSecret.Name, Key: r.ExistingSecret.Key}
+	}
+	if r.URL != "" {
+		return r.URL, SecretKeyRef{}
+	}
+	if r.Host != "" {
+		port := int32(6379)
+		if r.Port != 0 {
+			port = r.Port
+		}
+		userPart := ""
+		if r.User != "" {
+			userPart = r.User + "@"
+		}
+		return fmt.Sprintf("redis://%s%s:%d/%d", userPart, r.Host, port, r.DB), SecretKeyRef{}
+	}
+	return defaultURL, defaultSecret
+}
+
+// sessionConfigHash hashes the runtime-relevant fields of a session
+// service group (database SecretRef name + per-workspace Redis target)
+// into a short stable string. Mirrors memoryConfigHash so flipping
+// the Redis target rolls the pod.
+func sessionConfigHash(sg omniav1alpha1.WorkspaceServiceGroup) string {
+	var dbSecret, redisDescriptor string
+	if sg.Session != nil {
+		if sg.Session.Database.SecretRef.Name != "" {
+			dbSecret = sg.Session.Database.SecretRef.Name
+		}
+		redisDescriptor = redisHashDescriptor(sg.Session.Redis)
+	}
+	sum := sha256.Sum256([]byte(dbSecret + "|" + redisDescriptor))
+	return hex.EncodeToString(sum[:8])
 }
 
 // Default worker intervals for the operator-managed memory-api. Each

--- a/internal/controller/service_builder_test.go
+++ b/internal/controller/service_builder_test.go
@@ -167,6 +167,76 @@ func TestBuildSessionDeployment_PerWorkspaceRedisURLOverridesOperator(t *testing
 	assert.NotContains(t, args, "--redis-url=redis://operator-default:6379/0")
 }
 
+// TestBuildSessionDeployment_PerWorkspaceRedisHostSynthesisesURL
+// proves the decomposed form: workspace sets host (+ optional port/db/
+// user), operator synthesises a URL. No auth — decomposed is cleartext-
+// only by design (auth flows via existingSecret).
+func TestBuildSessionDeployment_PerWorkspaceRedisHostSynthesisesURL(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sg := newTestServiceGroup("prod")
+	sg.Session = &omniav1alpha1.SessionServiceConfig{
+		Database: omniav1alpha1.DatabaseConfig{SecretRef: corev1.LocalObjectReference{Name: "session-db"}},
+		Redis: &omniav1alpha1.RedisConfig{
+			Host: "tenant-session-redis.example.com",
+			Port: 6390,
+			DB:   3,
+			User: "sessions",
+		},
+	}
+
+	dep := sb.BuildSessionDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	args := dep.Spec.Template.Spec.Containers[0].Args
+	assert.Contains(t, args, "--redis-url=redis://sessions@tenant-session-redis.example.com:6390/3")
+}
+
+// TestBuildSessionDeployment_PerWorkspaceRedisEmptyFallsThrough proves
+// that a workspace whose Session.Redis block is set but with all
+// three input forms empty (CEL should reject this at admission, but
+// the unit's defensive fallback returns the operator default to keep
+// the Deployment renderable rather than emitting a broken --redis-url).
+func TestBuildSessionDeployment_PerWorkspaceRedisEmptyFallsThrough(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sb.SessionRedisURL = testOperatorRedisURL
+	sg := newTestServiceGroup("prod")
+	sg.Session = &omniav1alpha1.SessionServiceConfig{
+		Database: omniav1alpha1.DatabaseConfig{SecretRef: corev1.LocalObjectReference{Name: "session-db"}},
+		Redis:    &omniav1alpha1.RedisConfig{}, // all forms empty
+	}
+
+	dep := sb.BuildSessionDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Args,
+		"--redis-url="+testOperatorRedisURL)
+}
+
+// TestBuildSessionDeployment_RollsOnRedisChange proves the
+// sessionConfigHash annotation flips when the Redis target changes,
+// so the session-api pod rolls and picks up the new --redis-url.
+func TestBuildSessionDeployment_RollsOnRedisChange(t *testing.T) {
+	sb := newTestServiceBuilder()
+	baseSession := omniav1alpha1.SessionServiceConfig{
+		Database: omniav1alpha1.DatabaseConfig{SecretRef: corev1.LocalObjectReference{Name: "session-db"}},
+	}
+
+	sgA := newTestServiceGroup("prod")
+	sessA := baseSession
+	sessA.Redis = &omniav1alpha1.RedisConfig{URL: "redis://a.example.com:6379/0"}
+	sgA.Session = &sessA
+	depA := sb.BuildSessionDeployment("acme", "acme-ns", sgA)
+
+	sgB := newTestServiceGroup("prod")
+	sessB := baseSession
+	sessB.Redis = &omniav1alpha1.RedisConfig{URL: "redis://b.example.com:6379/0"}
+	sgB.Session = &sessB
+	depB := sb.BuildSessionDeployment("acme", "acme-ns", sgB)
+
+	annoA := depA.Spec.Template.Annotations[annotationConfigHash]
+	annoB := depB.Spec.Template.Annotations[annotationConfigHash]
+	assert.NotEqual(t, annoA, annoB,
+		"per-workspace session Redis URL change must alter the configHash so the pod rolls")
+}
+
 // TestBuildSessionDeployment_PerWorkspaceRedisExistingSecret proves
 // the secret form on a per-workspace session override: $(REDIS_URL)
 // flag placeholder + REDIS_URL env from the workspace's Secret.

--- a/internal/controller/service_builder_test.go
+++ b/internal/controller/service_builder_test.go
@@ -27,6 +27,12 @@ import (
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 )
 
+// Test constants extracted to satisfy goconst.
+const (
+	testOperatorRedisURL = "redis://operator-default:6379/0"
+	testRedisURLEnvName  = "REDIS_URL"
+)
+
 func newTestServiceGroup(name string) omniav1alpha1.WorkspaceServiceGroup {
 	return omniav1alpha1.WorkspaceServiceGroup{
 		Name: name,
@@ -105,6 +111,96 @@ func TestBuildSessionDeployment(t *testing.T) {
 	assert.Contains(t, sc.Capabilities.Drop, corev1.Capability("ALL"))
 	require.NotNil(t, sc.SeccompProfile)
 	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, sc.SeccompProfile.Type)
+}
+
+// TestBuildSessionDeployment_NoRedisFlagByDefault proves session-api
+// pods are built without --redis-url when no Redis is configured —
+// session-api gracefully degrades to warm-tier-only when REDIS_URL is
+// empty, but emitting the flag with empty value would surface
+// confusing "parse redis URL" errors at startup.
+func TestBuildSessionDeployment_NoRedisFlagByDefault(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sg := newTestServiceGroup("default")
+
+	dep := sb.BuildSessionDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	for _, a := range dep.Spec.Template.Spec.Containers[0].Args {
+		if strings.HasPrefix(a, "--redis-url=") {
+			t.Errorf("expected no --redis-url flag, got %q", a)
+		}
+	}
+}
+
+// TestBuildSessionDeployment_OperatorRedisURLLiteral proves the
+// operator-wide --session-redis-url flag flows through to session-api
+// pods. Without this, configuring SessionRedisURL on ServiceBuilder
+// would be cosmetic.
+func TestBuildSessionDeployment_OperatorRedisURLLiteral(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sb.SessionRedisURL = testOperatorRedisURL
+	sg := newTestServiceGroup("default")
+
+	dep := sb.BuildSessionDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	assert.Contains(t, dep.Spec.Template.Spec.Containers[0].Args,
+		"--redis-url=redis://operator-default:6379/0")
+}
+
+// TestBuildSessionDeployment_PerWorkspaceRedisURLOverridesOperator
+// proves per-workspace session.redis.url shadows the operator-wide
+// SessionRedisURL. Mirrors the memory-api per-workspace test from #1062.
+func TestBuildSessionDeployment_PerWorkspaceRedisURLOverridesOperator(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sb.SessionRedisURL = testOperatorRedisURL
+	sg := newTestServiceGroup("prod")
+	sg.Session = &omniav1alpha1.SessionServiceConfig{
+		Database: omniav1alpha1.DatabaseConfig{SecretRef: corev1.LocalObjectReference{Name: "session-db"}},
+		Redis: &omniav1alpha1.RedisConfig{
+			URL: "rediss://customer-acme-sessions.example.com:6379/2",
+		},
+	}
+
+	dep := sb.BuildSessionDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	args := dep.Spec.Template.Spec.Containers[0].Args
+	assert.Contains(t, args, "--redis-url=rediss://customer-acme-sessions.example.com:6379/2")
+	assert.NotContains(t, args, "--redis-url=redis://operator-default:6379/0")
+}
+
+// TestBuildSessionDeployment_PerWorkspaceRedisExistingSecret proves
+// the secret form on a per-workspace session override: $(REDIS_URL)
+// flag placeholder + REDIS_URL env from the workspace's Secret.
+func TestBuildSessionDeployment_PerWorkspaceRedisExistingSecret(t *testing.T) {
+	sb := newTestServiceBuilder()
+	sb.SessionRedisURL = testOperatorRedisURL
+	sg := newTestServiceGroup("prod")
+	sg.Session = &omniav1alpha1.SessionServiceConfig{
+		Database: omniav1alpha1.DatabaseConfig{SecretRef: corev1.LocalObjectReference{Name: "session-db"}},
+		Redis: &omniav1alpha1.RedisConfig{
+			ExistingSecret: &omniav1alpha1.RedisSecretRef{
+				Name: "acme-session-redis",
+				Key:  "url",
+			},
+		},
+	}
+
+	dep := sb.BuildSessionDeployment("acme", "acme-ns", sg)
+	require.Len(t, dep.Spec.Template.Spec.Containers, 1)
+	container := dep.Spec.Template.Spec.Containers[0]
+	assert.Contains(t, container.Args, "--redis-url=$(REDIS_URL)")
+
+	var env *corev1.EnvVar
+	for i := range container.Env {
+		if container.Env[i].Name == testRedisURLEnvName {
+			env = &container.Env[i]
+			break
+		}
+	}
+	require.NotNil(t, env, "expected REDIS_URL env from per-workspace Secret")
+	require.NotNil(t, env.ValueFrom)
+	require.NotNil(t, env.ValueFrom.SecretKeyRef)
+	assert.Equal(t, "acme-session-redis", env.ValueFrom.SecretKeyRef.Name)
+	assert.Equal(t, "url", env.ValueFrom.SecretKeyRef.Key)
 }
 
 func TestBuildMemoryDeployment(t *testing.T) {
@@ -214,7 +310,7 @@ func TestBuildMemoryDeployment_RedisFlagsAbsentByDefault(t *testing.T) {
 		}
 	}
 	for _, e := range container.Env {
-		if e.Name == "REDIS_URL" {
+		if e.Name == testRedisURLEnvName {
 			t.Errorf("expected no REDIS_URL env when no Secret reference is configured, got %+v", e)
 		}
 	}
@@ -237,7 +333,7 @@ func TestBuildMemoryDeployment_RedisURLLiteralThreaded(t *testing.T) {
 	assert.Contains(t, container.Args, "--redis-url=redis://omnia-redis-master.omnia-system.svc.cluster.local:6379/0")
 	assert.Contains(t, container.Args, "--cache-ttl=10m")
 	for _, e := range container.Env {
-		if e.Name == "REDIS_URL" {
+		if e.Name == testRedisURLEnvName {
 			t.Errorf("expected no REDIS_URL env for literal URL, got %+v", e)
 		}
 	}
@@ -267,7 +363,7 @@ func TestBuildMemoryDeployment_RedisURLFromSecretMountsEnv(t *testing.T) {
 
 	var redisURLEnv *corev1.EnvVar
 	for i := range container.Env {
-		if container.Env[i].Name == "REDIS_URL" {
+		if container.Env[i].Name == testRedisURLEnvName {
 			redisURLEnv = &container.Env[i]
 			break
 		}
@@ -286,7 +382,7 @@ func TestBuildMemoryDeployment_RedisURLFromSecretMountsEnv(t *testing.T) {
 // specific Redis (data residency, blast-radius isolation).
 func TestBuildMemoryDeployment_PerWorkspaceRedisURLOverridesOperator(t *testing.T) {
 	sb := newTestServiceBuilder()
-	sb.MemoryRedisURL = "redis://operator-default:6379/0"
+	sb.MemoryRedisURL = testOperatorRedisURL
 	sg := newTestServiceGroup("prod")
 	sg.Memory = &omniav1alpha1.MemoryServiceConfig{
 		Database: omniav1alpha1.DatabaseConfig{SecretRef: corev1.LocalObjectReference{Name: "memory-db"}},
@@ -310,7 +406,7 @@ func TestBuildMemoryDeployment_PerWorkspaceRedisURLOverridesOperator(t *testing.
 // a tenant-specific password.
 func TestBuildMemoryDeployment_PerWorkspaceRedisExistingSecret(t *testing.T) {
 	sb := newTestServiceBuilder()
-	sb.MemoryRedisURL = "redis://operator-default:6379/0"
+	sb.MemoryRedisURL = testOperatorRedisURL
 	sb.MemoryRedisURLSecret = SecretKeyRef{Name: "operator-secret", Key: "url"}
 	sg := newTestServiceGroup("prod")
 	sg.Memory = &omniav1alpha1.MemoryServiceConfig{
@@ -330,7 +426,7 @@ func TestBuildMemoryDeployment_PerWorkspaceRedisExistingSecret(t *testing.T) {
 
 	var env *corev1.EnvVar
 	for i := range container.Env {
-		if container.Env[i].Name == "REDIS_URL" {
+		if container.Env[i].Name == testRedisURLEnvName {
 			env = &container.Env[i]
 			break
 		}


### PR DESCRIPTION
## Summary

Phase 4 of the Redis cleanup. Closes the two outstanding items worth doing — IAM-auth and Sentinel-mode remain deferred (no customer asks).

## Per-workspace session-api hot-cache Redis

Mirror of the Phase 2 memory-api work for the session-api hot-cache layer:

- **`api/v1alpha1/workspace_types.go`** — `RedisConfig` field added to `SessionServiceConfig` with the same CEL `XValidation` mutual-exclusion as memory's redis block.
- **`internal/controller/service_builder.go`** — `SessionRedisURL` + `SessionRedisURLSecret` on `ServiceBuilder`. `resolveSessionRedis()` mirrors `resolveMemoryRedis`: per-workspace `sg.Session.Redis` wins over the operator-wide default. `BuildSessionDeployment` emits `--redis-url` + `REDIS_URL` env mount, plus a `sessionConfigHash` annotation so per-workspace Redis changes roll the pod.
- **`cmd/main.go`** — `--session-redis-url` + `--session-redis-url-secret-{name,key}` flags.
- **`charts/omnia/templates/deployment.yaml`** — emits the new operator flags from the `dashboard.session.redis` consumer block (session-api hot-cache and dashboard session-store share Redis topology by default; per-workspace overrides split them).

**Why this matters**: session-api's hot-cache code path was un-wired by the operator pre-Phase-4. The binary takes `--redis-url` and `REDIS_URL` env fallback (added in #1063), but the operator's `BuildSessionDeployment` passed only `--workspace` + `--service-group`. Net effect: session-api ran in warm-tier-only mode in every operator-built install. Mirrors the "CachedStore was implemented but never constructed" gap that #1059 fixed for memory-api.

## Doctor URL form + helper deletion

- **`cmd/doctor/main.go`** — `--redis-addr` → `--redis-url`. Internal `goredis.ParseURL` extracts host:port for the existing TCPCheck (auth is irrelevant for a reachability probe). `REDIS_URL` env fallback so the chart can mount via secretKeyRef.
- **`charts/omnia/templates/doctor/deployment.yaml`** — switches from `--redis-addr` (via the deleted `omnia.redis.hostPort`) to `--redis-url` (via `omnia.redis.url`). existingSecret form mounts `REDIS_URL` env from the Secret.
- **`charts/omnia/templates/_helpers.tpl`** — `omnia.redis.hostPort` helper deleted. Every pod in the cluster now takes URL form.
- **`charts/omnia/tests/doctor-redis-skip_test.yaml`** — rewritten with 4 cases for the new shape.

## Tests

- 4 new `internal/controller` assertions covering `BuildSessionDeployment` no-flag-default, operator-wide URL, per-workspace URL override, per-workspace existingSecret + REDIS_URL env mount.
- 4 rewritten `tests/doctor-redis-skip_test.yaml` cases.

## Backwards compatibility

Zero. Per-workspace `session.redis` is new (no migration). Doctor's `--redis-addr` flag is renamed (no users on old shape).

## Test plan

- [x] `env GOWORK=off go test ./...` — full suite green
- [x] 85/85 helm-unittest
- [x] `validate-helm.sh` — default + enterprise+redis + enterprise-without-redis-fails
- [x] `golangci-lint run --new-from-rev=main` — clean
- [ ] Verify in dev cluster after merge: session-api logs `hot cache initialized` (was warm-tier-only pre-Phase-4); Doctor's RedisReachable passes when Redis is configured

## What's left

The Redis cleanup is now functionally complete. The two remaining deferred items have no customer demand:

- AWS / GCP IAM-auth Redis (token-refresh loop). Workaround: external-secrets reconciles the password into chart values.
- Sentinel / Cluster client modes (`goredis.NewFailoverClient` / `NewClusterClient`).
