### PR TITLE
feat(runtime): composite memory retriever for ambient cross-session context

### DIFF
--- a/internal/memory/retriever_integration_test.go
+++ b/internal/memory/retriever_integration_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package memory
+
+import (
+	"context"
+	"testing"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/runtime"
+)
+
+// TestCompositeRetriever_RealStore exercises the runtime CompositeRetriever
+// against the real PostgresMemoryStore. Proves that the metadata-based
+// category filter survives the round-trip through Save → List, that
+// similarity search finds episodic content via Retrieve, and that the
+// merged result respects the profile / episodic split.
+//
+// This is the integration counterpart to memory_retriever_test.go's unit
+// tests — those use a fake Store; this uses the real one with metadata
+// serialization, postgres column writes, and the retrieval ranker.
+func TestCompositeRetriever_RealStore(t *testing.T) {
+	store := newStore(t)
+	ctx := context.Background()
+	scope := testScope(testWorkspace1)
+
+	// Seed: 3 profile-category memories + 2 episodic memories. The
+	// episodic ones intentionally include lexical hooks ("Boston",
+	// "Kimpton") so similarity search has something to land on.
+	type seed struct {
+		category string
+		content  string
+	}
+	seeds := []seed{
+		{"memory:identity", "User name: Sarah Kim, email sarah.kim@example.com"},
+		{"memory:preferences", "Aisle seat preferred; mid-range hotels"},
+		{"memory:health", "Severe peanut allergy — flag on bookings"},
+		{"memory:context", "Currently planning a Boston trip for May 17–19"},
+		{"memory:history", "Last trip: Chicago October, Kimpton Gray hotel, very positive"},
+	}
+	for _, s := range seeds {
+		mem := &Memory{
+			Type:       "fact",
+			Content:    s.content,
+			Confidence: 0.9,
+			Scope:      scope,
+			Metadata: map[string]any{
+				MetaKeyConsentCategory: s.category,
+			},
+		}
+		require.NoError(t, store.Save(ctx, mem), "save %s", s.category)
+	}
+
+	retriever := runtime.NewCompositeRetriever(store, logr.Discard())
+
+	t.Run("cold start (no user message) returns profile only", func(t *testing.T) {
+		got, err := retriever.RetrieveContext(ctx, scope, nil)
+		require.NoError(t, err)
+
+		require.Len(t, got, 3, "expected 3 profile-category memories")
+		gotCats := categoryStrings(got)
+		assert.ElementsMatch(t,
+			[]string{"memory:identity", "memory:preferences", "memory:health"},
+			gotCats,
+			"profile pull should be exactly identity / preferences / health",
+		)
+	})
+
+	t.Run("with user query returns profile + episodic merge", func(t *testing.T) {
+		got, err := retriever.RetrieveContext(ctx, scope, []types.Message{
+			{Role: "user", Content: "remind me where I stayed in Chicago"},
+		})
+		require.NoError(t, err)
+
+		// Always at least the 3 profile memories. Episodic adds 0+
+		// non-profile-category hits depending on the ranker — assert
+		// the floor and that none of the episodic results duplicate
+		// a profile memory.
+		require.GreaterOrEqual(t, len(got), 3, "profile slice always present")
+
+		profileIDs := profileIDsFromList(got)
+		assert.Len(t, profileIDs, 3, "all 3 profile memories should appear")
+
+		// Any episodic results must be from non-profile categories
+		// (the retriever filters them out) and must not duplicate
+		// profile entries by ID.
+		for _, m := range got {
+			cat := categoryOf(m)
+			if isProfileCat(cat) {
+				continue // expected from the profile pull
+			}
+			assert.NotContains(t, []string{"memory:identity", "memory:preferences", "memory:health"}, cat,
+				"non-profile-category memories must not be in the profile set")
+		}
+	})
+
+	t.Run("empty user_id scope returns nil", func(t *testing.T) {
+		emptyUserScope := map[string]string{ScopeWorkspaceID: testWorkspace1}
+		got, err := retriever.RetrieveContext(ctx, emptyUserScope, []types.Message{
+			{Role: "user", Content: "anything"},
+		})
+		require.NoError(t, err)
+		assert.Nil(t, got, "no user_id → no retrieval")
+	})
+
+	t.Run("profile cache hit avoids extra List calls", func(t *testing.T) {
+		// Fresh retriever to isolate the cache from the prior subtests.
+		r2 := runtime.NewCompositeRetriever(store, logr.Discard())
+
+		for i := 0; i < 3; i++ {
+			got, err := r2.RetrieveContext(ctx, scope, nil)
+			require.NoError(t, err)
+			require.Len(t, got, 3, "iteration %d", i)
+		}
+		// We can't assert the call count without instrumenting the
+		// store (covered in the unit test). The functional check is
+		// that repeated calls are stable and fast — three sequential
+		// calls completing under 1s on a local container is the
+		// implicit cache-hit signal. testcontainer cold path on
+		// first call would dominate if we recomputed every time.
+	})
+}
+
+// Test helpers — kept package-private to memory_test scope.
+
+func categoryOf(m *pkmemory.Memory) string {
+	if m == nil || m.Metadata == nil {
+		return ""
+	}
+	v, _ := m.Metadata[MetaKeyConsentCategory].(string)
+	return v
+}
+
+func categoryStrings(memories []*pkmemory.Memory) []string {
+	out := make([]string, 0, len(memories))
+	for _, m := range memories {
+		out = append(out, categoryOf(m))
+	}
+	return out
+}
+
+func isProfileCat(cat string) bool {
+	switch cat {
+	case "memory:identity", "memory:preferences", "memory:health":
+		return true
+	}
+	return false
+}
+
+func profileIDsFromList(memories []*pkmemory.Memory) []string {
+	out := make([]string, 0, 3)
+	for _, m := range memories {
+		if isProfileCat(categoryOf(m)) {
+			out = append(out, m.ID)
+		}
+	}
+	return out
+}

--- a/internal/memory/retriever_integration_test.go
+++ b/internal/memory/retriever_integration_test.go
@@ -8,7 +8,9 @@ package memory
 
 import (
 	"context"
+	"strings"
 	"testing"
+	"time"
 
 	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
 	"github.com/AltairaLabs/PromptKit/runtime/types"
@@ -47,6 +49,7 @@ func TestCompositeRetriever_RealStore(t *testing.T) {
 		{"memory:context", "Currently planning a Boston trip for May 17–19"},
 		{"memory:history", "Last trip: Chicago October, Kimpton Gray hotel, very positive"},
 	}
+	saveStart := time.Now()
 	for _, s := range seeds {
 		mem := &Memory{
 			Type:       "fact",
@@ -59,11 +62,14 @@ func TestCompositeRetriever_RealStore(t *testing.T) {
 		}
 		require.NoError(t, store.Save(ctx, mem), "save %s", s.category)
 	}
+	t.Logf("seeded %d memories into postgres in %s", len(seeds), time.Since(saveStart))
 
 	retriever := runtime.NewCompositeRetriever(store, logr.Discard())
 
 	t.Run("cold start (no user message) returns profile only", func(t *testing.T) {
+		start := time.Now()
 		got, err := retriever.RetrieveContext(ctx, scope, nil)
+		t.Logf("RetrieveContext (cold start) took %s, returned %d memories", time.Since(start), len(got))
 		require.NoError(t, err)
 
 		require.Len(t, got, 3, "expected 3 profile-category memories")
@@ -73,33 +79,59 @@ func TestCompositeRetriever_RealStore(t *testing.T) {
 			gotCats,
 			"profile pull should be exactly identity / preferences / health",
 		)
+		for _, m := range got {
+			t.Logf("  profile: [%s] %s", categoryOf(m), m.Content)
+		}
 	})
 
 	t.Run("with user query returns profile + episodic merge", func(t *testing.T) {
-		got, err := retriever.RetrieveContext(ctx, scope, []types.Message{
+		// Fresh retriever to bypass the cache from the prior subtest —
+		// otherwise we wouldn't be timing a real list call.
+		r2 := runtime.NewCompositeRetriever(store, logr.Discard())
+		start := time.Now()
+		got, err := r2.RetrieveContext(ctx, scope, []types.Message{
 			{Role: "user", Content: "remind me where I stayed in Chicago"},
 		})
+		t.Logf("RetrieveContext (with query) took %s, returned %d memories", time.Since(start), len(got))
 		require.NoError(t, err)
 
-		// Always at least the 3 profile memories. Episodic adds 0+
-		// non-profile-category hits depending on the ranker — assert
-		// the floor and that none of the episodic results duplicate
-		// a profile memory.
-		require.GreaterOrEqual(t, len(got), 3, "profile slice always present")
+		for _, m := range got {
+			t.Logf("  result: [%s] %s", categoryOf(m), m.Content)
+		}
 
+		// Strong assertions:
+		// 1. All 3 profile memories present.
 		profileIDs := profileIDsFromList(got)
-		assert.Len(t, profileIDs, 3, "all 3 profile memories should appear")
+		require.Len(t, profileIDs, 3, "all 3 profile memories should appear")
 
-		// Any episodic results must be from non-profile categories
-		// (the retriever filters them out) and must not duplicate
-		// profile entries by ID.
+		// 2. At least one episodic result. If FTS returns nothing for
+		// a query that lexically overlaps "Chicago" / "Kimpton" /
+		// "October" (one of which is in the seeded history memory),
+		// we are NOT exercising similarity search — silent failure.
+		require.Greater(t, len(got), 3, "expected episodic memories on top of the profile slice — similarity search returned nothing")
+
+		// 3. The Chicago history memory specifically should rank.
+		// This is the demo-critical claim ("session 2 recalls past
+		// trip"). If this fails, the demo doesn't work.
+		foundChicago := false
+		for _, m := range got {
+			if strings.Contains(m.Content, "Chicago") {
+				foundChicago = true
+				break
+			}
+		}
+		assert.True(t, foundChicago, "expected the Chicago history memory to surface for a Chicago query")
+
+		// 4. Any episodic result must be from a non-profile category.
 		for _, m := range got {
 			cat := categoryOf(m)
 			if isProfileCat(cat) {
-				continue // expected from the profile pull
+				continue
 			}
-			assert.NotContains(t, []string{"memory:identity", "memory:preferences", "memory:health"}, cat,
-				"non-profile-category memories must not be in the profile set")
+			assert.NotContains(t,
+				[]string{"memory:identity", "memory:preferences", "memory:health"},
+				cat,
+				"non-profile-category memories must not appear in the episodic slice")
 		}
 	})
 
@@ -112,21 +144,30 @@ func TestCompositeRetriever_RealStore(t *testing.T) {
 		assert.Nil(t, got, "no user_id → no retrieval")
 	})
 
-	t.Run("profile cache hit avoids extra List calls", func(t *testing.T) {
-		// Fresh retriever to isolate the cache from the prior subtests.
+	t.Run("profile cache hit avoids extra DB calls", func(t *testing.T) {
+		// Fresh retriever to isolate the cache from prior subtests.
+		// First call is cold, subsequent should be cached. We can't
+		// see the call count without instrumenting the store, so
+		// we rely on a relative timing assertion: the cached call
+		// must be at least 5× faster than the cold one. On a local
+		// container the cold call typically takes ~1ms and the
+		// cached one ~10µs — a 100× ratio is normal.
 		r2 := runtime.NewCompositeRetriever(store, logr.Discard())
 
-		for i := 0; i < 3; i++ {
-			got, err := r2.RetrieveContext(ctx, scope, nil)
-			require.NoError(t, err)
-			require.Len(t, got, 3, "iteration %d", i)
-		}
-		// We can't assert the call count without instrumenting the
-		// store (covered in the unit test). The functional check is
-		// that repeated calls are stable and fast — three sequential
-		// calls completing under 1s on a local container is the
-		// implicit cache-hit signal. testcontainer cold path on
-		// first call would dominate if we recomputed every time.
+		coldStart := time.Now()
+		_, err := r2.RetrieveContext(ctx, scope, nil)
+		require.NoError(t, err)
+		coldDur := time.Since(coldStart)
+
+		warmStart := time.Now()
+		_, err = r2.RetrieveContext(ctx, scope, nil)
+		require.NoError(t, err)
+		warmDur := time.Since(warmStart)
+
+		t.Logf("cold call: %s, warm call: %s, ratio: %.1fx",
+			coldDur, warmDur, float64(coldDur)/float64(warmDur))
+
+		assert.Less(t, warmDur*5, coldDur, "warm call should be substantially faster than cold")
 	})
 }
 

--- a/internal/runtime/conversation.go
+++ b/internal/runtime/conversation.go
@@ -176,13 +176,21 @@ func (s *Server) buildConversationOptions(ctx context.Context, sessionID string)
 		if s.agentUID != "" {
 			scope["agent_id"] = s.agentUID
 		}
-		opts = append(opts, sdk.WithMemory(s.memoryStore, scope))
+		// CompositeRetriever auto-injects the user's profile + a per-turn
+		// similarity search into the prompt via PromptKit's
+		// MemoryRetrievalStage. Without it the agent only "knows" the
+		// user when it explicitly calls memory__recall — which is
+		// unreliable on cold-start turns where the user's opening
+		// message has no lexical overlap with stored facts.
+		retriever := NewCompositeRetriever(s.memoryStore, log)
+		opts = append(opts, sdk.WithMemory(s.memoryStore, scope, sdk.WithMemoryRetriever(retriever)))
 		log.V(1).Info("memory store wired",
 			"session_id", sessionID,
 			"trace_id", sessionID,
 			"hasUserID", scope["user_id"] != "",
 			"hasAgentID", scope["agent_id"] != "",
 			"scopeKeys", len(scope),
+			"hasRetriever", true,
 		)
 	}
 

--- a/internal/runtime/memory_retriever.go
+++ b/internal/runtime/memory_retriever.go
@@ -1,0 +1,236 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/go-logr/logr"
+)
+
+// Categories that are part of the user's "profile" — facts the agent
+// should always have in ambient context regardless of what the user
+// just said. The first turn of session 2 ("plan me a trip to Philly")
+// has no lexical overlap with "peanut allergy", so a pure
+// similarity-search retriever would miss it. Profile categories
+// guarantee identity / preferences / health are present.
+var profileCategories = map[string]bool{
+	"memory:identity":    true,
+	"memory:preferences": true,
+	"memory:health":      true,
+}
+
+const (
+	// defaultProfileLimit caps the always-included subset.
+	defaultProfileLimit = 20
+	// defaultEpisodicLimit caps the per-turn similarity-search subset.
+	defaultEpisodicLimit = 10
+	// profileCacheTTL controls how long the profile pull is cached
+	// per (workspace, user). Long enough to avoid per-turn list
+	// calls in a chatty conversation, short enough that a fresh
+	// remember in this session shows up before the next turn.
+	profileCacheTTL = 30 * time.Second
+	// listFetchLimit is how many memories we ask for client-side
+	// when filtering by category. memory-api's List endpoint takes
+	// a Type filter, not a consent_category filter, so we pull a
+	// generous prefix and filter in Go. Demo-scale only — see the
+	// follow-up issue to add a category param to memory-api.
+	listFetchLimit = 200
+)
+
+// CompositeRetriever combines an always-on "profile" pull with a
+// per-turn similarity search. It satisfies pkmemory.Retriever and is
+// wired by the conversation builder when a memory store is configured.
+//
+// Strategy: pull memory:identity / memory:preferences / memory:health
+// for the user (the "profile") and merge with similarity search hits
+// for the rest (memory:context / memory:history / memory:location)
+// against the last user message.
+type CompositeRetriever struct {
+	store         pkmemory.Store
+	log           logr.Logger
+	profileLimit  int
+	episodicLimit int
+
+	mu    sync.Mutex
+	cache map[string]profileCacheEntry
+}
+
+type profileCacheEntry struct {
+	memories []*pkmemory.Memory
+	expires  time.Time
+}
+
+// NewCompositeRetriever builds a retriever backed by the given store.
+func NewCompositeRetriever(store pkmemory.Store, log logr.Logger) *CompositeRetriever {
+	return &CompositeRetriever{
+		store:         store,
+		log:           log.WithName("memory-retriever"),
+		profileLimit:  defaultProfileLimit,
+		episodicLimit: defaultEpisodicLimit,
+		cache:         make(map[string]profileCacheEntry),
+	}
+}
+
+// RetrieveContext implements pkmemory.Retriever. Returns nil when the
+// scope has no user_id (anonymous deviceId not yet plumbed, or
+// scope-less invocation): the PromptKit retrieval stage treats nil as
+// "no memories" and skips injection.
+func (r *CompositeRetriever) RetrieveContext(
+	ctx context.Context, scope map[string]string, messages []types.Message,
+) ([]*pkmemory.Memory, error) {
+	if scope["user_id"] == "" {
+		return nil, nil
+	}
+
+	profile := r.fetchProfile(ctx, scope)
+
+	query := lastUserContent(messages)
+	if query == "" {
+		// Cold-start turn (system prompt only) — profile alone.
+		return profile, nil
+	}
+
+	episodic, err := r.store.Retrieve(ctx, scope, query, pkmemory.RetrieveOptions{
+		Limit: r.episodicLimit,
+	})
+	if err != nil {
+		// Profile is still useful; episodic failure shouldn't black out
+		// the whole context.
+		r.log.V(1).Info("episodic retrieve failed",
+			"err", err.Error(),
+			"workspace", scope["workspace_id"])
+		return profile, nil
+	}
+
+	return mergeNoDup(profile, filterOutProfile(episodic)), nil
+}
+
+// fetchProfile returns the always-include subset, populating the cache
+// on miss. Errors are logged and swallowed — a partial context is more
+// useful than nothing.
+func (r *CompositeRetriever) fetchProfile(
+	ctx context.Context, scope map[string]string,
+) []*pkmemory.Memory {
+	cacheKey := scope["workspace_id"] + "|" + scope["user_id"]
+
+	r.mu.Lock()
+	if entry, ok := r.cache[cacheKey]; ok && time.Now().Before(entry.expires) {
+		r.mu.Unlock()
+		return entry.memories
+	}
+	r.mu.Unlock()
+
+	all, err := r.store.List(ctx, scope, pkmemory.ListOptions{Limit: listFetchLimit})
+	if err != nil {
+		r.log.V(1).Info("profile list failed",
+			"err", err.Error(),
+			"workspace", scope["workspace_id"])
+		return nil
+	}
+
+	profile := make([]*pkmemory.Memory, 0, r.profileLimit)
+	for _, m := range all {
+		if !isProfileCategory(m) {
+			continue
+		}
+		profile = append(profile, m)
+		if len(profile) >= r.profileLimit {
+			break
+		}
+	}
+
+	r.mu.Lock()
+	r.cache[cacheKey] = profileCacheEntry{
+		memories: profile,
+		expires:  time.Now().Add(profileCacheTTL),
+	}
+	r.mu.Unlock()
+
+	return profile
+}
+
+// metaKeyConsentCategory mirrors PromptKit's pkmemory.MetaKeyConsentCategory.
+// Duplicated as a string literal because the constant isn't in the
+// published SDK yet — switch to the symbol once a release ships it.
+// TODO: replace with pkmemory.MetaKeyConsentCategory after PromptKit publish.
+const metaKeyConsentCategory = "consent_category"
+
+// isProfileCategory reports whether the memory's consent category is in
+// the always-include set. Memories with no category fall through to
+// the episodic path (similarity search).
+func isProfileCategory(m *pkmemory.Memory) bool {
+	if m == nil || m.Metadata == nil {
+		return false
+	}
+	cat, _ := m.Metadata[metaKeyConsentCategory].(string)
+	return profileCategories[cat]
+}
+
+// filterOutProfile drops memories that are already covered by the
+// profile pull, so similarity-search results don't double up identity
+// / preferences / health rows.
+func filterOutProfile(memories []*pkmemory.Memory) []*pkmemory.Memory {
+	out := make([]*pkmemory.Memory, 0, len(memories))
+	for _, m := range memories {
+		if isProfileCategory(m) {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+// mergeNoDup concatenates two slices, dropping any episodic memory
+// whose ID already appeared in the profile slice.
+func mergeNoDup(profile, episodic []*pkmemory.Memory) []*pkmemory.Memory {
+	seen := make(map[string]bool, len(profile))
+	out := make([]*pkmemory.Memory, 0, len(profile)+len(episodic))
+	for _, m := range profile {
+		if m == nil || seen[m.ID] {
+			continue
+		}
+		seen[m.ID] = true
+		out = append(out, m)
+	}
+	for _, m := range episodic {
+		if m == nil || seen[m.ID] {
+			continue
+		}
+		seen[m.ID] = true
+		out = append(out, m)
+	}
+	return out
+}
+
+// lastUserContent returns the trimmed Content of the most recent user
+// message, or "" when no user message is present (cold-start turn).
+func lastUserContent(messages []types.Message) string {
+	for i := len(messages) - 1; i >= 0; i-- {
+		if messages[i].Role == "user" {
+			return strings.TrimSpace(messages[i].Content)
+		}
+	}
+	return ""
+}

--- a/internal/runtime/memory_retriever.go
+++ b/internal/runtime/memory_retriever.go
@@ -112,7 +112,15 @@ func (r *CompositeRetriever) RetrieveContext(
 		return profile, nil
 	}
 
-	episodic, err := r.store.Retrieve(ctx, scope, query, pkmemory.RetrieveOptions{
+	// memory-api's PostgresMemoryStore uses websearch_to_tsquery, which
+	// applies AND semantics across terms — a query like "remind me where
+	// I stayed in Chicago" requires *every* word to appear in the doc.
+	// That's right for memory__recall (precise lookup) but wrong for
+	// ambient retrieval, where we want any meaningful overlap to surface
+	// context. Rewrite to OR semantics: postgres's stopword filter then
+	// drops "remind / me / where / I / in" and what's left ("stay /
+	// chicago") matches ambiently.
+	episodic, err := r.store.Retrieve(ctx, scope, toFTSOrQuery(query), pkmemory.RetrieveOptions{
 		Limit: r.episodicLimit,
 	})
 	if err != nil {
@@ -233,4 +241,19 @@ func lastUserContent(messages []types.Message) string {
 		}
 	}
 	return ""
+}
+
+// toFTSOrQuery rewrites whitespace-separated terms into a websearch
+// OR query — "alpha beta gamma" → "alpha OR beta OR gamma". Postgres's
+// websearch_to_tsquery treats the literal token "OR" as alternation,
+// and its stopword filter strips noise tokens before matching, so
+// the resulting query matches any document containing any meaningful
+// term. Empty input passes through unchanged so the store's empty-
+// query branch (recency list) still triggers if a caller hands us "".
+func toFTSOrQuery(query string) string {
+	fields := strings.Fields(query)
+	if len(fields) <= 1 {
+		return query
+	}
+	return strings.Join(fields, " OR ")
 }

--- a/internal/runtime/memory_retriever_test.go
+++ b/internal/runtime/memory_retriever_test.go
@@ -1,0 +1,293 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package runtime
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	pkmemory "github.com/AltairaLabs/PromptKit/runtime/memory"
+	"github.com/AltairaLabs/PromptKit/runtime/types"
+	"github.com/go-logr/logr"
+)
+
+// fakeStore is a minimal pkmemory.Store implementation for retriever tests.
+type fakeStore struct {
+	listMemories     []*pkmemory.Memory
+	listErr          error
+	listCalls        atomic.Int32
+	retrieveMemories []*pkmemory.Memory
+	retrieveErr      error
+	retrieveCalls    atomic.Int32
+	lastQuery        string
+}
+
+func (f *fakeStore) Save(_ context.Context, _ *pkmemory.Memory) error { return nil }
+
+func (f *fakeStore) Retrieve(
+	_ context.Context, _ map[string]string, query string, _ pkmemory.RetrieveOptions,
+) ([]*pkmemory.Memory, error) {
+	f.retrieveCalls.Add(1)
+	f.lastQuery = query
+	if f.retrieveErr != nil {
+		return nil, f.retrieveErr
+	}
+	return f.retrieveMemories, nil
+}
+
+func (f *fakeStore) List(
+	_ context.Context, _ map[string]string, _ pkmemory.ListOptions,
+) ([]*pkmemory.Memory, error) {
+	f.listCalls.Add(1)
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	return f.listMemories, nil
+}
+
+func (f *fakeStore) Delete(_ context.Context, _ map[string]string, _ string) error { return nil }
+func (f *fakeStore) DeleteAll(_ context.Context, _ map[string]string) error        { return nil }
+
+func mem(id, category, content string) *pkmemory.Memory {
+	return &pkmemory.Memory{
+		ID:      id,
+		Content: content,
+		Metadata: map[string]any{
+			metaKeyConsentCategory: category,
+		},
+	}
+}
+
+func userMsg(content string) types.Message { return types.Message{Role: "user", Content: content} }
+
+func defaultScope() map[string]string {
+	return map[string]string{"workspace_id": "ws", "user_id": "u"}
+}
+
+func TestCompositeRetriever_NoUserIDReturnsNil(t *testing.T) {
+	r := NewCompositeRetriever(&fakeStore{}, logr.Discard())
+	got, err := r.RetrieveContext(context.Background(), map[string]string{"workspace_id": "ws"}, []types.Message{userMsg("hi")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected nil result for empty user_id, got %d memories", len(got))
+	}
+}
+
+func TestCompositeRetriever_ProfileOnlyWhenNoQuery(t *testing.T) {
+	store := &fakeStore{
+		listMemories: []*pkmemory.Memory{
+			mem("1", "memory:identity", "name: Sarah"),
+			mem("2", "memory:preferences", "aisle seat"),
+			mem("3", "memory:health", "peanut allergy"),
+			mem("4", "memory:context", "planning Boston trip"),
+		},
+	}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	// No user message → no episodic query → profile only.
+	got, err := r.RetrieveContext(context.Background(), defaultScope(), nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 profile memories, got %d", len(got))
+	}
+	if store.retrieveCalls.Load() != 0 {
+		t.Errorf("Retrieve should not be called without a query")
+	}
+}
+
+func TestCompositeRetriever_CompositeMergesProfileAndEpisodic(t *testing.T) {
+	profile := []*pkmemory.Memory{
+		mem("p1", "memory:identity", "name: Sarah"),
+		mem("p2", "memory:preferences", "aisle seat"),
+	}
+	episodic := []*pkmemory.Memory{
+		mem("e1", "memory:history", "stayed at Kimpton Gray"),
+		mem("e2", "memory:context", "October Chicago trip"),
+	}
+	store := &fakeStore{listMemories: profile, retrieveMemories: episodic}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	got, err := r.RetrieveContext(context.Background(), defaultScope(), []types.Message{userMsg("plan philly")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("expected 4 memories (2 profile + 2 episodic), got %d", len(got))
+	}
+	if store.lastQuery != "plan philly" {
+		t.Errorf("expected query %q, got %q", "plan philly", store.lastQuery)
+	}
+}
+
+func TestCompositeRetriever_DropsEpisodicProfileCategoryDuplicates(t *testing.T) {
+	profile := []*pkmemory.Memory{
+		mem("p1", "memory:identity", "name: Sarah"),
+	}
+	// Similarity search returns a profile-category memory; should be dropped.
+	episodic := []*pkmemory.Memory{
+		mem("p1", "memory:identity", "name: Sarah"), // same id → dedup
+		mem("e1", "memory:health", "vegetarian"),    // profile-category → filtered
+		mem("e2", "memory:history", "October trip"), // keep
+	}
+	store := &fakeStore{listMemories: profile, retrieveMemories: episodic}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	got, err := r.RetrieveContext(context.Background(), defaultScope(), []types.Message{userMsg("hi")})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 memories (profile + 1 non-dup non-profile-category episodic), got %d", len(got))
+	}
+	gotIDs := []string{got[0].ID, got[1].ID}
+	if gotIDs[0] != "p1" || gotIDs[1] != "e2" {
+		t.Errorf("unexpected merge order: %v", gotIDs)
+	}
+}
+
+func TestCompositeRetriever_EpisodicErrorFallsBackToProfile(t *testing.T) {
+	profile := []*pkmemory.Memory{mem("p1", "memory:identity", "Sarah")}
+	store := &fakeStore{listMemories: profile, retrieveErr: errors.New("upstream down")}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	got, err := r.RetrieveContext(context.Background(), defaultScope(), []types.Message{userMsg("hi")})
+	if err != nil {
+		t.Fatalf("RetrieveContext should not propagate episodic errors, got %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 profile memory, got %d", len(got))
+	}
+}
+
+func TestCompositeRetriever_ListErrorReturnsEmptyProfile(t *testing.T) {
+	store := &fakeStore{
+		listErr:          errors.New("memory-api down"),
+		retrieveMemories: []*pkmemory.Memory{mem("e1", "memory:history", "thing")},
+	}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	got, err := r.RetrieveContext(context.Background(), defaultScope(), []types.Message{userMsg("hi")})
+	if err != nil {
+		t.Fatalf("RetrieveContext should not propagate list errors, got %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "e1" {
+		t.Fatalf("expected episodic-only fallback, got %+v", got)
+	}
+}
+
+func TestCompositeRetriever_ProfileCachedWithinTTL(t *testing.T) {
+	store := &fakeStore{listMemories: []*pkmemory.Memory{mem("p1", "memory:identity", "Sarah")}}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	for i := 0; i < 5; i++ {
+		_, err := r.RetrieveContext(context.Background(), defaultScope(), nil)
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if calls := store.listCalls.Load(); calls != 1 {
+		t.Errorf("expected 1 List call (cached), got %d", calls)
+	}
+}
+
+func TestCompositeRetriever_ProfileCacheExpires(t *testing.T) {
+	store := &fakeStore{listMemories: []*pkmemory.Memory{mem("p1", "memory:identity", "Sarah")}}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	if _, err := r.RetrieveContext(context.Background(), defaultScope(), nil); err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Force-expire cache.
+	r.mu.Lock()
+	for k, e := range r.cache {
+		e.expires = time.Now().Add(-time.Second)
+		r.cache[k] = e
+	}
+	r.mu.Unlock()
+
+	if _, err := r.RetrieveContext(context.Background(), defaultScope(), nil); err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+	if calls := store.listCalls.Load(); calls != 2 {
+		t.Errorf("expected 2 List calls after TTL, got %d", calls)
+	}
+}
+
+func TestCompositeRetriever_ProfileCacheKeyedPerUser(t *testing.T) {
+	store := &fakeStore{listMemories: []*pkmemory.Memory{mem("p1", "memory:identity", "Sarah")}}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	if _, err := r.RetrieveContext(context.Background(), map[string]string{"workspace_id": "ws", "user_id": "alice"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := r.RetrieveContext(context.Background(), map[string]string{"workspace_id": "ws", "user_id": "bob"}, nil); err != nil {
+		t.Fatal(err)
+	}
+	if calls := store.listCalls.Load(); calls != 2 {
+		t.Errorf("expected 2 List calls (one per user), got %d", calls)
+	}
+}
+
+func TestCompositeRetriever_NonProfileMemoriesFromListAreIgnored(t *testing.T) {
+	// List returns mixed; only profile categories survive into the
+	// always-include slice. Episodic categories are NOT pulled this way
+	// — they come from Retrieve.
+	store := &fakeStore{
+		listMemories: []*pkmemory.Memory{
+			mem("p1", "memory:identity", "Sarah"),
+			mem("c1", "memory:context", "trip"),
+			mem("h1", "memory:history", "old trip"),
+			mem("noCat", "", "untagged"),
+		},
+	}
+	r := NewCompositeRetriever(store, logr.Discard())
+
+	got, err := r.RetrieveContext(context.Background(), defaultScope(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].ID != "p1" {
+		t.Errorf("expected only profile-category memory, got %v", got)
+	}
+}
+
+func TestLastUserContent(t *testing.T) {
+	cases := []struct {
+		name     string
+		messages []types.Message
+		want     string
+	}{
+		{name: "empty", messages: nil, want: ""},
+		{name: "no user", messages: []types.Message{{Role: "system", Content: "x"}}, want: ""},
+		{name: "single user", messages: []types.Message{userMsg("hello")}, want: "hello"},
+		{name: "trims whitespace", messages: []types.Message{userMsg("  hi  ")}, want: "hi"},
+		{
+			name: "picks last user",
+			messages: []types.Message{
+				userMsg("first"),
+				{Role: "assistant", Content: "ok"},
+				userMsg("second"),
+			},
+			want: "second",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := lastUserContent(tc.messages); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/runtime/memory_retriever_test.go
+++ b/internal/runtime/memory_retriever_test.go
@@ -125,8 +125,8 @@ func TestCompositeRetriever_CompositeMergesProfileAndEpisodic(t *testing.T) {
 	if len(got) != 4 {
 		t.Fatalf("expected 4 memories (2 profile + 2 episodic), got %d", len(got))
 	}
-	if store.lastQuery != "plan philly" {
-		t.Errorf("expected query %q, got %q", "plan philly", store.lastQuery)
+	if store.lastQuery != "plan OR philly" {
+		t.Errorf("expected OR-rewritten query %q, got %q", "plan OR philly", store.lastQuery)
 	}
 }
 
@@ -260,6 +260,27 @@ func TestCompositeRetriever_NonProfileMemoriesFromListAreIgnored(t *testing.T) {
 	}
 	if len(got) != 1 || got[0].ID != "p1" {
 		t.Errorf("expected only profile-category memory, got %v", got)
+	}
+}
+
+func TestToFTSOrQuery(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty passes through", in: "", want: ""},
+		{name: "single word unchanged", in: "Chicago", want: "Chicago"},
+		{name: "multi word joined with OR", in: "remind me about Chicago", want: "remind OR me OR about OR Chicago"},
+		{name: "extra whitespace collapsed", in: "  hello   world  ", want: "hello OR world"},
+		{name: "single word with surrounding whitespace passes through unchanged", in: "  hello  ", want: "  hello  "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := toFTSOrQuery(tc.in); got != tc.want {
+				t.Errorf("got %q want %q", got, tc.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements PromptKit's \`memory.Retriever\` so the \`MemoryRetrievalStage\` actually does something — without an impl, the agent only ever \"knows\" the user when it explicitly calls \`memory__recall\`, which is unreliable on cold-start turns where the opener has no lexical overlap with stored facts.

**Strategy: profile + similarity composite.**

| Tier | Source | When |
|---|---|---|
| Profile | \`store.List\` filtered to \`memory:identity\` / \`memory:preferences\` / \`memory:health\` | Every turn (cached 30s per workspace+user) |
| Episodic | \`store.Retrieve\` (FTS) against the last user message | When there's a user message; non-profile categories only |

Merged with profile-first dedup. Cold-start turns (no user message) get profile alone — that's the whole point: \"plan me a trip to Philly\" should still trigger \"with your peanut allergy in mind\" without the agent calling recall.

Wired via \`sdk.WithMemory(store, scope, sdk.WithMemoryRetriever(retriever))\` in the existing conversation builder.

## The OR-rewrite fix

A first version of the integration test passed falsely — it required the profile slice to be present but never asserted episodic actually surfaced. Tightening the assertion revealed that \`store.Retrieve(\"remind me where I stayed in Chicago\")\` returned 0 memories despite a clear lexical match in the seeded data.

Root cause: \`PostgresMemoryStore\` uses \`websearch_to_tsquery\` which applies AND across query terms. That's right for \`memory__recall\` (LLM picks a focused keyword) but wrong for ambient retrieval where the retriever hands the whole user message to the store and most multi-word phrases fail the AND match.

Fix: rewrite multi-word queries to OR semantics in the retriever before calling \`Retrieve\`. Postgres's stopword filter then strips noise (\"remind / me / where / I / in\") and what's left (\"chicago\", \"stay\") matches ambiently. Single-word queries pass through unchanged so \`memory__recall\` semantics are unaffected.

## Test coverage

- **Unit (\`internal/runtime/memory_retriever_test.go\`)** — 12 tests: empty user_id, profile-only, composite merge, dedup of profile-category episodic hits, episodic-error fallback, list-error fallback, cache hit / TTL expiry / per-user keying, the OR-rewrite helper.
- **Integration (\`internal/memory/retriever_integration_test.go\`)** — 4 subtests against real Postgres (testcontainer-backed): cold-start returns exactly the 3 profile categories; query-driven retrieval returns profile + the Chicago history memory specifically (proving the fix); empty user_id returns nil; cache stays warm with a 400×+ ratio.

Verified end-to-end:
\`\`\`
RetrieveContext (with query) took 989.75µs, returned 4 memories
  [memory:identity]    User name: Sarah Kim ...
  [memory:preferences] Aisle seat preferred ...
  [memory:health]      Severe peanut allergy ...
  [memory:history]     Last trip: Chicago October, Kimpton Gray hotel ...
\`\`\`

## Follow-ups (not in this PR)

- memory-api List endpoint should accept a \`category\` query param so the profile pull is server-side instead of client-side filter over a 200-row prefix.
- Read-side consent filter — revoked categories shouldn't surface in retrieval before the cascade-delete worker runs.
- Token-budget cap on the formatted context (clean to add once PromptKit #1073 lands and the formatter is host-controlled).
- Auto-extractor implementation (separate concern — relies on system-prompt-driven \`memory__remember\` for now).

## Test Plan
- [x] \`go test ./internal/runtime/...\` (447 tests, all pass)
- [x] \`go test ./internal/memory/... -run TestCompositeRetriever_RealStore\` (5 passes against real pgvector container)
- [x] \`golangci-lint run\` clean for changed files
- [x] Pre-commit per-file coverage: \`memory_retriever.go\` 92% aggregate (95-100% on hot paths)