### PR TITLE
chore(sonar): clear 11 CRITICAL code smells (cognitive complexity + S1192)

### DIFF
--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -694,7 +694,7 @@ func buildAPIMux(
 func wrapPrivacyMiddleware(ctx context.Context, next http.Handler, pool *pgxpool.Pool, embeddingSvc *memory.EmbeddingService, log logr.Logger) http.Handler {
 	kubeConfig, err := rest.InClusterConfig()
 	if err != nil {
-		log.Info("memory privacy middleware skipped", "reason", "no in-cluster kubeconfig")
+		log.Info("memory privacy middleware skipped", "reason", reasonNoInClusterKubeconfig)
 		return next
 	}
 
@@ -894,7 +894,7 @@ func buildRetentionPolicyLoader(legacyInterval, workspace, serviceGroup string, 
 		}
 		log.Error(clientErr, "k8s client creation failed, falling back to legacy interval")
 	} else {
-		log.V(1).Info("no in-cluster kubeconfig", "error", err.Error())
+		log.V(1).Info(reasonNoInClusterKubeconfig, "error", err.Error())
 	}
 	if legacyInterval == "" {
 		log.Info("retention worker disabled", "reason", "no policy source")
@@ -917,7 +917,7 @@ func buildRetentionPolicyLoader(legacyInterval, workspace, serviceGroup string, 
 func createEmbeddingService(ctx context.Context, providerName string, store *memory.PostgresMemoryStore, log logr.Logger) *memory.EmbeddingService {
 	kubeConfig, err := rest.InClusterConfig()
 	if err != nil {
-		log.Info("embedding service skipped", "reason", "no in-cluster kubeconfig")
+		log.Info("embedding service skipped", "reason", reasonNoInClusterKubeconfig)
 		return nil
 	}
 
@@ -1053,6 +1053,11 @@ const (
 	defaultMaxConnLifetime = time.Hour
 	defaultMaxConnIdleTime = 30 * time.Minute
 )
+
+// reasonNoInClusterKubeconfig is the log reason used by initialisation paths
+// that gracefully degrade when the binary is not running inside a Kubernetes
+// pod (no in-cluster kubeconfig). Extracted for S1192 — duplicated 3+ times.
+const reasonNoInClusterKubeconfig = "no in-cluster kubeconfig"
 
 // initPool creates and returns a pgxpool connection pool with configured limits.
 func initPool(ctx context.Context, connStr string) (*pgxpool.Pool, error) {

--- a/internal/controller/workspace_controller.go
+++ b/internal/controller/workspace_controller.go
@@ -77,6 +77,10 @@ const (
 // Network policy constants
 const (
 	labelSharedNamespace = "omnia.altairalabs.ai/shared"
+	// labelK8sMetadataName is the Kubernetes-managed namespace label that
+	// `kubernetes.io/metadata.name` selectors match against. Duplicated 3+
+	// times in NetworkPolicy peers; extracted for S1192.
+	labelK8sMetadataName = "kubernetes.io/metadata.name"
 )
 
 // WorkspaceReconciler reconciles a Workspace object
@@ -870,7 +874,7 @@ func (r *WorkspaceReconciler) buildIngressRules(workspace *omniav1alpha1.Workspa
 				{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"kubernetes.io/metadata.name": r.OperatorNamespace,
+							labelK8sMetadataName: r.OperatorNamespace,
 						},
 					},
 				},
@@ -941,7 +945,7 @@ func (r *WorkspaceReconciler) buildEgressRules(workspace *omniav1alpha1.Workspac
 			{
 				NamespaceSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						"kubernetes.io/metadata.name": "kube-system",
+						labelK8sMetadataName: "kube-system",
 					},
 				},
 			},
@@ -965,7 +969,7 @@ func (r *WorkspaceReconciler) buildEgressRules(workspace *omniav1alpha1.Workspac
 				{
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"kubernetes.io/metadata.name": r.OperatorNamespace,
+							labelK8sMetadataName: r.OperatorNamespace,
 						},
 					},
 				},

--- a/internal/memory/api/service.go
+++ b/internal/memory/api/service.go
@@ -45,6 +45,11 @@ const (
 // eventTypeMemoryDeleted is the event type published when a memory is deleted.
 const eventTypeMemoryDeleted = "memory_deleted"
 
+// logMemoryEventPublishFailed is the structured-log message emitted when an
+// event-bus publish fails. Extracted to a constant to keep grep-ability
+// across 5+ call sites (and satisfy Sonar's S1192).
+const logMemoryEventPublishFailed = "memory event publish failed"
+
 // Sentinel errors returned by the memory service and handler.
 var (
 	ErrMissingWorkspace = errors.New("workspace parameter is required")
@@ -313,7 +318,7 @@ func (s *MemoryService) SaveMemoryWithResult(ctx context.Context, mem *memory.Me
 		}
 		s.safeGo("event_publish", func() {
 			if err := s.eventPublisher.PublishMemoryEvent(context.Background(), event); err != nil {
-				s.log.Error(err, "memory event publish failed", "eventType", event.EventType, "memoryID", event.MemoryID)
+				s.log.Error(err, logMemoryEventPublishFailed, "eventType", event.EventType, "memoryID", event.MemoryID)
 			}
 		})
 	}
@@ -665,7 +670,7 @@ func (s *MemoryService) applyAutoSupersedeViaSimilarity(
 		}
 		s.safeGo("event_publish", func() {
 			if err := s.eventPublisher.PublishMemoryEvent(context.Background(), event); err != nil {
-				s.log.Error(err, "memory event publish failed", "eventType", event.EventType, "memoryID", event.MemoryID)
+				s.log.Error(err, logMemoryEventPublishFailed, "eventType", event.EventType, "memoryID", event.MemoryID)
 			}
 		})
 	}
@@ -732,7 +737,7 @@ func (s *MemoryService) UpdateMemory(ctx context.Context, entityID string, mem *
 		}
 		s.safeGo("event_publish", func() {
 			if err := s.eventPublisher.PublishMemoryEvent(context.Background(), event); err != nil {
-				s.log.Error(err, "memory event publish failed",
+				s.log.Error(err, logMemoryEventPublishFailed,
 					"eventType", event.EventType, "memoryID", event.MemoryID)
 			}
 		})
@@ -802,7 +807,7 @@ func (s *MemoryService) SupersedeManyMemories(ctx context.Context, sourceMemoryI
 		}
 		s.safeGo("event_publish", func() {
 			if err := s.eventPublisher.PublishMemoryEvent(context.Background(), event); err != nil {
-				s.log.Error(err, "memory event publish failed",
+				s.log.Error(err, logMemoryEventPublishFailed,
 					"eventType", event.EventType, "memoryID", event.MemoryID)
 			}
 		})
@@ -978,7 +983,7 @@ func (s *MemoryService) DeleteMemory(ctx context.Context, scope map[string]strin
 		}
 		s.safeGo("event_publish", func() {
 			if err := s.eventPublisher.PublishMemoryEvent(context.Background(), event); err != nil {
-				s.log.Error(err, "memory event publish failed", "eventType", event.EventType, "memoryID", event.MemoryID)
+				s.log.Error(err, logMemoryEventPublishFailed, "eventType", event.EventType, "memoryID", event.MemoryID)
 			}
 		})
 	}

--- a/internal/memory/retention.go
+++ b/internal/memory/retention.go
@@ -20,6 +20,11 @@ import (
 // defaultRetentionBatchSize mirrors the CRD's default BatchSize.
 const defaultRetentionBatchSize int32 = 1000
 
+// logRetentionWorkerNotStarted is the structured-log message emitted by
+// startup paths that opt out of running the retention worker. Extracted
+// for S1192 — duplicated 3+ times.
+const logRetentionWorkerNotStarted = "retention worker not started"
+
 // RetentionWorker composites TTL and LRU pruning across the three
 // memory tiers, driven by a MemoryPolicy CRD. Each run is
 // one pass per (tier, branch); rows are soft-deleted first then
@@ -57,20 +62,20 @@ func NewRetentionWorker(store *PostgresMemoryStore, loader PolicyLoader, log log
 func (w *RetentionWorker) Run(ctx context.Context) {
 	policy, err := w.loader.Load(ctx)
 	if err != nil || policy == nil {
-		w.log.Info("retention worker not started",
+		w.log.Info(logRetentionWorkerNotStarted,
 			"reason", "no active MemoryPolicy",
 			"error", errString(err))
 		return
 	}
 	schedule := policy.Spec.Schedule
 	if schedule == "" {
-		w.log.Info("retention worker not started", "reason", "policy has no schedule")
+		w.log.Info(logRetentionWorkerNotStarted, "reason", "policy has no schedule")
 		return
 	}
 	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
 	sched, err := parser.Parse(schedule)
 	if err != nil {
-		w.log.Error(err, "retention worker not started", "reason", "invalid cron", "schedule", schedule)
+		w.log.Error(err, logRetentionWorkerNotStarted, "reason", "invalid cron", "schedule", schedule)
 		return
 	}
 	MarkWorkerRunning(WorkerNameRetention)

--- a/internal/memory/stats.go
+++ b/internal/memory/stats.go
@@ -41,6 +41,10 @@ const DefaultAggregateLimit = 100
 // MaxAggregateLimit clamps absurd LIMITs.
 const MaxAggregateLimit = 1000
 
+// orderByValueDesc is the ORDER BY clause used by the categorical group-by
+// branches. Extracted to avoid S1192 duplication across 3 cases.
+const orderByValueDesc = "ORDER BY value DESC"
+
 // AggregateOptions parameterises the Aggregate query.
 type AggregateOptions struct {
 	Workspace string
@@ -132,10 +136,10 @@ func (s *PostgresMemoryStore) Aggregate(ctx context.Context, opts AggregateOptio
 func groupByFragments(g AggregateGroupBy) (keyExpr, extraWhere, orderClause string, err error) {
 	switch g {
 	case AggregateGroupByCategory:
-		return "COALESCE(e.consent_category, 'unknown')", "", "ORDER BY value DESC", nil
+		return "COALESCE(e.consent_category, 'unknown')", "", orderByValueDesc, nil
 	case AggregateGroupByAgent:
 		// Skip institutional rows: agent_id IS NULL clutters the chart.
-		return "e.agent_id", " AND e.agent_id IS NOT NULL", "ORDER BY value DESC", nil
+		return "e.agent_id", " AND e.agent_id IS NOT NULL", orderByValueDesc, nil
 	case AggregateGroupByDay:
 		return "to_char(date_trunc('day', e.created_at)::date, 'YYYY-MM-DD')",
 			"", "ORDER BY 1 ASC", nil
@@ -151,7 +155,7 @@ func groupByFragments(g AggregateGroupBy) (keyExpr, extraWhere, orderClause stri
 			WHEN e.virtual_user_id IS NOT NULL THEN 'user'
 			WHEN e.agent_id        IS NOT NULL THEN 'agent'
 			ELSE                                    'institutional'
-		END`, "", "ORDER BY value DESC", nil
+		END`, "", orderByValueDesc, nil
 	default:
 		return "", "", "", fmt.Errorf("memory: invalid groupBy %q", g)
 	}

--- a/internal/memory/store.go
+++ b/internal/memory/store.go
@@ -50,6 +50,9 @@ const (
 const (
 	errWorkspaceRequired = "memory: workspace_id scope is required"
 	errUserIDRequired    = "memory: user_id scope is required"
+	// errBeginTxFormat is the fmt.Errorf format used when pgxpool.Begin
+	// fails. Duplicated 3+ times across the store; extracted for S1192.
+	errBeginTxFormat = "memory: begin tx: %w"
 )
 
 // ErrNotFound is returned by GetMemory when the requested entity
@@ -148,7 +151,7 @@ func (s *PostgresMemoryStore) SaveWithResult(ctx context.Context, mem *Memory) (
 
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("memory: begin tx: %w", err)
+		return nil, fmt.Errorf(errBeginTxFormat, err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -1036,7 +1039,7 @@ func (s *PostgresMemoryStore) AppendObservationToEntity(
 
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("memory: begin tx: %w", err)
+		return nil, fmt.Errorf(errBeginTxFormat, err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
@@ -1093,7 +1096,7 @@ func (s *PostgresMemoryStore) SupersedeMany(
 
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
-		return "", nil, fmt.Errorf("memory: begin tx: %w", err)
+		return "", nil, fmt.Errorf(errBeginTxFormat, err)
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 

--- a/internal/session/providers/postgres/eval_store.go
+++ b/internal/session/providers/postgres/eval_store.go
@@ -51,6 +51,22 @@ const evalResultColumns = `id, session_id, message_id, agent_name, namespace,
 	passed, score, details, duration_ms, judge_tokens, judge_cost_usd,
 	source, created_at`
 
+// Reusable QueryBuilder filter fragments. The QueryBuilder substitutes the
+// `$?` placeholder with the appropriate positional argument index, so a
+// single constant safely serves multiple call sites.
+const (
+	filterAgentName      = "agent_name=$?"
+	filterNamespace      = "namespace=$?"
+	filterEvalID         = "eval_id=$?"
+	filterEvalType       = "eval_type=$?"
+	filterPromptPackName = "promptpack_name=$?"
+	filterPassed         = "passed=$?"
+	filterCreatedAfter   = "created_at >= $?"
+	filterCreatedBefore  = "created_at < $?"
+
+	orderByValueDesc = "ORDER BY value DESC"
+)
+
 // InsertEvalResults persists one or more eval results using a batch insert.
 func (s *EvalStoreImpl) InsertEvalResults(ctx context.Context, results []*api.EvalResult) error {
 	query := `INSERT INTO eval_results (
@@ -189,35 +205,7 @@ func (s *EvalStoreImpl) AggregateEvalResults(ctx context.Context, opts api.EvalA
 		return nil, err
 	}
 
-	limit := opts.Limit
-	if limit <= 0 {
-		limit = api.DefaultEvalAggregateLimit
-	}
-	if limit > api.MaxEvalAggregateLimit {
-		limit = api.MaxEvalAggregateLimit
-	}
-
-	qb := &pgutil.QueryBuilder{}
-	qb.Add("namespace=$?", opts.Namespace)
-	if opts.AgentName != "" {
-		qb.Add("agent_name=$?", opts.AgentName)
-	}
-	if opts.PromptPackName != "" {
-		qb.Add("promptpack_name=$?", opts.PromptPackName)
-	}
-	if opts.EvalID != "" {
-		qb.Add("eval_id=$?", opts.EvalID)
-	}
-	if opts.EvalType != "" {
-		qb.Add("eval_type=$?", opts.EvalType)
-	}
-	if !opts.From.IsZero() {
-		qb.Add("created_at>=$?", opts.From)
-	}
-	if !opts.To.IsZero() {
-		qb.Add("created_at<$?", opts.To)
-	}
-
+	qb := buildEvalAggregateFilters(opts)
 	query := fmt.Sprintf(`
 		SELECT %s AS key, %s AS value, COUNT(*) AS count
 		FROM eval_results
@@ -225,14 +213,60 @@ func (s *EvalStoreImpl) AggregateEvalResults(ctx context.Context, opts api.EvalA
 		GROUP BY 1
 		%s
 		LIMIT %d`,
-		keyExpr, valueExpr, qb.Where(), orderClause, limit)
+		keyExpr, valueExpr, qb.Where(), orderClause, clampEvalAggregateLimit(opts.Limit))
 
 	rows, err := s.pool.Query(ctx, query, qb.Args()...)
 	if err != nil {
 		return nil, fmt.Errorf("postgres: aggregate eval results: %w", err)
 	}
 	defer rows.Close()
+	return collectEvalAggregateRows(rows)
+}
 
+// buildEvalAggregateFilters seeds a QueryBuilder with the required namespace
+// filter plus any optional filters set on opts. Extracted from
+// AggregateEvalResults to keep its cognitive complexity below the Sonar Way
+// threshold (≤15).
+func buildEvalAggregateFilters(opts api.EvalAggregateOpts) *pgutil.QueryBuilder {
+	qb := &pgutil.QueryBuilder{}
+	qb.Add(filterNamespace, opts.Namespace)
+	if opts.AgentName != "" {
+		qb.Add(filterAgentName, opts.AgentName)
+	}
+	if opts.PromptPackName != "" {
+		qb.Add(filterPromptPackName, opts.PromptPackName)
+	}
+	if opts.EvalID != "" {
+		qb.Add(filterEvalID, opts.EvalID)
+	}
+	if opts.EvalType != "" {
+		qb.Add(filterEvalType, opts.EvalType)
+	}
+	if !opts.From.IsZero() {
+		qb.Add(filterCreatedAfter, opts.From)
+	}
+	if !opts.To.IsZero() {
+		qb.Add(filterCreatedBefore, opts.To)
+	}
+	return qb
+}
+
+// clampEvalAggregateLimit applies the package defaults / ceiling to a
+// caller-supplied limit.
+func clampEvalAggregateLimit(limit int) int {
+	if limit <= 0 {
+		return api.DefaultEvalAggregateLimit
+	}
+	if limit > api.MaxEvalAggregateLimit {
+		return api.MaxEvalAggregateLimit
+	}
+	return limit
+}
+
+// collectEvalAggregateRows scans an aggregate result set into the API row
+// shape. avg/percentile over an empty group is NULL; emit 0.0 so callers
+// don't have to special-case missing values for buckets with only NULL scores.
+func collectEvalAggregateRows(rows pgx.Rows) ([]*api.EvalAggregateRow, error) {
 	out := []*api.EvalAggregateRow{}
 	for rows.Next() {
 		var r api.EvalAggregateRow
@@ -240,8 +274,6 @@ func (s *EvalStoreImpl) AggregateEvalResults(ctx context.Context, opts api.EvalA
 		if err := rows.Scan(&r.Key, &v, &r.Count); err != nil {
 			return nil, fmt.Errorf("postgres: scan eval aggregate row: %w", err)
 		}
-		// avg/percentile over an empty group is NULL; emit 0.0 so callers
-		// don't special-case missing values for buckets with only NULL scores.
 		if v != nil {
 			r.Value = *v
 		}
@@ -259,11 +291,11 @@ func (s *EvalStoreImpl) AggregateEvalResults(ctx context.Context, opts api.EvalA
 func evalGroupByFragments(g api.EvalAggregateGroupBy) (keyExpr, orderClause string, err error) {
 	switch g {
 	case api.EvalAggregateGroupByEvalID:
-		return "eval_id", "ORDER BY value DESC", nil
+		return "eval_id", orderByValueDesc, nil
 	case api.EvalAggregateGroupByEvalType:
-		return "eval_type", "ORDER BY value DESC", nil
+		return "eval_type", orderByValueDesc, nil
 	case api.EvalAggregateGroupByAgent:
-		return "agent_name", "ORDER BY value DESC", nil
+		return "agent_name", orderByValueDesc, nil
 	case api.EvalAggregateGroupByTimeHour:
 		return "to_char(date_trunc('hour', created_at) AT TIME ZONE 'UTC', 'YYYY-MM-DD\"T\"HH24:00:00\"Z\"')",
 			"ORDER BY 1 ASC", nil
@@ -334,43 +366,43 @@ func (s *EvalStoreImpl) DistinctEvals(ctx context.Context, namespace string) ([]
 
 func applyEvalFilters(qb *pgutil.QueryBuilder, opts api.EvalResultListOpts) {
 	if opts.AgentName != "" {
-		qb.Add("agent_name=$?", opts.AgentName)
+		qb.Add(filterAgentName, opts.AgentName)
 	}
 	if opts.Namespace != "" {
-		qb.Add("namespace=$?", opts.Namespace)
+		qb.Add(filterNamespace, opts.Namespace)
 	}
 	if opts.EvalID != "" {
-		qb.Add("eval_id=$?", opts.EvalID)
+		qb.Add(filterEvalID, opts.EvalID)
 	}
 	if opts.EvalType != "" {
-		qb.Add("eval_type=$?", opts.EvalType)
+		qb.Add(filterEvalType, opts.EvalType)
 	}
 	if opts.Passed != nil {
-		qb.Add("passed=$?", *opts.Passed)
+		qb.Add(filterPassed, *opts.Passed)
 	}
 	if !opts.CreatedAfter.IsZero() {
-		qb.Add("created_at >= $?", opts.CreatedAfter)
+		qb.Add(filterCreatedAfter, opts.CreatedAfter)
 	}
 	if !opts.CreatedBefore.IsZero() {
-		qb.Add("created_at < $?", opts.CreatedBefore)
+		qb.Add(filterCreatedBefore, opts.CreatedBefore)
 	}
 }
 
 func applySummaryFilters(qb *pgutil.QueryBuilder, opts api.EvalResultSummaryOpts) {
 	if opts.AgentName != "" {
-		qb.Add("agent_name=$?", opts.AgentName)
+		qb.Add(filterAgentName, opts.AgentName)
 	}
 	if opts.Namespace != "" {
-		qb.Add("namespace=$?", opts.Namespace)
+		qb.Add(filterNamespace, opts.Namespace)
 	}
 	if opts.EvalType != "" {
-		qb.Add("eval_type=$?", opts.EvalType)
+		qb.Add(filterEvalType, opts.EvalType)
 	}
 	if !opts.CreatedAfter.IsZero() {
-		qb.Add("created_at >= $?", opts.CreatedAfter)
+		qb.Add(filterCreatedAfter, opts.CreatedAfter)
 	}
 	if !opts.CreatedBefore.IsZero() {
-		qb.Add("created_at < $?", opts.CreatedBefore)
+		qb.Add(filterCreatedBefore, opts.CreatedBefore)
 	}
 }
 

--- a/internal/session/providers/postgres/eval_store_test.go
+++ b/internal/session/providers/postgres/eval_store_test.go
@@ -714,6 +714,70 @@ func TestApplySummaryFilters_Empty(t *testing.T) {
 	assert.Empty(t, qb.Where())
 }
 
+// --- Aggregate helpers: branch coverage on extracted helpers ----------------
+
+func TestClampEvalAggregateLimit(t *testing.T) {
+	t.Run("zero returns default", func(t *testing.T) {
+		assert.Equal(t, api.DefaultEvalAggregateLimit, clampEvalAggregateLimit(0))
+	})
+	t.Run("negative returns default", func(t *testing.T) {
+		assert.Equal(t, api.DefaultEvalAggregateLimit, clampEvalAggregateLimit(-5))
+	})
+	t.Run("within range passes through", func(t *testing.T) {
+		assert.Equal(t, 42, clampEvalAggregateLimit(42))
+	})
+	t.Run("above max clamps to max", func(t *testing.T) {
+		assert.Equal(t, api.MaxEvalAggregateLimit,
+			clampEvalAggregateLimit(api.MaxEvalAggregateLimit+1000))
+	})
+}
+
+func TestBuildEvalAggregateFilters(t *testing.T) {
+	t.Run("namespace only", func(t *testing.T) {
+		qb := buildEvalAggregateFilters(api.EvalAggregateOpts{Namespace: "ns"})
+		assert.Equal(t, []any{"ns"}, qb.Args())
+		assert.Contains(t, qb.Where(), "namespace=$1")
+	})
+
+	t.Run("agent_name filter included", func(t *testing.T) {
+		qb := buildEvalAggregateFilters(api.EvalAggregateOpts{
+			Namespace: "ns", AgentName: "chatbot",
+		})
+		assert.Contains(t, qb.Args(), "chatbot")
+		assert.Contains(t, qb.Where(), "agent_name=$2")
+	})
+
+	t.Run("promptpack_name filter included", func(t *testing.T) {
+		qb := buildEvalAggregateFilters(api.EvalAggregateOpts{
+			Namespace: "ns", PromptPackName: "pack-v2",
+		})
+		assert.Contains(t, qb.Args(), "pack-v2")
+		assert.Contains(t, qb.Where(), "promptpack_name=$2")
+	})
+
+	t.Run("all filters set", func(t *testing.T) {
+		from := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+		to := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+		qb := buildEvalAggregateFilters(api.EvalAggregateOpts{
+			Namespace:      "ns",
+			AgentName:      "chatbot",
+			PromptPackName: "pack-v2",
+			EvalID:         aggregateEvalIDAcc,
+			EvalType:       "llm_judge",
+			From:           from,
+			To:             to,
+		})
+		args := qb.Args()
+		assert.Contains(t, args, "ns")
+		assert.Contains(t, args, "chatbot")
+		assert.Contains(t, args, "pack-v2")
+		assert.Contains(t, args, "acc")
+		assert.Contains(t, args, "llm_judge")
+		assert.Contains(t, args, from)
+		assert.Contains(t, args, to)
+	})
+}
+
 // --- AggregateEvalResults ---------------------------------------------------
 
 // Fixture constants for the aggregate test set. Extracted to satisfy goconst.


### PR DESCRIPTION
## Summary

Clears every CRITICAL SonarCloud code smell in code I touched recently (#1084), plus a batch of trivial pre-existing duplicated-literal issues that were cheap to fix in the same sweep.

**My new issues from #1084** (5):
- `AggregateEvalResults` cognitive complexity 18 → 13 by extracting `buildEvalAggregateFilters`, `clampEvalAggregateLimit`, and `collectEvalAggregateRows`. Behaviour unchanged.
- 4 × S1192 SQL literal duplications (`"namespace=$?"`, `"agent_name=$?"`, `"eval_type=$?"`, `"ORDER BY value DESC"`) → named constants reused by `applyEvalFilters` and `applySummaryFilters` too.

**Pre-existing S1192 cleanups** (6):
| File | Literal | Constant |
|---|---|---|
| `internal/memory/api/service.go` | `"memory event publish failed"` (5×) | `logMemoryEventPublishFailed` |
| `internal/memory/store.go` | `"memory: begin tx: %w"` (3×) | `errBeginTxFormat` |
| `internal/memory/stats.go` | `"ORDER BY value DESC"` (3×) | `orderByValueDesc` |
| `internal/memory/retention.go` | `"retention worker not started"` (3×) | `logRetentionWorkerNotStarted` |
| `cmd/memory-api/main.go` | `"no in-cluster kubeconfig"` (3×) | `reasonNoInClusterKubeconfig` |
| `internal/controller/workspace_controller.go` | `"kubernetes.io/metadata.name"` (3×) | `labelK8sMetadataName` |

## Out of scope
- The remaining 36 CRITICAL cognitive-complexity findings are in older code unrelated to this branch's churn. Each one is a proper refactor and deserves its own PR.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/session/providers/postgres/... ./internal/memory/... ./cmd/memory-api/... ./internal/controller/... -count=1` all pass
- [x] `golangci-lint run --new-from-rev=main ./...` → 0 issues
- [x] gocognit check confirms `AggregateEvalResults` is now under the 15 threshold
- [ ] CI green