### PR TITLE
feat(observability): migrate use-eval-filter off Prometheus

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -20,8 +20,13 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
   `evalId`, `evalType`, `from`, `to` (RFC3339). Returns
   `{rows: [{key, value, count}, …]}`.
 - `GET /api/v1/eval-results/discover?namespace=X` — distinct
-  `(eval_id, eval_type)` pairs that have at least one row in this
-  namespace's `eval_results`. Returns `{evals: [{evalId, evalType}, …]}`.
+  `(eval_id, eval_type)` pairs plus distinct `agent_name` and
+  `promptpack_name` values that appear in this namespace's
+  `eval_results`. Returns
+  `{evals: [{evalId, evalType}, …], agents: […], promptpacks: […]}`.
+  The `agents` / `promptpacks` fields were added as part of the
+  use-eval-filter migration; the proxy route's shape is unchanged
+  (existing callers reading `body.evals` keep working).
 - Dashboard proxy routes: `GET /api/workspaces/{name}/eval-results/aggregate`
   and `GET /api/workspaces/{name}/eval-results/discover`. The workspace
   name from the URL is pinned as `namespace` on the forwarded query so

--- a/dashboard/src/hooks/use-eval-filter.test.ts
+++ b/dashboard/src/hooks/use-eval-filter.test.ts
@@ -1,5 +1,10 @@
 /**
- * Tests for useEvalFilter hook.
+ * Tests for useEvalFilter — session-api flavour.
+ *
+ * Previously mocked Prometheus client functions; after the observability
+ * split (CLAUDE.md → Observability Boundaries) this hook fetches from
+ * `/api/workspaces/{name}/eval-results/discover`, so tests mock the
+ * structured service module instead.
  *
  * Copyright 2026 Altaira Labs.
  * SPDX-License-Identifier: Apache-2.0
@@ -10,93 +15,88 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 
-const mockQueryPrometheus = vi.fn();
-
-vi.mock("@/lib/prometheus", () => ({
-  queryPrometheus: (...args: unknown[]) => mockQueryPrometheus(...args),
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: vi.fn(),
 }));
 
-vi.mock("@/lib/prometheus-queries", () => ({
-  EvalQueries: {
-    discoverAgents: () => 'group({__name__=~"omnia_eval_.*"}) by (agent)',
-    discoverPromptPacks: () => 'group({__name__=~"omnia_eval_.*"}) by (promptpack_name)',
-  },
+vi.mock("@/lib/data/eval-results-service", () => ({
+  fetchEvalDiscovery: vi.fn(),
 }));
 
+import { useWorkspace } from "@/contexts/workspace-context";
+import { fetchEvalDiscovery } from "@/lib/data/eval-results-service";
 import { useEvalFilter } from "./use-eval-filter";
 
-function createWrapper() {
-  const queryClient = new QueryClient({
+const mockedUseWorkspace = vi.mocked(useWorkspace);
+const mockedFetchDiscovery = vi.mocked(fetchEvalDiscovery);
+
+function makeWrapper() {
+  const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  function TestQueryProvider({ children }: { children: React.ReactNode }) {
-    return React.createElement(QueryClientProvider, { client: queryClient }, children);
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
   }
-  return TestQueryProvider;
+  return Wrapper;
 }
 
+function workspaceCtx(name: string | null) {
+  return {
+    currentWorkspace: name ? { name } : null,
+  } as unknown as ReturnType<typeof useWorkspace>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe("useEvalFilter", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
-  it("discovers agents and promptpacks from Prometheus", async () => {
-    mockQueryPrometheus
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            { metric: { agent: "chatbot" }, value: [1000, "1"] },
-            { metric: { agent: "support-agent" }, value: [1000, "1"] },
-          ],
-        },
-      })
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            { metric: { promptpack_name: "default-pack" }, value: [1000, "1"] },
-          ],
-        },
-      });
-
-    const { result } = renderHook(() => useEvalFilter(), {
-      wrapper: createWrapper(),
+  it("populates agents and promptpacks from one discovery call", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDiscovery.mockResolvedValue({
+      evals: [{ evalId: "tone", evalType: "llm_judge" }],
+      agents: ["chatbot", "support-agent"],
+      promptpacks: ["default-pack"],
     });
+
+    const { result } = renderHook(() => useEvalFilter(), { wrapper: makeWrapper() });
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.agents).toEqual(["chatbot", "support-agent"]);
     expect(result.current.promptpacks).toEqual(["default-pack"]);
     expect(result.current.filter).toEqual({});
+    expect(mockedFetchDiscovery).toHaveBeenCalledOnce();
+    expect(mockedFetchDiscovery).toHaveBeenCalledWith("test-ws");
   });
 
-  it("returns empty arrays when Prometheus returns no data", async () => {
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: { result: [] },
-    });
+  it("returns empty arrays when discovery yields nothing", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDiscovery.mockResolvedValue({ evals: [], agents: [], promptpacks: [] });
 
-    const { result } = renderHook(() => useEvalFilter(), {
-      wrapper: createWrapper(),
-    });
-
+    const { result } = renderHook(() => useEvalFilter(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.agents).toEqual([]);
     expect(result.current.promptpacks).toEqual([]);
   });
 
-  it("returns empty arrays when Prometheus returns error", async () => {
-    mockQueryPrometheus.mockResolvedValue({
-      status: "error",
-      error: "bad query",
-    });
+  it("returns empty arrays and is idle when no workspace is selected", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx(null));
 
-    const { result } = renderHook(() => useEvalFilter(), {
-      wrapper: createWrapper(),
-    });
+    const { result } = renderHook(() => useEvalFilter(), { wrapper: makeWrapper() });
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
+    expect(mockedFetchDiscovery).not.toHaveBeenCalled();
+    expect(result.current.agents).toEqual([]);
+    expect(result.current.promptpacks).toEqual([]);
+  });
+
+  it("returns empty arrays when discovery throws", async () => {
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDiscovery.mockRejectedValue(new Error("boom"));
+
+    const { result } = renderHook(() => useEvalFilter(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.agents).toEqual([]);
@@ -104,80 +104,38 @@ describe("useEvalFilter", () => {
   });
 
   it("builds filter from selected values", async () => {
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: {
-        result: [
-          { metric: { agent: "chatbot" }, value: [1000, "1"] },
-        ],
-      },
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDiscovery.mockResolvedValue({
+      evals: [],
+      agents: ["chatbot"],
+      promptpacks: ["my-pack"],
     });
 
-    const { result } = renderHook(() => useEvalFilter(), {
-      wrapper: createWrapper(),
-    });
-
+    const { result } = renderHook(() => useEvalFilter(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    act(() => {
-      result.current.setAgent("chatbot");
-    });
-
+    act(() => result.current.setAgent("chatbot"));
     expect(result.current.selectedAgent).toBe("chatbot");
     expect(result.current.filter).toEqual({ agent: "chatbot" });
 
-    act(() => {
-      result.current.setPromptPack("my-pack");
+    act(() => result.current.setPromptPack("my-pack"));
+    expect(result.current.filter).toEqual({
+      agent: "chatbot",
+      promptpackName: "my-pack",
     });
-
-    expect(result.current.filter).toEqual({ agent: "chatbot", promptpackName: "my-pack" });
   });
 
   it("clears filter when selection is set to undefined", async () => {
-    mockQueryPrometheus.mockResolvedValue({
-      status: "success",
-      data: { result: [] },
-    });
+    mockedUseWorkspace.mockReturnValue(workspaceCtx("test-ws"));
+    mockedFetchDiscovery.mockResolvedValue({ evals: [], agents: [], promptpacks: [] });
 
-    const { result } = renderHook(() => useEvalFilter(), {
-      wrapper: createWrapper(),
-    });
-
+    const { result } = renderHook(() => useEvalFilter(), { wrapper: makeWrapper() });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    act(() => {
-      result.current.setAgent("chatbot");
-    });
+    act(() => result.current.setAgent("chatbot"));
     expect(result.current.filter).toEqual({ agent: "chatbot" });
 
-    act(() => {
-      result.current.setAgent(undefined);
-    });
+    act(() => result.current.setAgent(undefined));
     expect(result.current.filter).toEqual({});
-  });
-
-  it("filters out empty label values", async () => {
-    mockQueryPrometheus
-      .mockResolvedValueOnce({
-        status: "success",
-        data: {
-          result: [
-            { metric: { agent: "chatbot" }, value: [1000, "1"] },
-            { metric: { agent: "" }, value: [1000, "1"] },
-          ],
-        },
-      })
-      .mockResolvedValueOnce({
-        status: "success",
-        data: { result: [] },
-      });
-
-    const { result } = renderHook(() => useEvalFilter(), {
-      wrapper: createWrapper(),
-    });
-
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    expect(result.current.agents).toEqual(["chatbot"]);
   });
 });

--- a/dashboard/src/hooks/use-eval-filter.ts
+++ b/dashboard/src/hooks/use-eval-filter.ts
@@ -1,8 +1,15 @@
 /**
- * Hook for discovering eval label values and managing filter state.
+ * Hook for discovering eval filter values and managing filter state.
  *
- * Queries Prometheus to discover available agent and promptpack_name
- * label values from omnia_eval_* metrics.
+ * Previously discovered `agent` and `promptpack_name` label values from
+ * Prometheus eval gauges; migrated to the structured session-api
+ * `/api/workspaces/{name}/eval-results/discover` endpoint as the third
+ * wave of the observability split — see CLAUDE.md → Observability
+ * Boundaries and
+ * `docs/local-backlog/implemented/2026-04-17-observability-split-design.md`.
+ *
+ * Public surface (`UseEvalFilterResult`, `useEvalFilter`) is unchanged so
+ * the `/quality` page consumes it without modification.
  *
  * Copyright 2026 Altaira Labs.
  * SPDX-License-Identifier: Apache-2.0
@@ -12,22 +19,17 @@
 
 import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { queryPrometheus, type PrometheusVectorResult } from "@/lib/prometheus";
-import { EvalQueries, type EvalFilter } from "@/lib/prometheus-queries";
+import { useWorkspace } from "@/contexts/workspace-context";
+import { fetchEvalDiscovery } from "@/lib/data/eval-results-service";
 import { DEFAULT_STALE_TIME } from "@/lib/query-config";
 
-/** Extract unique non-empty label values from a Prometheus group-by result. */
-function extractLabelValues(
-  result: PrometheusVectorResult[] | undefined,
-  labelKey: string,
-): string[] {
-  if (!result) return [];
-  const values = new Set<string>();
-  for (const item of result) {
-    const val = item.metric[labelKey];
-    if (val) values.add(val);
-  }
-  return Array.from(values).sort((a, b) => a.localeCompare(b));
+/**
+ * Filter shape mirrors the prom-era EvalFilter so /quality and chart
+ * consumers can pass it through unchanged.
+ */
+export interface EvalFilter {
+  agent?: string;
+  promptpackName?: string;
 }
 
 export interface UseEvalFilterResult {
@@ -44,24 +46,15 @@ export interface UseEvalFilterResult {
 export function useEvalFilter(): UseEvalFilterResult {
   const [selectedAgent, setAgent] = useState<string | undefined>();
   const [selectedPromptPack, setPromptPack] = useState<string | undefined>();
+  const { currentWorkspace } = useWorkspace();
+  const workspace = currentWorkspace?.name;
 
-  const agentsQuery = useQuery({
-    queryKey: ["eval-filter-agents"],
+  const discoveryQuery = useQuery({
+    queryKey: ["eval-filter-discovery", workspace],
+    enabled: Boolean(workspace),
     queryFn: async () => {
-      const resp = await queryPrometheus(EvalQueries.discoverAgents());
-      if (resp.status !== "success" || !resp.data?.result) return [];
-      return extractLabelValues(resp.data.result, "agent");
-    },
-    staleTime: DEFAULT_STALE_TIME,
-    retry: false,
-  });
-
-  const promptpacksQuery = useQuery({
-    queryKey: ["eval-filter-promptpacks"],
-    queryFn: async () => {
-      const resp = await queryPrometheus(EvalQueries.discoverPromptPacks());
-      if (resp.status !== "success" || !resp.data?.result) return [];
-      return extractLabelValues(resp.data.result, "promptpack_name");
+      if (!workspace) return { evals: [], agents: [], promptpacks: [] };
+      return fetchEvalDiscovery(workspace);
     },
     staleTime: DEFAULT_STALE_TIME,
     retry: false,
@@ -75,13 +68,13 @@ export function useEvalFilter(): UseEvalFilterResult {
   }, [selectedAgent, selectedPromptPack]);
 
   return {
-    agents: agentsQuery.data ?? [],
-    promptpacks: promptpacksQuery.data ?? [],
+    agents: discoveryQuery.data?.agents ?? [],
+    promptpacks: discoveryQuery.data?.promptpacks ?? [],
     selectedAgent,
     selectedPromptPack,
     setAgent,
     setPromptPack,
     filter,
-    isLoading: agentsQuery.isLoading || promptpacksQuery.isLoading,
+    isLoading: discoveryQuery.isLoading,
   };
 }

--- a/dashboard/src/lib/data/eval-results-service.test.ts
+++ b/dashboard/src/lib/data/eval-results-service.test.ts
@@ -11,6 +11,7 @@ import {
   classifyEvalType,
   fetchEvalAggregate,
   fetchEvalDescriptors,
+  fetchEvalDiscovery,
 } from "./eval-results-service";
 
 beforeEach(() => {
@@ -136,6 +137,61 @@ describe("classifyEvalType", () => {
   it("defaults unknown eval types to 'gauge'", () => {
     expect(classifyEvalType("")).toBe("gauge");
     expect(classifyEvalType("future_handler")).toBe("gauge");
+  });
+});
+
+describe("fetchEvalDiscovery", () => {
+  it("hits the workspace-scoped /discover endpoint and returns full payload", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          evals: [{ evalId: "acc", evalType: "llm_judge" }],
+          agents: ["agent-a", "agent-b"],
+          promptpacks: ["pack-v1"],
+        }),
+        { status: 200 },
+      ),
+    );
+
+    const res = await fetchEvalDiscovery("test-ws", fakeFetch as unknown as typeof fetch);
+
+    expect(res.evals).toHaveLength(1);
+    expect(res.agents).toEqual(["agent-a", "agent-b"]);
+    expect(res.promptpacks).toEqual(["pack-v1"]);
+
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toBe("/api/workspaces/test-ws/eval-results/discover");
+  });
+
+  it("normalises missing slices to empty arrays", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(JSON.stringify({}), { status: 200 }),
+    );
+    const res = await fetchEvalDiscovery("ws", fakeFetch as unknown as typeof fetch);
+    expect(res).toEqual({ evals: [], agents: [], promptpacks: [] });
+  });
+
+  it("encodes workspace names with special characters in the path", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response(JSON.stringify({ evals: [], agents: [], promptpacks: [] }), {
+        status: 200,
+      }),
+    );
+
+    await fetchEvalDiscovery("ws/with-slash", fakeFetch as unknown as typeof fetch);
+
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toContain("/api/workspaces/ws%2Fwith-slash/");
+  });
+
+  it("throws on non-2xx response", async () => {
+    const fakeFetch = vi.fn(async () =>
+      new Response("nope", { status: 500, statusText: "Internal Server Error" }),
+    );
+
+    await expect(
+      fetchEvalDiscovery("ws", fakeFetch as unknown as typeof fetch),
+    ).rejects.toThrow(/eval-discover: 500/);
   });
 });
 

--- a/dashboard/src/lib/data/eval-results-service.ts
+++ b/dashboard/src/lib/data/eval-results-service.ts
@@ -83,20 +83,48 @@ export async function fetchEvalAggregate(
 }
 
 /**
- * Fetch the set of distinct (evalId, evalType) pairs for a workspace.
- * Replaces Prometheus' metric-name discovery for product views.
+ * Discovery payload returned by the workspace's /eval-results/discover
+ * proxy. Mirrors session-api's `EvalDiscoveryResult` JSON shape.
  */
-export async function fetchEvalDescriptors(
+export interface EvalDiscoveryResult {
+  evals: EvalDescriptor[];
+  agents: string[];
+  promptpacks: string[];
+}
+
+/**
+ * Fetch the full discovery payload for a workspace — distinct evals plus
+ * the agent_name / promptpack_name label values used by the filter UI.
+ * Replaces Prometheus' metric-name + label-value discovery for product views.
+ */
+export async function fetchEvalDiscovery(
   workspace: string,
   fetchImpl: typeof fetch = fetch,
-): Promise<EvalDescriptor[]> {
+): Promise<EvalDiscoveryResult> {
   const url = `/api/workspaces/${encodeURIComponent(workspace)}/eval-results/discover`;
   const resp = await fetchImpl(url, { headers: { Accept: "application/json" } });
   if (!resp.ok) {
     throw new Error(`eval-discover: ${resp.status} ${resp.statusText}`);
   }
-  const body = (await resp.json()) as { evals?: EvalDescriptor[] };
-  return body.evals ?? [];
+  const body = (await resp.json()) as Partial<EvalDiscoveryResult>;
+  return {
+    evals: body.evals ?? [],
+    agents: body.agents ?? [],
+    promptpacks: body.promptpacks ?? [],
+  };
+}
+
+/**
+ * Convenience wrapper for callers that only need the evals slice. Hits the
+ * same endpoint as fetchEvalDiscovery — React Query will dedupe when both
+ * are called with the same workspace key.
+ */
+export async function fetchEvalDescriptors(
+  workspace: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<EvalDescriptor[]> {
+  const { evals } = await fetchEvalDiscovery(workspace, fetchImpl);
+  return evals;
 }
 
 /**

--- a/hack/no-prom-product-deps.allowlist
+++ b/hack/no-prom-product-deps.allowlist
@@ -10,5 +10,4 @@
 # (proposal); CLAUDE.md → Observability Boundaries (principle).
 
 dashboard/src/hooks/use-agent-cost.ts
-dashboard/src/hooks/use-eval-filter.ts
 dashboard/src/hooks/use-provider-metrics.ts

--- a/internal/session/api/eval_handler.go
+++ b/internal/session/api/eval_handler.go
@@ -201,11 +201,6 @@ type EvalAggregateResponse struct {
 	Rows []*EvalAggregateRow `json:"rows"`
 }
 
-// EvalDiscoverResponse is the JSON body for /api/v1/eval-results/discover.
-type EvalDiscoverResponse struct {
-	Evals []EvalDescriptor `json:"evals"`
-}
-
 // handleAggregateEvalResults runs a namespace-scoped GROUP BY over eval_results.
 // GET /api/v1/eval-results/aggregate?namespace=X&groupBy=time:day&metric=avg_score
 func (h *Handler) handleAggregateEvalResults(w http.ResponseWriter, r *http.Request) {
@@ -233,8 +228,9 @@ func (h *Handler) handleAggregateEvalResults(w http.ResponseWriter, r *http.Requ
 	_ = json.NewEncoder(w).Encode(EvalAggregateResponse{Rows: rows})
 }
 
-// handleDiscoverEvals returns the set of (eval_id, eval_type) pairs that
-// exist for a namespace. Replaces dashboard Prometheus metric-name discovery.
+// handleDiscoverEvals returns the namespace-scoped set of evals + agents +
+// promptpacks observed in eval_results. Replaces dashboard Prometheus
+// metric-name and label-value discovery.
 // GET /api/v1/eval-results/discover?namespace=X
 func (h *Handler) handleDiscoverEvals(w http.ResponseWriter, r *http.Request) {
 	if h.evalService == nil {
@@ -248,17 +244,28 @@ func (h *Handler) handleDiscoverEvals(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	evals, err := h.evalService.DistinctEvals(r.Context(), namespace)
+	result, err := h.evalService.EvalDiscovery(r.Context(), namespace)
 	if err != nil {
 		writeEvalError(w, err)
 		return
 	}
-	if evals == nil {
-		evals = []EvalDescriptor{}
+	if result == nil {
+		result = &EvalDiscoveryResult{}
+	}
+	// Normalise nil slices to empty arrays so JSON renders [] not null —
+	// dashboard consumers iterate without a null check.
+	if result.Evals == nil {
+		result.Evals = []EvalDescriptor{}
+	}
+	if result.Agents == nil {
+		result.Agents = []string{}
+	}
+	if result.PromptPacks == nil {
+		result.PromptPacks = []string{}
 	}
 
 	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
-	_ = json.NewEncoder(w).Encode(EvalDiscoverResponse{Evals: evals})
+	_ = json.NewEncoder(w).Encode(result)
 }
 
 // parseEvalAggregateOpts extracts EvalAggregateOpts from the request query.

--- a/internal/session/api/eval_handler_test.go
+++ b/internal/session/api/eval_handler_test.go
@@ -413,9 +413,13 @@ func TestHandleAggregateEvalResults_NilRowsReturnsEmptyArray(t *testing.T) {
 
 func TestHandleDiscoverEvals_Success(t *testing.T) {
 	store := &mockEvalStore{
-		distinctEvals: []EvalDescriptor{
-			{EvalID: "acc", EvalType: "llm_judge"},
-			{EvalID: "lat", EvalType: "assertion"},
+		discoveryResult: &EvalDiscoveryResult{
+			Evals: []EvalDescriptor{
+				{EvalID: "acc", EvalType: "llm_judge"},
+				{EvalID: "lat", EvalType: "assertion"},
+			},
+			Agents:      []string{"agent-a", "agent-b"},
+			PromptPacks: []string{"pack-v1", "pack-v2"},
 		},
 	}
 	mux := newTestEvalHandler(store)
@@ -426,11 +430,13 @@ func TestHandleDiscoverEvals_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp EvalDiscoverResponse
+	var resp EvalDiscoveryResult
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	require.Len(t, resp.Evals, 2)
 	assert.Equal(t, "acc", resp.Evals[0].EvalID)
 	assert.Equal(t, "llm_judge", resp.Evals[0].EvalType)
+	assert.Equal(t, []string{"agent-a", "agent-b"}, resp.Agents)
+	assert.Equal(t, []string{"pack-v1", "pack-v2"}, resp.PromptPacks)
 }
 
 func TestHandleDiscoverEvals_MissingNamespace(t *testing.T) {
@@ -456,13 +462,16 @@ func TestHandleDiscoverEvals_NoEvalService(t *testing.T) {
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
 }
 
-func TestHandleDiscoverEvals_NilReturnsEmptyArray(t *testing.T) {
-	mux := newTestEvalHandler(&mockEvalStore{distinctEvals: nil})
+func TestHandleDiscoverEvals_NilReturnsEmptyArrays(t *testing.T) {
+	mux := newTestEvalHandler(&mockEvalStore{discoveryResult: nil})
 
 	req := httptest.NewRequest(http.MethodGet, "/api/v1/eval-results/discover?namespace=default", nil)
 	w := httptest.NewRecorder()
 	mux.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	assert.Contains(t, w.Body.String(), `"evals":[]`)
+	body := w.Body.String()
+	assert.Contains(t, body, `"evals":[]`)
+	assert.Contains(t, body, `"agents":[]`)
+	assert.Contains(t, body, `"promptpacks":[]`)
 }

--- a/internal/session/api/eval_service.go
+++ b/internal/session/api/eval_service.go
@@ -142,14 +142,14 @@ func (s *EvalService) AggregateEvalResults(ctx context.Context, opts EvalAggrega
 	return s.store.AggregateEvalResults(ctx, opts)
 }
 
-// DistinctEvals returns (eval_id, eval_type) pairs for a namespace. Powers
-// GET /api/v1/eval-results/discover so dashboard can list available evals
-// without going through Prometheus metric metadata.
-func (s *EvalService) DistinctEvals(ctx context.Context, namespace string) ([]EvalDescriptor, error) {
+// EvalDiscovery returns the namespace-scoped set of evals + agents +
+// promptpacks. Powers GET /api/v1/eval-results/discover, replacing both
+// Prometheus metric-metadata and label-discovery for dashboard product views.
+func (s *EvalService) EvalDiscovery(ctx context.Context, namespace string) (*EvalDiscoveryResult, error) {
 	if s.store == nil {
 		return nil, ErrMissingEvalStore
 	}
-	return s.store.DistinctEvals(ctx, namespace)
+	return s.store.EvalDiscovery(ctx, namespace)
 }
 
 // GetEvalResultSummary returns aggregate statistics for eval results.

--- a/internal/session/api/eval_service_test.go
+++ b/internal/session/api/eval_service_test.go
@@ -40,8 +40,8 @@ type mockEvalStore struct {
 	summaryErr       error
 	aggregateResults []*EvalAggregateRow
 	aggregateErr     error
-	distinctEvals    []EvalDescriptor
-	distinctEvalsErr error
+	discoveryResult  *EvalDiscoveryResult
+	discoveryErr     error
 }
 
 func (m *mockEvalStore) InsertEvalResults(_ context.Context, _ []*EvalResult) error {
@@ -64,8 +64,8 @@ func (m *mockEvalStore) AggregateEvalResults(_ context.Context, _ EvalAggregateO
 	return m.aggregateResults, m.aggregateErr
 }
 
-func (m *mockEvalStore) DistinctEvals(_ context.Context, _ string) ([]EvalDescriptor, error) {
-	return m.distinctEvals, m.distinctEvalsErr
+func (m *mockEvalStore) EvalDiscovery(_ context.Context, _ string) (*EvalDiscoveryResult, error) {
+	return m.discoveryResult, m.discoveryErr
 }
 
 func TestNewEvalService(t *testing.T) {

--- a/internal/session/api/eval_store.go
+++ b/internal/session/api/eval_store.go
@@ -173,14 +173,24 @@ type EvalStore interface {
 	// for the design rationale.
 	AggregateEvalResults(ctx context.Context, opts EvalAggregateOpts) ([]*EvalAggregateRow, error)
 
-	// DistinctEvals returns the set of (eval_id, eval_type) pairs that appear
-	// in eval_results for the given namespace. Used by the dashboard's
-	// eval-metric discovery, replacing the Prometheus /api/v1/metadata path.
-	DistinctEvals(ctx context.Context, namespace string) ([]EvalDescriptor, error)
+	// EvalDiscovery returns the distinct eval/agent/promptpack values that
+	// appear in eval_results for the given namespace. Used by the dashboard's
+	// eval discovery + filter UI, replacing the Prometheus /api/v1/metadata
+	// and label-discovery query paths.
+	EvalDiscovery(ctx context.Context, namespace string) (*EvalDiscoveryResult, error)
 }
 
-// EvalDescriptor is one (eval_id, eval_type) pair returned by DistinctEvals.
+// EvalDescriptor is one (eval_id, eval_type) pair.
 type EvalDescriptor struct {
 	EvalID   string `json:"evalId"`
 	EvalType string `json:"evalType"`
+}
+
+// EvalDiscoveryResult is the namespace-scoped discovery payload returned by
+// EvalStore.EvalDiscovery. Slices are non-nil so callers can JSON-serialise
+// without a null check.
+type EvalDiscoveryResult struct {
+	Evals       []EvalDescriptor `json:"evals"`
+	Agents      []string         `json:"agents"`
+	PromptPacks []string         `json:"promptpacks"`
 }

--- a/internal/session/providers/postgres/eval_store.go
+++ b/internal/session/providers/postgres/eval_store.go
@@ -330,14 +330,42 @@ func evalMetricExpression(m api.EvalAggregateMetric) (string, error) {
 	}
 }
 
-// DistinctEvals returns the set of (eval_id, eval_type) pairs that have at
-// least one row in eval_results for the given namespace. Replaces Prometheus'
-// metric-discovery for dashboard product views.
-func (s *EvalStoreImpl) DistinctEvals(ctx context.Context, namespace string) ([]api.EvalDescriptor, error) {
+// EvalDiscovery returns the distinct evals + agents + promptpacks seen in
+// eval_results for the given namespace. Powers both the dashboard's
+// eval-metric discovery (replaces Prometheus /api/v1/metadata) and the
+// agent/promptpack filter dropdowns (replaces label-discovery PromQL).
+//
+// Implementation: three independent SELECT DISTINCTs against the same table.
+// Each touches the namespace index and returns a tiny result set, so the
+// extra round-trips are cheaper than building a single CTE that has to
+// reorganise the rows server-side.
+func (s *EvalStoreImpl) EvalDiscovery(ctx context.Context, namespace string) (*api.EvalDiscoveryResult, error) {
 	if namespace == "" {
-		return nil, fmt.Errorf("postgres: distinct evals: namespace is required")
+		return nil, fmt.Errorf("postgres: eval discovery: namespace is required")
 	}
 
+	evals, err := s.distinctEvals(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	agents, err := s.distinctStringColumn(ctx, namespace, "agent_name")
+	if err != nil {
+		return nil, err
+	}
+	promptpacks, err := s.distinctStringColumn(ctx, namespace, "promptpack_name")
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.EvalDiscoveryResult{
+		Evals:       evals,
+		Agents:      agents,
+		PromptPacks: promptpacks,
+	}, nil
+}
+
+// distinctEvals reads the (eval_id, eval_type) pairs for a namespace.
+func (s *EvalStoreImpl) distinctEvals(ctx context.Context, namespace string) ([]api.EvalDescriptor, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT DISTINCT eval_id, eval_type
 		FROM eval_results
@@ -358,6 +386,36 @@ func (s *EvalStoreImpl) DistinctEvals(ctx context.Context, namespace string) ([]
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("postgres: iterate distinct evals: %w", err)
+	}
+	return out, nil
+}
+
+// distinctStringColumn reads sorted DISTINCT non-empty values for a single
+// column in eval_results. The column name is interpolated into the SQL — it
+// MUST be an internal identifier (never user input).
+func (s *EvalStoreImpl) distinctStringColumn(ctx context.Context, namespace, column string) ([]string, error) {
+	//nolint:gosec // column comes from a closed set of internal identifiers.
+	q := fmt.Sprintf(`
+		SELECT DISTINCT %s
+		FROM eval_results
+		WHERE namespace = $1 AND %s <> ''
+		ORDER BY 1`, column, column)
+	rows, err := s.pool.Query(ctx, q, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: distinct %s: %w", column, err)
+	}
+	defer rows.Close()
+
+	out := []string{}
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("postgres: scan distinct %s: %w", column, err)
+		}
+		out = append(out, v)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate distinct %s: %w", column, err)
 	}
 	return out, nil
 }

--- a/internal/session/providers/postgres/eval_store_test.go
+++ b/internal/session/providers/postgres/eval_store_test.go
@@ -1034,42 +1034,81 @@ func TestAggregateEvalResults_InvalidMetric(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid metric")
 }
 
-// --- DistinctEvals ----------------------------------------------------------
+// --- EvalDiscovery ----------------------------------------------------------
 
-func TestDistinctEvals(t *testing.T) {
+func TestEvalDiscovery(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
 	store := newEvalStore(t)
 	seedAggregateRows(t, store)
 
-	descs, err := store.DistinctEvals(context.Background(), "default")
+	res, err := store.EvalDiscovery(context.Background(), "default")
 	require.NoError(t, err)
-	require.Len(t, descs, 2)
-	// Sorted by eval_id ascending.
-	assert.Equal(t, "acc", descs[0].EvalID)
-	assert.Equal(t, "llm_judge", descs[0].EvalType)
-	assert.Equal(t, "lat", descs[1].EvalID)
-	assert.Equal(t, "assertion", descs[1].EvalType)
+	require.NotNil(t, res)
+
+	// Evals sorted by eval_id ascending.
+	require.Len(t, res.Evals, 2)
+	assert.Equal(t, aggregateEvalIDAcc, res.Evals[0].EvalID)
+	assert.Equal(t, "llm_judge", res.Evals[0].EvalType)
+	assert.Equal(t, aggregateEvalIDLat, res.Evals[1].EvalID)
+	assert.Equal(t, "assertion", res.Evals[1].EvalType)
+
+	// Agents distinct + sorted.
+	assert.Equal(t, []string{aggregateAgentA, aggregateAgentB}, res.Agents)
+
+	// Promptpacks distinct + sorted (single value in the fixture).
+	assert.Equal(t, []string{"test-pack"}, res.PromptPacks)
 }
 
-func TestDistinctEvals_NamespaceIsolation(t *testing.T) {
+func TestEvalDiscovery_NamespaceIsolation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
 	store := newEvalStore(t)
 	seedAggregateRows(t, store)
 
-	descs, err := store.DistinctEvals(context.Background(), "other-namespace")
+	res, err := store.EvalDiscovery(context.Background(), "other-namespace")
 	require.NoError(t, err)
-	assert.Empty(t, descs)
+	require.NotNil(t, res)
+	assert.Empty(t, res.Evals)
+	assert.Empty(t, res.Agents)
+	assert.Empty(t, res.PromptPacks)
 }
 
-func TestDistinctEvals_MissingNamespace(t *testing.T) {
+func TestEvalDiscovery_MissingNamespace(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
 	store := newEvalStore(t)
-	_, err := store.DistinctEvals(context.Background(), "")
+	_, err := store.EvalDiscovery(context.Background(), "")
 	require.Error(t, err)
+}
+
+func TestEvalDiscovery_SkipsEmptyAgentAndPromptpack(t *testing.T) {
+	// Insert a row with empty agent_name and empty promptpack_name. The
+	// distinct-column queries filter `<column> <> ''` so these values must
+	// not appear in the result.
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	store := newEvalStore(t)
+	ctx := context.Background()
+	sid := "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13"
+	seedSession(t, store, sid)
+
+	r := makeEvalResult(sid, "blank-eval", "llm_judge")
+	r.AgentName = ""
+	r.PromptPackName = ""
+	require.NoError(t, store.InsertEvalResults(ctx, []*api.EvalResult{r}))
+
+	res, err := store.EvalDiscovery(ctx, "default")
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	for _, a := range res.Agents {
+		assert.NotEmpty(t, a, "empty agent_name should be filtered out")
+	}
+	for _, p := range res.PromptPacks {
+		assert.NotEmpty(t, p, "empty promptpack_name should be filtered out")
+	}
 }


### PR DESCRIPTION
## Summary

Third-wave follow-up to #1084. Extends the `/eval-results/discover` endpoint to return distinct `agent_name` and `promptpack_name` values alongside the existing `(eval_id, eval_type)` pairs, then rewrites `useEvalFilter` to consume that one round-trip instead of two PromQL label-discovery queries.

Public surface (`UseEvalFilterResult`, `useEvalFilter`) is unchanged; `/quality` consumes it without modification.

## Backend
- `EvalStore.DistinctEvals` → `EvalDiscovery` returning new `EvalDiscoveryResult{Evals, Agents, PromptPacks}` struct.
- Postgres impl: `distinctEvals` + reusable `distinctStringColumn` helper (column name is a closed set of internal identifiers, never user input; `gosec` annotated).
- Handler renders `{evals, agents, promptpacks}` and normalises nil slices to `[]`.
- Proxy route is unchanged passthrough (the additive response shape is forwarded as-is).

## Frontend
- New `fetchEvalDiscovery` service returning the full payload; `fetchEvalDescriptors` retained as a thin wrapper for `use-eval-trends` and `use-eval-quality` (React Query dedupes when both hit the same endpoint).
- `useEvalFilter` now uses `currentWorkspace` from `WorkspaceContext`; returns empty arrays when no workspace is selected.

## Allowlist
- Drops `dashboard/src/hooks/use-eval-filter.ts` from `hack/no-prom-product-deps.allowlist`. **Two entries left** (`use-agent-cost`, `use-provider-metrics`); each needs new session-api endpoints over `provider_calls` and is separate PR work.

## Test plan
- [x] Store: `TestEvalDiscovery` (sorted distinct evals + agents + promptpacks), `TestEvalDiscovery_NamespaceIsolation`, `TestEvalDiscovery_MissingNamespace`, `TestEvalDiscovery_SkipsEmptyAgentAndPromptpack`
- [x] Handler: discovery test exercises the full `{evals, agents, promptpacks}` shape; nil-result test verifies all three arrays normalise to `[]`
- [x] Service: `fetchEvalDiscovery` tests cover workspace URL encoding, slice normalisation when fields are missing, error path
- [x] Hook: 6 cases covering populated/empty/no-workspace/error paths and filter state transitions
- [x] Per-file coverage ≥80% on changed files (use-eval-filter.ts 93.8%, eval-results-service.ts 100%, eval_handler.go 83%, eval_service.go 93.5%)
- [x] `golangci-lint run --new-from-rev=main` → 0 issues
- [x] Pre-commit hook clean
- [ ] CI green