### PR TITLE
fix(provider): phase=Error when CredentialValid=False or placeholder

### DIFF
--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -158,8 +158,14 @@ func (r *ProviderReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		})
 	}
 
-	// Set phase to Ready if all validations pass
-	provider.Status.Phase = omniav1alpha1.ProviderPhaseReady
+	// Phase reflects terminal credential conditions. CredentialValid=False
+	// (probe rejected the key) and CredentialConfigured=False (placeholder
+	// or other config defect that can't possibly authenticate) both push
+	// phase=Error so AgentRuntime gates and the runtime stops sending —
+	// otherwise the first chat surfaces a raw INVALID_API_KEY mid-stream.
+	// Unknown leaves phase=Ready: a transient probe failure shouldn't
+	// fail closed.
+	provider.Status.Phase = derivePhaseFromCredentialConditions(provider)
 	provider.Status.ObservedGeneration = provider.Generation
 
 	if err := r.Status().Update(ctx, provider); err != nil {
@@ -369,6 +375,21 @@ func (r *ProviderReconciler) runCredentialValidation(ctx context.Context, provid
 			"secretKey", secretKey,
 			"err", probeErr.Error())
 	}
+}
+
+// derivePhaseFromCredentialConditions returns Error when the credential is
+// known-bad (CredentialValid=False from a probe rejection, or
+// CredentialConfigured=False from a placeholder / config defect).
+// Unknown / missing conditions don't downgrade the phase — we only fail
+// closed on a definitive negative signal.
+func derivePhaseFromCredentialConditions(provider *omniav1alpha1.Provider) omniav1alpha1.ProviderPhase {
+	if cond := meta.FindStatusCondition(provider.Status.Conditions, ProviderConditionTypeCredentialValid); cond != nil && cond.Status == metav1.ConditionFalse {
+		return omniav1alpha1.ProviderPhaseError
+	}
+	if cond := meta.FindStatusCondition(provider.Status.Conditions, ProviderConditionTypeCredentialConfigured); cond != nil && cond.Status == metav1.ConditionFalse {
+		return omniav1alpha1.ProviderPhaseError
+	}
+	return omniav1alpha1.ProviderPhaseReady
 }
 
 // applyCredentialValidationResult sets CredentialValid based on the probe outcome.

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -1690,6 +1690,108 @@ var _ = Describe("Provider Controller", func() {
 			Expect(reconciler.validateCredentialSecretRef(ctx, provider, ref)).To(Succeed())
 			Expect(calls).To(Equal(1), "second reconcile should hit cache")
 		})
+
+		It("Reconcile sets phase=Error when validator rejects the credential", func() {
+			provider := &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{Name: "phase-error-on-rejected", Namespace: "default"},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:  omniav1alpha1.ProviderTypeClaude,
+					Model: "claude-sonnet-4-20250514",
+					Credential: &omniav1alpha1.CredentialConfig{
+						SecretRef: &omniav1alpha1.SecretKeyRef{Name: "validate-creds-secret"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, provider) }()
+
+			reconciler := &ProviderReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				HTTPClient: alwaysHealthyClient(),
+				CredentialValidatorFactory: func(_ *omniav1alpha1.Provider, _ *http.Client) CredentialValidator {
+					return fakeCredentialValidator{err: ErrCredentialInvalid}
+				},
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: provider.Name, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var updated omniav1alpha1.Provider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: "default"}, &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(omniav1alpha1.ProviderPhaseError))
+		})
+
+		It("Reconcile keeps phase=Ready when validator returns Unknown (transient error)", func() {
+			provider := &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{Name: "phase-ready-on-unknown", Namespace: "default"},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:  omniav1alpha1.ProviderTypeClaude,
+					Model: "claude-sonnet-4-20250514",
+					Credential: &omniav1alpha1.CredentialConfig{
+						SecretRef: &omniav1alpha1.SecretKeyRef{Name: "validate-creds-secret"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, provider) }()
+
+			reconciler := &ProviderReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				HTTPClient: alwaysHealthyClient(),
+				CredentialValidatorFactory: func(_ *omniav1alpha1.Provider, _ *http.Client) CredentialValidator {
+					return fakeCredentialValidator{err: errors.New("connection refused")}
+				},
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: provider.Name, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var updated omniav1alpha1.Provider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: "default"}, &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(omniav1alpha1.ProviderPhaseReady))
+		})
+
+		It("Reconcile sets phase=Error for placeholder credential", func() {
+			placeholderSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "placeholder-cred-secret", Namespace: "default"},
+				Data: map[string][]byte{
+					"ANTHROPIC_API_KEY": []byte("replace-with-real-key"),
+				},
+			}
+			Expect(k8sClient.Create(ctx, placeholderSecret)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, placeholderSecret) }()
+
+			provider := &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{Name: "phase-error-placeholder", Namespace: "default"},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:  omniav1alpha1.ProviderTypeClaude,
+					Model: "claude-sonnet-4-20250514",
+					Credential: &omniav1alpha1.CredentialConfig{
+						SecretRef: &omniav1alpha1.SecretKeyRef{Name: "placeholder-cred-secret"},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, provider) }()
+
+			reconciler := &ProviderReconciler{
+				Client:     k8sClient,
+				Scheme:     k8sClient.Scheme(),
+				HTTPClient: alwaysHealthyClient(),
+			}
+			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: provider.Name, Namespace: "default"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			var updated omniav1alpha1.Provider
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: provider.Name, Namespace: "default"}, &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(omniav1alpha1.ProviderPhaseError))
+		})
 	})
 
 	Context("emitWarningEvent", func() {

--- a/internal/controller/provider_phase_test.go
+++ b/internal/controller/provider_phase_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
+)
+
+func TestDerivePhaseFromCredentialConditions(t *testing.T) {
+	tests := []struct {
+		name       string
+		conditions []metav1.Condition
+		want       omniav1alpha1.ProviderPhase
+	}{
+		{
+			name:       "no conditions defaults to Ready",
+			conditions: nil,
+			want:       omniav1alpha1.ProviderPhaseReady,
+		},
+		{
+			name: "CredentialValid=True keeps Ready",
+			conditions: []metav1.Condition{
+				{Type: ProviderConditionTypeCredentialValid, Status: metav1.ConditionTrue, Reason: "CredentialAccepted"},
+			},
+			want: omniav1alpha1.ProviderPhaseReady,
+		},
+		{
+			name: "CredentialValid=Unknown keeps Ready (transient probe failure)",
+			conditions: []metav1.Condition{
+				{Type: ProviderConditionTypeCredentialValid, Status: metav1.ConditionUnknown, Reason: "CredentialValidationError"},
+			},
+			want: omniav1alpha1.ProviderPhaseReady,
+		},
+		{
+			name: "CredentialValid=False forces Error",
+			conditions: []metav1.Condition{
+				{Type: ProviderConditionTypeCredentialValid, Status: metav1.ConditionFalse, Reason: "CredentialRejected"},
+			},
+			want: omniav1alpha1.ProviderPhaseError,
+		},
+		{
+			name: "CredentialConfigured=False (placeholder) forces Error",
+			conditions: []metav1.Condition{
+				{Type: ProviderConditionTypeCredentialConfigured, Status: metav1.ConditionFalse, Reason: "PlaceholderCredential"},
+			},
+			want: omniav1alpha1.ProviderPhaseError,
+		},
+		{
+			name: "CredentialValid=False wins over CredentialConfigured=True",
+			conditions: []metav1.Condition{
+				{Type: ProviderConditionTypeCredentialConfigured, Status: metav1.ConditionTrue, Reason: "SecretFound"},
+				{Type: ProviderConditionTypeCredentialValid, Status: metav1.ConditionFalse, Reason: "CredentialRejected"},
+			},
+			want: omniav1alpha1.ProviderPhaseError,
+		},
+		{
+			name: "all green stays Ready",
+			conditions: []metav1.Condition{
+				{Type: ProviderConditionTypeSecretFound, Status: metav1.ConditionTrue},
+				{Type: ProviderConditionTypeCredentialConfigured, Status: metav1.ConditionTrue},
+				{Type: ProviderConditionTypeCredentialValid, Status: metav1.ConditionTrue},
+			},
+			want: omniav1alpha1.ProviderPhaseReady,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider := &omniav1alpha1.Provider{
+				Status: omniav1alpha1.ProviderStatus{Conditions: tt.conditions},
+			}
+			got := derivePhaseFromCredentialConditions(provider)
+			if got != tt.want {
+				t.Errorf("derivePhaseFromCredentialConditions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

The Provider reconciler's credential probe (#1048) sets the `CredentialValid` condition correctly, but the reconciler then unconditionally sets `phase=Ready` afterwards. AgentRuntime gates on `phase == ProviderPhaseError`, so it never sees a rejected key — and the runtime hits the provider mid-conversation, surfacing a raw `INVALID_API_KEY` instead of a clean operator-visible failure.

This PR makes phase reflect the terminal credential conditions:

| Condition | Phase |
|-----------|-------|
| `CredentialValid: False` (probe rejected) | `Error` |
| `CredentialConfigured: False` (placeholder etc.) | `Error` |
| `Unknown` / missing | `Ready` |

`Unknown` stays `Ready` so a transient probe failure (network blip, 5xx) doesn't fail closed. Secret rotation still invalidates the probe cache via the existing `resourceVersion`-keyed cache, so a fixed key flips phase back to `Ready` on the next reconcile.

AgentRuntime gating was already in place at `agentruntime_controller.go:223` — this PR just makes the upstream signal accurate.

## Test Plan
- [x] New `TestDerivePhaseFromCredentialConditions` table-driven unit test covers all condition combinations
- [x] New Ginkgo Reconcile-level `It` blocks verify phase transitions for rejected, Unknown, and placeholder cases
- [x] Full `internal/controller/...` suite (685 tests) passes
- [x] golangci-lint clean
- [x] Pre-commit coverage: 88.7% on `provider_controller.go` (changed file); 100% on `derivePhaseFromCredentialConditions`