### PR TITLE
fix(provider): rename role inference→llm, align CEL matrix with PromptKit

### DIFF
--- a/api/v1alpha1/agentruntime_types.go
+++ b/api/v1alpha1/agentruntime_types.go
@@ -254,11 +254,11 @@ type AutoscalingConfig struct {
 	KEDA *KEDAConfig `json:"keda,omitempty"`
 }
 
-// ProviderType defines the LLM provider type.
+// ProviderType defines the provider vendor / wire protocol.
 // Hyperscaler hosting (Bedrock/Vertex/Azure) is expressed via spec.platform
 // on the Provider CRD, not as a provider type. The provider type describes
-// the wire protocol (message/response format) that the runtime uses.
-// +kubebuilder:validation:Enum=claude;openai;gemini;ollama;mock;vllm;voyageai
+// the wire protocol the runtime uses; the role (spec.role) is orthogonal.
+// +kubebuilder:validation:Enum=claude;openai;gemini;ollama;mock;vllm;voyageai;cartesia;elevenlabs;imagen
 type ProviderType string
 
 const (
@@ -276,13 +276,20 @@ const (
 	ProviderTypeOllama ProviderType = "ollama"
 	// ProviderTypeMock uses PromptKit's mock provider for testing.
 	// Does not require secretRef. Returns canned responses based on scenario.
+	// LLM-role only; no mock factory is registered for embedding/tts/stt/image.
 	ProviderTypeMock ProviderType = "mock"
 	// ProviderTypeVLLM uses a vLLM-served OpenAI-compatible endpoint.
 	// Requires baseURL. Auth is typically via custom headers (spec.headers).
 	ProviderTypeVLLM ProviderType = "vllm"
-	// ProviderTypeVoyageAI uses Voyage AI embedding models.
+	// ProviderTypeVoyageAI uses Voyage AI embedding models. Embedding-role only.
 	// Requires an API key via secretRef (VOYAGE_API_KEY).
 	ProviderTypeVoyageAI ProviderType = "voyageai"
+	// ProviderTypeCartesia uses Cartesia TTS. TTS-role only.
+	ProviderTypeCartesia ProviderType = "cartesia"
+	// ProviderTypeElevenLabs uses ElevenLabs TTS. TTS-role only.
+	ProviderTypeElevenLabs ProviderType = "elevenlabs"
+	// ProviderTypeImagen uses Google's Imagen image-generation model. Image-role only.
+	ProviderTypeImagen ProviderType = "imagen"
 )
 
 // TruncationStrategy defines how to handle context overflow.
@@ -380,10 +387,10 @@ type NamedProviderRef struct {
 	// the referenced Provider's `spec.role` matches; mismatch puts the
 	// AgentRuntime in Phase=Error with ProvidersReady=False.
 	//
-	// Defaults to 'inference' for back-compat with existing AgentRuntimes
+	// Defaults to 'llm' for back-compat with existing AgentRuntimes
 	// (which were authored before per-ref roles existed).
 	// +optional
-	// +kubebuilder:default=inference
+	// +kubebuilder:default=llm
 	Role ProviderRole `json:"role,omitempty"`
 
 	// requiredCapabilities lists capabilities the provider must support for

--- a/api/v1alpha1/provider_role_test.go
+++ b/api/v1alpha1/provider_role_test.go
@@ -13,15 +13,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestProvider_EffectiveRole_DefaultsToInference(t *testing.T) {
+func TestProvider_EffectiveRole_DefaultsToLLM(t *testing.T) {
 	t.Run("nil receiver", func(t *testing.T) {
 		var p *Provider
-		assert.Equal(t, ProviderRoleInference, p.EffectiveRole())
+		assert.Equal(t, ProviderRoleLLM, p.EffectiveRole())
 	})
 
 	t.Run("empty role", func(t *testing.T) {
 		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}}
-		assert.Equal(t, ProviderRoleInference, p.EffectiveRole())
+		assert.Equal(t, ProviderRoleLLM, p.EffectiveRole())
 	})
 
 	t.Run("explicit role passes through", func(t *testing.T) {
@@ -36,12 +36,12 @@ func TestRequireProviderRole(t *testing.T) {
 		require.NoError(t, RequireProviderRole(p, ProviderRoleEmbedding))
 	})
 
-	t.Run("empty role on Provider treated as inference", func(t *testing.T) {
+	t.Run("empty role on Provider treated as llm", func(t *testing.T) {
 		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}}
-		require.NoError(t, RequireProviderRole(p, ProviderRoleInference))
+		require.NoError(t, RequireProviderRole(p, ProviderRoleLLM))
 	})
 
-	t.Run("empty required treated as inference", func(t *testing.T) {
+	t.Run("empty required treated as llm", func(t *testing.T) {
 		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}}
 		require.NoError(t, RequireProviderRole(p, ""))
 	})
@@ -58,16 +58,16 @@ func TestRequireProviderRole(t *testing.T) {
 		assert.Contains(t, err.Error(), "embedding")
 	})
 
-	t.Run("inference-default mismatch (caller wants embedding)", func(t *testing.T) {
-		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}} // role defaults to inference
+	t.Run("llm-default mismatch (caller wants embedding)", func(t *testing.T) {
+		p := &Provider{Spec: ProviderSpec{Type: ProviderTypeClaude}} // role defaults to llm
 		err := RequireProviderRole(p, ProviderRoleEmbedding)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "inference")
+		assert.Contains(t, err.Error(), "llm")
 		assert.Contains(t, err.Error(), "embedding")
 	})
 
 	t.Run("nil provider", func(t *testing.T) {
-		err := RequireProviderRole(nil, ProviderRoleInference)
+		err := RequireProviderRole(nil, ProviderRoleLLM)
 		require.Error(t, err)
 	})
 }

--- a/api/v1alpha1/provider_types.go
+++ b/api/v1alpha1/provider_types.go
@@ -24,26 +24,29 @@ import (
 
 // ProviderRole describes what kind of provider this is — the closed enum
 // that selects which factory registry the provider plugs into. Mirrors
-// PromptKit's Provider.Role enum.
+// PromptKit's pkg/config.Role enum.
 //
-//	inference  — chat / completion LLMs (default; existing behaviour)
+//	llm        — chat / completion LLMs (default; existing behaviour)
 //	embedding  — vector embedding models
 //	tts        — text-to-speech
 //	stt        — speech-to-text
-//	image      — image generation
+//	image      — image generation (declarable; no Omnia consumer yet)
 //
 // Distinct from `spec.capabilities` (free-form feature tags like "vision"
 // or "streaming") — role is the kind of provider, capabilities are the
 // features it supports within that role.
 //
-// +kubebuilder:validation:Enum=inference;embedding;tts;stt;image
+// "inference" is intentionally NOT a value here so we can reuse that name
+// later for a more generic role (e.g. Hugging Face Inference Endpoints).
+//
+// +kubebuilder:validation:Enum=llm;embedding;tts;stt;image
 type ProviderRole string
 
 const (
-	// ProviderRoleInference is the role for chat / completion LLM providers.
+	// ProviderRoleLLM is the role for chat / completion LLM providers.
 	// This is the back-compat default — Providers without an explicit role
-	// are treated as inference.
-	ProviderRoleInference ProviderRole = "inference"
+	// are treated as llm.
+	ProviderRoleLLM ProviderRole = "llm"
 	// ProviderRoleEmbedding is the role for vector embedding providers.
 	ProviderRoleEmbedding ProviderRole = "embedding"
 	// ProviderRoleTTS is the role for text-to-speech providers.
@@ -51,7 +54,8 @@ const (
 	// ProviderRoleSTT is the role for speech-to-text providers.
 	ProviderRoleSTT ProviderRole = "stt"
 	// ProviderRoleImage is the role for image-generation providers. Accepted
-	// by the CRD but no consumer wires it through yet; reserved for future work.
+	// by the CRD but no Omnia consumer wires it through yet; reserved for
+	// future work.
 	ProviderRoleImage ProviderRole = "image"
 )
 
@@ -266,19 +270,35 @@ type AuthConfig struct {
 
 // ProviderSpec defines the desired state of Provider.
 //
-// Role-block + (role × type) validations:
+// Role-block + (role × type) validations. The vendor list per role mirrors
+// the PromptKit factory registrations that Omnia binaries link in:
+//   - llm:        claude | openai | gemini | ollama | mock | vllm
+//   - embedding:  openai | voyageai | gemini | ollama
+//   - tts:        openai | cartesia | elevenlabs
+//   - stt:        openai
+//   - image:      imagen
+//
+// Vendors that are exclusive to a single role (voyageai → embedding,
+// cartesia/elevenlabs → tts, imagen → image) are pinned to that role so
+// CEL fails closed instead of letting an authoring mistake reach the
+// factory layer.
+//
 // +kubebuilder:validation:XValidation:rule="(has(self.tts) ? 1 : 0) + (has(self.stt) ? 1 : 0) + (has(self.embedding) ? 1 : 0) <= 1",message="at most one of spec.tts, spec.stt, spec.embedding may be set"
 // +kubebuilder:validation:XValidation:rule="!has(self.tts) || self.role == 'tts'",message="spec.tts is only valid when spec.role is 'tts'"
 // +kubebuilder:validation:XValidation:rule="!has(self.stt) || self.role == 'stt'",message="spec.stt is only valid when spec.role is 'stt'"
 // +kubebuilder:validation:XValidation:rule="!has(self.embedding) || self.role == 'embedding'",message="spec.embedding is only valid when spec.role is 'embedding'"
-// +kubebuilder:validation:XValidation:rule="self.role != 'embedding' || self.type in ['openai', 'voyageai', 'gemini', 'ollama', 'mock']",message="role 'embedding' requires type in [openai, voyageai, gemini, ollama, mock]"
-// +kubebuilder:validation:XValidation:rule="self.role != 'tts' || self.type in ['openai', 'mock']",message="role 'tts' requires type in [openai, mock] (additional vendors land as PromptKit adds them)"
-// +kubebuilder:validation:XValidation:rule="self.role != 'stt' || self.type in ['openai', 'mock']",message="role 'stt' requires type in [openai, mock] (additional vendors land as PromptKit adds them)"
-// +kubebuilder:validation:XValidation:rule="self.role != 'image' || self.type in ['openai', 'gemini', 'mock']",message="role 'image' requires type in [openai, gemini, mock]"
-// +kubebuilder:validation:XValidation:rule="self.role != 'inference' || self.type != 'voyageai'",message="voyageai is an embedding-only vendor; set spec.role to 'embedding'"
+// +kubebuilder:validation:XValidation:rule="self.role != 'llm' || self.type in ['claude', 'openai', 'gemini', 'ollama', 'mock', 'vllm']",message="role 'llm' requires type in [claude, openai, gemini, ollama, mock, vllm]"
+// +kubebuilder:validation:XValidation:rule="self.role != 'embedding' || self.type in ['openai', 'voyageai', 'gemini', 'ollama']",message="role 'embedding' requires type in [openai, voyageai, gemini, ollama]"
+// +kubebuilder:validation:XValidation:rule="self.role != 'tts' || self.type in ['openai', 'cartesia', 'elevenlabs']",message="role 'tts' requires type in [openai, cartesia, elevenlabs]"
+// +kubebuilder:validation:XValidation:rule="self.role != 'stt' || self.type in ['openai']",message="role 'stt' requires type in [openai]"
+// +kubebuilder:validation:XValidation:rule="self.role != 'image' || self.type in ['imagen']",message="role 'image' requires type in [imagen]"
+// +kubebuilder:validation:XValidation:rule="self.type != 'voyageai' || self.role == 'embedding'",message="voyageai is an embedding-only vendor; set spec.role to 'embedding'"
+// +kubebuilder:validation:XValidation:rule="self.type != 'cartesia' || self.role == 'tts'",message="cartesia is a tts-only vendor; set spec.role to 'tts'"
+// +kubebuilder:validation:XValidation:rule="self.type != 'elevenlabs' || self.role == 'tts'",message="elevenlabs is a tts-only vendor; set spec.role to 'tts'"
+// +kubebuilder:validation:XValidation:rule="self.type != 'imagen' || self.role == 'image'",message="imagen is an image-only vendor; set spec.role to 'image'"
 //
-// Hyperscaler-platform validations (apply only when spec.role is 'inference'):
-// +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.role == 'inference'",message="spec.platform is only valid when spec.role is 'inference'"
+// Hyperscaler-platform validations (apply only when spec.role is 'llm'):
+// +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.role == 'llm'",message="spec.platform is only valid when spec.role is 'llm'"
 // +kubebuilder:validation:XValidation:rule="!has(self.platform) || (self.type in ['claude', 'openai', 'gemini'])",message="platform is only valid for provider types claude, openai, or gemini"
 // +kubebuilder:validation:XValidation:rule="has(self.platform) == has(self.auth)",message="spec.platform and spec.auth must be set together"
 // +kubebuilder:validation:XValidation:rule="!has(self.platform) || self.platform.type != 'bedrock' || self.auth.type in ['workloadIdentity', 'accessKey']",message="platform.type bedrock requires auth.type of workloadIdentity or accessKey"
@@ -294,10 +314,10 @@ type ProviderSpec struct {
 	Type ProviderType `json:"type"`
 
 	// role declares which kind of provider this is — selects the factory
-	// registry the provider plugs into. Defaults to 'inference' for
-	// back-compat; existing Providers continue to work without YAML changes.
+	// registry the provider plugs into. Defaults to 'llm' for back-compat;
+	// existing Providers continue to work without YAML changes.
 	// +optional
-	// +kubebuilder:default=inference
+	// +kubebuilder:default=llm
 	Role ProviderRole `json:"role,omitempty"`
 
 	// tts is the TTS-role config block. Required when spec.role is 'tts';
@@ -429,18 +449,18 @@ type Provider struct {
 }
 
 // EffectiveRole returns the Provider's declared role, defaulting to
-// ProviderRoleInference when unset for back-compat with pre-role Providers.
-// Safe to call on a nil receiver (returns inference).
+// ProviderRoleLLM when unset for back-compat with pre-role Providers.
+// Safe to call on a nil receiver (returns llm).
 func (p *Provider) EffectiveRole() ProviderRole {
 	if p == nil || p.Spec.Role == "" {
-		return ProviderRoleInference
+		return ProviderRoleLLM
 	}
 	return p.Spec.Role
 }
 
 // RequireProviderRole asserts that the Provider's role matches the required
-// role. Pre-role Providers default to ProviderRoleInference. Returns nil on
-// match, a user-facing error on mismatch. Consumers (memory-api, arena-worker,
+// role. Pre-role Providers default to ProviderRoleLLM. Returns nil on match,
+// a user-facing error on mismatch. Consumers (memory-api, arena-worker,
 // eval-worker) call this before constructing a PromptKit provider to surface
 // a clear error instead of a downstream factory complaint.
 func RequireProviderRole(provider *Provider, required ProviderRole) error {
@@ -448,7 +468,7 @@ func RequireProviderRole(provider *Provider, required ProviderRole) error {
 		return fmt.Errorf("provider is nil")
 	}
 	if required == "" {
-		required = ProviderRoleInference
+		required = ProviderRoleLLM
 	}
 	if actual := provider.EffectiveRole(); actual != required {
 		return fmt.Errorf("provider %q has role %q but %q is required",

--- a/charts/omnia/crds/omnia.altairalabs.ai_agentruntimes.yaml
+++ b/charts/omnia/crds/omnia.altairalabs.ai_agentruntimes.yaml
@@ -7943,17 +7943,17 @@ spec:
                         type: string
                       type: array
                     role:
-                      default: inference
+                      default: llm
                       description: |-
                         role declares the role the AgentRuntime expects the referenced
                         Provider to fulfil. The controller asserts at reconcile time that
                         the referenced Provider's `spec.role` matches; mismatch puts the
                         AgentRuntime in Phase=Error with ProvidersReady=False.
 
-                        Defaults to 'inference' for back-compat with existing AgentRuntimes
+                        Defaults to 'llm' for back-compat with existing AgentRuntimes
                         (which were authored before per-ref roles existed).
                       enum:
-                      - inference
+                      - llm
                       - embedding
                       - tts
                       - stt
@@ -8034,17 +8034,17 @@ spec:
                                 type: string
                               type: array
                             role:
-                              default: inference
+                              default: llm
                               description: |-
                                 role declares the role the AgentRuntime expects the referenced
                                 Provider to fulfil. The controller asserts at reconcile time that
                                 the referenced Provider's `spec.role` matches; mismatch puts the
                                 AgentRuntime in Phase=Error with ProvidersReady=False.
 
-                                Defaults to 'inference' for back-compat with existing AgentRuntimes
+                                Defaults to 'llm' for back-compat with existing AgentRuntimes
                                 (which were authored before per-ref roles existed).
                               enum:
-                              - inference
+                              - llm
                               - embedding
                               - tts
                               - stt

--- a/charts/omnia/crds/omnia.altairalabs.ai_providers.yaml
+++ b/charts/omnia/crds/omnia.altairalabs.ai_providers.yaml
@@ -333,13 +333,13 @@ spec:
                     type: string
                 type: object
               role:
-                default: inference
+                default: llm
                 description: |-
                   role declares which kind of provider this is — selects the factory
-                  registry the provider plugs into. Defaults to 'inference' for
-                  back-compat; existing Providers continue to work without YAML changes.
+                  registry the provider plugs into. Defaults to 'llm' for back-compat;
+                  existing Providers continue to work without YAML changes.
                 enum:
-                - inference
+                - llm
                 - embedding
                 - tts
                 - stt
@@ -410,6 +410,9 @@ spec:
                 - mock
                 - vllm
                 - voyageai
+                - cartesia
+                - elevenlabs
+                - imagen
                 type: string
             required:
             - type
@@ -424,22 +427,30 @@ spec:
               rule: '!has(self.stt) || self.role == ''stt'''
             - message: spec.embedding is only valid when spec.role is 'embedding'
               rule: '!has(self.embedding) || self.role == ''embedding'''
+            - message: role 'llm' requires type in [claude, openai, gemini, ollama,
+                mock, vllm]
+              rule: self.role != 'llm' || self.type in ['claude', 'openai', 'gemini',
+                'ollama', 'mock', 'vllm']
             - message: role 'embedding' requires type in [openai, voyageai, gemini,
-                ollama, mock]
+                ollama]
               rule: self.role != 'embedding' || self.type in ['openai', 'voyageai',
-                'gemini', 'ollama', 'mock']
-            - message: role 'tts' requires type in [openai, mock] (additional vendors
-                land as PromptKit adds them)
-              rule: self.role != 'tts' || self.type in ['openai', 'mock']
-            - message: role 'stt' requires type in [openai, mock] (additional vendors
-                land as PromptKit adds them)
-              rule: self.role != 'stt' || self.type in ['openai', 'mock']
-            - message: role 'image' requires type in [openai, gemini, mock]
-              rule: self.role != 'image' || self.type in ['openai', 'gemini', 'mock']
+                'gemini', 'ollama']
+            - message: role 'tts' requires type in [openai, cartesia, elevenlabs]
+              rule: self.role != 'tts' || self.type in ['openai', 'cartesia', 'elevenlabs']
+            - message: role 'stt' requires type in [openai]
+              rule: self.role != 'stt' || self.type in ['openai']
+            - message: role 'image' requires type in [imagen]
+              rule: self.role != 'image' || self.type in ['imagen']
             - message: voyageai is an embedding-only vendor; set spec.role to 'embedding'
-              rule: self.role != 'inference' || self.type != 'voyageai'
-            - message: spec.platform is only valid when spec.role is 'inference'
-              rule: '!has(self.platform) || self.role == ''inference'''
+              rule: self.type != 'voyageai' || self.role == 'embedding'
+            - message: cartesia is a tts-only vendor; set spec.role to 'tts'
+              rule: self.type != 'cartesia' || self.role == 'tts'
+            - message: elevenlabs is a tts-only vendor; set spec.role to 'tts'
+              rule: self.type != 'elevenlabs' || self.role == 'tts'
+            - message: imagen is an image-only vendor; set spec.role to 'image'
+              rule: self.type != 'imagen' || self.role == 'image'
+            - message: spec.platform is only valid when spec.role is 'llm'
+              rule: '!has(self.platform) || self.role == ''llm'''
             - message: platform is only valid for provider types claude, openai, or
                 gemini
               rule: '!has(self.platform) || (self.type in [''claude'', ''openai'',

--- a/cmd/memory-api/main.go
+++ b/cmd/memory-api/main.go
@@ -49,10 +49,12 @@ import (
 	pkproviders "github.com/AltairaLabs/PromptKit/runtime/providers"
 	// Side-effect imports register each provider's embedding factory with
 	// pkproviders.CreateEmbeddingProviderFromSpec — keeps this file out of
-	// the per-provider option-builder business.
+	// the per-provider option-builder business. Vendors must match the
+	// (embedding × vendor) row in api/v1alpha1.ProviderSpec CEL.
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/gemini"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/ollama"
 	_ "github.com/AltairaLabs/PromptKit/runtime/providers/openai"
+	_ "github.com/AltairaLabs/PromptKit/runtime/providers/voyageai"
 
 	omniav1alpha1 "github.com/altairalabs/omnia/api/v1alpha1"
 	eev1alpha1 "github.com/altairalabs/omnia/ee/api/v1alpha1"

--- a/config/crd/bases/omnia.altairalabs.ai_agentruntimes.yaml
+++ b/config/crd/bases/omnia.altairalabs.ai_agentruntimes.yaml
@@ -7943,17 +7943,17 @@ spec:
                         type: string
                       type: array
                     role:
-                      default: inference
+                      default: llm
                       description: |-
                         role declares the role the AgentRuntime expects the referenced
                         Provider to fulfil. The controller asserts at reconcile time that
                         the referenced Provider's `spec.role` matches; mismatch puts the
                         AgentRuntime in Phase=Error with ProvidersReady=False.
 
-                        Defaults to 'inference' for back-compat with existing AgentRuntimes
+                        Defaults to 'llm' for back-compat with existing AgentRuntimes
                         (which were authored before per-ref roles existed).
                       enum:
-                      - inference
+                      - llm
                       - embedding
                       - tts
                       - stt
@@ -8034,17 +8034,17 @@ spec:
                                 type: string
                               type: array
                             role:
-                              default: inference
+                              default: llm
                               description: |-
                                 role declares the role the AgentRuntime expects the referenced
                                 Provider to fulfil. The controller asserts at reconcile time that
                                 the referenced Provider's `spec.role` matches; mismatch puts the
                                 AgentRuntime in Phase=Error with ProvidersReady=False.
 
-                                Defaults to 'inference' for back-compat with existing AgentRuntimes
+                                Defaults to 'llm' for back-compat with existing AgentRuntimes
                                 (which were authored before per-ref roles existed).
                               enum:
-                              - inference
+                              - llm
                               - embedding
                               - tts
                               - stt

--- a/config/crd/bases/omnia.altairalabs.ai_providers.yaml
+++ b/config/crd/bases/omnia.altairalabs.ai_providers.yaml
@@ -333,13 +333,13 @@ spec:
                     type: string
                 type: object
               role:
-                default: inference
+                default: llm
                 description: |-
                   role declares which kind of provider this is — selects the factory
-                  registry the provider plugs into. Defaults to 'inference' for
-                  back-compat; existing Providers continue to work without YAML changes.
+                  registry the provider plugs into. Defaults to 'llm' for back-compat;
+                  existing Providers continue to work without YAML changes.
                 enum:
-                - inference
+                - llm
                 - embedding
                 - tts
                 - stt
@@ -410,6 +410,9 @@ spec:
                 - mock
                 - vllm
                 - voyageai
+                - cartesia
+                - elevenlabs
+                - imagen
                 type: string
             required:
             - type
@@ -424,22 +427,30 @@ spec:
               rule: '!has(self.stt) || self.role == ''stt'''
             - message: spec.embedding is only valid when spec.role is 'embedding'
               rule: '!has(self.embedding) || self.role == ''embedding'''
+            - message: role 'llm' requires type in [claude, openai, gemini, ollama,
+                mock, vllm]
+              rule: self.role != 'llm' || self.type in ['claude', 'openai', 'gemini',
+                'ollama', 'mock', 'vllm']
             - message: role 'embedding' requires type in [openai, voyageai, gemini,
-                ollama, mock]
+                ollama]
               rule: self.role != 'embedding' || self.type in ['openai', 'voyageai',
-                'gemini', 'ollama', 'mock']
-            - message: role 'tts' requires type in [openai, mock] (additional vendors
-                land as PromptKit adds them)
-              rule: self.role != 'tts' || self.type in ['openai', 'mock']
-            - message: role 'stt' requires type in [openai, mock] (additional vendors
-                land as PromptKit adds them)
-              rule: self.role != 'stt' || self.type in ['openai', 'mock']
-            - message: role 'image' requires type in [openai, gemini, mock]
-              rule: self.role != 'image' || self.type in ['openai', 'gemini', 'mock']
+                'gemini', 'ollama']
+            - message: role 'tts' requires type in [openai, cartesia, elevenlabs]
+              rule: self.role != 'tts' || self.type in ['openai', 'cartesia', 'elevenlabs']
+            - message: role 'stt' requires type in [openai]
+              rule: self.role != 'stt' || self.type in ['openai']
+            - message: role 'image' requires type in [imagen]
+              rule: self.role != 'image' || self.type in ['imagen']
             - message: voyageai is an embedding-only vendor; set spec.role to 'embedding'
-              rule: self.role != 'inference' || self.type != 'voyageai'
-            - message: spec.platform is only valid when spec.role is 'inference'
-              rule: '!has(self.platform) || self.role == ''inference'''
+              rule: self.type != 'voyageai' || self.role == 'embedding'
+            - message: cartesia is a tts-only vendor; set spec.role to 'tts'
+              rule: self.type != 'cartesia' || self.role == 'tts'
+            - message: elevenlabs is a tts-only vendor; set spec.role to 'tts'
+              rule: self.type != 'elevenlabs' || self.role == 'tts'
+            - message: imagen is an image-only vendor; set spec.role to 'image'
+              rule: self.type != 'imagen' || self.role == 'image'
+            - message: spec.platform is only valid when spec.role is 'llm'
+              rule: '!has(self.platform) || self.role == ''llm'''
             - message: platform is only valid for provider types claude, openai, or
                 gemini
               rule: '!has(self.platform) || (self.type in [''claude'', ''openai'',

--- a/dashboard/src/app/providers/page.test.tsx
+++ b/dashboard/src/app/providers/page.test.tsx
@@ -70,8 +70,8 @@ function makeProvider(name: string, role: Provider["spec"]["role"] | undefined, 
 }
 
 const PROVIDERS: Provider[] = [
-  makeProvider("inf-1", "inference"),
-  makeProvider("inf-2", "inference"),
+  makeProvider("inf-1", "llm"),
+  makeProvider("inf-2", "llm"),
   makeProvider("embed-1", "embedding"),
   makeProvider("tts-1", "tts"),
   makeProvider("legacy-no-role", undefined), // pre-role: should count as inference
@@ -96,14 +96,14 @@ describe("ProvidersPage role filter chips", () => {
     render(<ProvidersPage />);
   }
 
-  it("renders one chip per role with correct counts (pre-role counts as inference)", async () => {
+  it("renders one chip per role with correct counts (pre-role counts as llm)", async () => {
     await renderPage();
 
     const group = screen.getByRole("group", { name: /filter by role/i });
     // All providers across roles.
     expect(within(group).getByRole("button", { name: /all roles \(5\)/i })).toBeInTheDocument();
-    // Two explicit inference + one legacy (no spec.role) = 3.
-    expect(within(group).getByRole("button", { name: /inference \(3\)/i })).toBeInTheDocument();
+    // Two explicit llm + one legacy (no spec.role) = 3.
+    expect(within(group).getByRole("button", { name: /llm \(3\)/i })).toBeInTheDocument();
     expect(within(group).getByRole("button", { name: /embedding \(1\)/i })).toBeInTheDocument();
     expect(within(group).getByRole("button", { name: /tts \(1\)/i })).toBeInTheDocument();
     expect(within(group).getByRole("button", { name: /stt \(0\)/i })).toBeInTheDocument();
@@ -135,13 +135,13 @@ describe("ProvidersPage role filter chips", () => {
     // Each card renders a "Role" label and the effective role beneath it.
     expect(screen.getAllByText("Role").length).toBe(PROVIDERS.length);
     // Filter to just the legacy (pre-role) provider and verify its card shows
-    // "inference" (the effective default).
+    // "llm" (the effective default).
     const group = screen.getByRole("group", { name: /filter by role/i });
-    fireEvent.click(within(group).getByRole("button", { name: /inference/i }));
+    fireEvent.click(within(group).getByRole("button", { name: /llm/i }));
 
-    // 3 inference cards remain (inf-1, inf-2, legacy-no-role).
+    // 3 llm cards remain (inf-1, inf-2, legacy-no-role).
     expect(screen.getByText("legacy-no-role")).toBeInTheDocument();
-    // The card body labels each role; one card per inference provider.
-    expect(screen.getAllByText(/inference/i).length).toBeGreaterThanOrEqual(3);
+    // The card body labels each role; one card per llm provider.
+    expect(screen.getAllByText(/llm/i).length).toBeGreaterThanOrEqual(3);
   });
 });

--- a/dashboard/src/app/providers/page.tsx
+++ b/dashboard/src/app/providers/page.tsx
@@ -42,17 +42,17 @@ type FilterRole = "all" | ProviderRole;
 
 const ROLE_FILTERS: { value: FilterRole; label: string }[] = [
   { value: "all", label: "All roles" },
-  { value: "inference", label: "Inference" },
+  { value: "llm", label: "LLM" },
   { value: "embedding", label: "Embedding" },
   { value: "tts", label: "TTS" },
   { value: "stt", label: "STT" },
   { value: "image", label: "Image" },
 ];
 
-// Pre-role Providers omit spec.role — treat them as inference for filtering
-// and display so the migration is backwards-compatible.
+// Pre-role Providers omit spec.role — treat them as llm for filtering and
+// display so the migration is backwards-compatible.
 function effectiveRole(provider: Provider): ProviderRole {
-  return provider.spec?.role ?? "inference";
+  return provider.spec?.role ?? "llm";
 }
 
 /** Color mapping for provider types */
@@ -304,7 +304,7 @@ export default function ProvidersPage() {
   const roleCounts = useMemo(() => {
     const counts: Record<FilterRole, number> = {
       all: namespaceFilteredProviders.length,
-      inference: 0,
+      llm: 0,
       embedding: 0,
       tts: 0,
       stt: 0,

--- a/dashboard/src/components/providers/provider-dialog.test.tsx
+++ b/dashboard/src/components/providers/provider-dialog.test.tsx
@@ -1141,7 +1141,7 @@ describe("ProviderDialog", () => {
   });
 
   describe("role wizard (Phase 3)", () => {
-    it("defaults role to 'inference' for new providers and includes role in spec", async () => {
+    it("defaults role to 'llm' for new providers and includes role in spec", async () => {
       vi.useRealTimers();
       const user = userEvent.setup();
 
@@ -1160,11 +1160,11 @@ describe("ProviderDialog", () => {
       });
       expect(mockCreateProvider.mock.calls[0][1]).toMatchObject({
         type: "claude",
-        role: "inference",
+        role: "llm",
       });
     });
 
-    it("treats a pre-role Provider (no spec.role) as inference in edit mode", () => {
+    it("treats a pre-role Provider (no spec.role) as llm in edit mode", () => {
       const provider = createMockProvider({
         spec: { type: "claude", model: "claude-sonnet-4-20250514" },
       });
@@ -1176,8 +1176,8 @@ describe("ProviderDialog", () => {
       );
 
       // Role select is rendered as a combobox by Radix; the trigger shows the
-      // currently selected label. With no spec.role we expect "Inference".
-      expect(screen.getByLabelText("Role")).toHaveTextContent(/inference/i);
+      // currently selected label. With no spec.role we expect "LLM".
+      expect(screen.getByLabelText("Role")).toHaveTextContent(/llm/i);
     });
 
     it("narrows the vendor list when switching to TTS role and snaps to a valid vendor", async () => {
@@ -1292,7 +1292,7 @@ describe("ProviderDialog", () => {
       // The Role select is disabled in edit mode — clicking it must not open
       // the option list.
       await user.click(screen.getByLabelText("Role"));
-      expect(screen.queryByRole("option", { name: /inference/i })).toBeNull();
+      expect(screen.queryByRole("option", { name: /^llm/i })).toBeNull();
 
       // Submit should pass through the existing tts block.
       fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
@@ -1393,7 +1393,7 @@ describe("ProviderDialog", () => {
       });
     });
 
-    it("forbids voyageai under the inference role (vendor filtered out)", async () => {
+    it("forbids voyageai under the llm role (vendor filtered out)", async () => {
       vi.useRealTimers();
       const user = userEvent.setup();
 
@@ -1403,8 +1403,8 @@ describe("ProviderDialog", () => {
         </TestWrapper>
       );
 
-      // Default role is inference. voyageai is embedding-only per the CRD's
-      // CEL matrix and must not appear in the Provider Type list.
+      // Default role is llm. voyageai is embedding-only per the CRD's CEL
+      // matrix and must not appear in the Provider Type list.
       await user.click(screen.getByLabelText("Provider Type"));
       expect(screen.queryByRole("option", { name: /voyage/i })).toBeNull();
     });

--- a/dashboard/src/components/providers/provider-dialog.tsx
+++ b/dashboard/src/components/providers/provider-dialog.tsx
@@ -58,7 +58,7 @@ interface FormState {
   inputCostPer1K: string;
   outputCostPer1K: string;
   cachedCostPer1K: string;
-  // Platform (hyperscaler hosting; inference role only)
+  // Platform (hyperscaler hosting; llm role only)
   platformType: "" | "bedrock" | "vertex" | "azure";
   platformRegion: string;
   platformProject: string;
@@ -94,6 +94,9 @@ const PROVIDER_TYPES: { value: ProviderSpec["type"]; label: string }[] = [
   { value: "gemini", label: "Gemini (Google)" },
   { value: "vllm", label: "vLLM" },
   { value: "voyageai", label: "Voyage AI" },
+  { value: "cartesia", label: "Cartesia" },
+  { value: "elevenlabs", label: "ElevenLabs" },
+  { value: "imagen", label: "Imagen (Google)" },
   { value: "ollama", label: "Ollama (Local)" },
   { value: "mock", label: "Mock (Testing)" },
 ];
@@ -107,7 +110,7 @@ const PLATFORM_ELIGIBLE_TYPES: Set<ProviderSpec["type"]> = new Set([
 ]);
 
 const ROLE_OPTIONS: { value: ProviderRole; label: string; description: string }[] = [
-  { value: "inference", label: "Inference (chat / completion)", description: "Standard LLM chat and completion." },
+  { value: "llm", label: "LLM (chat / completion)", description: "Standard LLM chat and completion." },
   { value: "embedding", label: "Embedding", description: "Vector embeddings for retrieval." },
   { value: "tts", label: "Text-to-Speech", description: "Synthesize audio from text." },
   { value: "stt", label: "Speech-to-Text", description: "Transcribe audio to text." },
@@ -117,11 +120,11 @@ const ROLE_OPTIONS: { value: ProviderRole; label: string; description: string }[
 // Mirrors the CRD CEL matrix (api/v1alpha1/provider_types.go). Keep in sync
 // when PromptKit adds vendor support for additional roles.
 const VENDORS_BY_ROLE: Record<ProviderRole, readonly ProviderSpec["type"][]> = {
-  inference: ["claude", "openai", "gemini", "ollama", "mock", "vllm"],
-  embedding: ["openai", "voyageai", "gemini", "ollama", "mock"],
-  tts: ["openai", "mock"],
-  stt: ["openai", "mock"],
-  image: ["openai", "gemini", "mock"],
+  llm: ["claude", "openai", "gemini", "ollama", "mock", "vllm"],
+  embedding: ["openai", "voyageai", "gemini", "ollama"],
+  tts: ["openai", "cartesia", "elevenlabs"],
+  stt: ["openai"],
+  image: ["imagen"],
 };
 
 function vendorAllowedForRole(role: ProviderRole, type: ProviderSpec["type"]): boolean {
@@ -132,8 +135,8 @@ function firstVendorForRole(role: ProviderRole): ProviderSpec["type"] {
   return VENDORS_BY_ROLE[role][0];
 }
 
-// Slice of FormState that only inference-role Providers may carry. Cleared
-// when the user switches off the inference role.
+// Slice of FormState that only llm-role Providers may carry. Cleared when
+// the user switches off the llm role.
 const PLATFORM_FIELDS_BLANK = {
   platformType: "" as FormState["platformType"],
   platformRegion: "",
@@ -216,7 +219,7 @@ function applyRoleChange(prev: FormState, role: ProviderRole): FormState {
     ...prev,
     role,
     providerType,
-    ...(role === "inference" ? preservePlatformFields(prev) : PLATFORM_FIELDS_BLANK),
+    ...(role === "llm" ? preservePlatformFields(prev) : PLATFORM_FIELDS_BLANK),
     ...(role === "tts" ? preserveTTSFields(prev) : TTS_FIELDS_BLANK),
     ...(role === "stt" ? preserveSTTFields(prev) : STT_FIELDS_BLANK),
     ...(role === "embedding" ? preserveEmbeddingFields(prev) : EMBEDDING_FIELDS_BLANK),
@@ -273,8 +276,8 @@ function getInitialFormState(provider?: Provider | null): FormState {
 
     const platform = spec.platform;
     const auth = spec.auth;
-    // Pre-role Providers omit spec.role; treat as inference for back-compat.
-    const role: ProviderRole = spec.role ?? "inference";
+    // Pre-role Providers omit spec.role; treat as llm for back-compat.
+    const role: ProviderRole = spec.role ?? "llm";
     return {
       name: provider.metadata?.name || "",
       role,
@@ -320,7 +323,7 @@ function getInitialFormState(provider?: Provider | null): FormState {
 
   return {
     name: "",
-    role: "inference",
+    role: "llm",
     providerType: "claude",
     model: "",
     baseURL: "",
@@ -411,11 +414,11 @@ function validateRoleAndVendor(form: FormState): string | null {
   if (!vendorAllowedForRole(form.role, form.providerType)) {
     return `Vendor "${form.providerType}" is not supported for role "${form.role}"`;
   }
-  // Platform is inference-only. Block submit if someone left platform set after
-  // switching to a non-inference role (the wizard clears it, but defend the
+  // Platform is llm-only. Block submit if someone left platform set after
+  // switching to a non-llm role (the wizard clears it, but defend the
   // contract anyway so manual state never escapes).
-  if (form.role !== "inference" && form.platformType) {
-    return "Hosting platform is only valid when role is inference";
+  if (form.role !== "llm" && form.platformType) {
+    return "Hosting platform is only valid when role is llm";
   }
   return null;
 }
@@ -559,9 +562,9 @@ function buildSpec(form: FormState): ProviderSpec {
     spec.capabilities = form.capabilities as ProviderSpec["capabilities"];
   }
 
-  // Platform/auth are inference-only; the wizard hides those fields for other
+  // Platform/auth are llm-only; the wizard hides those fields for other
   // roles but be defensive anyway.
-  if (form.role === "inference") {
+  if (form.role === "llm") {
     const platformPart = buildPlatformAndAuth(form);
     if (platformPart.platform) {
       spec.platform = platformPart.platform;
@@ -1308,7 +1311,7 @@ function ProviderDialogForm({
 
   const handleProviderTypeChange = (type: ProviderSpec["type"]) => {
     setFormState((prev) => {
-      const keepPlatform = supportsPlatform(type) && prev.role === "inference";
+      const keepPlatform = supportsPlatform(type) && prev.role === "llm";
       return {
         ...prev,
         providerType: type,
@@ -1361,10 +1364,10 @@ function ProviderDialogForm({
     }
   };
 
-  const isInferenceRole = formState.role === "inference";
+  const isLLMRole = formState.role === "llm";
   const showCredential =
-    !isLocal(formState.providerType) && (isInferenceRole ? !formState.platformType : true);
-  const showPlatform = isInferenceRole && supportsPlatform(formState.providerType);
+    !isLocal(formState.providerType) && (isLLMRole ? !formState.platformType : true);
+  const showPlatform = isLLMRole && supportsPlatform(formState.providerType);
 
   // Narrow the vendor list to those the CRD CEL matrix accepts for this role
   // so the user can't pick an invalid (role, vendor) pair from the UI.

--- a/dashboard/src/types/generated/agentruntime.ts
+++ b/dashboard/src/types/generated/agentruntime.ts
@@ -4407,9 +4407,9 @@ export interface AgentRuntimeSpec {
      * the referenced Provider's `spec.role` matches; mismatch puts the
      * AgentRuntime in Phase=Error with ProvidersReady=False.
      * 
-     * Defaults to 'inference' for back-compat with existing AgentRuntimes
+     * Defaults to 'llm' for back-compat with existing AgentRuntimes
      * (which were authored before per-ref roles existed). */
-    role?: "inference" | "embedding" | "tts" | "stt" | "image";
+    role?: "llm" | "embedding" | "tts" | "stt" | "image";
   }[];
   /** rollout configures a progressive delivery rollout for this AgentRuntime.
    * When nil, no rollout is active and all traffic goes to the current spec. */
@@ -4443,9 +4443,9 @@ export interface AgentRuntimeSpec {
          * the referenced Provider's `spec.role` matches; mismatch puts the
          * AgentRuntime in Phase=Error with ProvidersReady=False.
          * 
-         * Defaults to 'inference' for back-compat with existing AgentRuntimes
+         * Defaults to 'llm' for back-compat with existing AgentRuntimes
          * (which were authored before per-ref roles existed). */
-        role?: "inference" | "embedding" | "tts" | "stt" | "image";
+        role?: "llm" | "embedding" | "tts" | "stt" | "image";
       }[];
       /** toolRegistryRef overrides the tool registry for the candidate. */
       toolRegistryRef?: {

--- a/dashboard/src/types/generated/provider.ts
+++ b/dashboard/src/types/generated/provider.ts
@@ -151,9 +151,9 @@ export interface ProviderSpec {
     outputCostPer1K?: string;
   };
   /** role declares which kind of provider this is — selects the factory
-   * registry the provider plugs into. Defaults to 'inference' for
-   * back-compat; existing Providers continue to work without YAML changes. */
-  role?: "inference" | "embedding" | "tts" | "stt" | "image";
+   * registry the provider plugs into. Defaults to 'llm' for back-compat;
+   * existing Providers continue to work without YAML changes. */
+  role?: "llm" | "embedding" | "tts" | "stt" | "image";
   /** stt is the STT-role config block. Required when spec.role is 'stt';
    * forbidden otherwise (CEL-gated). */
   stt?: {
@@ -180,7 +180,7 @@ export interface ProviderSpec {
     voice?: string;
   };
   /** type specifies the provider wire protocol / vendor. */
-  type: "claude" | "openai" | "gemini" | "ollama" | "mock" | "vllm" | "voyageai";
+  type: "claude" | "openai" | "gemini" | "ollama" | "mock" | "vllm" | "voyageai" | "cartesia" | "elevenlabs" | "imagen";
 }
 
 export interface ProviderStatus {

--- a/ee/cmd/arena-worker/provider_groups.go
+++ b/ee/cmd/arena-worker/provider_groups.go
@@ -220,7 +220,7 @@ func resolveProviderRefEntry(
 		return nil, fmt.Errorf("group %q: failed to get provider %s: %w", groupName, ref.Name, err)
 	}
 
-	if err := v1alpha1.RequireProviderRole(provider, v1alpha1.ProviderRoleInference); err != nil {
+	if err := v1alpha1.RequireProviderRole(provider, v1alpha1.ProviderRoleLLM); err != nil {
 		return nil, fmt.Errorf("group %q: %w", groupName, err)
 	}
 

--- a/ee/pkg/evals/provider_resolver.go
+++ b/ee/pkg/evals/provider_resolver.go
@@ -162,11 +162,11 @@ func (r *ProviderResolver) resolveOne(
 		return providers.ProviderSpec{}, fmt.Errorf("get Provider CRD: %w", err)
 	}
 
-	// Eval judges are inference providers; refuse anything else early
+	// Eval judges are llm-role providers; refuse anything else early
 	// rather than letting the PromptKit factory fail with a less clear error.
 	required := np.Role
 	if required == "" {
-		required = v1alpha1.ProviderRoleInference
+		required = v1alpha1.ProviderRoleLLM
 	}
 	if err := v1alpha1.RequireProviderRole(provider, required); err != nil {
 		return providers.ProviderSpec{}, err

--- a/internal/controller/agentruntime_controller.go
+++ b/internal/controller/agentruntime_controller.go
@@ -257,11 +257,11 @@ func (r *AgentRuntimeReconciler) fetchAndValidateProvider(
 
 // providerRoleMismatch returns an empty string when the Provider's role
 // matches the ref's required role, or a user-facing message describing the
-// mismatch otherwise. Treats an empty role on either side as `inference`
-// for back-compat with pre-role Providers and AgentRuntimes.
+// mismatch otherwise. Treats an empty role on either side as `llm` for
+// back-compat with pre-role Providers and AgentRuntimes.
 func providerRoleMismatch(provider *omniav1alpha1.Provider, required omniav1alpha1.ProviderRole) string {
 	if required == "" {
-		required = omniav1alpha1.ProviderRoleInference
+		required = omniav1alpha1.ProviderRoleLLM
 	}
 	if provider.EffectiveRole() == required {
 		return ""

--- a/internal/controller/agentruntime_controller_test.go
+++ b/internal/controller/agentruntime_controller_test.go
@@ -2908,7 +2908,7 @@ var _ = Describe("AgentRuntime Controller", func() {
 			Expect(k8sClient.Status().Update(ctx, provider)).To(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, provider) }()
 
-			By("creating an AgentRuntime that references it as role=inference")
+			By("creating an AgentRuntime that references it as role=llm")
 			ref := omniav1alpha1.ProviderRef{Name: "embed-provider"}
 			agentRuntime := &omniav1alpha1.AgentRuntime{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2919,7 +2919,7 @@ var _ = Describe("AgentRuntime Controller", func() {
 					PromptPackRef: omniav1alpha1.PromptPackRef{Name: "test-pack"},
 					Facade:        omniav1alpha1.FacadeConfig{Type: omniav1alpha1.FacadeTypeWebSocket},
 					Providers: []omniav1alpha1.NamedProviderRef{
-						{Name: "default", ProviderRef: ref, Role: omniav1alpha1.ProviderRoleInference},
+						{Name: "default", ProviderRef: ref, Role: omniav1alpha1.ProviderRoleLLM},
 					},
 				},
 			}
@@ -2940,7 +2940,7 @@ var _ = Describe("AgentRuntime Controller", func() {
 			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
 			Expect(condition.Reason).To(Equal("RoleMismatch"))
 			Expect(condition.Message).To(ContainSubstring("embedding"))
-			Expect(condition.Message).To(ContainSubstring("inference"))
+			Expect(condition.Message).To(ContainSubstring("llm"))
 		})
 
 		It("should accept a provider where role matches ref role (embedding)", func() {

--- a/internal/controller/provider_controller.go
+++ b/internal/controller/provider_controller.go
@@ -590,7 +590,7 @@ func providerRequiresCredentials(provider *omniav1alpha1.Provider) bool {
 }
 
 // providerRole returns the provider's declared role, defaulting to
-// ProviderRoleInference when unset for back-compat with pre-role Providers.
+// ProviderRoleLLM when unset for back-compat with pre-role Providers.
 // Thin wrapper over Provider.EffectiveRole() so existing call sites stay concise.
 func providerRole(provider *omniav1alpha1.Provider) omniav1alpha1.ProviderRole {
 	return provider.EffectiveRole()

--- a/internal/controller/provider_controller_test.go
+++ b/internal/controller/provider_controller_test.go
@@ -2609,25 +2609,25 @@ var _ = Describe("Provider Controller", func() {
 
 	Context("getExpectedKeysForProvider", func() {
 		It("should return correct keys for Claude", func() {
-			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleInference, omniav1alpha1.ProviderTypeClaude)
+			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleLLM, omniav1alpha1.ProviderTypeClaude)
 			Expect(keys).To(ContainElement("ANTHROPIC_API_KEY"))
 			Expect(keys).To(ContainElement("api-key"))
 		})
 
 		It("should return correct keys for OpenAI", func() {
-			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleInference, omniav1alpha1.ProviderTypeOpenAI)
+			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleLLM, omniav1alpha1.ProviderTypeOpenAI)
 			Expect(keys).To(ContainElement("OPENAI_API_KEY"))
 			Expect(keys).To(ContainElement("api-key"))
 		})
 
 		It("should return correct keys for Gemini", func() {
-			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleInference, omniav1alpha1.ProviderTypeGemini)
+			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleLLM, omniav1alpha1.ProviderTypeGemini)
 			Expect(keys).To(ContainElement("GEMINI_API_KEY"))
 			Expect(keys).To(ContainElement("api-key"))
 		})
 
 		It("should return default keys for unknown provider types", func() {
-			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleInference, omniav1alpha1.ProviderType("unknown"))
+			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleLLM, omniav1alpha1.ProviderType("unknown"))
 			Expect(keys).To(ContainElement("api-key"))
 			Expect(keys).To(ContainElement("ANTHROPIC_API_KEY"))
 			Expect(keys).To(ContainElement("OPENAI_API_KEY"))
@@ -2635,12 +2635,12 @@ var _ = Describe("Provider Controller", func() {
 		})
 
 		It("should return default keys for mock provider", func() {
-			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleInference, omniav1alpha1.ProviderTypeMock)
+			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleLLM, omniav1alpha1.ProviderTypeMock)
 			Expect(keys).To(ContainElement("api-key"))
 		})
 
 		It("should return default keys for ollama provider", func() {
-			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleInference, omniav1alpha1.ProviderTypeOllama)
+			keys := getExpectedKeysForProvider(omniav1alpha1.ProviderRoleLLM, omniav1alpha1.ProviderTypeOllama)
 			Expect(keys).To(ContainElement("api-key"))
 		})
 
@@ -2798,7 +2798,7 @@ var _ = Describe("Provider Controller", func() {
 			p := &omniav1alpha1.Provider{
 				Spec: omniav1alpha1.ProviderSpec{Type: omniav1alpha1.ProviderTypeClaude},
 			}
-			Expect(providerRole(p)).To(Equal(omniav1alpha1.ProviderRoleInference))
+			Expect(providerRole(p)).To(Equal(omniav1alpha1.ProviderRoleLLM))
 		})
 
 		It("returns the declared role when set", func() {
@@ -2812,7 +2812,7 @@ var _ = Describe("Provider Controller", func() {
 		})
 
 		It("returns inference for a nil receiver", func() {
-			Expect(providerRole(nil)).To(Equal(omniav1alpha1.ProviderRoleInference))
+			Expect(providerRole(nil)).To(Equal(omniav1alpha1.ProviderRoleLLM))
 		})
 	})
 
@@ -2827,7 +2827,7 @@ var _ = Describe("Provider Controller", func() {
 
 		It("returns openai keys for any role on an openai provider", func() {
 			for _, role := range []omniav1alpha1.ProviderRole{
-				omniav1alpha1.ProviderRoleInference,
+				omniav1alpha1.ProviderRoleLLM,
 				omniav1alpha1.ProviderRoleEmbedding,
 				omniav1alpha1.ProviderRoleTTS,
 				omniav1alpha1.ProviderRoleSTT,
@@ -2881,7 +2881,7 @@ var _ = Describe("Provider Controller", func() {
 			p := &omniav1alpha1.Provider{
 				Spec: omniav1alpha1.ProviderSpec{
 					Type: omniav1alpha1.ProviderTypeClaude,
-					Role: omniav1alpha1.ProviderRoleInference,
+					Role: omniav1alpha1.ProviderRoleLLM,
 				},
 			}
 			Expect(r.resolveHealthURL(p)).To(Equal("https://api.anthropic.com"))

--- a/pkg/provider/types.go
+++ b/pkg/provider/types.go
@@ -46,9 +46,15 @@ const (
 	// TypeVLLM uses a vLLM-served OpenAI-compatible endpoint.
 	// Requires baseURL. Auth is typically via custom headers.
 	TypeVLLM Type = "vllm"
-	// TypeVoyageAI uses Voyage AI embedding models.
+	// TypeVoyageAI uses Voyage AI embedding models. Embedding-role only.
 	// Requires an API key (VOYAGE_API_KEY).
 	TypeVoyageAI Type = "voyageai"
+	// TypeCartesia uses Cartesia TTS. TTS-role only.
+	TypeCartesia Type = "cartesia"
+	// TypeElevenLabs uses ElevenLabs TTS. TTS-role only.
+	TypeElevenLabs Type = "elevenlabs"
+	// TypeImagen uses Google's Imagen image generation. Image-role only.
+	TypeImagen Type = "imagen"
 )
 
 // ValidTypes contains all valid provider types.
@@ -61,6 +67,9 @@ var ValidTypes = []Type{
 	TypeMock,
 	TypeVLLM,
 	TypeVoyageAI,
+	TypeCartesia,
+	TypeElevenLabs,
+	TypeImagen,
 }
 
 // IsValid returns true if the provider type is valid.

--- a/pkg/provider/types_test.go
+++ b/pkg/provider/types_test.go
@@ -71,6 +71,9 @@ func TestType_RequiresCredentials(t *testing.T) {
 		{"mock", TypeMock, false},
 		{"vllm", TypeVLLM, false},
 		{"voyageai", TypeVoyageAI, true},
+		{"cartesia", TypeCartesia, true},
+		{"elevenlabs", TypeElevenLabs, true},
+		{"imagen", TypeImagen, true},
 	}
 
 	for _, tt := range tests {
@@ -82,7 +85,10 @@ func TestType_RequiresCredentials(t *testing.T) {
 
 func TestValidTypes_Complete(t *testing.T) {
 	// Ensure ValidTypes contains all defined constants
-	expected := []Type{TypeClaude, TypeOpenAI, TypeGemini, TypeOllama, TypeMock, TypeVLLM, TypeVoyageAI}
+	expected := []Type{
+		TypeClaude, TypeOpenAI, TypeGemini, TypeOllama, TypeMock, TypeVLLM,
+		TypeVoyageAI, TypeCartesia, TypeElevenLabs, TypeImagen,
+	}
 	assert.ElementsMatch(t, expected, ValidTypes)
 }
 


### PR DESCRIPTION
## Summary

PromptKit's \`pkg/config.Role\` enum uses **\`llm\`** for chat/completion, not \`inference\`. Yesterday's Phase 1-3 of the role multi-kind feature (#1089) shipped with \`inference\`. This rename + matrix audit aligns Omnia with PromptKit and corrects the CEL gates against the factories that actually exist.

\`inference\` is intentionally reserved for a future, more generic role (e.g. Hugging Face Inference Endpoints).

## CRD changes

- \`ProviderRole\` enum: \`inference\` → \`llm\`. Constant \`ProviderRoleInference\` → \`ProviderRoleLLM\`.
- \`ProviderType\` enum gains \`cartesia\`, \`elevenlabs\`, \`imagen\`.
- CEL matrix corrected to mirror what PromptKit's factory registries actually contain:

| Role | Allowed vendors |
|------|-----------------|
| llm | claude, openai, gemini, ollama, mock, vllm |
| embedding | openai, voyageai, gemini, ollama (dropped mock) |
| tts | openai, cartesia, elevenlabs (dropped mock) |
| stt | openai (dropped mock) |
| image | imagen (dropped openai, gemini, mock) |

- New \"vendor pinned to one role\" CEL rules: \`voyageai\` → embedding, \`cartesia\`/\`elevenlabs\` → tts, \`imagen\` → image.
- Default flipped from \`+kubebuilder:default=inference\` to \`=llm\` on both \`Provider.spec.role\` and \`AgentRuntime.spec.providers[].role\`.

## Code changes

- \`EffectiveRole\`, \`RequireProviderRole\`, \`providerRoleMismatch\` default to \`llm\`.
- \`ee/cmd/arena-worker\` and \`ee/pkg/evals\` consumer guards updated.
- \`cmd/memory-api\` **blank-imports \`promptkit/runtime/providers/voyageai\`** so the embedding factory actually registers — previously the CEL matrix permitted voyageai but the binary couldn't construct one at runtime.

## Dashboard

- \`ROLE_OPTIONS\`, \`VENDORS_BY_ROLE\`, \`PROVIDER_TYPES\` updated. Pre-role Providers display as \`llm\`.

## Migration

Any Providers stored with \`role: inference\` (created since #1093 landed yesterday) must be re-applied with \`role: llm\`. Local: \`kubectl get providers -A\` then patch/recreate. No production deployments yet.

## Test plan

- [x] \`go test ./api/...\` — passes
- [x] \`go test ./internal/controller/...\` — passes
- [x] \`go test ./pkg/provider/...\` — passes (kubebuilder enum + ValidTypes consistency)
- [x] \`go test ./cmd/memory-api/... ./ee/cmd/arena-worker/... ./ee/pkg/evals/...\` — passes
- [x] Dashboard typecheck + 48 vitest tests pass
- [x] Per-file coverage on changed Go + TS files all ≥80% (provider_types.go 100%, dialog 92.5%)
- [x] \`make manifests\`, \`make generate-dashboard-types\`, helm lint all clean
- [ ] Smoke-test in dev cluster: create a Provider with \`role: llm\` and a voyageai \`role: embedding\` Provider in memory-API namespace