### PR TITLE
feat(provider): AgentRuntime ref-role + consumer guards (#1091)

### DIFF
--- a/api/v1alpha1/agentruntime_types.go
+++ b/api/v1alpha1/agentruntime_types.go
@@ -375,6 +375,17 @@ type NamedProviderRef struct {
 	// +kubebuilder:validation:Required
 	ProviderRef ProviderRef `json:"providerRef"`
 
+	// role declares the role the AgentRuntime expects the referenced
+	// Provider to fulfil. The controller asserts at reconcile time that
+	// the referenced Provider's `spec.role` matches; mismatch puts the
+	// AgentRuntime in Phase=Error with ProvidersReady=False.
+	//
+	// Defaults to 'inference' for back-compat with existing AgentRuntimes
+	// (which were authored before per-ref roles existed).
+	// +optional
+	// +kubebuilder:default=inference
+	Role ProviderRole `json:"role,omitempty"`
+
 	// requiredCapabilities lists capabilities the provider must support for
 	// this binding. If the provider does not advertise all listed capabilities,
 	// the AgentRuntime enters a Pending phase with a descriptive condition.

--- a/api/v1alpha1/provider_role_test.go
+++ b/api/v1alpha1/provider_role_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Altaira Labs.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvider_EffectiveRole_DefaultsToInference(t *testing.T) {
+	t.Run("nil receiver", func(t *testing.T) {
+		var p *Provider
+		assert.Equal(t, ProviderRoleInference, p.EffectiveRole())
+	})
+
+	t.Run("empty role", func(t *testing.T) {
+		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}}
+		assert.Equal(t, ProviderRoleInference, p.EffectiveRole())
+	})
+
+	t.Run("explicit role passes through", func(t *testing.T) {
+		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeVoyageAI, Role: ProviderRoleEmbedding}}
+		assert.Equal(t, ProviderRoleEmbedding, p.EffectiveRole())
+	})
+}
+
+func TestRequireProviderRole(t *testing.T) {
+	t.Run("matching role returns nil", func(t *testing.T) {
+		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeVoyageAI, Role: ProviderRoleEmbedding}}
+		require.NoError(t, RequireProviderRole(p, ProviderRoleEmbedding))
+	})
+
+	t.Run("empty role on Provider treated as inference", func(t *testing.T) {
+		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}}
+		require.NoError(t, RequireProviderRole(p, ProviderRoleInference))
+	})
+
+	t.Run("empty required treated as inference", func(t *testing.T) {
+		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}}
+		require.NoError(t, RequireProviderRole(p, ""))
+	})
+
+	t.Run("mismatch returns error with both roles and provider name", func(t *testing.T) {
+		p := &Provider{}
+		p.Name = "openai-echo"
+		p.Spec.Type = ProviderTypeOpenAI
+		p.Spec.Role = ProviderRoleTTS
+		err := RequireProviderRole(p, ProviderRoleEmbedding)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "openai-echo")
+		assert.Contains(t, err.Error(), "tts")
+		assert.Contains(t, err.Error(), "embedding")
+	})
+
+	t.Run("inference-default mismatch (caller wants embedding)", func(t *testing.T) {
+		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}} // role defaults to inference
+		err := RequireProviderRole(p, ProviderRoleEmbedding)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "inference")
+		assert.Contains(t, err.Error(), "embedding")
+	})
+
+	t.Run("nil provider", func(t *testing.T) {
+		err := RequireProviderRole(nil, ProviderRoleInference)
+		require.Error(t, err)
+	})
+}

--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -424,6 +426,35 @@ type Provider struct {
 	// status defines the observed state of Provider
 	// +optional
 	Status ProviderStatus `json:"status,omitzero"`
+}
+
+// EffectiveRole returns the Provider's declared role, defaulting to
+// ProviderRoleInference when unset for back-compat with pre-role Providers.
+// Safe to call on a nil receiver (returns inference).
+func (p *Provider) EffectiveRole() ProviderRole {
+	if p == nil || p.Spec.Role == "" {
+		return ProviderRoleInference
+	}
+	return p.Spec.Role
+}
+
+// RequireProviderRole asserts that the Provider's role matches the required
+// role. Pre-role Providers default to ProviderRoleInference. Returns nil on
+// match, a user-facing error on mismatch. Consumers (memory-api, arena-worker,
+// eval-worker) call this before constructing a PromptKit provider to surface
+// a clear error instead of a downstream factory complaint.
+func RequireProviderRole(provider *Provider, required ProviderRole) error {
+	if provider == nil {
+		return fmt.Errorf("provider is nil")
+	}
+	if required == "" {
+		required = ProviderRoleInference
+	}
+	if actual := provider.EffectiveRole(); actual != required {
+		return fmt.Errorf("provider %q has role %q but %q is required",
+			provider.Name, actual, required)
+	}
+	return nil
 }
 
 // +kubebuilder:object:root=true

--- a/charts/omnia/crds/omnia.altairalabs.ai_agentruntimes.yaml
+++ b/charts/omnia/crds/omnia.altairalabs.ai_agentruntimes.yaml
@@ -7942,6 +7942,23 @@ spec:
                         - duplex
                         type: string
                       type: array
+                    role:
+                      default: inference
+                      description: |-
+                        role declares the role the AgentRuntime expects the referenced
+                        Provider to fulfil. The controller asserts at reconcile time that
+                        the referenced Provider's `spec.role` matches; mismatch puts the
+                        AgentRuntime in Phase=Error with ProvidersReady=False.
+
+                        Defaults to 'inference' for back-compat with existing AgentRuntimes
+                        (which were authored before per-ref roles existed).
+                      enum:
+                      - inference
+                      - embedding
+                      - tts
+                      - stt
+                      - image
+                      type: string
                   required:
                   - name
                   - providerRef
@@ -8016,6 +8033,23 @@ spec:
                                 - duplex
                                 type: string
                               type: array
+                            role:
+                              default: inference
+                              description: |-
+                                role declares the role the AgentRuntime expects the referenced
+                                Provider to fulfil. The controller asserts at reconcile time that
+                                the referenced Provider's `spec.role` matches; mismatch puts the
+                                AgentRuntime in Phase=Error with ProvidersReady=False.
+
+                                Defaults to 'inference' for back-compat with existing AgentRuntimes
+                                (which were authored before per-ref roles existed).
+                              enum:
+                              - inference
+                              - embedding
+                              - tts
+                              - stt
+                              - image
+                              type: string
                           required:
                           - name
                           - providerRef

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -946,6 +946,14 @@ func createEmbeddingService(ctx context.Context, providerName string, store *mem
 		return nil
 	}
 
+	// Require role=embedding. Pre-role Providers default to inference
+	// (and rejecting them here gives a clearer error than the downstream
+	// PromptKit factory complaint).
+	if err := omniav1alpha1.RequireProviderRole(&provider, omniav1alpha1.ProviderRoleEmbedding); err != nil {
+		log.Error(err, "embedding service skipped", "provider", providerName)
+		return nil
+	}
+
 	embeddingProvider, err := createEmbeddingProviderFromCRD(ctx, k8sClient, &provider, ns, log)
 	if err != nil {
 		log.Error(err, "failed to create embedding provider", "name", providerName, "type", provider.Spec.Type)

--- a/config/crd/bases/omnia.altairalabs.ai_agentruntimes.yaml
+++ b/config/crd/bases/omnia.altairalabs.ai_agentruntimes.yaml
@@ -7942,6 +7942,23 @@ spec:
                         - duplex
                         type: string
                       type: array
+                    role:
+                      default: inference
+                      description: |-
+                        role declares the role the AgentRuntime expects the referenced
+                        Provider to fulfil. The controller asserts at reconcile time that
+                        the referenced Provider's `spec.role` matches; mismatch puts the
+                        AgentRuntime in Phase=Error with ProvidersReady=False.
+
+                        Defaults to 'inference' for back-compat with existing AgentRuntimes
+                        (which were authored before per-ref roles existed).
+                      enum:
+                      - inference
+                      - embedding
+                      - tts
+                      - stt
+                      - image
+                      type: string
                   required:
                   - name
                   - providerRef
@@ -8016,6 +8033,23 @@ spec:
                                 - duplex
                                 type: string
                               type: array
+                            role:
+                              default: inference
+                              description: |-
+                                role declares the role the AgentRuntime expects the referenced
+                                Provider to fulfil. The controller asserts at reconcile time that
+                                the referenced Provider's `spec.role` matches; mismatch puts the
+                                AgentRuntime in Phase=Error with ProvidersReady=False.
+
+                                Defaults to 'inference' for back-compat with existing AgentRuntimes
+                                (which were authored before per-ref roles existed).
+                              enum:
+                              - inference
+                              - embedding
+                              - tts
+                              - stt
+                              - image
+                              type: string
                           required:
                           - name
                           - providerRef

--- a/dashboard/src/types/generated/agentruntime.ts
+++ b/dashboard/src/types/generated/agentruntime.ts
@@ -4402,6 +4402,14 @@ export interface AgentRuntimeSpec {
      * this binding. If the provider does not advertise all listed capabilities,
      * the AgentRuntime enters a Pending phase with a descriptive condition. */
     requiredCapabilities?: ("text" | "streaming" | "vision" | "tools" | "json" | "audio" | "video" | "documents" | "duplex")[];
+    /** role declares the role the AgentRuntime expects the referenced
+     * Provider to fulfil. The controller asserts at reconcile time that
+     * the referenced Provider's `spec.role` matches; mismatch puts the
+     * AgentRuntime in Phase=Error with ProvidersReady=False.
+     * 
+     * Defaults to 'inference' for back-compat with existing AgentRuntimes
+     * (which were authored before per-ref roles existed). */
+    role?: "inference" | "embedding" | "tts" | "stt" | "image";
   }[];
   /** rollout configures a progressive delivery rollout for this AgentRuntime.
    * When nil, no rollout is active and all traffic goes to the current spec. */
@@ -4430,6 +4438,14 @@ export interface AgentRuntimeSpec {
          * this binding. If the provider does not advertise all listed capabilities,
          * the AgentRuntime enters a Pending phase with a descriptive condition. */
         requiredCapabilities?: ("text" | "streaming" | "vision" | "tools" | "json" | "audio" | "video" | "documents" | "duplex")[];
+        /** role declares the role the AgentRuntime expects the referenced
+         * Provider to fulfil. The controller asserts at reconcile time that
+         * the referenced Provider's `spec.role` matches; mismatch puts the
+         * AgentRuntime in Phase=Error with ProvidersReady=False.
+         * 
+         * Defaults to 'inference' for back-compat with existing AgentRuntimes
+         * (which were authored before per-ref roles existed). */
+        role?: "inference" | "embedding" | "tts" | "stt" | "image";
       }[];
       /** toolRegistryRef overrides the tool registry for the candidate. */
       toolRegistryRef?: {

--- a/ee/cmd/arena-worker/provider_groups.go
+++ b/ee/cmd/arena-worker/provider_groups.go
@@ -201,8 +201,15 @@ func resolveEntry(
 	return nil, nil, nil
 }
 
-// resolveProviderRefEntry resolves a single Provider CRD and adds it to LoadedProviders.
-// Returns parsed pricing if the provider has spec.pricing configured.
+// resolveProviderRefEntry resolves a single Provider CRD and adds it to
+// LoadedProviders (Arena's inference-provider map). Returns parsed pricing
+// if the provider has spec.pricing configured.
+//
+// LoadedProviders is the inference-only registry; TTS/STT/embedding
+// providers would route through separate Arena config blocks that
+// don't exist yet. Until those land, refuse any non-inference Provider
+// at the resolution boundary so the failure mode is a clear error rather
+// than a confusing PromptKit factory complaint downstream.
 func resolveProviderRefEntry(
 	rc *resolveContext,
 	ref v1alpha1.ProviderRef,
@@ -211,6 +218,10 @@ func resolveProviderRefEntry(
 	provider, err := k8s.GetProvider(rc.ctx, rc.c, ref, rc.namespace)
 	if err != nil {
 		return nil, fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
+	}
+
+	if err := v1alpha1.RequireProviderRole(provider, v1alpha1.ProviderRoleInference); err != nil {
+		return nil, fmt.Errorf("group %q: %w", groupName, err)
 	}
 
 	providerID := sanitizeID(provider.Name)

--- a/ee/pkg/evals/provider_resolver.go
+++ b/ee/pkg/evals/provider_resolver.go
@@ -162,6 +162,16 @@ func (r *ProviderResolver) resolveOne(
 		return providers.ProviderSpec{}, fmt.Errorf("get Provider CRD: %w", err)
 	}
 
+	// Eval judges are inference providers; refuse anything else early
+	// rather than letting the PromptKit factory fail with a less clear error.
+	required := np.Role
+	if required == "" {
+		required = v1alpha1.ProviderRoleInference
+	}
+	if err := v1alpha1.RequireProviderRole(provider, required); err != nil {
+		return providers.ProviderSpec{}, err
+	}
+
 	spec := providers.ProviderSpec{
 		ID:      np.Name,
 		Type:    string(provider.Spec.Type),

--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -229,6 +229,17 @@ func (r *AgentRuntimeReconciler) fetchAndValidateProvider(
 		}
 		return nil, ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
+	if mismatch := providerRoleMismatch(provider, np.Role); mismatch != "" {
+		SetCondition(&agentRuntime.Status.Conditions, agentRuntime.Generation, ConditionTypeProviderReady, metav1.ConditionFalse,
+			"RoleMismatch", mismatch)
+		// Role mismatch is a configuration error — won't self-resolve
+		// until the spec changes. Park the runtime in Failed phase.
+		agentRuntime.Status.Phase = omniav1alpha1.AgentRuntimePhaseFailed
+		if statusErr := r.Status().Update(ctx, agentRuntime); statusErr != nil {
+			log.Error(statusErr, logMsgFailedToUpdateStatus)
+		}
+		return nil, ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 	if missing := missingCapabilities(provider, np.RequiredCapabilities); len(missing) > 0 {
 		msg := fmt.Sprintf("Provider %s missing required capabilities: %v", provider.Name, missing)
 		SetCondition(&agentRuntime.Status.Conditions, agentRuntime.Generation, ConditionTypeProviderReady, metav1.ConditionFalse,
@@ -242,6 +253,21 @@ func (r *AgentRuntimeReconciler) fetchAndValidateProvider(
 	SetCondition(&agentRuntime.Status.Conditions, agentRuntime.Generation, ConditionTypeProviderReady, metav1.ConditionTrue,
 		"ProviderFound", "Provider resource found and ready")
 	return provider, ctrl.Result{}, nil
+}
+
+// providerRoleMismatch returns an empty string when the Provider's role
+// matches the ref's required role, or a user-facing message describing the
+// mismatch otherwise. Treats an empty role on either side as `inference`
+// for back-compat with pre-role Providers and AgentRuntimes.
+func providerRoleMismatch(provider *omniav1alpha1.Provider, required omniav1alpha1.ProviderRole) string {
+	if required == "" {
+		required = omniav1alpha1.ProviderRoleInference
+	}
+	if provider.EffectiveRole() == required {
+		return ""
+	}
+	return fmt.Sprintf("Provider %s has role %q but ref requires role %q",
+		provider.Name, provider.EffectiveRole(), required)
 }
 
 // missingCapabilities returns the required capabilities not present in the

--- a/internal/controller/agentruntime_controller_test.go
+++ b/internal/controller/agentruntime_controller_test.go
@@ -2889,6 +2889,111 @@ var _ = Describe("AgentRuntime Controller", func() {
 			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
 		})
 
+		It("should put runtime in Failed phase when provider role mismatches ref role", func() {
+			By("creating an embedding-role Provider")
+			provider := &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "embed-provider",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:      omniav1alpha1.ProviderTypeVoyageAI,
+					Role:      omniav1alpha1.ProviderRoleEmbedding,
+					Model:     "voyage-2",
+					Embedding: &omniav1alpha1.EmbeddingConfig{Dimensions: 1024},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+			provider.Status.Phase = omniav1alpha1.ProviderPhaseReady
+			Expect(k8sClient.Status().Update(ctx, provider)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, provider) }()
+
+			By("creating an AgentRuntime that references it as role=inference")
+			ref := omniav1alpha1.ProviderRef{Name: "embed-provider"}
+			agentRuntime := &omniav1alpha1.AgentRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "role-mismatch-runtime",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.AgentRuntimeSpec{
+					PromptPackRef: omniav1alpha1.PromptPackRef{Name: "test-pack"},
+					Facade:        omniav1alpha1.FacadeConfig{Type: omniav1alpha1.FacadeTypeWebSocket},
+					Providers: []omniav1alpha1.NamedProviderRef{
+						{Name: "default", ProviderRef: ref, Role: omniav1alpha1.ProviderRoleInference},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agentRuntime)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, agentRuntime) }()
+
+			By("calling fetchAndValidateProvider")
+			log := logf.FromContext(ctx)
+			_, result, err := reconciler.fetchAndValidateProvider(ctx, log, agentRuntime, agentRuntime.Spec.Providers[0])
+
+			By("verifying it requeues with RoleMismatch and parks runtime in Failed")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(30 * time.Second))
+			Expect(agentRuntime.Status.Phase).To(Equal(omniav1alpha1.AgentRuntimePhaseFailed))
+
+			condition := meta.FindStatusCondition(agentRuntime.Status.Conditions, ConditionTypeProviderReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal("RoleMismatch"))
+			Expect(condition.Message).To(ContainSubstring("embedding"))
+			Expect(condition.Message).To(ContainSubstring("inference"))
+		})
+
+		It("should accept a provider where role matches ref role (embedding)", func() {
+			By("creating an embedding-role Provider")
+			provider := &omniav1alpha1.Provider{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "embed-provider-match",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.ProviderSpec{
+					Type:      omniav1alpha1.ProviderTypeVoyageAI,
+					Role:      omniav1alpha1.ProviderRoleEmbedding,
+					Model:     "voyage-2",
+					Embedding: &omniav1alpha1.EmbeddingConfig{Dimensions: 1024},
+				},
+			}
+			Expect(k8sClient.Create(ctx, provider)).To(Succeed())
+			provider.Status.Phase = omniav1alpha1.ProviderPhaseReady
+			Expect(k8sClient.Status().Update(ctx, provider)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, provider) }()
+
+			By("creating an AgentRuntime that references it as role=embedding")
+			ref := omniav1alpha1.ProviderRef{Name: "embed-provider-match"}
+			agentRuntime := &omniav1alpha1.AgentRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "role-match-runtime",
+					Namespace: "default",
+				},
+				Spec: omniav1alpha1.AgentRuntimeSpec{
+					PromptPackRef: omniav1alpha1.PromptPackRef{Name: "test-pack"},
+					Facade:        omniav1alpha1.FacadeConfig{Type: omniav1alpha1.FacadeTypeWebSocket},
+					Providers: []omniav1alpha1.NamedProviderRef{
+						{Name: "embed", ProviderRef: ref, Role: omniav1alpha1.ProviderRoleEmbedding},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, agentRuntime)).To(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, agentRuntime) }()
+
+			By("calling fetchAndValidateProvider")
+			log := logf.FromContext(ctx)
+			fetched, result, err := reconciler.fetchAndValidateProvider(ctx, log, agentRuntime, agentRuntime.Spec.Providers[0])
+
+			By("verifying it succeeds")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(time.Duration(0)))
+			Expect(fetched).NotTo(BeNil())
+
+			condition := meta.FindStatusCondition(agentRuntime.Status.Conditions, ConditionTypeProviderReady)
+			Expect(condition).NotTo(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+		})
+
 	})
 
 	Context("When using spec.providers list", func() {

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -591,11 +591,9 @@ func providerRequiresCredentials(provider *omniav1alpha1.Provider) bool {
 
 // providerRole returns the provider's declared role, defaulting to
 // ProviderRoleInference when unset for back-compat with pre-role Providers.
+// Thin wrapper over Provider.EffectiveRole() so existing call sites stay concise.
 func providerRole(provider *omniav1alpha1.Provider) omniav1alpha1.ProviderRole {
-	if provider == nil || provider.Spec.Role == "" {
-		return omniav1alpha1.ProviderRoleInference
-	}
-	return provider.Spec.Role
+	return provider.EffectiveRole()
 }
 
 // emitWarningEvent emits a Kubernetes warning event if a Recorder is available.


### PR DESCRIPTION
## Summary

Phase 2 of the Provider CRD multi-role extension (umbrella #1089, builds on #1093). Threads the role discriminator through AgentRuntime provider refs and the three consumer call sites that resolve Provider CRDs.

Resolves #1091.

## Changes

### CRD
- `NamedProviderRef.role` (default `inference` via `+kubebuilder:default`). The AgentRuntime controller asserts at reconcile time that the referenced Provider's `spec.role` matches; mismatch → `AgentRuntimePhaseFailed` with `ConditionTypeProviderReady=False`, reason `RoleMismatch`.

### Shared helpers (api/v1alpha1)
- `Provider.EffectiveRole()` returns the declared role; defaults to `ProviderRoleInference` for pre-role Providers; safe on nil receiver.
- `v1alpha1.RequireProviderRole(provider, required)` — the shared precondition consumers call before constructing a PromptKit provider.

### Consumer guards
- **memory-api** (`createEmbeddingService`): requires `role=embedding`.
- **eval-worker** (`provider_resolver.resolveOne`): requires the role declared on the NamedProviderRef (defaults to inference; eval judges run as inference by default).
- **arena-worker** (`resolveProviderRefEntry`): requires `role=inference`. Arena's `LoadedProviders` is the inference-only registry; TTS/STT/embedding providers would route through separate Arena config blocks that don't exist yet. Until those land, refusing non-inference at the resolution boundary gives a clear error instead of a confusing PromptKit factory complaint.

### Back-compat
- `NamedProviderRef.role` defaults to `inference`; every existing AgentRuntime keeps admitting and reconciling without YAML changes.
- `EffectiveRole()` defaults to `inference` for pre-role Provider CRDs; existing consumer flows unaffected.

## Test plan
- [x] **api/v1alpha1 unit tests**: `EffectiveRole` (nil receiver, missing role, explicit role); `RequireProviderRole` (match + multiple mismatch shapes; empty-default behaviour; nil provider).
- [x] **envtest controller tests**:
  - Embedding-role Provider + inference-role ref → `Phase=Failed`, `RoleMismatch` condition with both roles in the message.
  - Embedding-role Provider + embedding-role ref → `Phase` unchanged, `ProviderReady=True`.
- [x] Per-file coverage ≥80% on every changed file (api types 100%, controllers 85-89%, consumers 95%).
- [x] `golangci-lint run --new-from-rev=main` → 0 issues.
- [x] Pre-commit hook fully clean.
- [ ] CI green.

## Out of scope
- Dashboard role-first wizard (#1092). The dashboard's existing provider edit form continues to work — it just doesn't surface the new `role` field on AgentRuntime refs until Phase 3 lands.