### PR TITLE
feat(observability): split product reads off Prometheus (pilot)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,17 @@ Architecture docs are only useful if they reflect reality. When your changes aff
 **When to update `api/websocket/asyncapi.yaml`**:
 - Adding/removing/changing WebSocket message types or payload schemas
 
+## Observability Boundaries
+
+Two read paths, two purposes. Pick by classification:
+
+- **Operational signals** (rates, latencies, system health, scrape-style time series, control-plane decisions): **Prometheus is the source of truth.** `RolloutAnalysis` PromQL config, system-health dashboards, request-rate hooks read from Prometheus.
+- **Product data** (eval results, tokens, cost, per-tenant usage, anything a customer might cite or export): **structured tables read via session-api are the source of truth.** Product hooks must work when Prometheus is offline.
+
+The dashboard's existing operational views stay on Prom. New product-y read paths go through session-api endpoints (e.g. `GET /api/v1/eval-results/aggregate`). The repo's `hack/check-no-prom-product-deps` pre-commit hook blocks new `dashboard/src/hooks/use-eval-*.ts(x)`, `use-*-cost.ts(x)`, or `use-provider-*.ts(x)` files that import `prometheus-service`, `prometheus-proxy`, or `@/lib/prometheus*` — existing files are allowlisted in the script.
+
+When you're unsure which class your data is, ask: *would a customer's compliance / billing / quality team ever read this directly?* If yes, product. If it only matters for an SRE on-call, operational.
+
 ## Pre-commit Hooks
 
 The repo has a pre-commit hook at `hack/pre-commit` that runs on every commit. **Run checks locally before committing to avoid retry cycles.**

--- a/SERVICES.md
+++ b/SERVICES.md
@@ -148,6 +148,7 @@ Browser ──WebSocket──▶ Facade ──gRPC──▶ Runtime ──HTTP�
 3. **The dashboard never talks to the runtime directly.** All communication goes through the facade's WebSocket.
 4. **WebSocket types are generated from Go.** Run `make generate-websocket-types` after changing `internal/facade/protocol.go`. The pre-commit hook enforces this.
 5. **Generated files are never manually conflict-resolved.** After merging, re-run `make generate && make manifests && go mod tidy`.
+6. **Observability has two read paths.** Prometheus is for **operational** signals (rates, latencies, system health, control-plane PromQL); session-api structured endpoints are for **product** data (eval results, cost, per-tenant usage). New product hooks must work when Prometheus is offline. See `CLAUDE.md` → "Observability Boundaries" for the classification rule; `hack/check-no-prom-product-deps` enforces it on new files.
 
 ## Adding a New Service
 

--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,29 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Added (eval-results aggregate + discover endpoints)
+
+- `GET /api/v1/eval-results/aggregate?namespace=X&groupBy=Y&metric=Z` —
+  namespace-scoped GROUP BY over `eval_results`. `groupBy` is one of
+  `eval_id` | `eval_type` | `agent` | `time:hour` | `time:day`; `metric`
+  is one of `count` | `avg_score` | `p50_score` | `p95_score` |
+  `avg_latency_ms` | `p95_latency_ms`. Optional filters `agentName`,
+  `evalId`, `evalType`, `from`, `to` (RFC3339). Returns
+  `{rows: [{key, value, count}, …]}`.
+- `GET /api/v1/eval-results/discover?namespace=X` — distinct
+  `(eval_id, eval_type)` pairs that have at least one row in this
+  namespace's `eval_results`. Returns `{evals: [{evalId, evalType}, …]}`.
+- Dashboard proxy routes: `GET /api/workspaces/{name}/eval-results/aggregate`
+  and `GET /api/workspaces/{name}/eval-results/discover`. The workspace
+  name from the URL is pinned as `namespace` on the forwarded query so
+  callers cannot read another workspace's data.
+
+Together these replace direct Prometheus reads for product-class
+dashboard hooks (eval trends, eval discovery). See CLAUDE.md →
+Observability Boundaries for the principle; the design proposal at
+`docs/local-backlog/implemented/2026-04-17-observability-split-design.md`
+covers rationale.
+
 ### Breaking (SessionRetentionPolicy schema flatten + policyRef, #1016)
 
 - `SessionRetentionPolicy.spec.default` and `spec.perWorkspace` removed.

--- a/dashboard/src/app/api/workspaces/[name]/eval-results/aggregate/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/eval-results/aggregate/route.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for workspace eval-results aggregate proxy route.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/workspace-authz", () => ({
+  checkWorkspaceAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/service-url-resolver", () => ({
+  resolveServiceURLs: vi.fn(),
+}));
+
+const mockUser = {
+  id: "testuser-id",
+  provider: "oauth" as const,
+  username: "testuser",
+  email: "test@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function makeRequest(query: string): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/workspaces/test-ws/eval-results/aggregate?${query}`,
+    { method: "GET" }
+  );
+}
+
+function makeContext() {
+  return { params: Promise.resolve({ name: "test-ws" }) };
+}
+
+describe("GET /api/workspaces/[name]/eval-results/aggregate", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  async function setupAuth() {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(resolveServiceURLs).mockResolvedValue({
+      sessionURL: "https://session-api:8080",
+      memoryURL: "https://memory-api:8080",
+    });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+  }
+
+  it("proxies aggregate request and injects namespace from workspace name", async () => {
+    await setupAuth();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          rows: [
+            { key: "2026-05-01", value: 0.85, count: 2 },
+            { key: "2026-05-02", value: 0.8, count: 2 },
+          ],
+        }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(
+      makeRequest("groupBy=time:day&metric=avg_score&evalId=acc"),
+      makeContext()
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.rows).toHaveLength(2);
+    expect(body.rows[0].key).toBe("2026-05-01");
+
+    // Verify the proxy forwarded query params AND pinned namespace=test-ws.
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const calledURL = mockFetch.mock.calls[0][0] as string;
+    expect(calledURL).toContain("session-api:8080/api/v1/eval-results/aggregate?");
+    expect(calledURL).toContain("namespace=test-ws");
+    expect(calledURL).toContain("groupBy=time%3Aday");
+    expect(calledURL).toContain("metric=avg_score");
+    expect(calledURL).toContain("evalId=acc");
+  });
+
+  it("overrides caller-supplied namespace with the workspace name", async () => {
+    await setupAuth();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ rows: [] }),
+    });
+
+    const { GET } = await import("./route");
+    await GET(
+      // Caller tries to read another workspace's data — should be ignored.
+      makeRequest("namespace=other-ws&groupBy=eval_id&metric=count"),
+      makeContext()
+    );
+
+    const calledURL = mockFetch.mock.calls[0][0] as string;
+    expect(calledURL).toContain("namespace=test-ws");
+    expect(calledURL).not.toContain("namespace=other-ws");
+  });
+
+  it("returns 503 when session-api URL cannot be resolved", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(resolveServiceURLs).mockResolvedValue(null);
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(
+      makeRequest("groupBy=time:day&metric=count"),
+      makeContext()
+    );
+
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.rows).toEqual([]);
+  });
+
+  it("returns 502 when session-api fetch throws", async () => {
+    await setupAuth();
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const { GET } = await import("./route");
+    const response = await GET(
+      makeRequest("groupBy=time:day&metric=count"),
+      makeContext()
+    );
+
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.error).toContain("Session API");
+    expect(body.rows).toEqual([]);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/eval-results/aggregate/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/eval-results/aggregate/route.ts
@@ -1,0 +1,73 @@
+/**
+ * Workspace eval-results aggregate proxy route.
+ *
+ * GET /api/workspaces/{name}/eval-results/aggregate
+ *   -> SESSION_API_URL/api/v1/eval-results/aggregate?namespace={name}&...
+ *
+ * Forwards `groupBy`, `metric`, optional filters (`agentName`, `evalId`,
+ * `evalType`), and time bounds (`from`, `to`) to session-api. The workspace
+ * `name` from the URL is injected as the `namespace` query param so the
+ * caller cannot accidentally read another workspace's eval data.
+ *
+ * Part of the observability split: see CLAUDE.md → Observability Boundaries.
+ * Replaces direct Prometheus reads for product-class dashboard views.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { resolveServiceURLs } from "@/lib/k8s/service-url-resolver";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+
+type Params = { name: string };
+
+export const GET = withWorkspaceAccess<Params>(
+  "viewer",
+  async (
+    request: NextRequest,
+    context: WorkspaceRouteContext<Params>,
+    _access: WorkspaceAccess,
+    _user: User
+  ): Promise<NextResponse> => {
+    const { name } = await context.params;
+
+    const urls = await resolveServiceURLs(name);
+    if (!urls) {
+      return NextResponse.json(
+        { error: "Session API not configured", rows: [] },
+        { status: 503 }
+      );
+    }
+
+    const baseUrl = urls.sessionURL.endsWith("/")
+      ? urls.sessionURL.slice(0, -1)
+      : urls.sessionURL;
+
+    // Pin namespace to the URL-scoped workspace so a caller can't read
+    // another workspace's data by setting ?namespace=other.
+    const params = new URLSearchParams(request.nextUrl.searchParams);
+    params.set("namespace", name);
+    const targetUrl = `${baseUrl}/api/v1/eval-results/aggregate?${params.toString()}`;
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { Accept: "application/json" },
+      });
+      const data = await response.json();
+      return NextResponse.json(data, { status: response.status });
+    } catch (error) {
+      console.error("Session API eval-results aggregate proxy error:", error);
+      return NextResponse.json(
+        {
+          error: "Failed to connect to Session API",
+          details: error instanceof Error ? error.message : String(error),
+          rows: [],
+        },
+        { status: 502 }
+      );
+    }
+  }
+);

--- a/dashboard/src/app/api/workspaces/[name]/eval-results/discover/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/eval-results/discover/route.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for workspace eval-results discover proxy route.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/workspace-authz", () => ({
+  checkWorkspaceAccess: vi.fn(),
+}));
+
+vi.mock("@/lib/k8s/service-url-resolver", () => ({
+  resolveServiceURLs: vi.fn(),
+}));
+
+const mockUser = {
+  id: "testuser-id",
+  provider: "oauth" as const,
+  username: "testuser",
+  email: "test@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function makeRequest(): NextRequest {
+  return new NextRequest(
+    "http://localhost:3000/api/workspaces/test-ws/eval-results/discover",
+    { method: "GET" }
+  );
+}
+
+function makeContext() {
+  return { params: Promise.resolve({ name: "test-ws" }) };
+}
+
+describe("GET /api/workspaces/[name]/eval-results/discover", () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  async function setupAuth() {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(resolveServiceURLs).mockResolvedValue({
+      sessionURL: "https://session-api:8080",
+      memoryURL: "https://memory-api:8080",
+    });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+  }
+
+  it("returns the list of distinct evals for the workspace", async () => {
+    await setupAuth();
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          evals: [
+            { evalId: "acc", evalType: "llm_judge" },
+            { evalId: "lat", evalType: "assertion" },
+          ],
+        }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.evals).toHaveLength(2);
+    expect(body.evals[0].evalId).toBe("acc");
+
+    const calledURL = mockFetch.mock.calls[0][0] as string;
+    expect(calledURL).toBe(
+      "https://session-api:8080/api/v1/eval-results/discover?namespace=test-ws"
+    );
+  });
+
+  it("returns 503 when session-api URL cannot be resolved", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+
+    vi.mocked(resolveServiceURLs).mockResolvedValue(null);
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.evals).toEqual([]);
+  });
+
+  it("returns 502 when session-api fetch throws", async () => {
+    await setupAuth();
+    mockFetch.mockRejectedValueOnce(new Error("network down"));
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.evals).toEqual([]);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/eval-results/discover/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/eval-results/discover/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Workspace eval-results discover proxy route.
+ *
+ * GET /api/workspaces/{name}/eval-results/discover
+ *   -> SESSION_API_URL/api/v1/eval-results/discover?namespace={name}
+ *
+ * Returns the distinct (eval_id, eval_type) pairs that exist in this
+ * workspace's eval_results table. Replaces dashboard discovery via
+ * Prometheus' /api/v1/metadata for product views.
+ *
+ * Part of the observability split: see CLAUDE.md → Observability Boundaries.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { resolveServiceURLs } from "@/lib/k8s/service-url-resolver";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+
+type Params = { name: string };
+
+export const GET = withWorkspaceAccess<Params>(
+  "viewer",
+  async (
+    _request: NextRequest,
+    context: WorkspaceRouteContext<Params>,
+    _access: WorkspaceAccess,
+    _user: User
+  ): Promise<NextResponse> => {
+    const { name } = await context.params;
+
+    const urls = await resolveServiceURLs(name);
+    if (!urls) {
+      return NextResponse.json(
+        { error: "Session API not configured", evals: [] },
+        { status: 503 }
+      );
+    }
+
+    const baseUrl = urls.sessionURL.endsWith("/")
+      ? urls.sessionURL.slice(0, -1)
+      : urls.sessionURL;
+    const targetUrl = `${baseUrl}/api/v1/eval-results/discover?namespace=${encodeURIComponent(name)}`;
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { Accept: "application/json" },
+      });
+      const data = await response.json();
+      return NextResponse.json(data, { status: response.status });
+    } catch (error) {
+      console.error("Session API eval-results discover proxy error:", error);
+      return NextResponse.json(
+        {
+          error: "Failed to connect to Session API",
+          details: error instanceof Error ? error.message : String(error),
+          evals: [],
+        },
+        { status: 502 }
+      );
+    }
+  }
+);

--- a/dashboard/src/hooks/use-eval-trends.test.ts
+++ b/dashboard/src/hooks/use-eval-trends.test.ts
@@ -1,5 +1,10 @@
 /**
- * Tests for useEvalScoreTrends and useEvalMetrics hooks.
+ * Tests for useEvalScoreTrends / useEvalMetrics — session-api flavour.
+ *
+ * Previously mocked Prometheus client functions; after the observability
+ * split (see CLAUDE.md → Observability Boundaries) these hooks fetch from
+ * `/api/workspaces/{name}/eval-results/aggregate` and `.../discover`, so
+ * the tests mock the structured service module instead.
  *
  * Copyright 2026 Altaira Labs.
  * SPDX-License-Identifier: Apache-2.0
@@ -10,399 +15,224 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 
-// Mock dependencies
-const mockQueryPrometheus = vi.fn();
-const mockQueryPrometheusRange = vi.fn();
-const mockQueryPrometheusMetadata = vi.fn();
-
-vi.mock("@/lib/prometheus", () => ({
-  queryPrometheus: (...args: unknown[]) => mockQueryPrometheus(...args),
-  queryPrometheusRange: (...args: unknown[]) => mockQueryPrometheusRange(...args),
-  queryPrometheusMetadata: (...args: unknown[]) => mockQueryPrometheusMetadata(...args),
-}));
-
-vi.mock("@/lib/prometheus-queries", () => ({
-  EvalQueries: {
-    discoverMetrics: () => '{__name__=~"omnia_eval_.*"}',
-    metricAvgOverTime: (name: string, window: string) =>
-      `avg_over_time(${name}[${window}])`,
-    metricValue: (name: string) => name,
-  },
-}));
-
 import { useEvalScoreTrends, useEvalMetrics, EVAL_TREND_RANGES } from "./use-eval-trends";
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+// --- Mocks ----------------------------------------------------------------
+
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: vi.fn(),
+}));
+
+vi.mock("@/lib/data/eval-results-service", () => ({
+  fetchEvalAggregate: vi.fn(),
+  fetchEvalDescriptors: vi.fn(),
+}));
+
+import { useWorkspace } from "@/contexts/workspace-context";
+import {
+  fetchEvalAggregate,
+  fetchEvalDescriptors,
+} from "@/lib/data/eval-results-service";
+
+const mockedUseWorkspace = vi.mocked(useWorkspace);
+const mockedFetchAggregate = vi.mocked(fetchEvalAggregate);
+const mockedFetchDescriptors = vi.mocked(fetchEvalDescriptors);
+
+function makeWrapper() {
+  const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  function TestQueryProvider({ children }: { children: React.ReactNode }) {
-    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
   }
-  return TestQueryProvider;
+  return Wrapper;
 }
 
+function workspaceCtx(name: string | null) {
+  return {
+    currentWorkspace: name ? { name } : null,
+  } as unknown as ReturnType<typeof useWorkspace>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- EVAL_TREND_RANGES surface --------------------------------------------
+
 describe("EVAL_TREND_RANGES", () => {
-  it("defines expected time ranges", () => {
-    expect(EVAL_TREND_RANGES).toHaveProperty("1h");
-    expect(EVAL_TREND_RANGES).toHaveProperty("6h");
-    expect(EVAL_TREND_RANGES).toHaveProperty("24h");
-    expect(EVAL_TREND_RANGES).toHaveProperty("7d");
-    expect(EVAL_TREND_RANGES).toHaveProperty("30d");
-    expect(EVAL_TREND_RANGES["1h"].seconds).toBe(3600);
-    expect(EVAL_TREND_RANGES["1h"].step).toBe("1m");
+  it("exposes the expected ranges with a groupBy mapping", () => {
+    expect(EVAL_TREND_RANGES["24h"].seconds).toBe(86400);
+    expect(EVAL_TREND_RANGES["24h"].groupBy).toBe("time:hour");
+    expect(EVAL_TREND_RANGES["7d"].groupBy).toBe("time:day");
   });
 });
+
+// --- useEvalScoreTrends ---------------------------------------------------
 
 describe("useEvalScoreTrends", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockQueryPrometheusMetadata.mockResolvedValue({});
+  it("returns empty trends when no workspace is selected", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx(null));
+
+    const { result } = renderHook(() => useEvalScoreTrends(), { wrapper: makeWrapper() });
+
+    // The query is disabled without a workspace; data stays undefined and
+    // service calls don't happen.
+    await waitFor(() => {
+      expect(result.current.isFetching).toBe(false);
+    });
+    expect(mockedFetchDescriptors).not.toHaveBeenCalled();
+    expect(mockedFetchAggregate).not.toHaveBeenCalled();
   });
 
-  it("returns empty array when no metrics are discovered", async () => {
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: { result: [] },
+  it("discovers evals then fetches aggregate per eval and merges by timestamp", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDescriptors.mockResolvedValue([
+      { evalId: "acc", evalType: "llm_judge" },
+      { evalId: "lat", evalType: "llm_judge" },
+    ]);
+    mockedFetchAggregate.mockImplementation(async ({ evalId }) => {
+      if (evalId === "acc") {
+        return [
+          { key: "2026-05-01T00:00:00Z", value: 0.85, count: 2 },
+          { key: "2026-05-02T00:00:00Z", value: 0.9, count: 2 },
+        ];
+      }
+      return [{ key: "2026-05-01T00:00:00Z", value: 0.5, count: 1 }];
     });
 
     const { result } = renderHook(
-      () => useEvalScoreTrends({ timeRange: "1h" }),
-      { wrapper: createWrapper() }
+      () => useEvalScoreTrends({ timeRange: "7d" }),
+      { wrapper: makeWrapper() },
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual([]);
+    expect(result.current.data).toHaveLength(2);
+    // Sorted ascending by timestamp; first row merges both evals' values.
+    expect(result.current.data?.[0].values).toEqual({ acc: 0.85, lat: 0.5 });
+    expect(result.current.data?.[1].values).toEqual({ acc: 0.9 });
+
+    // Discovery was called once; aggregate once per discovered eval.
+    expect(mockedFetchDescriptors).toHaveBeenCalledOnce();
+    expect(mockedFetchAggregate).toHaveBeenCalledTimes(2);
+    // Time bucket choice follows EVAL_TREND_RANGES["7d"] → "time:day".
+    expect(mockedFetchAggregate.mock.calls[0][0].groupBy).toBe("time:day");
+    expect(mockedFetchAggregate.mock.calls[0][0].metric).toBe("avg_score");
   });
 
-  it("returns empty array when Prometheus returns no data for discovery", async () => {
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: { result: [] },
-    });
+  it("uses caller-supplied metric names without calling discovery", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchAggregate.mockResolvedValue([
+      { key: "2026-05-01T00:00:00Z", value: 0.9, count: 1 },
+    ]);
 
     const { result } = renderHook(
-      () => useEvalScoreTrends(),
-      { wrapper: createWrapper() }
+      () => useEvalScoreTrends({ metricNames: ["only-this"] }),
+      { wrapper: makeWrapper() },
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual([]);
+    expect(mockedFetchDescriptors).not.toHaveBeenCalled();
+    expect(mockedFetchAggregate).toHaveBeenCalledOnce();
+    expect(mockedFetchAggregate.mock.calls[0][0].evalId).toBe("only-this");
   });
 
-  it("merges time series data correctly from multiple metrics", async () => {
-    // Discovery returns two metrics
-    mockQueryPrometheusMetadata.mockResolvedValue({
-      omnia_eval_tone: "gauge",
-      omnia_eval_safety: "gauge",
-    });
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: {
-        result: [
-          { metric: { __name__: "omnia_eval_tone" }, value: [1000, "0.9"] },
-          { metric: { __name__: "omnia_eval_safety" }, value: [1000, "0.8"] },
-        ],
-      },
-    });
+  it("propagates the filter through to aggregate calls", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchAggregate.mockResolvedValue([]);
 
-    // Range query returns time series for each metric
-    mockQueryPrometheusRange
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            {
-              metric: { __name__: "omnia_eval_tone" },
-              values: [
-                [1000, "0.85"],
-                [1060, "0.90"],
-              ],
-            },
-          ],
-        },
-      })
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            {
-              metric: { __name__: "omnia_eval_safety" },
-              values: [
-                [1000, "0.95"],
-                [1060, "0.80"],
-              ],
-            },
-          ],
-        },
-      });
-
-    const { result } = renderHook(
+    renderHook(
       () =>
         useEvalScoreTrends({
-          metricNames: ["omnia_eval_tone", "omnia_eval_safety"],
-          timeRange: "1h",
+          metricNames: ["acc"],
+          filter: { agent: "chatbot", promptpackName: "v2" },
         }),
-      { wrapper: createWrapper() }
+      { wrapper: makeWrapper() },
     );
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    const data = result.current.data!;
-    expect(data).toHaveLength(2);
-    // Timestamps are sorted
-    expect(data[0].timestamp).toEqual(new Date(1000 * 1000));
-    expect(data[1].timestamp).toEqual(new Date(1060 * 1000));
-    // Values merged from both metrics (prefix stripped)
-    expect(data[0].values).toEqual({ tone: 0.85, safety: 0.95 });
-    expect(data[1].values).toEqual({ tone: 0.9, safety: 0.8 });
+    await waitFor(() => expect(mockedFetchAggregate).toHaveBeenCalledOnce());
+    expect(mockedFetchAggregate.mock.calls[0][0]).toMatchObject({
+      agentName: "chatbot",
+      promptpackName: "v2",
+      evalId: "acc",
+    });
   });
 
-  it("skips metrics with failed status in range response", async () => {
-    mockQueryPrometheusRange
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            {
-              metric: { __name__: "omnia_eval_tone" },
-              values: [[1000, "0.9"]],
-            },
-          ],
-        },
-      })
-      .mockResolvedValueOnce({
-        status: "error",
-        error: "bad query",
-      });
+  it("strips the omnia_eval_ prefix from merged value keys for back-compat", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDescriptors.mockResolvedValue([
+      { evalId: "omnia_eval_acc", evalType: "llm_judge" },
+    ]);
+    mockedFetchAggregate.mockResolvedValue([
+      { key: "2026-05-01T00:00:00Z", value: 0.7, count: 1 },
+    ]);
 
-    const { result } = renderHook(
-      () =>
-        useEvalScoreTrends({
-          metricNames: ["omnia_eval_tone", "omnia_eval_bad"],
-          timeRange: "1h",
-        }),
-      { wrapper: createWrapper() }
-    );
-
+    const { result } = renderHook(() => useEvalScoreTrends(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    const data = result.current.data!;
-    expect(data).toHaveLength(1);
-    expect(data[0].values).toEqual({ tone: 0.9 });
+    expect(result.current.data?.[0].values).toEqual({ acc: 0.7 });
   });
 
-  it("handles Prometheus discovery errors gracefully (returns empty)", async () => {
-    // discoverEvalMetrics catches errors internally and returns []
-    mockQueryPrometheus.mockRejectedValue(new Error("Network error"));
+  it("returns empty trends when discovery yields no evals", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDescriptors.mockResolvedValue([]);
 
-    const { result } = renderHook(
-      () => useEvalScoreTrends({ timeRange: "1h" }),
-      { wrapper: createWrapper() }
-    );
-
+    const { result } = renderHook(() => useEvalScoreTrends(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual([]);
-  });
-
-  it("propagates range query errors with retry: false", async () => {
-    // When metricNames are provided, discovery is skipped, so range query errors propagate
-    mockQueryPrometheusRange.mockRejectedValue(new Error("Range query failed"));
-
-    const { result } = renderHook(
-      () =>
-        useEvalScoreTrends({
-          metricNames: ["omnia_eval_tone"],
-          timeRange: "1h",
-        }),
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => expect(result.current.isError).toBe(true));
-    expect(result.current.error).toBeDefined();
-    // Should not retry (retry: false in the hook)
-    expect(mockQueryPrometheusRange).toHaveBeenCalledTimes(1);
-  });
-
-  it("filters out histogram sub-metrics using metadata during discovery", async () => {
-    mockQueryPrometheusMetadata.mockResolvedValue({
-      omnia_eval_latency: "histogram",
-    });
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: {
-        result: [
-          { metric: { __name__: "omnia_eval_latency" }, value: [1000, "1"] },
-          { metric: { __name__: "omnia_eval_latency_bucket" }, value: [1000, "1"] },
-          { metric: { __name__: "omnia_eval_latency_sum" }, value: [1000, "1"] },
-          { metric: { __name__: "omnia_eval_latency_count" }, value: [1000, "1"] },
-          { metric: { __name__: "omnia_eval_executed_total" }, value: [1000, "47"] },
-          { metric: { __name__: "omnia_eval_passed_total" }, value: [1000, "42"] },
-          { metric: { __name__: "omnia_eval_failed_total" }, value: [1000, "5"] },
-          { metric: { __name__: "omnia_eval_score" }, value: [1000, "0.9"] },
-          { metric: { __name__: "omnia_eval_duration_seconds" }, value: [1000, "1.2"] },
-          { metric: { __name__: "omnia_eval_worker_events_received_total" }, value: [1000, "99"] },
-        ],
-      },
-    });
-
-    mockQueryPrometheusRange.mockResolvedValue({
-      status: "success",
-      data: {
-        result: [
-          {
-            metric: {},
-            values: [[1000, "0.5"]],
-          },
-        ],
-      },
-    });
-
-    const { result } = renderHook(
-      () => useEvalScoreTrends({ timeRange: "1h" }),
-      { wrapper: createWrapper() }
-    );
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    // Only latency survives: _bucket/_sum/_count excluded by metadata,
-    // omnia_eval_worker_* excluded, core infra metrics excluded
-    expect(mockQueryPrometheusRange).toHaveBeenCalledTimes(1);
+    expect(mockedFetchAggregate).not.toHaveBeenCalled();
   });
 });
 
-/** Default range query response for sparkline data. */
-const defaultRangeResponse = {
-  status: "success",
-  data: { result: [{ metric: {}, values: [[1000, "0.5"]] }] },
-};
+// --- useEvalMetrics -------------------------------------------------------
 
 describe("useEvalMetrics", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockQueryPrometheusMetadata.mockResolvedValue({
-      omnia_eval_safety: "gauge",
-      omnia_eval_tone: "gauge",
-    });
-    mockQueryPrometheusRange.mockResolvedValue(defaultRangeResponse);
+  it("returns empty when no workspace", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx(null));
+
+    const { result } = renderHook(() => useEvalMetrics(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+    expect(mockedFetchDescriptors).not.toHaveBeenCalled();
   });
 
-  it("discovers and returns metrics with values and types", async () => {
-    mockQueryPrometheusMetadata.mockResolvedValue({
-      omnia_eval_safety: "gauge",
-      omnia_eval_tone: "counter",
+  it("builds EvalMetricInfo[] from discovery + current + sparkline aggregates", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDescriptors.mockResolvedValue([
+      { evalId: "acc", evalType: "llm_judge" },
+      { evalId: "exact-match", evalType: "assertion" },
+    ]);
+    // Each eval results in TWO aggregate calls: current value + sparkline.
+    mockedFetchAggregate.mockImplementation(async ({ groupBy, evalId }) => {
+      if (groupBy === "eval_id") {
+        return [{ key: evalId ?? "", value: evalId === "acc" ? 0.92 : 1.0, count: 1 }];
+      }
+      // sparkline
+      return [
+        { key: "2026-05-01T00:00:00Z", value: 0.9, count: 1 },
+        { key: "2026-05-01T01:00:00Z", value: 0.95, count: 1 },
+      ];
     });
-    // Discovery call returns sorted names: safety, tone
-    mockQueryPrometheus
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            { metric: { __name__: "omnia_eval_tone" }, value: [1000, "0.9"] },
-            { metric: { __name__: "omnia_eval_safety" }, value: [1000, "0.8"] },
-          ],
-        },
-      })
-      // Individual metric value calls (alphabetical: safety first, then tone)
-      .mockResolvedValueOnce({
-        status: "success",
-        data: { result: [{ metric: {}, value: [1000, "0.78"] }] },
-      })
-      .mockResolvedValueOnce({
-        status: "success",
-        data: { result: [{ metric: {}, value: [1000, "0.92"] }] },
-      });
 
-    const { result } = renderHook(() => useEvalMetrics(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHook(() => useEvalMetrics(), { wrapper: makeWrapper() });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toHaveLength(2);
 
-    const metrics = result.current.data!;
-    expect(metrics).toHaveLength(2);
-    expect(metrics[0]).toEqual({ name: "omnia_eval_safety", value: 0.78, metricType: "gauge", sparkline: [{ value: 0.5 }] });
-    expect(metrics[1]).toEqual({ name: "omnia_eval_tone", value: 0.92, metricType: "counter", sparkline: [{ value: 0.5 }] });
+    const byName = new Map(result.current.data!.map((m) => [m.name, m]));
+
+    expect(byName.get("acc")?.value).toBeCloseTo(0.92);
+    expect(byName.get("acc")?.metricType).toBe("gauge");
+    expect(byName.get("acc")?.sparkline).toEqual([{ value: 0.9 }, { value: 0.95 }]);
+
+    expect(byName.get("exact-match")?.value).toBeCloseTo(1.0);
+    // assertion eval_type → boolean classification
+    expect(byName.get("exact-match")?.metricType).toBe("boolean");
   });
 
-  it("returns empty array when no metrics discovered", async () => {
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: { result: [] },
-    });
+  it("returns empty list when discovery yields nothing", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDescriptors.mockResolvedValue([]);
 
-    const { result } = renderHook(() => useEvalMetrics(), {
-      wrapper: createWrapper(),
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual([]);
-  });
-
-  it("returns value 0 when Prometheus returns error for individual metric", async () => {
-    mockQueryPrometheus
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            { metric: { __name__: "omnia_eval_tone" }, value: [1000, "0.9"] },
-          ],
-        },
-      })
-      .mockResolvedValueOnce({
-        status: "error",
-        error: "bad query",
-      });
-
-    const { result } = renderHook(() => useEvalMetrics(), {
-      wrapper: createWrapper(),
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual([{ name: "omnia_eval_tone", value: 0, metricType: "gauge", sparkline: [{ value: 0.5 }] }]);
-  });
-
-  it("handles discovery failure gracefully by returning empty", async () => {
-    mockQueryPrometheus.mockRejectedValue(new Error("Network error"));
-
-    const { result } = renderHook(() => useEvalMetrics(), {
-      wrapper: createWrapper(),
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual([]);
-  });
-
-  it("returns 0 when metric value is missing from result", async () => {
-    mockQueryPrometheus
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            { metric: { __name__: "omnia_eval_tone" }, value: [1000, "0.9"] },
-          ],
-        },
-      })
-      .mockResolvedValueOnce({
-        status: "success",
-        data: { result: [] },
-      });
-
-    const { result } = renderHook(() => useEvalMetrics(), {
-      wrapper: createWrapper(),
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual([{ name: "omnia_eval_tone", value: 0, metricType: "gauge", sparkline: [{ value: 0.5 }] }]);
-  });
-
-  it("defaults to gauge when metadata fetch fails", async () => {
-    mockQueryPrometheusMetadata.mockRejectedValue(new Error("Metadata error"));
-    mockQueryPrometheus.mockRejectedValue(new Error("Network error"));
-
-    const { result } = renderHook(() => useEvalMetrics(), {
-      wrapper: createWrapper(),
-    });
-
-    // discoverEvalMetrics catches both errors and returns []
+    const { result } = renderHook(() => useEvalMetrics(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual([]);
   });

--- a/dashboard/src/hooks/use-eval-trends.ts
+++ b/dashboard/src/hooks/use-eval-trends.ts
@@ -1,9 +1,16 @@
 /**
- * Hook for fetching eval metric trends from Prometheus.
+ * Hooks for fetching eval-metric trends from session-api.
  *
- * Uses Prometheus range queries to get time-series data for eval metrics.
- * Eval metrics are dynamically named with "omnia_eval_" prefix and emitted
- * by the runtime MetricCollector.
+ * Previously read from Prometheus. Migrated to the structured read path
+ * (`/api/workspaces/{name}/eval-results/aggregate` + `.../discover`) as
+ * the pilot for the observability split — see CLAUDE.md → Observability
+ * Boundaries and
+ * `docs/local-backlog/implemented/2026-04-17-observability-split-design.md`.
+ *
+ * The exported surface (EVAL_TREND_RANGES, EvalTrendPoint, EvalMetricInfo,
+ * useEvalScoreTrends, useEvalMetrics) is unchanged so existing consumers
+ * (`components/quality/eval-score-trend-chart.tsx`,
+ * `components/quality/eval-score-breakdown.tsx`) don't need to change.
  *
  * Copyright 2026 Altaira Labs.
  * SPDX-License-Identifier: Apache-2.0
@@ -12,29 +19,39 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { useWorkspace } from "@/contexts/workspace-context";
 import {
-  queryPrometheusRange,
-  queryPrometheus,
-  type PrometheusMatrixResult,
-} from "@/lib/prometheus";
-import { EvalQueries, type EvalFilter } from "@/lib/prometheus-queries";
+  fetchEvalAggregate,
+  fetchEvalDescriptors,
+  type EvalAggregateGroupBy,
+} from "@/lib/data/eval-results-service";
 import { DEFAULT_STALE_TIME } from "@/lib/query-config";
-import { discoverEvalMetrics } from "@/lib/eval-discovery";
 import type { EvalMetricType } from "@/types/eval";
+
+/**
+ * Filter for eval queries by dimensional values. Kept structurally
+ * compatible with the previous EvalFilter from `@/lib/prometheus-queries`
+ * so existing consumers can re-use the same shape verbatim.
+ */
+export interface EvalFilter {
+  agent?: string;
+  promptpackName?: string;
+}
 
 /** Time range options for trend queries. */
 export const EVAL_TREND_RANGES = {
-  "1h": { seconds: 3600, step: "1m" },
-  "6h": { seconds: 21600, step: "5m" },
-  "24h": { seconds: 86400, step: "15m" },
-  "7d": { seconds: 604800, step: "1h" },
-  "30d": { seconds: 2592000, step: "6h" },
+  "1h": { seconds: 3600, groupBy: "time:hour" as EvalAggregateGroupBy },
+  "6h": { seconds: 21600, groupBy: "time:hour" as EvalAggregateGroupBy },
+  "24h": { seconds: 86400, groupBy: "time:hour" as EvalAggregateGroupBy },
+  "7d": { seconds: 604800, groupBy: "time:day" as EvalAggregateGroupBy },
+  "30d": { seconds: 2592000, groupBy: "time:day" as EvalAggregateGroupBy },
 } as const;
 
 export type EvalTrendRange = keyof typeof EVAL_TREND_RANGES;
 
 export interface EvalTrendPoint {
   timestamp: Date;
+  /** Eval name → metric value at this timestamp. */
   values: Record<string, number>;
 }
 
@@ -45,88 +62,121 @@ export interface EvalMetricInfo {
   sparkline?: Array<{ value: number }>;
 }
 
+/** Sparkline range — last 1h at hour-precision buckets. */
+const SPARKLINE_RANGE = { seconds: 3600, groupBy: "time:hour" as EvalAggregateGroupBy };
+
 /**
- * Fetch eval score trends from Prometheus as time-series data.
+ * Fetch eval score trends for the current workspace.
  *
- * Queries all omnia_eval_* metrics using avg_over_time for trend data.
+ * Behaviour:
+ * 1. If no metric names are provided, discover them first from session-api.
+ * 2. For each eval, fetch a time-bucketed avg_score series.
+ * 3. Merge into the EvalTrendPoint[] shape callers expect.
  */
 export function useEvalScoreTrends(params?: {
   metricNames?: string[];
   timeRange?: EvalTrendRange;
   filter?: EvalFilter;
 }) {
+  const { currentWorkspace } = useWorkspace();
+  const workspace = currentWorkspace?.name;
   const timeRange = params?.timeRange ?? "24h";
   const metricNames = params?.metricNames;
   const filter = params?.filter;
   const rangeConfig = EVAL_TREND_RANGES[timeRange];
 
   return useQuery({
-    queryKey: ["eval-trends", metricNames, timeRange, filter],
+    queryKey: ["eval-trends", workspace, metricNames, timeRange, filter],
+    enabled: Boolean(workspace),
     queryFn: async (): Promise<EvalTrendPoint[]> => {
+      if (!workspace) return [];
+
       const end = new Date();
       const start = new Date(end.getTime() - rangeConfig.seconds * 1000);
 
       let names: string[];
-      if (metricNames) {
+      if (metricNames && metricNames.length > 0) {
         names = metricNames;
       } else {
-        const discovered = await discoverEvalMetrics(filter);
-        names = discovered.map((m) => m.name);
+        const descriptors = await fetchEvalDescriptors(workspace);
+        names = descriptors.map((d) => d.evalId);
       }
       if (names.length === 0) return [];
 
-      const results = await Promise.all(
+      const seriesPerEval = await Promise.all(
         names.map(async (name) => {
-          const query = EvalQueries.metricAvgOverTime(name, rangeConfig.step, filter);
-          const resp = await queryPrometheusRange(query, start, end, rangeConfig.step);
-          return { name, data: resp };
-        })
+          const rows = await fetchEvalAggregate({
+            workspace,
+            groupBy: rangeConfig.groupBy,
+            metric: "avg_score",
+            evalId: name,
+            agentName: filter?.agent,
+            promptpackName: filter?.promptpackName,
+            from: start,
+            to: end,
+          });
+          return { name, rows };
+        }),
       );
 
-      return mergeTimeSeries(results);
+      return mergeTimeSeries(seriesPerEval);
     },
-    staleTime: 60000,
+    staleTime: 60_000,
     retry: false,
   });
 }
 
-/** Sparkline range config — last 1h at 1m resolution. */
-const SPARKLINE_RANGE = { seconds: 3600, step: "1m" };
-
 /**
- * Discover available eval metrics with current values, types, and sparkline data.
- *
- * Types come from the discovery call (metadata-resolved), not a separate fetch.
+ * Discover available eval metrics for the current workspace with current
+ * values, types, and sparkline data.
  */
 export function useEvalMetrics(filter?: EvalFilter) {
+  const { currentWorkspace } = useWorkspace();
+  const workspace = currentWorkspace?.name;
+
   return useQuery({
-    queryKey: ["eval-metrics-discovery", filter],
+    queryKey: ["eval-metrics-discovery", workspace, filter],
+    enabled: Boolean(workspace),
     queryFn: async (): Promise<EvalMetricInfo[]> => {
-      const discovered = await discoverEvalMetrics(filter);
-      if (discovered.length === 0) return [];
+      if (!workspace) return [];
+
+      const descriptors = await fetchEvalDescriptors(workspace);
+      if (descriptors.length === 0) return [];
 
       const end = new Date();
       const start = new Date(end.getTime() - SPARKLINE_RANGE.seconds * 1000);
 
       const perMetric = await Promise.all(
-        discovered.map(async (metric) => {
-          const [instant, range] = await Promise.all([
-            queryPrometheus(EvalQueries.metricValue(metric.name, filter)),
-            queryPrometheusRange(
-              EvalQueries.metricAvgOverTime(metric.name, SPARKLINE_RANGE.step, filter),
-              start, end, SPARKLINE_RANGE.step,
-            ),
+        descriptors.map(async (desc) => {
+          const [current, history] = await Promise.all([
+            // Current value: collapse to a single number via groupBy=eval_id.
+            fetchEvalAggregate({
+              workspace,
+              groupBy: "eval_id",
+              metric: "avg_score",
+              evalId: desc.evalId,
+              agentName: filter?.agent,
+              promptpackName: filter?.promptpackName,
+              from: start,
+              to: end,
+            }),
+            // Sparkline: time-bucketed series over the same window.
+            fetchEvalAggregate({
+              workspace,
+              groupBy: SPARKLINE_RANGE.groupBy,
+              metric: "avg_score",
+              evalId: desc.evalId,
+              agentName: filter?.agent,
+              promptpackName: filter?.promptpackName,
+              from: start,
+              to: end,
+            }),
           ]);
-          const value =
-            instant.status === "success" && instant.data?.result?.[0]?.value
-              ? Number.parseFloat(instant.data.result[0].value[1]) || 0
-              : 0;
-          const sparkline = extractSparkline(range);
           return {
-            name: metric.name,
-            value,
-            metricType: metric.metricType,
-            sparkline,
+            name: desc.evalId,
+            value: current[0]?.value ?? 0,
+            metricType: classifyEvalType(desc.evalType),
+            sparkline: history.map((p) => ({ value: p.value })),
           };
         }),
       );
@@ -138,40 +188,54 @@ export function useEvalMetrics(filter?: EvalFilter) {
   });
 }
 
-/** Extract sparkline points from a Prometheus range query response. */
-function extractSparkline(
-  resp: { status: string; data?: { result: PrometheusMatrixResult[] } },
-): Array<{ value: number }> {
-  if (resp.status !== "success" || !resp.data?.result?.[0]?.values) return [];
-  return resp.data.result[0].values.map(([, v]: [number, string]) => ({
-    value: Number.parseFloat(v) || 0,
-  }));
+/**
+ * Map session-api's eval_type string onto the EvalMetricType taxonomy used
+ * by the dashboard's score-breakdown widgets. The previous Prom path
+ * resolved this via metric metadata; here we infer from the eval_type label.
+ */
+function classifyEvalType(evalType: string): EvalMetricType {
+  switch (evalType) {
+    case "assertion":
+    case "regex":
+    case "json_path":
+      return "boolean";
+    default:
+      // llm_judge, llm_judge_session, and anything else surface as a
+      // continuous score (0..1 range; the chart's Y axis is [0,1]).
+      return "gauge";
+  }
 }
 
-/** Merge multiple time series into a unified array of points. */
+/**
+ * Merge per-eval time-bucket rows into one chronologically-ordered series of
+ * `{timestamp, values}` rows.
+ *
+ * Bucket keys arrive as either `YYYY-MM-DD` (day) or
+ * `YYYY-MM-DDTHH:00:00Z` (hour) — both parse with `new Date(...)`.
+ */
 function mergeTimeSeries(
-  results: { name: string; data: { status: string; data?: { result: PrometheusMatrixResult[] } } }[]
+  perEval: { name: string; rows: { key: string; value: number }[] }[],
 ): EvalTrendPoint[] {
   const timeMap = new Map<number, Record<string, number>>();
 
-  for (const { name, data } of results) {
-    if (data.status !== "success" || !data.data?.result) continue;
-
+  for (const { name, rows } of perEval) {
     const displayName = name.replace(/^omnia_eval_/, "");
-    for (const series of data.data.result) {
-      for (const [timestamp, value] of series.values ?? []) {
-        if (!timeMap.has(timestamp)) {
-          timeMap.set(timestamp, {});
-        }
-        timeMap.get(timestamp)![displayName] = Number.parseFloat(value) || 0;
+    for (const row of rows) {
+      const ts = new Date(row.key).getTime();
+      if (!Number.isFinite(ts)) continue;
+      let bucket = timeMap.get(ts);
+      if (!bucket) {
+        bucket = {};
+        timeMap.set(ts, bucket);
       }
+      bucket[displayName] = row.value;
     }
   }
 
   return Array.from(timeMap.entries())
     .sort(([a], [b]) => a - b)
-    .map(([timestamp, values]) => ({
-      timestamp: new Date(timestamp * 1000),
+    .map(([ts, values]) => ({
+      timestamp: new Date(ts),
       values,
     }));
 }

--- a/dashboard/src/lib/data/eval-results-service.test.ts
+++ b/dashboard/src/lib/data/eval-results-service.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for eval-results-service: the thin fetch wrapper used by
+ * useEvalScoreTrends / useEvalMetrics after the observability split.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchEvalAggregate, fetchEvalDescriptors } from "./eval-results-service";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("fetchEvalAggregate", () => {
+  it("builds the workspace-scoped URL with required + optional params", async () => {
+    const calls: Array<{ url: string }> = [];
+    const fakeFetch = vi.fn(async (url: string) => {
+      calls.push({ url });
+      return new Response(
+        JSON.stringify({
+          rows: [
+            { key: "2026-05-01", value: 0.9, count: 2 },
+            { key: "2026-05-02", value: 0.85, count: 3 },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+
+    const rows = await fetchEvalAggregate(
+      {
+        workspace: "test-ws",
+        groupBy: "time:day",
+        metric: "avg_score",
+        evalId: "acc",
+        agentName: "chatbot",
+        promptpackName: "v2",
+        evalType: "llm_judge",
+        from: new Date("2026-05-01T00:00:00Z"),
+        to: new Date("2026-05-02T00:00:00Z"),
+      },
+      fakeFetch as unknown as typeof fetch,
+    );
+
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toEqual({ key: "2026-05-01", value: 0.9, count: 2 });
+
+    expect(calls).toHaveLength(1);
+    const url = calls[0].url;
+    expect(url.startsWith("/api/workspaces/test-ws/eval-results/aggregate?")).toBe(true);
+    expect(url).toContain("groupBy=time%3Aday");
+    expect(url).toContain("metric=avg_score");
+    expect(url).toContain("evalId=acc");
+    expect(url).toContain("agentName=chatbot");
+    expect(url).toContain("promptpackName=v2");
+    expect(url).toContain("evalType=llm_judge");
+    expect(url).toContain("from=2026-05-01T00%3A00%3A00.000Z");
+    expect(url).toContain("to=2026-05-02T00%3A00%3A00.000Z");
+  });
+
+  it("encodes workspace names with special characters in the path", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ rows: [] }), { status: 200 }),
+    );
+
+    await fetchEvalAggregate(
+      { workspace: "ws/with-slash", groupBy: "eval_id", metric: "count" },
+      fakeFetch as unknown as typeof fetch,
+    );
+
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toContain("/api/workspaces/ws%2Fwith-slash/");
+  });
+
+  it("returns [] when the body has no rows field", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+
+    const rows = await fetchEvalAggregate(
+      { workspace: "ws", groupBy: "eval_id", metric: "count" },
+      fakeFetch as unknown as typeof fetch,
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("throws on non-2xx response", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response("nope", { status: 500, statusText: "Internal Server Error" }),
+    );
+
+    await expect(
+      fetchEvalAggregate(
+        { workspace: "ws", groupBy: "eval_id", metric: "count" },
+        fakeFetch as unknown as typeof fetch,
+      ),
+    ).rejects.toThrow(/eval-aggregate: 500/);
+  });
+
+  it("omits optional params from the query when not provided", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ rows: [] }), { status: 200 }),
+    );
+
+    await fetchEvalAggregate(
+      { workspace: "ws", groupBy: "eval_id", metric: "count" },
+      fakeFetch as unknown as typeof fetch,
+    );
+
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).not.toContain("agentName=");
+    expect(url).not.toContain("evalId=");
+    expect(url).not.toContain("from=");
+    expect(url).not.toContain("to=");
+  });
+});
+
+describe("fetchEvalDescriptors", () => {
+  it("requests the workspace-scoped discover endpoint and returns evals", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          evals: [
+            { evalId: "acc", evalType: "llm_judge" },
+            { evalId: "lat", evalType: "assertion" },
+          ],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const evals = await fetchEvalDescriptors("test-ws", fakeFetch as unknown as typeof fetch);
+
+    expect(evals).toEqual([
+      { evalId: "acc", evalType: "llm_judge" },
+      { evalId: "lat", evalType: "assertion" },
+    ]);
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toBe("/api/workspaces/test-ws/eval-results/discover");
+  });
+
+  it("returns [] when the body has no evals field", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    const evals = await fetchEvalDescriptors("ws", fakeFetch as unknown as typeof fetch);
+    expect(evals).toEqual([]);
+  });
+
+  it("throws on non-2xx response", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response("denied", { status: 403, statusText: "Forbidden" }),
+    );
+
+    await expect(
+      fetchEvalDescriptors("ws", fakeFetch as unknown as typeof fetch),
+    ).rejects.toThrow(/eval-discover: 403/);
+  });
+});

--- a/dashboard/src/lib/data/eval-results-service.ts
+++ b/dashboard/src/lib/data/eval-results-service.ts
@@ -1,0 +1,98 @@
+/**
+ * Eval-results service: structured (session-api) read path that replaces
+ * Prometheus for product-class dashboard views.
+ *
+ * See CLAUDE.md → Observability Boundaries for the operational/product split.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Valid groupBy values mirror session-api's EvalAggregateGroupBy. */
+export type EvalAggregateGroupBy =
+  | "eval_id"
+  | "eval_type"
+  | "agent"
+  | "time:hour"
+  | "time:day";
+
+/** Valid metric values mirror session-api's EvalAggregateMetric. */
+export type EvalAggregateMetric =
+  | "count"
+  | "avg_score"
+  | "p50_score"
+  | "p95_score"
+  | "avg_latency_ms"
+  | "p95_latency_ms";
+
+/** One row of an aggregate response. */
+export interface EvalAggregateRow {
+  key: string;
+  value: number;
+  count: number;
+}
+
+/** A discovered eval scenario. */
+export interface EvalDescriptor {
+  evalId: string;
+  evalType: string;
+}
+
+export interface EvalAggregateParams {
+  /** Workspace name. Pinned to `namespace` server-side. Required. */
+  workspace: string;
+  groupBy: EvalAggregateGroupBy;
+  metric: EvalAggregateMetric;
+  /** Optional filters. */
+  agentName?: string;
+  promptpackName?: string;
+  evalId?: string;
+  evalType?: string;
+  /** RFC3339 timestamps. */
+  from?: Date;
+  to?: Date;
+}
+
+/**
+ * Fetch aggregate eval metrics for a workspace.
+ * Throws on non-2xx response so React Query can surface the failure.
+ */
+export async function fetchEvalAggregate(
+  params: EvalAggregateParams,
+  fetchImpl: typeof fetch = fetch,
+): Promise<EvalAggregateRow[]> {
+  const qs = new URLSearchParams();
+  qs.set("groupBy", params.groupBy);
+  qs.set("metric", params.metric);
+  if (params.agentName) qs.set("agentName", params.agentName);
+  if (params.promptpackName) qs.set("promptpackName", params.promptpackName);
+  if (params.evalId) qs.set("evalId", params.evalId);
+  if (params.evalType) qs.set("evalType", params.evalType);
+  if (params.from) qs.set("from", params.from.toISOString());
+  if (params.to) qs.set("to", params.to.toISOString());
+
+  const url = `/api/workspaces/${encodeURIComponent(params.workspace)}/eval-results/aggregate?${qs}`;
+  const resp = await fetchImpl(url, { headers: { Accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`eval-aggregate: ${resp.status} ${resp.statusText}`);
+  }
+  const body = (await resp.json()) as { rows?: EvalAggregateRow[] };
+  return body.rows ?? [];
+}
+
+/**
+ * Fetch the set of distinct (evalId, evalType) pairs for a workspace.
+ * Replaces Prometheus' metric-name discovery for product views.
+ */
+export async function fetchEvalDescriptors(
+  workspace: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<EvalDescriptor[]> {
+  const url = `/api/workspaces/${encodeURIComponent(workspace)}/eval-results/discover`;
+  const resp = await fetchImpl(url, { headers: { Accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`eval-discover: ${resp.status} ${resp.statusText}`);
+  }
+  const body = (await resp.json()) as { evals?: EvalDescriptor[] };
+  return body.evals ?? [];
+}

--- a/hack/check-no-prom-product-deps.sh
+++ b/hack/check-no-prom-product-deps.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# check-no-prom-product-deps.sh
+#
+# Enforces the "Prometheus is for operational signals, structured tables
+# are for product data" classification from CLAUDE.md → Observability
+# Boundaries. The dashboard currently has two read paths; this lint
+# prevents *new* product-class hooks from being added against Prometheus
+# while the existing prom-coupled product hooks are migrated piecemeal.
+#
+# Product-class file patterns (any one of these flags the file):
+#   dashboard/src/hooks/use-eval-*.ts(x)
+#   dashboard/src/hooks/use-*-cost.ts(x)         (also matches use-*-costs.ts(x))
+#   dashboard/src/hooks/use-provider-*.ts(x)
+#
+# A flagged file violates the rule if it imports any of:
+#   @/lib/prometheus
+#   @/lib/prometheus-proxy
+#   @/lib/prometheus-queries
+#   @/lib/data/prometheus-service
+#
+# Operational hooks (use-stats, use-system-metrics, use-agent-activity,
+# use-agent-metrics) are intentionally NOT in the product pattern set —
+# they may keep reading Prometheus.
+#
+# Exit codes:
+#   0  no new violations
+#   1  one or more new product-class files import a Prometheus client
+#
+# Allowlist: existing violations pinned in `hack/no-prom-product-deps.allowlist`.
+# Removing a file from that list (by migrating it to a session-api endpoint)
+# requires deleting the line below — the lint will tell you to.
+#
+# Usage:
+#   bash hack/check-no-prom-product-deps.sh
+
+set -u
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$repo_root"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+allowlist_file="hack/no-prom-product-deps.allowlist"
+
+allowlist="$tmp/allowed"
+if [ -f "$allowlist_file" ]; then
+    sed -e 's/#.*//' -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' "$allowlist_file" \
+        | grep -v '^$' \
+        | LC_ALL=C sort -u >"$allowlist"
+else
+    : >"$allowlist"
+fi
+
+# Build the set of files that match a product-class pattern AND import a
+# Prometheus client. We scan everything that matches the patterns then
+# grep their imports — fewer than 20 files total, no perf concern.
+current="$tmp/current"
+: >"$current"
+
+# Patterns: hooks/use-eval-*.{ts,tsx}, use-*-cost{,s}.{ts,tsx}, use-provider-*.{ts,tsx}
+shopt -s nullglob
+candidates=(
+    dashboard/src/hooks/use-eval-*.ts
+    dashboard/src/hooks/use-eval-*.tsx
+    dashboard/src/hooks/use-*-cost.ts
+    dashboard/src/hooks/use-*-cost.tsx
+    dashboard/src/hooks/use-*-costs.ts
+    dashboard/src/hooks/use-*-costs.tsx
+    dashboard/src/hooks/use-provider-*.ts
+    dashboard/src/hooks/use-provider-*.tsx
+)
+shopt -u nullglob
+
+for f in "${candidates[@]}"; do
+    # Skip test files — they may import Prom helpers to mock them.
+    case "$f" in
+        *.test.ts|*.test.tsx) continue ;;
+    esac
+    if grep -qE 'from "@/lib/(data/)?prometheus(-proxy|-queries|-service)?"' "$f"; then
+        echo "$f" >>"$current"
+    fi
+done
+LC_ALL=C sort -o "$current" "$current"
+
+new_violations="$(comm -23 "$current" "$allowlist")"
+stale_allowlist="$(comm -13 "$current" "$allowlist")"
+
+fail=0
+if [ -n "$new_violations" ]; then
+    fail=1
+    echo "✗ new product-class hooks importing a Prometheus client (not in $allowlist_file):"
+    while IFS= read -r f; do
+        echo "  - $f"
+    done <<<"$new_violations"
+    echo ""
+    echo "Product data (eval results, cost, per-tenant usage) should read from session-api,"
+    echo "not Prometheus. See CLAUDE.md → 'Observability Boundaries' for the classification."
+    echo ""
+    echo "If you genuinely need an operational signal and the file name happens to match a"
+    echo "product pattern, rename the hook to something that doesn't match (e.g. use-eval-rate"
+    echo "→ use-eval-request-rate) or split the file."
+fi
+
+if [ -n "$stale_allowlist" ]; then
+    fail=1
+    echo "✗ stale entries in $allowlist_file (these no longer import Prom — remove them):"
+    while IFS= read -r f; do
+        echo "  - $f"
+    done <<<"$stale_allowlist"
+fi
+
+if [ $fail -eq 0 ]; then
+    current_count=$(wc -l <"$current" | tr -d '[:space:]')
+    if [ "$current_count" = "0" ]; then
+        echo "✓ no product-class hooks import Prometheus"
+    else
+        echo "✓ no new prom-product violations ($current_count pre-existing, all allowlisted)"
+    fi
+    exit 0
+fi
+
+exit 1

--- a/hack/no-prom-product-deps.allowlist
+++ b/hack/no-prom-product-deps.allowlist
@@ -1,0 +1,15 @@
+# Pre-existing product-class dashboard hooks that import a Prometheus
+# client. These are exempt from `hack/check-no-prom-product-deps.sh` so
+# the lint can land without rewriting them all in one PR.
+#
+# To remove a line: migrate the hook to read from a session-api endpoint
+# (e.g. /api/v1/eval-results/aggregate). The lint will fail with a
+# "stale allowlist entry" message until you delete the line.
+#
+# See: docs/local-backlog/implemented/2026-04-17-observability-split-design.md
+# (proposal); CLAUDE.md → Observability Boundaries (principle).
+
+dashboard/src/hooks/use-agent-cost.ts
+dashboard/src/hooks/use-eval-filter.ts
+dashboard/src/hooks/use-eval-quality.ts
+dashboard/src/hooks/use-provider-metrics.ts

--- a/hack/pre-commit
+++ b/hack/pre-commit
@@ -377,6 +377,19 @@ else
 fi
 
 #
+# 3c. Observability boundary check: no new product-class dashboard hooks
+# may import Prometheus. See CLAUDE.md → Observability Boundaries.
+#
+print_header "Checking Observability Boundaries"
+
+if "$REPO_ROOT/hack/check-no-prom-product-deps.sh" 2>&1; then
+    print_success "Observability boundary check passed"
+else
+    print_error "New product-class hook imports Prometheus"
+    CHECKS_FAILED=1
+fi
+
+#
 # 4. Build check
 #
 print_header "Building"

--- a/internal/session/api/eval_handler.go
+++ b/internal/session/api/eval_handler.go
@@ -20,10 +20,27 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/altairalabs/omnia/internal/httputil"
+)
+
+// Errors for the aggregate + discover endpoints. The handler writes 400 with
+// the textual message; the store/service wraps with a leading "postgres:" or
+// similar prefix that we strip before user-facing exposure.
+var (
+	errAggregateBadGroupBy = errors.New(
+		"groupBy must be one of: eval_id, eval_type, agent, time:hour, time:day")
+	errAggregateBadMetric = errors.New(
+		"metric must be one of: count, avg_score, p50_score, p95_score, avg_latency_ms, p95_latency_ms")
+	errAggregateBadFrom = errors.New(
+		"from must be RFC3339 (e.g. 2026-04-01T00:00:00Z)")
+	errAggregateBadTo = errors.New(
+		"to must be RFC3339 (e.g. 2026-04-01T00:00:00Z)")
+	errAggregateMissingNamespace = errors.New("namespace query param is required")
 )
 
 // handleGetSessionEvalResults returns eval results for a specific session.
@@ -176,6 +193,185 @@ func parseSummaryOpts(r *http.Request) EvalResultSummaryOpts {
 		AgentName: q.Get("agentName"),
 		Namespace: q.Get("namespace"),
 		EvalType:  q.Get("evalType"),
+	}
+}
+
+// EvalAggregateResponse is the JSON body for /api/v1/eval-results/aggregate.
+type EvalAggregateResponse struct {
+	Rows []*EvalAggregateRow `json:"rows"`
+}
+
+// EvalDiscoverResponse is the JSON body for /api/v1/eval-results/discover.
+type EvalDiscoverResponse struct {
+	Evals []EvalDescriptor `json:"evals"`
+}
+
+// handleAggregateEvalResults runs a namespace-scoped GROUP BY over eval_results.
+// GET /api/v1/eval-results/aggregate?namespace=X&groupBy=time:day&metric=avg_score
+func (h *Handler) handleAggregateEvalResults(w http.ResponseWriter, r *http.Request) {
+	if h.evalService == nil {
+		writeEvalError(w, ErrMissingEvalStore)
+		return
+	}
+
+	opts, err := parseEvalAggregateOpts(r)
+	if err != nil {
+		writeAggregateError(w, err)
+		return
+	}
+
+	rows, err := h.evalService.AggregateEvalResults(r.Context(), opts)
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+	if rows == nil {
+		rows = []*EvalAggregateRow{}
+	}
+
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	_ = json.NewEncoder(w).Encode(EvalAggregateResponse{Rows: rows})
+}
+
+// handleDiscoverEvals returns the set of (eval_id, eval_type) pairs that
+// exist for a namespace. Replaces dashboard Prometheus metric-name discovery.
+// GET /api/v1/eval-results/discover?namespace=X
+func (h *Handler) handleDiscoverEvals(w http.ResponseWriter, r *http.Request) {
+	if h.evalService == nil {
+		writeEvalError(w, ErrMissingEvalStore)
+		return
+	}
+
+	namespace := r.URL.Query().Get("namespace")
+	if namespace == "" {
+		writeAggregateError(w, errAggregateMissingNamespace)
+		return
+	}
+
+	evals, err := h.evalService.DistinctEvals(r.Context(), namespace)
+	if err != nil {
+		writeEvalError(w, err)
+		return
+	}
+	if evals == nil {
+		evals = []EvalDescriptor{}
+	}
+
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	_ = json.NewEncoder(w).Encode(EvalDiscoverResponse{Evals: evals})
+}
+
+// parseEvalAggregateOpts extracts EvalAggregateOpts from the request query.
+// Returns one of the err* sentinels above for client-facing 400s.
+func parseEvalAggregateOpts(r *http.Request) (EvalAggregateOpts, error) {
+	q := r.URL.Query()
+
+	namespace := q.Get("namespace")
+	if namespace == "" {
+		return EvalAggregateOpts{}, errAggregateMissingNamespace
+	}
+
+	groupBy, err := parseEvalGroupBy(q.Get("groupBy"))
+	if err != nil {
+		return EvalAggregateOpts{}, err
+	}
+
+	metric, err := parseEvalMetric(q.Get("metric"))
+	if err != nil {
+		return EvalAggregateOpts{}, err
+	}
+
+	opts := EvalAggregateOpts{
+		Namespace:      namespace,
+		AgentName:      q.Get("agentName"),
+		PromptPackName: q.Get("promptpackName"),
+		EvalID:         q.Get("evalId"),
+		EvalType:       q.Get("evalType"),
+		GroupBy:        groupBy,
+		Metric:         metric,
+		Limit:          clampEvalAggregateLimit(parseIntQueryParam(q.Get("limit"), DefaultEvalAggregateLimit)),
+	}
+
+	if v := q.Get("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return EvalAggregateOpts{}, errAggregateBadFrom
+		}
+		opts.From = t
+	}
+	if v := q.Get("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			return EvalAggregateOpts{}, errAggregateBadTo
+		}
+		opts.To = t
+	}
+
+	return opts, nil
+}
+
+func parseEvalGroupBy(v string) (EvalAggregateGroupBy, error) {
+	switch EvalAggregateGroupBy(v) {
+	case EvalAggregateGroupByEvalID,
+		EvalAggregateGroupByEvalType,
+		EvalAggregateGroupByAgent,
+		EvalAggregateGroupByTimeHour,
+		EvalAggregateGroupByTimeDay:
+		return EvalAggregateGroupBy(v), nil
+	default:
+		return "", errAggregateBadGroupBy
+	}
+}
+
+func parseEvalMetric(v string) (EvalAggregateMetric, error) {
+	switch EvalAggregateMetric(v) {
+	case EvalAggregateMetricCount,
+		EvalAggregateMetricAvgScore,
+		EvalAggregateMetricP50Score,
+		EvalAggregateMetricP95Score,
+		EvalAggregateMetricAvgLatencyMs,
+		EvalAggregateMetricP95LatencyMs:
+		return EvalAggregateMetric(v), nil
+	default:
+		return "", errAggregateBadMetric
+	}
+}
+
+func clampEvalAggregateLimit(n int) int {
+	if n < 1 {
+		return DefaultEvalAggregateLimit
+	}
+	if n > MaxEvalAggregateLimit {
+		return MaxEvalAggregateLimit
+	}
+	return n
+}
+
+func parseIntQueryParam(v string, fallback int) int {
+	if v == "" {
+		return fallback
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return fallback
+	}
+	return n
+}
+
+// writeAggregateError emits a 400 with the textual message for the err*
+// sentinels above. Any other error falls through to writeError.
+func writeAggregateError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, errAggregateBadGroupBy),
+		errors.Is(err, errAggregateBadMetric),
+		errors.Is(err, errAggregateBadFrom),
+		errors.Is(err, errAggregateBadTo),
+		errors.Is(err, errAggregateMissingNamespace):
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+		w.WriteHeader(http.StatusBadRequest)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: err.Error()})
+	default:
+		writeError(w, err)
 	}
 }
 

--- a/internal/session/api/eval_handler_test.go
+++ b/internal/session/api/eval_handler_test.go
@@ -308,3 +308,161 @@ func TestHandleEvaluateSession_NoService(t *testing.T) {
 
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
+
+// --- /api/v1/eval-results/aggregate ---------------------------------------
+
+func TestHandleAggregateEvalResults_Success(t *testing.T) {
+	store := &mockEvalStore{
+		aggregateResults: []*EvalAggregateRow{
+			{Key: "2026-05-01", Value: 0.85, Count: 2},
+			{Key: "2026-05-02", Value: 0.80, Count: 2},
+		},
+	}
+	mux := newTestEvalHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/eval-results/aggregate?namespace=default&groupBy=time:day&metric=avg_score", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp EvalAggregateResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Rows, 2)
+	assert.Equal(t, "2026-05-01", resp.Rows[0].Key)
+	assert.InDelta(t, 0.85, resp.Rows[0].Value, 0.001)
+}
+
+func TestHandleAggregateEvalResults_MissingNamespace(t *testing.T) {
+	mux := newTestEvalHandler(&mockEvalStore{})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/eval-results/aggregate?groupBy=time:day&metric=avg_score", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "namespace")
+}
+
+func TestHandleAggregateEvalResults_InvalidGroupBy(t *testing.T) {
+	mux := newTestEvalHandler(&mockEvalStore{})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/eval-results/aggregate?namespace=default&groupBy=invalid&metric=count", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "groupBy")
+}
+
+func TestHandleAggregateEvalResults_InvalidMetric(t *testing.T) {
+	mux := newTestEvalHandler(&mockEvalStore{})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/eval-results/aggregate?namespace=default&groupBy=time:day&metric=invalid", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "metric")
+}
+
+func TestHandleAggregateEvalResults_InvalidFrom(t *testing.T) {
+	mux := newTestEvalHandler(&mockEvalStore{})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/eval-results/aggregate?namespace=default&groupBy=time:day&metric=count&from=yesterday", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "from")
+}
+
+func TestHandleAggregateEvalResults_NoEvalService(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/eval-results/aggregate?namespace=default&groupBy=time:day&metric=count", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleAggregateEvalResults_NilRowsReturnsEmptyArray(t *testing.T) {
+	// Store returns nil; handler should normalize to [] so the dashboard
+	// doesn't need to special-case null.
+	mux := newTestEvalHandler(&mockEvalStore{aggregateResults: nil})
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/eval-results/aggregate?namespace=default&groupBy=time:day&metric=count", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"rows":[]`)
+}
+
+// --- /api/v1/eval-results/discover ----------------------------------------
+
+func TestHandleDiscoverEvals_Success(t *testing.T) {
+	store := &mockEvalStore{
+		distinctEvals: []EvalDescriptor{
+			{EvalID: "acc", EvalType: "llm_judge"},
+			{EvalID: "lat", EvalType: "assertion"},
+		},
+	}
+	mux := newTestEvalHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/eval-results/discover?namespace=default", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp EvalDiscoverResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Evals, 2)
+	assert.Equal(t, "acc", resp.Evals[0].EvalID)
+	assert.Equal(t, "llm_judge", resp.Evals[0].EvalType)
+}
+
+func TestHandleDiscoverEvals_MissingNamespace(t *testing.T) {
+	mux := newTestEvalHandler(&mockEvalStore{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/eval-results/discover", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "namespace")
+}
+
+func TestHandleDiscoverEvals_NoEvalService(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/eval-results/discover?namespace=default", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleDiscoverEvals_NilReturnsEmptyArray(t *testing.T) {
+	mux := newTestEvalHandler(&mockEvalStore{distinctEvals: nil})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/eval-results/discover?namespace=default", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"evals":[]`)
+}

--- a/internal/session/api/eval_service.go
+++ b/internal/session/api/eval_service.go
@@ -133,6 +133,25 @@ func (s *EvalService) ListEvalResults(ctx context.Context, opts EvalResultListOp
 	return s.store.ListEvalResults(ctx, opts)
 }
 
+// AggregateEvalResults runs a GROUP BY over eval_results scoped to opts.Namespace.
+// Powers GET /api/v1/eval-results/aggregate.
+func (s *EvalService) AggregateEvalResults(ctx context.Context, opts EvalAggregateOpts) ([]*EvalAggregateRow, error) {
+	if s.store == nil {
+		return nil, ErrMissingEvalStore
+	}
+	return s.store.AggregateEvalResults(ctx, opts)
+}
+
+// DistinctEvals returns (eval_id, eval_type) pairs for a namespace. Powers
+// GET /api/v1/eval-results/discover so dashboard can list available evals
+// without going through Prometheus metric metadata.
+func (s *EvalService) DistinctEvals(ctx context.Context, namespace string) ([]EvalDescriptor, error) {
+	if s.store == nil {
+		return nil, ErrMissingEvalStore
+	}
+	return s.store.DistinctEvals(ctx, namespace)
+}
+
 // GetEvalResultSummary returns aggregate statistics for eval results.
 func (s *EvalService) GetEvalResultSummary(ctx context.Context, opts EvalResultSummaryOpts) ([]*EvalResultSummary, error) {
 	if s.store == nil {

--- a/internal/session/api/eval_service_test.go
+++ b/internal/session/api/eval_service_test.go
@@ -30,14 +30,18 @@ import (
 
 // mockEvalStore is a test double for EvalStore.
 type mockEvalStore struct {
-	insertErr      error
-	getResults     []*EvalResult
-	getErr         error
-	listResults    []*EvalResult
-	listTotal      int64
-	listErr        error
-	summaryResults []*EvalResultSummary
-	summaryErr     error
+	insertErr        error
+	getResults       []*EvalResult
+	getErr           error
+	listResults      []*EvalResult
+	listTotal        int64
+	listErr          error
+	summaryResults   []*EvalResultSummary
+	summaryErr       error
+	aggregateResults []*EvalAggregateRow
+	aggregateErr     error
+	distinctEvals    []EvalDescriptor
+	distinctEvalsErr error
 }
 
 func (m *mockEvalStore) InsertEvalResults(_ context.Context, _ []*EvalResult) error {
@@ -54,6 +58,14 @@ func (m *mockEvalStore) ListEvalResults(_ context.Context, _ EvalResultListOpts)
 
 func (m *mockEvalStore) GetEvalResultSummary(_ context.Context, _ EvalResultSummaryOpts) ([]*EvalResultSummary, error) {
 	return m.summaryResults, m.summaryErr
+}
+
+func (m *mockEvalStore) AggregateEvalResults(_ context.Context, _ EvalAggregateOpts) ([]*EvalAggregateRow, error) {
+	return m.aggregateResults, m.aggregateErr
+}
+
+func (m *mockEvalStore) DistinctEvals(_ context.Context, _ string) ([]EvalDescriptor, error) {
+	return m.distinctEvals, m.distinctEvalsErr
 }
 
 func TestNewEvalService(t *testing.T) {

--- a/internal/session/api/eval_store.go
+++ b/internal/session/api/eval_store.go
@@ -86,6 +86,73 @@ type EvalResultSummaryOpts struct {
 	CreatedBefore time.Time
 }
 
+// EvalAggregateGroupBy enumerates valid groupBy values for AggregateEvalResults.
+// The "time:*" forms bucket created_at via date_trunc.
+type EvalAggregateGroupBy string
+
+const (
+	// EvalAggregateGroupByEvalID groups by the eval_id column (one row per
+	// eval scenario). The shape that replaces today's Prom-per-metric-name fanout.
+	EvalAggregateGroupByEvalID EvalAggregateGroupBy = "eval_id"
+	// EvalAggregateGroupByEvalType groups by the eval_type column (llm_judge,
+	// assertion, etc.).
+	EvalAggregateGroupByEvalType EvalAggregateGroupBy = "eval_type"
+	// EvalAggregateGroupByAgent groups by the agent_name column.
+	EvalAggregateGroupByAgent EvalAggregateGroupBy = "agent"
+	// EvalAggregateGroupByTimeHour buckets created_at by hour (UTC),
+	// formatted as RFC3339 hour-precision strings.
+	EvalAggregateGroupByTimeHour EvalAggregateGroupBy = "time:hour"
+	// EvalAggregateGroupByTimeDay buckets created_at by day (UTC),
+	// formatted as YYYY-MM-DD strings.
+	EvalAggregateGroupByTimeDay EvalAggregateGroupBy = "time:day"
+)
+
+// EvalAggregateMetric enumerates valid metric values for AggregateEvalResults.
+// Percentiles use Postgres' percentile_cont (continuous interpolation).
+type EvalAggregateMetric string
+
+const (
+	EvalAggregateMetricCount        EvalAggregateMetric = "count"
+	EvalAggregateMetricAvgScore     EvalAggregateMetric = "avg_score"
+	EvalAggregateMetricP50Score     EvalAggregateMetric = "p50_score"
+	EvalAggregateMetricP95Score     EvalAggregateMetric = "p95_score"
+	EvalAggregateMetricAvgLatencyMs EvalAggregateMetric = "avg_latency_ms"
+	EvalAggregateMetricP95LatencyMs EvalAggregateMetric = "p95_latency_ms"
+)
+
+// EvalAggregateLimit clamps the maximum number of returned rows. The default
+// is large enough to fit a day-bucket trend over 90 days (90 keys) without
+// pagination, and the max keeps a malformed query from sweeping the table.
+const (
+	DefaultEvalAggregateLimit = 500
+	MaxEvalAggregateLimit     = 5000
+)
+
+// EvalAggregateRow is one returned row from AggregateEvalResults. Key is the
+// stringified group value (eval_id, time bucket, etc.); Value is the metric;
+// Count is the number of source rows that contributed.
+type EvalAggregateRow struct {
+	Key   string  `json:"key"`
+	Value float64 `json:"value"`
+	Count int64   `json:"count"`
+}
+
+// EvalAggregateOpts configures the AggregateEvalResults query.
+// Namespace is the scoping field (mirrors the workspace_id role on memory_entities).
+// GroupBy and Metric are required; all other fields are optional filters.
+type EvalAggregateOpts struct {
+	Namespace      string // required
+	AgentName      string // optional
+	PromptPackName string // optional
+	EvalID         string // optional
+	EvalType       string // optional
+	From           time.Time
+	To             time.Time
+	GroupBy        EvalAggregateGroupBy // required
+	Metric         EvalAggregateMetric  // required
+	Limit          int
+}
+
 // EvalStore defines the persistence interface for eval results.
 type EvalStore interface {
 	// InsertEvalResults persists one or more eval results.
@@ -99,4 +166,21 @@ type EvalStore interface {
 
 	// GetEvalResultSummary returns aggregate statistics grouped by eval_id and eval_type.
 	GetEvalResultSummary(ctx context.Context, opts EvalResultSummaryOpts) ([]*EvalResultSummary, error)
+
+	// AggregateEvalResults runs a namespace-scoped GROUP BY over eval_results.
+	// Used by /api/v1/eval-results/aggregate to power product views without
+	// Prometheus. See docs/local-backlog/implemented/2026-04-17-observability-split-design.md
+	// for the design rationale.
+	AggregateEvalResults(ctx context.Context, opts EvalAggregateOpts) ([]*EvalAggregateRow, error)
+
+	// DistinctEvals returns the set of (eval_id, eval_type) pairs that appear
+	// in eval_results for the given namespace. Used by the dashboard's
+	// eval-metric discovery, replacing the Prometheus /api/v1/metadata path.
+	DistinctEvals(ctx context.Context, namespace string) ([]EvalDescriptor, error)
+}
+
+// EvalDescriptor is one (eval_id, eval_type) pair returned by DistinctEvals.
+type EvalDescriptor struct {
+	EvalID   string `json:"evalId"`
+	EvalType string `json:"evalType"`
 }

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -241,6 +241,10 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/v1/sessions/{sessionID}/evaluate", h.handleEvaluateSession)
 	mux.HandleFunc("POST /api/v1/eval-results", h.handleCreateEvalResults)
 	mux.HandleFunc("GET /api/v1/eval-results", h.handleListEvalResults)
+	// Aggregate + discover: powers product dashboard views without Prometheus.
+	// See CLAUDE.md → Observability Boundaries.
+	mux.HandleFunc("GET /api/v1/eval-results/aggregate", h.handleAggregateEvalResults)
+	mux.HandleFunc("GET /api/v1/eval-results/discover", h.handleDiscoverEvals)
 
 	// Privacy policy endpoint
 	mux.HandleFunc("GET /api/v1/privacy-policy", h.handleGetPrivacyPolicy)

--- a/internal/session/providers/postgres/eval_store.go
+++ b/internal/session/providers/postgres/eval_store.go
@@ -171,6 +171,165 @@ func (s *EvalStoreImpl) GetEvalResultSummary(ctx context.Context, opts api.EvalR
 	return summaries, nil
 }
 
+// AggregateEvalResults runs a namespace-scoped GROUP BY over eval_results.
+// Powers /api/v1/eval-results/aggregate so product views can read trends and
+// percentiles without going through Prometheus. See
+// docs/local-backlog/implemented/2026-04-17-observability-split-design.md.
+func (s *EvalStoreImpl) AggregateEvalResults(ctx context.Context, opts api.EvalAggregateOpts) ([]*api.EvalAggregateRow, error) {
+	if opts.Namespace == "" {
+		return nil, fmt.Errorf("postgres: aggregate eval results: namespace is required")
+	}
+
+	keyExpr, orderClause, err := evalGroupByFragments(opts.GroupBy)
+	if err != nil {
+		return nil, err
+	}
+	valueExpr, err := evalMetricExpression(opts.Metric)
+	if err != nil {
+		return nil, err
+	}
+
+	limit := opts.Limit
+	if limit <= 0 {
+		limit = api.DefaultEvalAggregateLimit
+	}
+	if limit > api.MaxEvalAggregateLimit {
+		limit = api.MaxEvalAggregateLimit
+	}
+
+	qb := &pgutil.QueryBuilder{}
+	qb.Add("namespace=$?", opts.Namespace)
+	if opts.AgentName != "" {
+		qb.Add("agent_name=$?", opts.AgentName)
+	}
+	if opts.PromptPackName != "" {
+		qb.Add("promptpack_name=$?", opts.PromptPackName)
+	}
+	if opts.EvalID != "" {
+		qb.Add("eval_id=$?", opts.EvalID)
+	}
+	if opts.EvalType != "" {
+		qb.Add("eval_type=$?", opts.EvalType)
+	}
+	if !opts.From.IsZero() {
+		qb.Add("created_at>=$?", opts.From)
+	}
+	if !opts.To.IsZero() {
+		qb.Add("created_at<$?", opts.To)
+	}
+
+	query := fmt.Sprintf(`
+		SELECT %s AS key, %s AS value, COUNT(*) AS count
+		FROM eval_results
+		WHERE 1=1%s
+		GROUP BY 1
+		%s
+		LIMIT %d`,
+		keyExpr, valueExpr, qb.Where(), orderClause, limit)
+
+	rows, err := s.pool.Query(ctx, query, qb.Args()...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: aggregate eval results: %w", err)
+	}
+	defer rows.Close()
+
+	out := []*api.EvalAggregateRow{}
+	for rows.Next() {
+		var r api.EvalAggregateRow
+		var v *float64
+		if err := rows.Scan(&r.Key, &v, &r.Count); err != nil {
+			return nil, fmt.Errorf("postgres: scan eval aggregate row: %w", err)
+		}
+		// avg/percentile over an empty group is NULL; emit 0.0 so callers
+		// don't special-case missing values for buckets with only NULL scores.
+		if v != nil {
+			r.Value = *v
+		}
+		out = append(out, &r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate eval aggregate rows: %w", err)
+	}
+	return out, nil
+}
+
+// evalGroupByFragments returns the SQL key expression and ORDER BY clause
+// for a given EvalAggregateGroupBy. Time buckets sort ASC (for chronological
+// charts); categorical groups sort DESC by value (largest first).
+func evalGroupByFragments(g api.EvalAggregateGroupBy) (keyExpr, orderClause string, err error) {
+	switch g {
+	case api.EvalAggregateGroupByEvalID:
+		return "eval_id", "ORDER BY value DESC", nil
+	case api.EvalAggregateGroupByEvalType:
+		return "eval_type", "ORDER BY value DESC", nil
+	case api.EvalAggregateGroupByAgent:
+		return "agent_name", "ORDER BY value DESC", nil
+	case api.EvalAggregateGroupByTimeHour:
+		return "to_char(date_trunc('hour', created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:00:00\"Z\"')",
+			"ORDER BY 1 ASC", nil
+	case api.EvalAggregateGroupByTimeDay:
+		return "to_char(date_trunc('day', created_at)::date, 'YYYY-MM-DD')",
+			"ORDER BY 1 ASC", nil
+	default:
+		return "", "", fmt.Errorf("postgres: invalid groupBy %q", g)
+	}
+}
+
+// evalMetricExpression returns the SQL value expression for a given metric.
+// Percentiles use percentile_cont (continuous interpolation, standard PG).
+// Score metrics filter out NULL scores so percentile calculations don't
+// degrade — assertion-type evals have NULL score by design.
+func evalMetricExpression(m api.EvalAggregateMetric) (string, error) {
+	switch m {
+	case api.EvalAggregateMetricCount:
+		return "COUNT(*)::float", nil
+	case api.EvalAggregateMetricAvgScore:
+		return "AVG(score) FILTER (WHERE score IS NOT NULL)", nil
+	case api.EvalAggregateMetricP50Score:
+		return "percentile_cont(0.5) WITHIN GROUP (ORDER BY score) FILTER (WHERE score IS NOT NULL)", nil
+	case api.EvalAggregateMetricP95Score:
+		return "percentile_cont(0.95) WITHIN GROUP (ORDER BY score) FILTER (WHERE score IS NOT NULL)", nil
+	case api.EvalAggregateMetricAvgLatencyMs:
+		return "AVG(duration_ms) FILTER (WHERE duration_ms IS NOT NULL)", nil
+	case api.EvalAggregateMetricP95LatencyMs:
+		return "percentile_cont(0.95) WITHIN GROUP (ORDER BY duration_ms) FILTER (WHERE duration_ms IS NOT NULL)", nil
+	default:
+		return "", fmt.Errorf("postgres: invalid metric %q", m)
+	}
+}
+
+// DistinctEvals returns the set of (eval_id, eval_type) pairs that have at
+// least one row in eval_results for the given namespace. Replaces Prometheus'
+// metric-discovery for dashboard product views.
+func (s *EvalStoreImpl) DistinctEvals(ctx context.Context, namespace string) ([]api.EvalDescriptor, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("postgres: distinct evals: namespace is required")
+	}
+
+	rows, err := s.pool.Query(ctx, `
+		SELECT DISTINCT eval_id, eval_type
+		FROM eval_results
+		WHERE namespace = $1
+		ORDER BY eval_id`, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: distinct evals: %w", err)
+	}
+	defer rows.Close()
+
+	out := []api.EvalDescriptor{}
+	for rows.Next() {
+		var d api.EvalDescriptor
+		if err := rows.Scan(&d.EvalID, &d.EvalType); err != nil {
+			return nil, fmt.Errorf("postgres: scan distinct eval: %w", err)
+		}
+		out = append(out, d)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate distinct evals: %w", err)
+	}
+	return out, nil
+}
+
 // --- helpers ----------------------------------------------------------------
 
 func applyEvalFilters(qb *pgutil.QueryBuilder, opts api.EvalResultListOpts) {

--- a/internal/session/providers/postgres/eval_store_test.go
+++ b/internal/session/providers/postgres/eval_store_test.go
@@ -713,3 +713,299 @@ func TestApplySummaryFilters_Empty(t *testing.T) {
 	assert.Empty(t, qb.Args())
 	assert.Empty(t, qb.Where())
 }
+
+// --- AggregateEvalResults ---------------------------------------------------
+
+// Fixture constants for the aggregate test set. Extracted to satisfy goconst.
+const (
+	aggregateEvalIDAcc = "acc"
+	aggregateEvalIDLat = "lat"
+	aggregateAgentA    = "agent-a"
+	aggregateAgentB    = "agent-b"
+)
+
+// seedAggregateRows populates eval_results with a fixed shape used by every
+// aggregate test below — two evals (acc + lat) across two days and two
+// agents. created_at is set explicitly so time-bucket tests are stable.
+// Always seeds against testSessionID; the constant is internal to avoid a
+// dead parameter (unparam).
+func seedAggregateRows(t *testing.T, store *EvalStoreImpl) {
+	t.Helper()
+	ctx := context.Background()
+	sessionID := testSessionID
+	seedSession(t, store, sessionID)
+
+	day1 := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+
+	type row struct {
+		evalID    string
+		evalType  string
+		agentName string
+		passed    bool
+		score     float64
+		duration  int
+		createdAt time.Time
+	}
+	rows := []row{
+		{aggregateEvalIDAcc, "llm_judge", aggregateAgentA, true, 0.90, 100, day1},
+		{aggregateEvalIDAcc, "llm_judge", aggregateAgentA, true, 0.80, 120, day1},
+		{aggregateEvalIDAcc, "llm_judge", aggregateAgentA, true, 1.00, 90, day2},
+		{aggregateEvalIDAcc, "llm_judge", aggregateAgentB, true, 0.60, 200, day2},
+		{aggregateEvalIDLat, "assertion", aggregateAgentA, false, 0.10, 500, day2},
+	}
+	for _, r := range rows {
+		er := makeEvalResult(sessionID, r.evalID, r.evalType)
+		er.AgentName = r.agentName
+		er.Passed = r.passed
+		er.Score = ptrFloat64(r.score)
+		er.DurationMs = ptrInt(r.duration)
+		require.NoError(t, store.InsertEvalResults(ctx, []*api.EvalResult{er}))
+	}
+
+	// InsertEvalResults uses now() for created_at; rewrite to the test
+	// timestamps in a single UPDATE keyed by score (unique in the fixture).
+	for _, r := range rows {
+		_, err := store.pool.Exec(ctx, `
+			UPDATE eval_results SET created_at = $1
+			WHERE session_id = $2 AND eval_id = $3 AND score = $4 AND agent_name = $5`,
+			r.createdAt, sessionID, r.evalID, r.score, r.agentName,
+		)
+		require.NoError(t, err)
+	}
+}
+
+func TestAggregateEvalResults_GroupByEvalID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	rows, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		GroupBy:   api.EvalAggregateGroupByEvalID,
+		Metric:    api.EvalAggregateMetricCount,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	byKey := map[string]*api.EvalAggregateRow{}
+	for _, r := range rows {
+		byKey[r.Key] = r
+	}
+	require.NotNil(t, byKey["acc"])
+	require.NotNil(t, byKey["lat"])
+	assert.InDelta(t, 4, byKey["acc"].Value, 0.001)
+	assert.Equal(t, int64(4), byKey["acc"].Count)
+	assert.InDelta(t, 1, byKey["lat"].Value, 0.001)
+	assert.Equal(t, int64(1), byKey["lat"].Count)
+}
+
+func TestAggregateEvalResults_TimeDayAvgScore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	rows, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		EvalID:    "acc",
+		GroupBy:   api.EvalAggregateGroupByTimeDay,
+		Metric:    api.EvalAggregateMetricAvgScore,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	// Day 1: (0.90 + 0.80) / 2 = 0.85
+	// Day 2: (1.00 + 0.60) / 2 = 0.80
+	assert.Equal(t, "2026-05-01", rows[0].Key)
+	assert.InDelta(t, 0.85, rows[0].Value, 0.001)
+	assert.Equal(t, int64(2), rows[0].Count)
+	assert.Equal(t, "2026-05-02", rows[1].Key)
+	assert.InDelta(t, 0.80, rows[1].Value, 0.001)
+	assert.Equal(t, int64(2), rows[1].Count)
+}
+
+func TestAggregateEvalResults_P95Score(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	rows, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		EvalID:    "acc",
+		GroupBy:   api.EvalAggregateGroupByEvalID,
+		Metric:    api.EvalAggregateMetricP95Score,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	// scores for acc: [0.60, 0.80, 0.90, 1.00] sorted; p95 by interpolation
+	// is between 0.90 and 1.00. Just confirm it's in the right band.
+	assert.GreaterOrEqual(t, rows[0].Value, 0.90)
+	assert.LessOrEqual(t, rows[0].Value, 1.00)
+	assert.Equal(t, int64(4), rows[0].Count)
+}
+
+func TestAggregateEvalResults_GroupByAgent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	rows, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		EvalID:    "acc",
+		GroupBy:   api.EvalAggregateGroupByAgent,
+		Metric:    api.EvalAggregateMetricCount,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 2)
+	byKey := map[string]int64{}
+	for _, r := range rows {
+		byKey[r.Key] = r.Count
+	}
+	assert.Equal(t, int64(3), byKey[aggregateAgentA])
+	assert.Equal(t, int64(1), byKey[aggregateAgentB])
+}
+
+func TestAggregateEvalResults_FilterByEvalType(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	rows, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		EvalType:  "assertion",
+		GroupBy:   api.EvalAggregateGroupByEvalID,
+		Metric:    api.EvalAggregateMetricCount,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "lat", rows[0].Key)
+}
+
+func TestAggregateEvalResults_FilterTimeRange(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	// Only day 1 — should drop the day-2 rows.
+	day1Start := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	day1End := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+
+	rows, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		From:      day1Start,
+		To:        day1End,
+		GroupBy:   api.EvalAggregateGroupByEvalID,
+		Metric:    api.EvalAggregateMetricCount,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 1)
+	assert.Equal(t, "acc", rows[0].Key)
+	assert.Equal(t, int64(2), rows[0].Count)
+}
+
+func TestAggregateEvalResults_NamespaceIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	rows, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "other-namespace",
+		GroupBy:   api.EvalAggregateGroupByEvalID,
+		Metric:    api.EvalAggregateMetricCount,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestAggregateEvalResults_MissingNamespace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	_, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		GroupBy: api.EvalAggregateGroupByEvalID,
+		Metric:  api.EvalAggregateMetricCount,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "namespace is required")
+}
+
+func TestAggregateEvalResults_InvalidGroupBy(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	_, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		GroupBy:   "not-a-groupby",
+		Metric:    api.EvalAggregateMetricCount,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid groupBy")
+}
+
+func TestAggregateEvalResults_InvalidMetric(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	_, err := store.AggregateEvalResults(context.Background(), api.EvalAggregateOpts{
+		Namespace: "default",
+		GroupBy:   api.EvalAggregateGroupByEvalID,
+		Metric:    "not-a-metric",
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid metric")
+}
+
+// --- DistinctEvals ----------------------------------------------------------
+
+func TestDistinctEvals(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	descs, err := store.DistinctEvals(context.Background(), "default")
+	require.NoError(t, err)
+	require.Len(t, descs, 2)
+	// Sorted by eval_id ascending.
+	assert.Equal(t, "acc", descs[0].EvalID)
+	assert.Equal(t, "llm_judge", descs[0].EvalType)
+	assert.Equal(t, "lat", descs[1].EvalID)
+	assert.Equal(t, "assertion", descs[1].EvalType)
+}
+
+func TestDistinctEvals_NamespaceIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	seedAggregateRows(t, store)
+
+	descs, err := store.DistinctEvals(context.Background(), "other-namespace")
+	require.NoError(t, err)
+	assert.Empty(t, descs)
+}
+
+func TestDistinctEvals_MissingNamespace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	_, err := store.DistinctEvals(context.Background(), "")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Pilots the operational/product observability split from `docs/local-backlog/implemented/2026-04-17-observability-split-design.md` — design dated 2026-04-17, refreshed and moved to `implemented/` as part of this PR.

**Principle (now in CLAUDE.md → Observability Boundaries):**
- **Operational signals** (rates, latencies, system health, control-plane PromQL, scrape-style time series) stay on Prometheus.
- **Product data** (eval results, cost, per-tenant usage) reads from session-api structured tables. Product hooks must work when Prometheus is offline.

**Pilot scope:** one hook (`use-eval-trends`), two new endpoints to fully replace its Prom path, plus the guardrail to prevent future drift.

## What's in this PR

**New session-api endpoints**
- `GET /api/v1/eval-results/aggregate?namespace=X&groupBy=Y&metric=Z`
  - `groupBy` ∈ {`eval_id`, `eval_type`, `agent`, `time:hour`, `time:day`}
  - `metric` ∈ {`count`, `avg_score`, `p50_score`, `p95_score`, `avg_latency_ms`, `p95_latency_ms`}
  - Optional filters: `agentName`, `promptpackName`, `evalId`, `evalType`, `from`, `to` (RFC3339)
  - Percentiles via Postgres `percentile_cont` (standard, no extension)
- `GET /api/v1/eval-results/discover?namespace=X` — distinct `(eval_id, eval_type)` pairs; replaces dashboard discovery via Prometheus `/api/v1/metadata`

**Dashboard proxy routes** (pin `namespace=workspace-name` so callers can't read another workspace's data)
- `/api/workspaces/{name}/eval-results/aggregate`
- `/api/workspaces/{name}/eval-results/discover`

**Hook migration**
- `dashboard/src/hooks/use-eval-trends.ts` rewritten to call the new endpoints via a new `dashboard/src/lib/data/eval-results-service.ts` client. Public surface (`EVAL_TREND_RANGES`, `EvalTrendPoint`, `EvalMetricInfo`, `useEvalScoreTrends`, `useEvalMetrics`) unchanged so `eval-score-trend-chart` and `eval-score-breakdown` need no changes.
- Hook now reads `currentWorkspace` from `WorkspaceContext`; returns empty when no workspace is selected.

**Guardrail**
- `hack/check-no-prom-product-deps.sh` (wired into `hack/pre-commit`) fails when a NEW dashboard hook matching product-class patterns (`use-eval-*`, `use-*-cost`, `use-provider-*`) imports a Prometheus client.
- Existing hooks pinned in `hack/no-prom-product-deps.allowlist` (4 entries; `use-eval-trends.ts` dropped here since this PR migrates it).

## Out of scope (intentional)
- `useEvalQuality`, `useEvalFilter`, `useAgentCost`, `useProviderMetrics` migrations — the discovery endpoint now makes each of these cheap (~half a day) but each is its own PR. Allowlisted for now.
- Cost / token aggregation API on `provider_calls` — next pilot when motivated.
- `RolloutAnalysis` PromQL — explicitly operational, stays on Prom.

## Test plan
- [x] Postgres store tests (testcontainers): GROUP BY for each `groupBy` × `metric` combination, namespace isolation, time-range filter, invalid groupBy/metric, missing namespace, percentile sanity, plus `DistinctEvals` (`internal/session/providers/postgres/eval_store_test.go`)
- [x] Session-api handler tests for both endpoints, error paths, nil-rows-as-empty-array (`internal/session/api/eval_handler_test.go`)
- [x] Dashboard proxy route tests including namespace-pinning + 502/503 paths (`dashboard/src/app/api/workspaces/[name]/eval-results/aggregate/route.test.ts`, `…/discover/route.test.ts`)
- [x] Dashboard service tests for URL construction + error mapping (`dashboard/src/lib/data/eval-results-service.test.ts`)
- [x] Migrated hook tests cover both old behaviours via the new service module (`dashboard/src/hooks/use-eval-trends.test.ts`)
- [x] Pre-commit hook clean (build, lint, per-file coverage ≥80%, helm, codegen)
- [ ] CI all green
- [ ] Manual smoke: scale Prometheus to 0, verify `/quality` page renders `useEvalScoreTrends` chart without errors