### PR TITLE
fix(dashboard): swap consent banner for dismissable EE upgrade CTA in OSS

### DIFF
--- a/dashboard/src/components/license/license-gate.test.tsx
+++ b/dashboard/src/components/license/license-gate.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import {
   LicenseGate,
   RequireEnterprise,
@@ -203,6 +204,42 @@ describe("license-gate components", () => {
       expect(screen.getByText(/Git Sources requires an Enterprise license/)).toBeInTheDocument();
       const link = screen.getByRole("link", { name: /Upgrade/i });
       expect(link).toBeInTheDocument();
+    });
+
+    describe("dismissable", () => {
+      beforeEach(() => {
+        window.localStorage.clear();
+      });
+
+      it("renders no dismiss button when dismissKey is omitted", () => {
+        render(<UpgradeBanner feature="Git Sources" />);
+        expect(screen.queryByTestId("upgrade-banner-dismiss")).not.toBeInTheDocument();
+      });
+
+      it("hides the banner after the dismiss button is clicked (compact)", async () => {
+        const user = userEvent.setup();
+        render(<UpgradeBanner feature="Git Sources" compact dismissKey="git" />);
+
+        expect(screen.getByTestId("upgrade-banner-compact")).toBeInTheDocument();
+        await user.click(screen.getByTestId("upgrade-banner-dismiss"));
+        expect(screen.queryByTestId("upgrade-banner-compact")).not.toBeInTheDocument();
+        expect(window.localStorage.getItem("omnia.upgradeBanner.dismissed.git")).toBe("1");
+      });
+
+      it("hides the banner after the dismiss button is clicked (full)", async () => {
+        const user = userEvent.setup();
+        render(<UpgradeBanner feature="Git Sources" dismissKey="git-full" />);
+
+        expect(screen.getByText("Enterprise Feature")).toBeInTheDocument();
+        await user.click(screen.getByTestId("upgrade-banner-dismiss"));
+        expect(screen.queryByText("Enterprise Feature")).not.toBeInTheDocument();
+      });
+
+      it("stays hidden across re-renders when previously dismissed", () => {
+        window.localStorage.setItem("omnia.upgradeBanner.dismissed.git", "1");
+        render(<UpgradeBanner feature="Git Sources" compact dismissKey="git" />);
+        expect(screen.queryByTestId("upgrade-banner-compact")).not.toBeInTheDocument();
+      });
     });
   });
 

--- a/dashboard/src/components/license/license-gate.tsx
+++ b/dashboard/src/components/license/license-gate.tsx
@@ -1,12 +1,32 @@
 "use client";
 
-import { type ReactNode } from "react";
+import { useCallback, useSyncExternalStore, type ReactNode } from "react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { Lock, Sparkles, ExternalLink } from "lucide-react";
+import { Lock, Sparkles, ExternalLink, X } from "lucide-react";
 import { useLicense } from "@/hooks/auth";
 import { useEnterpriseConfig } from "@/hooks/core";
 import type { LicenseFeatures } from "@/types/license";
+
+const DISMISS_KEY_PREFIX = "omnia.upgradeBanner.dismissed.";
+
+// useSyncExternalStore subscribe arg: localStorage doesn't fire on same-tab
+// writes by default, so register a custom event channel for cross-component
+// updates. The native `storage` event covers other tabs; we synthesise an
+// in-tab event when our own writes happen.
+const DISMISS_EVENT = "omnia:upgrade-banner-dismissed";
+
+function subscribeToDismiss(onChange: () => void): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  window.addEventListener("storage", onChange);
+  window.addEventListener(DISMISS_EVENT, onChange);
+  return () => {
+    window.removeEventListener("storage", onChange);
+    window.removeEventListener(DISMISS_EVENT, onChange);
+  };
+}
 
 const UPGRADE_URL = "https://altairalabs.ai/enterprise";
 
@@ -100,6 +120,12 @@ export interface UpgradeBannerProps {
   upgradeUrl?: string;
   /** Whether to show as a compact inline banner */
   compact?: boolean;
+  /**
+   * When set, renders a close button and persists the dismissed state in
+   * localStorage under `omnia.upgradeBanner.dismissed.<dismissKey>`.
+   * Subsequent renders return null until the key is cleared.
+   */
+  dismissKey?: string;
 }
 
 /**
@@ -108,6 +134,7 @@ export interface UpgradeBannerProps {
  * @example
  * ```tsx
  * <UpgradeBanner feature="Git Sources" />
+ * <UpgradeBanner feature="Privacy consent" dismissKey="memory-consent" compact />
  * ```
  */
 export function UpgradeBanner({
@@ -115,13 +142,42 @@ export function UpgradeBanner({
   description,
   upgradeUrl = UPGRADE_URL,
   compact = false,
+  dismissKey,
 }: UpgradeBannerProps) {
+  const storageKey = dismissKey ? DISMISS_KEY_PREFIX + dismissKey : null;
+  const getSnapshot = useCallback(
+    () => (storageKey ? window.localStorage.getItem(storageKey) === "1" : false),
+    [storageKey],
+  );
+  // SSR snapshot: assume not-dismissed; client effect resyncs to localStorage.
+  // Returning the dismissed state during SSR would briefly hide a banner the
+  // server can't actually know about, defeating the point.
+  const dismissed = useSyncExternalStore(
+    subscribeToDismiss,
+    getSnapshot,
+    () => false,
+  );
+
+  if (dismissed) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    if (storageKey) {
+      window.localStorage.setItem(storageKey, "1");
+      window.dispatchEvent(new Event(DISMISS_EVENT));
+    }
+  };
+
   if (compact) {
     return (
-      <div className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200">
-        <Lock className="h-4 w-4 flex-shrink-0" />
-        <span>
-          {feature} requires an Enterprise license.{" "}
+      <div
+        className="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-200"
+        data-testid="upgrade-banner-compact"
+      >
+        <Sparkles className="h-4 w-4 flex-shrink-0 text-amber-600 dark:text-amber-400" />
+        <span className="flex-1">
+          {description ?? `${feature} requires an Enterprise license.`}{" "}
           <a
             href={upgradeUrl}
             target="_blank"
@@ -131,6 +187,17 @@ export function UpgradeBanner({
             Upgrade
           </a>
         </span>
+        {storageKey && (
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss"
+            data-testid="upgrade-banner-dismiss"
+            className="rounded p-0.5 hover:bg-amber-100 dark:hover:bg-amber-900"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
       </div>
     );
   }
@@ -138,8 +205,19 @@ export function UpgradeBanner({
   return (
     <Alert className="border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950">
       <Sparkles className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-      <AlertTitle className="text-amber-800 dark:text-amber-200">
-        Enterprise Feature
+      <AlertTitle className="flex items-center justify-between text-amber-800 dark:text-amber-200">
+        <span>Enterprise Feature</span>
+        {storageKey && (
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss"
+            data-testid="upgrade-banner-dismiss"
+            className="rounded p-0.5 text-amber-700 hover:bg-amber-100 dark:text-amber-300 dark:hover:bg-amber-900"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        )}
       </AlertTitle>
       <AlertDescription className="text-amber-700 dark:text-amber-300">
         <p className="mb-3">

--- a/dashboard/src/components/memories/consent-banner.test.tsx
+++ b/dashboard/src/components/memories/consent-banner.test.tsx
@@ -9,21 +9,31 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
-const { mockUseConsent, mockUseUpdateConsent } = vi.hoisted(() => ({
-  mockUseConsent: vi.fn(),
-  mockUseUpdateConsent: vi.fn(),
-}));
+const { mockUseConsent, mockUseUpdateConsent, mockUseEnterpriseConfig } =
+  vi.hoisted(() => ({
+    mockUseConsent: vi.fn(),
+    mockUseUpdateConsent: vi.fn(),
+    mockUseEnterpriseConfig: vi.fn(),
+  }));
 
 vi.mock("@/hooks/use-consent", () => ({
   useConsent: mockUseConsent,
   useUpdateConsent: mockUseUpdateConsent,
 }));
 
+vi.mock("@/hooks/core", () => ({
+  useEnterpriseConfig: mockUseEnterpriseConfig,
+}));
+
 import { ConsentBanner } from "./consent-banner";
 
 const mockMutate = vi.fn();
 
-function setupMocks(grants: string[] = [], isLoading = false) {
+function setupMocks(
+  grants: string[] = [],
+  isLoading = false,
+  enterprise: { enterpriseEnabled?: boolean; hideEnterprise?: boolean; loading?: boolean } = {},
+) {
   mockUseConsent.mockReturnValue({
     data: { grants, defaults: [], denied: [] },
     isLoading,
@@ -32,27 +42,36 @@ function setupMocks(grants: string[] = [], isLoading = false) {
     mutate: mockMutate,
     isPending: false,
   });
+  mockUseEnterpriseConfig.mockReturnValue({
+    enterpriseEnabled: enterprise.enterpriseEnabled ?? true,
+    hideEnterprise: enterprise.hideEnterprise ?? false,
+    showUpgradePrompts: !(enterprise.enterpriseEnabled ?? true) && !(enterprise.hideEnterprise ?? false),
+    loading: enterprise.loading ?? false,
+  });
 }
 
 describe("ConsentBanner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockMutate.mockReset();
+    window.localStorage.clear();
   });
 
-  it("renders loading skeleton when isLoading is true", () => {
-    mockUseConsent.mockReturnValue({ data: undefined, isLoading: true });
-    mockUseUpdateConsent.mockReturnValue({ mutate: mockMutate, isPending: false });
-
+  it("renders loading skeleton while runtime config is loading", () => {
+    setupMocks([], false, { loading: true });
     render(<ConsentBanner />);
-
-    const banner = screen.getByTestId("consent-banner");
-    expect(banner).toBeInTheDocument();
-    // No toggles rendered during loading
+    expect(screen.getByTestId("consent-banner")).toBeInTheDocument();
     expect(screen.queryByTestId("consent-toggle-memory:identity")).not.toBeInTheDocument();
   });
 
-  it("renders all 6 category toggles when loaded", () => {
+  it("renders loading skeleton when consent data is loading (EE on)", () => {
+    setupMocks([], true);
+    render(<ConsentBanner />);
+    expect(screen.getByTestId("consent-banner")).toBeInTheDocument();
+    expect(screen.queryByTestId("consent-toggle-memory:identity")).not.toBeInTheDocument();
+  });
+
+  it("renders all 6 category toggles when EE is enabled", () => {
     setupMocks([]);
     render(<ConsentBanner />);
 
@@ -64,7 +83,7 @@ describe("ConsentBanner", () => {
     expect(screen.getByTestId("consent-toggle-memory:history")).toBeInTheDocument();
   });
 
-  it("shows Privacy Consent title with shield icon", () => {
+  it("shows Privacy Consent title with shield icon (EE on)", () => {
     setupMocks([]);
     render(<ConsentBanner />);
     expect(screen.getByText("Privacy Consent")).toBeInTheDocument();
@@ -74,13 +93,9 @@ describe("ConsentBanner", () => {
     setupMocks(["memory:identity", "memory:health"]);
     render(<ConsentBanner />);
 
-    const identityToggle = screen.getByTestId("consent-toggle-memory:identity");
-    const locationToggle = screen.getByTestId("consent-toggle-memory:location");
-    const healthToggle = screen.getByTestId("consent-toggle-memory:health");
-
-    expect(identityToggle).toBeChecked();
-    expect(locationToggle).not.toBeChecked();
-    expect(healthToggle).toBeChecked();
+    expect(screen.getByTestId("consent-toggle-memory:identity")).toBeChecked();
+    expect(screen.getByTestId("consent-toggle-memory:location")).not.toBeChecked();
+    expect(screen.getByTestId("consent-toggle-memory:health")).toBeChecked();
   });
 
   it("shows PII toggle as unchecked when category is not in grants", () => {
@@ -114,34 +129,64 @@ describe("ConsentBanner", () => {
     setupMocks([]);
     render(<ConsentBanner />);
 
-    const prefsToggle = screen.getByTestId("consent-toggle-memory:preferences");
-    const contextToggle = screen.getByTestId("consent-toggle-memory:context");
-    const historyToggle = screen.getByTestId("consent-toggle-memory:history");
-
-    expect(prefsToggle).toBeChecked();
-    expect(prefsToggle).toBeDisabled();
-    expect(contextToggle).toBeChecked();
-    expect(contextToggle).toBeDisabled();
-    expect(historyToggle).toBeChecked();
-    expect(historyToggle).toBeDisabled();
+    for (const cat of ["preferences", "context", "history"]) {
+      const toggle = screen.getByTestId(`consent-toggle-memory:${cat}`);
+      expect(toggle).toBeChecked();
+      expect(toggle).toBeDisabled();
+    }
   });
 
   it("shows (default) label for non-PII categories", () => {
     setupMocks([]);
     render(<ConsentBanner />);
-
-    const defaultLabels = screen.getAllByText("(default)");
-    expect(defaultLabels).toHaveLength(3);
+    expect(screen.getAllByText("(default)")).toHaveLength(3);
   });
 
   it("disables PII toggles when mutation is pending", () => {
     mockUseConsent.mockReturnValue({ data: { grants: [], defaults: [], denied: [] }, isLoading: false });
     mockUseUpdateConsent.mockReturnValue({ mutate: mockMutate, isPending: true });
+    mockUseEnterpriseConfig.mockReturnValue({
+      enterpriseEnabled: true,
+      hideEnterprise: false,
+      showUpgradePrompts: false,
+      loading: false,
+    });
 
     render(<ConsentBanner />);
 
     expect(screen.getByTestId("consent-toggle-memory:identity")).toBeDisabled();
     expect(screen.getByTestId("consent-toggle-memory:location")).toBeDisabled();
     expect(screen.getByTestId("consent-toggle-memory:health")).toBeDisabled();
+  });
+
+  describe("OSS mode (enterpriseEnabled=false)", () => {
+    it("renders the dismissable Enterprise upgrade CTA, no toggles", () => {
+      setupMocks([], false, { enterpriseEnabled: false });
+      render(<ConsentBanner />);
+
+      expect(screen.getByTestId("upgrade-banner-compact")).toBeInTheDocument();
+      expect(screen.getByTestId("upgrade-banner-dismiss")).toBeInTheDocument();
+      expect(screen.queryByTestId("consent-toggle-memory:identity")).not.toBeInTheDocument();
+      expect(screen.queryByText("Privacy Consent")).not.toBeInTheDocument();
+    });
+
+    it("renders nothing when hideEnterprise is true", () => {
+      setupMocks([], false, { enterpriseEnabled: false, hideEnterprise: true });
+      const { container } = render(<ConsentBanner />);
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it("hides the CTA after dismissal and remembers across re-renders", async () => {
+      const user = userEvent.setup();
+      setupMocks([], false, { enterpriseEnabled: false });
+      const { rerender } = render(<ConsentBanner />);
+
+      await user.click(screen.getByTestId("upgrade-banner-dismiss"));
+      expect(screen.queryByTestId("upgrade-banner-compact")).not.toBeInTheDocument();
+
+      rerender(<ConsentBanner />);
+      expect(screen.queryByTestId("upgrade-banner-compact")).not.toBeInTheDocument();
+      expect(window.localStorage.getItem("omnia.upgradeBanner.dismissed.memory-consent-banner")).toBe("1");
+    });
   });
 });

--- a/dashboard/src/components/memories/consent-banner.tsx
+++ b/dashboard/src/components/memories/consent-banner.tsx
@@ -13,6 +13,8 @@ import { Label } from "@/components/ui/label";
 import { Shield } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useConsent, useUpdateConsent } from "@/hooks/use-consent";
+import { useEnterpriseConfig } from "@/hooks/core";
+import { UpgradeBanner } from "@/components/license/license-gate";
 import { getCategoryLabel } from "./category-badge";
 
 // Categories that require explicit user grant (PII)
@@ -49,6 +51,8 @@ function LoadingSkeleton() {
 export function ConsentBanner() {
   const { data: consent, isLoading } = useConsent();
   const updateConsent = useUpdateConsent();
+  const { enterpriseEnabled, hideEnterprise, loading: licenseLoading } =
+    useEnterpriseConfig();
 
   const handleToggle = (category: string, granted: boolean) => {
     if (granted) {
@@ -57,6 +61,32 @@ export function ConsentBanner() {
       updateConsent.mutate({ revocations: [category] });
     }
   };
+
+  if (licenseLoading) {
+    return <LoadingSkeleton />;
+  }
+
+  // EE off + not hidden → show a dismissable upgrade CTA. The toggle UI
+  // would otherwise lie about what it does: the consent endpoint is
+  // unregistered in OSS session-api (cmd/session-api/main.go gates it on
+  // f.enterprise) and the memory-api privacy middleware that enforces
+  // grants is also EE-only — clicks would 502 and have no effect even if
+  // they didn't.
+  if (!enterpriseEnabled) {
+    if (hideEnterprise) {
+      return null;
+    }
+    return (
+      <div className="mb-4" data-testid="consent-banner">
+        <UpgradeBanner
+          compact
+          dismissKey="memory-consent-banner"
+          feature="Privacy consent"
+          description="Per-category memory consent (Identity / Location / Health) is an Enterprise feature. Without it, every memory is stored — there's no per-category opt-out."
+        />
+      </div>
+    );
+  }
 
   if (isLoading) {
     return <LoadingSkeleton />;


### PR DESCRIPTION
## Summary

The consent banner on \`/memories\` rendered the same toggle UI regardless of whether enterprise was enabled, but in OSS clicking a toggle returned 502: \`session-api\` doesn't register the consent endpoint (\`cmd/session-api/main.go\` gates it on \`f.enterprise\`), so PUT /api/v1/privacy/preferences/.../consent comes back as plain-text 404 and the dashboard proxy can't parse it. \`memory-api\`'s privacy middleware that *enforces* grants is also EE-gated, so even if the storage worked, no memory write would be filtered. The banner was effectively decorative and broken on first click.

This PR makes the banner adaptive:

- **\`enterpriseEnabled=true\`**: existing toggle UI (unchanged).
- **\`enterpriseEnabled=false, hideEnterprise=false\`**: compact dismissable Sparkles-icon CTA pointing at the upgrade URL, with the dismissal persisted under \`localStorage[omnia.upgradeBanner.dismissed.memory-consent-banner]\`.
- **\`hideEnterprise=true\`**: nothing rendered.

## Reusable seam

\`UpgradeBanner\` (in \`license-gate.tsx\`) gains a \`dismissKey\` prop driven by \`useSyncExternalStore\` so any consumer can opt in. Same-tab dismissals broadcast via a custom \`omnia:upgrade-banner-dismissed\` event so multiple banners with the same key stay in sync without a page reload.

## Test Plan
- [x] \`license-gate.test.tsx\`: dismissable variant covered (no button without \`dismissKey\`, hides after click in both compact and full layouts, stays hidden across re-renders, localStorage written)
- [x] \`consent-banner.test.tsx\`: OSS-mode renders the upgrade CTA and no toggles, dismiss button works and persists, \`hideEnterprise=true\` renders nothing, EE-mode renders the existing toggles unchanged
- [x] \`npm run lint\` clean (initial setState-in-effect lint resolved by switching to \`useSyncExternalStore\`)
- [x] \`npm run typecheck\` clean
- [x] Pre-commit per-file coverage: \`consent-banner.tsx\` 100%, \`license-gate.tsx\` 96.2%