### PR TITLE
feat(runtime): one-shot Invoke RPC for function-mode AgentRuntimes (Functions Phase 1 PR 2/7, #1103)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,23 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Added (runtime gRPC: Invoke for function-mode AgentRuntimes, #1103 PR 2)
+
+- `RuntimeService.Invoke(InvocationRequest) returns (InvocationResponse)` — new
+  unary RPC for one-shot Function calls. Facade-only consumer (PR 3); browsers
+  don't talk to this directly.
+- `InvocationRequest{input_json, invocation_id, metadata}` — `input_json` is
+  opaque to the runtime; the facade validates against
+  `AgentRuntime.spec.inputSchema` before sending.
+- `InvocationResponse{output_json, usage, duration_ms, invocation_id}` —
+  `output_json` is the raw assistant text. The facade validates against
+  `spec.outputSchema` and, on mismatch, returns HTTP 502 with the raw body
+  for debugging (per #1103 Q2 lock).
+- Error codes: `InvalidArgument` for missing `invocation_id` / `input_json`;
+  `FailedPrecondition` if a function emits a client-side tool call (function
+  mode has no WebSocket peer to fulfil them); `Internal` for stream / pack
+  failures.
+
 ### Added (provider-calls aggregate + discover endpoints)
 
 - `GET /api/v1/provider-calls/aggregate?namespace=X&groupBy=Y&metric=Z` —

--- a/api/proto/runtime/v1/runtime.proto
+++ b/api/proto/runtime/v1/runtime.proto
@@ -16,6 +16,17 @@ service RuntimeService {
   // text chunks, tool calls, tool results, and completion signals.
   rpc Converse(stream ClientMessage) returns (stream ServerMessage);
 
+  // Invoke runs a one-shot, non-conversational Function call. The facade
+  // forwards a payload-in / payload-out request from POST /functions/{name}
+  // and waits for the full response. Used for function-mode AgentRuntimes
+  // (spec.mode == "function"); see #1102 / #1103.
+  //
+  // The runtime is schema-agnostic — the facade validates input_json against
+  // AgentRuntime.spec.inputSchema before calling, and validates output_json
+  // against spec.outputSchema after returning. The runtime just executes
+  // the pack once.
+  rpc Invoke(InvocationRequest) returns (InvocationResponse);
+
   // Health checks the runtime's readiness to handle requests.
   rpc Health(HealthRequest) returns (HealthResponse);
 }
@@ -219,6 +230,41 @@ message MediaChunk {
 
   // data contains raw media bytes (avoids base64 overhead in gRPC path).
   bytes data = 5;
+}
+
+// InvocationRequest carries a Function call from the facade.
+message InvocationRequest {
+  // input_json is the raw JSON payload submitted by the caller. The facade
+  // has already validated this against AgentRuntime.spec.inputSchema; the
+  // runtime treats it as an opaque user message body.
+  string input_json = 1;
+
+  // invocation_id is a UUID for this Function call, used for log and
+  // trace correlation. Assigned by the facade.
+  string invocation_id = 2;
+
+  // metadata carries optional key-value context (caller identity, auth
+  // subject, custom headers). Not interpreted by the runtime.
+  map<string, string> metadata = 3;
+}
+
+// InvocationResponse carries the runtime's reply to the facade. On
+// success the facade then validates output_json against
+// AgentRuntime.spec.outputSchema before returning to the HTTP caller.
+message InvocationResponse {
+  // output_json is the raw assistant text. The facade validates it
+  // against the output schema; if invalid, the facade returns HTTP 502
+  // with this raw payload in the response body (per Q2 lock on #1103).
+  string output_json = 1;
+
+  // usage contains token + cost statistics for the call.
+  Usage usage = 2;
+
+  // duration_ms is the wall-clock time spent executing in the runtime.
+  int32 duration_ms = 3;
+
+  // invocation_id echoes InvocationRequest.invocation_id for correlation.
+  string invocation_id = 4;
 }
 
 // HealthRequest is an empty message for health checks.

--- a/internal/runtime/invoke.go
+++ b/internal/runtime/invoke.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/AltairaLabs/PromptKit/sdk"
+	"github.com/go-logr/logr"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/altairalabs/omnia/internal/tracing"
+	"github.com/altairalabs/omnia/pkg/logctx"
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// Invoke handles a single one-shot Function call. Unlike Converse, the
+// conversation is ephemeral: it isn't tracked in s.conversations and is
+// closed before the method returns. Schema validation lives in the facade
+// (per #1103 PR-2 scope); the runtime treats input_json as opaque user
+// content and returns the model's response verbatim.
+//
+// Client-side tools are not supported in function mode — there's no
+// WebSocket peer to fulfil them. If the model emits a client tool call,
+// Invoke returns codes.FailedPrecondition.
+func (s *Server) Invoke(ctx context.Context, req *runtimev1.InvocationRequest) (*runtimev1.InvocationResponse, error) {
+	invocationID := req.GetInvocationId()
+	if invocationID == "" {
+		return nil, status.Error(codes.InvalidArgument, "invocation_id is required")
+	}
+	if req.GetInputJson() == "" {
+		return nil, status.Error(codes.InvalidArgument, "input_json is required")
+	}
+
+	ctx = logctx.WithSessionID(ctx, invocationID)
+	ctx, span := s.startInvocationSpan(ctx, invocationID)
+	defer span.End()
+
+	ctx = logctx.WithTraceID(ctx, span.SpanContext().TraceID().String())
+	log := logctx.LoggerWithContext(s.log, ctx)
+	log.V(1).Info("invoke starting",
+		"invocationID", invocationID,
+		"inputBytes", len(req.GetInputJson()))
+
+	conv, err := s.createConversation(ctx, invocationID)
+	if err != nil {
+		tracing.RecordError(span, err)
+		return nil, status.Errorf(codes.Internal, "failed to create conversation: %v", err)
+	}
+	defer func() {
+		// Functions are stateless — close the conversation as soon as the
+		// invocation completes. We deliberately do NOT add the conversation
+		// to s.conversations.
+		if closeErr := conv.Close(); closeErr != nil {
+			log.Error(closeErr, "failed to close ephemeral conversation",
+				"invocationID", invocationID)
+		}
+	}()
+
+	start := time.Now()
+	response, content, err := s.runInvocation(ctx, conv, req.GetInputJson(), log)
+	durationMs := int32(time.Since(start).Milliseconds())
+
+	if err != nil {
+		tracing.RecordError(span, err)
+		log.Error(err, "invoke failed", "invocationID", invocationID, "durationMs", durationMs)
+		return nil, err
+	}
+
+	usage := buildInvocationUsage(response)
+	tracing.SetSuccess(span)
+
+	log.V(1).Info("invoke complete",
+		"invocationID", invocationID,
+		"durationMs", durationMs,
+		"outputBytes", len(content))
+
+	return &runtimev1.InvocationResponse{
+		OutputJson:   content,
+		Usage:        usage,
+		DurationMs:   durationMs,
+		InvocationId: invocationID,
+	}, nil
+}
+
+// startInvocationSpan wraps the invocation in a tracing span if a
+// provider is configured; otherwise returns a no-op span from context.
+func (s *Server) startInvocationSpan(ctx context.Context, invocationID string) (context.Context, trace.Span) {
+	if s.tracingProvider != nil {
+		// Reuse the conversation-span shape: the SDK + LLM children will
+		// nest under it. Turn index is always 0 for one-shot Functions.
+		return s.tracingProvider.StartConversationSpan(ctx, invocationID, s.promptPackName, s.promptPackVersion, 0)
+	}
+	return ctx, trace.SpanFromContext(ctx)
+}
+
+// runInvocation drives the SDK stream to completion and returns the
+// final Response plus accumulated text. Client-tool chunks are treated
+// as an authoring error — function mode has no WebSocket to fulfil them.
+func (s *Server) runInvocation(ctx context.Context, conv *sdk.Conversation, input string, log logr.Logger) (*sdk.Response, string, error) {
+	log.V(1).Info("calling PromptKit SDK for one-shot invoke")
+	var llmSpan trace.Span
+	if s.tracingProvider != nil {
+		ctx, llmSpan = s.tracingProvider.StartLLMSpan(ctx, s.model, s.providerType)
+		defer llmSpan.End()
+	}
+
+	streamCh := conv.Stream(ctx, input)
+
+	var finalResponse *sdk.Response
+	var accumulated strings.Builder
+
+	for chunk := range streamCh {
+		if chunk.Error != nil {
+			if llmSpan != nil {
+				tracing.RecordError(llmSpan, chunk.Error)
+			}
+			return nil, "", status.Errorf(codes.Internal,
+				"provider stream failed: %v", chunk.Error)
+		}
+		switch chunk.Type {
+		case sdk.ChunkText:
+			accumulated.WriteString(chunk.Text)
+		case sdk.ChunkClientTool:
+			// Function mode has no peer to fulfil client tools.
+			return nil, "", status.Errorf(codes.FailedPrecondition,
+				"function emitted a client-side tool call (%q); client tools are only supported in agent mode",
+				chunk.ClientTool.ToolName)
+		case sdk.ChunkDone:
+			finalResponse = chunk.Message
+		case sdk.ChunkMedia:
+			// Media chunks are dropped for function-mode invocations.
+			// PR 5 may add structured media to the response if needed.
+		}
+	}
+
+	if llmSpan != nil && finalResponse != nil && finalResponse.TokensUsed() > 0 {
+		tracing.AddLLMMetrics(llmSpan, finalResponse.InputTokens(), finalResponse.OutputTokens(), finalResponse.Cost())
+		tracing.AddFinishReason(llmSpan, "stop")
+		tracing.SetSuccess(llmSpan)
+	}
+
+	if finalResponse == nil {
+		return nil, "", status.Error(codes.Internal,
+			"provider stream closed without a done chunk")
+	}
+
+	return finalResponse, accumulated.String(), nil
+}
+
+// buildInvocationUsage extracts the protobuf Usage shape from the SDK
+// Response, returning nil if no token accounting is available.
+func buildInvocationUsage(r *sdk.Response) *runtimev1.Usage {
+	if r == nil || r.TokensUsed() == 0 {
+		return nil
+	}
+	return &runtimev1.Usage{
+		InputTokens:  int32(r.InputTokens()),
+		OutputTokens: int32(r.OutputTokens()),
+		CostUsd:      float32(r.Cost()),
+	}
+}

--- a/internal/runtime/invoke.go
+++ b/internal/runtime/invoke.go
@@ -50,7 +50,7 @@ func (s *Server) Invoke(ctx context.Context, req *runtimev1.InvocationRequest) (
 		return nil, status.Error(codes.InvalidArgument, "input_json is required")
 	}
 
-	ctx = logctx.WithSessionID(ctx, invocationID)
+	ctx = logctx.WithInvocationID(ctx, invocationID)
 	ctx, span := s.startInvocationSpan(ctx, invocationID)
 	defer span.End()
 
@@ -60,23 +60,17 @@ func (s *Server) Invoke(ctx context.Context, req *runtimev1.InvocationRequest) (
 		"invocationID", invocationID,
 		"inputBytes", len(req.GetInputJson()))
 
-	conv, err := s.createConversation(ctx, invocationID)
+	conv, err := s.openInvocationConversation(ctx, invocationID)
 	if err != nil {
 		tracing.RecordError(span, err)
 		return nil, status.Errorf(codes.Internal, "failed to create conversation: %v", err)
 	}
-	defer func() {
-		// Functions are stateless — close the conversation as soon as the
-		// invocation completes. We deliberately do NOT add the conversation
-		// to s.conversations.
-		if closeErr := conv.Close(); closeErr != nil {
-			log.Error(closeErr, "failed to close ephemeral conversation",
-				"invocationID", invocationID)
-		}
-	}()
+	defer s.closeInvocationConversation(invocationID, conv, log)
 
 	start := time.Now()
 	response, content, err := s.runInvocation(ctx, conv, req.GetInputJson(), log)
+	// durationMs is captured for both success and failure paths but only
+	// surfaced on the success-side gRPC response; logged on error.
 	durationMs := int32(time.Since(start).Milliseconds())
 
 	if err != nil {
@@ -101,20 +95,51 @@ func (s *Server) Invoke(ctx context.Context, req *runtimev1.InvocationRequest) (
 	}, nil
 }
 
+// openInvocationConversation acquires the conversation mutex and builds a
+// fresh PromptKit conversation for the invocation. The mutex is held for
+// the entire createConversation flow because subscribeToEventBusLogging
+// writes to s.unsubscribeFns under the same lock the Converse path holds.
+// The conversation is NOT added to s.conversations — Functions are
+// stateless and the lifecycle is closeInvocationConversation's
+// responsibility.
+func (s *Server) openInvocationConversation(ctx context.Context, invocationID string) (*sdk.Conversation, error) {
+	s.conversationMu.Lock()
+	defer s.conversationMu.Unlock()
+	return s.createConversation(ctx, invocationID)
+}
+
+// closeInvocationConversation runs the cleanup that removeConversation
+// runs for stateful sessions, minus the s.conversations / s.turnIndices
+// deletes (which aren't populated for invocations). Critically, it must
+// drain s.unsubscribeFns[invocationID] before returning — createConversation
+// subscribes ~11 event-bus listeners that would otherwise leak per call.
+func (s *Server) closeInvocationConversation(invocationID string, conv *sdk.Conversation, log logr.Logger) {
+	s.conversationMu.Lock()
+	for _, unsub := range s.unsubscribeFns[invocationID] {
+		unsub()
+	}
+	delete(s.unsubscribeFns, invocationID)
+	s.conversationMu.Unlock()
+
+	if err := conv.Close(); err != nil {
+		log.Error(err, "failed to close ephemeral conversation",
+			"invocationID", invocationID)
+	}
+}
+
 // startInvocationSpan wraps the invocation in a tracing span if a
 // provider is configured; otherwise returns a no-op span from context.
+// Uses a dedicated span name + omnia.mode="function" attribute so
+// downstream queries can tell stateful turns apart from stateless calls.
 func (s *Server) startInvocationSpan(ctx context.Context, invocationID string) (context.Context, trace.Span) {
 	if s.tracingProvider != nil {
-		// Reuse the conversation-span shape: the SDK + LLM children will
-		// nest under it. Turn index is always 0 for one-shot Functions.
-		return s.tracingProvider.StartConversationSpan(ctx, invocationID, s.promptPackName, s.promptPackVersion, 0)
+		return s.tracingProvider.StartInvocationSpan(ctx, invocationID, s.promptPackName, s.promptPackVersion)
 	}
 	return ctx, trace.SpanFromContext(ctx)
 }
 
 // runInvocation drives the SDK stream to completion and returns the
-// final Response plus accumulated text. Client-tool chunks are treated
-// as an authoring error — function mode has no WebSocket to fulfil them.
+// final Response plus accumulated text.
 func (s *Server) runInvocation(ctx context.Context, conv *sdk.Conversation, input string, log logr.Logger) (*sdk.Response, string, error) {
 	log.V(1).Info("calling PromptKit SDK for one-shot invoke")
 	var llmSpan trace.Span
@@ -124,7 +149,28 @@ func (s *Server) runInvocation(ctx context.Context, conv *sdk.Conversation, inpu
 	}
 
 	streamCh := conv.Stream(ctx, input)
+	response, content, err := consumeInvocationStream(streamCh, llmSpan)
+	if err != nil {
+		return nil, "", err
+	}
 
+	if llmSpan != nil && response.TokensUsed() > 0 {
+		tracing.AddLLMMetrics(llmSpan, response.InputTokens(), response.OutputTokens(), response.Cost())
+		tracing.AddFinishReason(llmSpan, "stop")
+		tracing.SetSuccess(llmSpan)
+	}
+
+	return response, content, nil
+}
+
+// consumeInvocationStream drains an SDK stream channel for a one-shot
+// Function invocation. Client-tool chunks are treated as an authoring
+// error — function mode has no WebSocket peer to fulfil them. Media
+// chunks are dropped (PR 5 may add structured media to the response).
+//
+// Extracted so tests can drive every Chunk branch without standing up
+// a full SDK Conversation.
+func consumeInvocationStream(streamCh <-chan sdk.StreamChunk, llmSpan trace.Span) (*sdk.Response, string, error) {
 	var finalResponse *sdk.Response
 	var accumulated strings.Builder
 
@@ -140,22 +186,18 @@ func (s *Server) runInvocation(ctx context.Context, conv *sdk.Conversation, inpu
 		case sdk.ChunkText:
 			accumulated.WriteString(chunk.Text)
 		case sdk.ChunkClientTool:
-			// Function mode has no peer to fulfil client tools.
+			toolName := ""
+			if chunk.ClientTool != nil {
+				toolName = chunk.ClientTool.ToolName
+			}
 			return nil, "", status.Errorf(codes.FailedPrecondition,
 				"function emitted a client-side tool call (%q); client tools are only supported in agent mode",
-				chunk.ClientTool.ToolName)
+				toolName)
 		case sdk.ChunkDone:
 			finalResponse = chunk.Message
 		case sdk.ChunkMedia:
 			// Media chunks are dropped for function-mode invocations.
-			// PR 5 may add structured media to the response if needed.
 		}
-	}
-
-	if llmSpan != nil && finalResponse != nil && finalResponse.TokensUsed() > 0 {
-		tracing.AddLLMMetrics(llmSpan, finalResponse.InputTokens(), finalResponse.OutputTokens(), finalResponse.Cost())
-		tracing.AddFinishReason(llmSpan, "stop")
-		tracing.SetSuccess(llmSpan)
 	}
 
 	if finalResponse == nil {

--- a/internal/runtime/invoke_test.go
+++ b/internal/runtime/invoke_test.go
@@ -18,8 +18,10 @@ package runtime
 
 import (
 	"context"
+	"errors"
 	"testing"
 
+	"github.com/AltairaLabs/PromptKit/sdk"
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -100,8 +102,6 @@ func TestServer_Invoke_HappyPath(t *testing.T) {
 	// should not be empty. The exact content depends on the mock pack
 	// configuration.
 	assert.NotEmpty(t, resp.GetOutputJson())
-	// Duration should be reported (>= 0; mock is fast but non-zero).
-	assert.GreaterOrEqual(t, resp.GetDurationMs(), int32(0))
 }
 
 func TestServer_Invoke_EphemeralConversation(t *testing.T) {
@@ -109,6 +109,7 @@ func TestServer_Invoke_EphemeralConversation(t *testing.T) {
 
 	// Sanity check: no conversations tracked before Invoke.
 	assert.Empty(t, s.conversations, "server should start with no tracked conversations")
+	assert.Empty(t, s.unsubscribeFns, "server should start with no tracked unsubscribes")
 
 	_, err := s.Invoke(context.Background(), &runtimev1.InvocationRequest{
 		InvocationId: "ephemeral-1",
@@ -122,6 +123,10 @@ func TestServer_Invoke_EphemeralConversation(t *testing.T) {
 		"Invoke should not leak conversations into the conversations map")
 	assert.Empty(t, s.turnIndices,
 		"Invoke should not leak turn indices")
+	// createConversation subscribes ~11 event-bus listeners; Invoke must
+	// unsubscribe them on completion or s.unsubscribeFns grows unboundedly.
+	assert.Empty(t, s.unsubscribeFns,
+		"Invoke must drain s.unsubscribeFns for the invocation")
 }
 
 func TestServer_Invoke_MultipleCallsStayIndependent(t *testing.T) {
@@ -137,10 +142,12 @@ func TestServer_Invoke_MultipleCallsStayIndependent(t *testing.T) {
 		assert.Equal(t, id, resp.GetInvocationId())
 	}
 
-	// After three Invoke calls, nothing should be tracked in the
-	// conversation map.
+	// After three Invoke calls, nothing should be tracked in either the
+	// conversation or unsubscribe maps.
 	assert.Empty(t, s.conversations,
 		"three Invoke calls should not accumulate tracked conversations")
+	assert.Empty(t, s.unsubscribeFns,
+		"three Invoke calls should not accumulate event-bus subscriptions")
 }
 
 func TestServer_Invoke_PackOpenFailure(t *testing.T) {
@@ -160,4 +167,87 @@ func TestServer_Invoke_PackOpenFailure(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "create conversation",
+		"error should mention the failing stage so authors can debug")
+}
+
+// streamFromChunks is a tiny test helper that publishes a fixed sequence
+// of StreamChunks on a closed channel, mirroring how the SDK exposes
+// stream completion. Used by the consumeInvocationStream unit tests.
+func streamFromChunks(chunks []sdk.StreamChunk) <-chan sdk.StreamChunk {
+	ch := make(chan sdk.StreamChunk, len(chunks))
+	for _, c := range chunks {
+		ch <- c
+	}
+	close(ch)
+	return ch
+}
+
+func TestConsumeInvocationStream_HappyPath(t *testing.T) {
+	stream := streamFromChunks([]sdk.StreamChunk{
+		{Type: sdk.ChunkText, Text: "hello "},
+		{Type: sdk.ChunkText, Text: "world"},
+		{Type: sdk.ChunkDone, Message: &sdk.Response{}},
+	})
+	resp, content, err := consumeInvocationStream(stream, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "hello world", content)
+}
+
+func TestConsumeInvocationStream_RejectsClientToolChunk(t *testing.T) {
+	stream := streamFromChunks([]sdk.StreamChunk{
+		{Type: sdk.ChunkText, Text: "thinking..."},
+		{
+			Type:       sdk.ChunkClientTool,
+			ClientTool: &sdk.PendingClientTool{ToolName: "read_clipboard"},
+		},
+		// A done chunk follows but we should bail before consuming it.
+		{Type: sdk.ChunkDone, Message: &sdk.Response{}},
+	})
+	_, _, err := consumeInvocationStream(stream, nil)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.FailedPrecondition, st.Code())
+	assert.Contains(t, st.Message(), "read_clipboard")
+	assert.Contains(t, st.Message(), "agent mode")
+}
+
+func TestConsumeInvocationStream_ProviderErrorChunkSurfacesAsInternal(t *testing.T) {
+	stream := streamFromChunks([]sdk.StreamChunk{
+		{Type: sdk.ChunkText, Text: "partial"},
+		{Error: errors.New("synthetic provider failure")},
+	})
+	_, _, err := consumeInvocationStream(stream, nil)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "synthetic provider failure")
+}
+
+func TestConsumeInvocationStream_MissingDoneChunkIsInternal(t *testing.T) {
+	stream := streamFromChunks([]sdk.StreamChunk{
+		{Type: sdk.ChunkText, Text: "no terminator"},
+	})
+	_, _, err := consumeInvocationStream(stream, nil)
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+	assert.Contains(t, st.Message(), "done chunk")
+}
+
+func TestConsumeInvocationStream_MediaChunksAreDropped(t *testing.T) {
+	stream := streamFromChunks([]sdk.StreamChunk{
+		{Type: sdk.ChunkText, Text: "before "},
+		{Type: sdk.ChunkMedia},
+		{Type: sdk.ChunkText, Text: "after"},
+		{Type: sdk.ChunkDone, Message: &sdk.Response{}},
+	})
+	_, content, err := consumeInvocationStream(stream, nil)
+	require.NoError(t, err)
+	assert.Equal(t, "before after", content,
+		"media chunks should not appear in the function output")
 }

--- a/internal/runtime/invoke_test.go
+++ b/internal/runtime/invoke_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package runtime
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// invokeTestPack is the minimal pack body shared by every Invoke test.
+const invokeTestPack = `{
+	"id": "test-pack",
+	"name": "test-pack",
+	"version": "1.0.0",
+	"template_engine": {
+		"version": "v1",
+		"syntax": "{{variable}}"
+	},
+	"prompts": {
+		"default": {
+			"id": "default",
+			"name": "default",
+			"version": "1.0.0",
+			"system_template": "You are a test assistant."
+		}
+	}
+}`
+
+func newInvokeTestServer(t *testing.T) *Server {
+	t.Helper()
+	tmpDir := t.TempDir()
+	packPath := tmpDir + "/pack.promptpack"
+	require.NoError(t, writeTestFile(t, packPath, invokeTestPack))
+
+	return NewServer(
+		WithLogger(logr.Discard()),
+		WithPackPath(packPath),
+		WithPromptName("default"),
+		WithMockProvider(true),
+	)
+}
+
+func TestServer_Invoke_RejectsMissingInvocationID(t *testing.T) {
+	s := newInvokeTestServer(t)
+	_, err := s.Invoke(context.Background(), &runtimev1.InvocationRequest{
+		InputJson: `{"q":"hi"}`,
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "invocation_id")
+}
+
+func TestServer_Invoke_RejectsEmptyInput(t *testing.T) {
+	s := newInvokeTestServer(t)
+	_, err := s.Invoke(context.Background(), &runtimev1.InvocationRequest{
+		InvocationId: "test-1",
+		InputJson:    "",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.InvalidArgument, st.Code())
+	assert.Contains(t, st.Message(), "input_json")
+}
+
+func TestServer_Invoke_HappyPath(t *testing.T) {
+	s := newInvokeTestServer(t)
+	resp, err := s.Invoke(context.Background(), &runtimev1.InvocationRequest{
+		InvocationId: "test-happy",
+		InputJson:    `{"q":"hello"}`,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "test-happy", resp.GetInvocationId())
+	// Mock provider always returns a non-empty response, so output_json
+	// should not be empty. The exact content depends on the mock pack
+	// configuration.
+	assert.NotEmpty(t, resp.GetOutputJson())
+	// Duration should be reported (>= 0; mock is fast but non-zero).
+	assert.GreaterOrEqual(t, resp.GetDurationMs(), int32(0))
+}
+
+func TestServer_Invoke_EphemeralConversation(t *testing.T) {
+	s := newInvokeTestServer(t)
+
+	// Sanity check: no conversations tracked before Invoke.
+	assert.Empty(t, s.conversations, "server should start with no tracked conversations")
+
+	_, err := s.Invoke(context.Background(), &runtimev1.InvocationRequest{
+		InvocationId: "ephemeral-1",
+		InputJson:    `{"q":"ping"}`,
+	})
+	require.NoError(t, err)
+
+	// The conversation must NOT be tracked in s.conversations — Functions
+	// are stateless and the conversation is closed immediately.
+	assert.Empty(t, s.conversations,
+		"Invoke should not leak conversations into the conversations map")
+	assert.Empty(t, s.turnIndices,
+		"Invoke should not leak turn indices")
+}
+
+func TestServer_Invoke_MultipleCallsStayIndependent(t *testing.T) {
+	s := newInvokeTestServer(t)
+
+	ids := []string{"invoke-iter-1", "invoke-iter-2", "invoke-iter-3"}
+	for _, id := range ids {
+		resp, err := s.Invoke(context.Background(), &runtimev1.InvocationRequest{
+			InvocationId: id,
+			InputJson:    `{"q":"hello"}`,
+		})
+		require.NoError(t, err, "invocation %s failed", id)
+		assert.Equal(t, id, resp.GetInvocationId())
+	}
+
+	// After three Invoke calls, nothing should be tracked in the
+	// conversation map.
+	assert.Empty(t, s.conversations,
+		"three Invoke calls should not accumulate tracked conversations")
+}
+
+func TestServer_Invoke_PackOpenFailure(t *testing.T) {
+	// Server with a bogus pack path forces sdk.Open to fail.
+	s := NewServer(
+		WithLogger(logr.Discard()),
+		WithPackPath("/nonexistent/path/to/pack.promptpack"),
+		WithPromptName("default"),
+		WithMockProvider(true),
+	)
+
+	_, err := s.Invoke(context.Background(), &runtimev1.InvocationRequest{
+		InvocationId: "bad-pack",
+		InputJson:    `{"q":"hi"}`,
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok)
+	assert.Equal(t, codes.Internal, st.Code())
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -237,6 +237,35 @@ func (p *Provider) StartConversationSpan(ctx context.Context, sessionID, promptP
 	return ctx, span
 }
 
+// StartInvocationSpan starts a new span for a one-shot function invocation.
+// Function-mode AgentRuntimes use this instead of StartConversationSpan so
+// that downstream queries can distinguish stateful turns from stateless
+// Function calls without overloading the conversation.turn attribute.
+func (p *Provider) StartInvocationSpan(ctx context.Context, invocationID, promptPackName, promptPackVersion string) (context.Context, trace.Span) {
+	attrs := []attribute.KeyValue{
+		attribute.String("omnia.invocation.id", invocationID),
+		attribute.String("omnia.mode", "function"),
+	}
+	if promptPackName != "" {
+		attrs = append(attrs, attribute.String("omnia.promptpack.name", promptPackName))
+	}
+	if promptPackVersion != "" {
+		attrs = append(attrs, attribute.String("omnia.promptpack.version", promptPackVersion))
+	}
+
+	ctx, span := p.tracer.Start(ctx, "omnia.runtime.function.invoke",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attrs...),
+	)
+	p.log.V(1).Info(msgSpanStarted,
+		"spanName", "omnia.runtime.function.invoke",
+		"invocationID", invocationID,
+		"promptPackName", promptPackName,
+		"promptPackVersion", promptPackVersion,
+		"traceID", span.SpanContext().TraceID())
+	return ctx, span
+}
+
 // StartLLMSpan starts a new span for an LLM call following GenAI semantic conventions.
 func (p *Provider) StartLLMSpan(ctx context.Context, model string, system string) (context.Context, trace.Span) {
 	ctx, span := p.tracer.Start(ctx, "genai.chat",

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -120,6 +120,69 @@ func TestProvider_StartConversationSpan(t *testing.T) {
 	}
 }
 
+func TestProvider_StartInvocationSpan(t *testing.T) {
+	provider, exporter := newTestProvider(t)
+
+	_, span := provider.StartInvocationSpan(context.Background(), "inv-42", "test-pack", "v1.0")
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	s := spans[0]
+	if s.Name != "omnia.runtime.function.invoke" {
+		t.Errorf("expected span name 'omnia.runtime.function.invoke', got %q", s.Name)
+	}
+	if s.SpanKind != trace.SpanKindInternal {
+		t.Errorf("expected SpanKindInternal, got %v", s.SpanKind)
+	}
+
+	val, ok := findAttr(s, "omnia.invocation.id")
+	if !ok {
+		t.Fatal("missing attribute 'omnia.invocation.id'")
+	}
+	if val.AsString() != "inv-42" {
+		t.Errorf("expected omnia.invocation.id='inv-42', got %q", val.AsString())
+	}
+
+	val, ok = findAttr(s, "omnia.mode")
+	if !ok {
+		t.Fatal("missing attribute 'omnia.mode'")
+	}
+	if val.AsString() != "function" {
+		t.Errorf("expected omnia.mode='function', got %q", val.AsString())
+	}
+
+	val, ok = findAttr(s, "omnia.promptpack.name")
+	if !ok {
+		t.Fatal("missing attribute 'omnia.promptpack.name'")
+	}
+	if val.AsString() != "test-pack" {
+		t.Errorf("expected omnia.promptpack.name='test-pack', got %q", val.AsString())
+	}
+}
+
+func TestProvider_StartInvocationSpan_OmitsEmptyPackInfo(t *testing.T) {
+	provider, exporter := newTestProvider(t)
+
+	_, span := provider.StartInvocationSpan(context.Background(), "inv-bare", "", "")
+	span.End()
+
+	spans := exporter.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+
+	if _, ok := findAttr(spans[0], "omnia.promptpack.name"); ok {
+		t.Error("expected omnia.promptpack.name to be omitted when empty")
+	}
+	if _, ok := findAttr(spans[0], "omnia.promptpack.version"); ok {
+		t.Error("expected omnia.promptpack.version to be omitted when empty")
+	}
+}
+
 func TestProvider_StartLLMSpan(t *testing.T) {
 	provider, exporter := newTestProvider(t)
 

--- a/pkg/logctx/context.go
+++ b/pkg/logctx/context.go
@@ -66,6 +66,10 @@ const (
 	// The JSON field name "trace_id" matches the Grafana Loki derived-field regex
 	// so that Loki can link log lines to Tempo traces automatically.
 	ContextKeyTraceID contextKey = "trace_id"
+
+	// ContextKeyInvocationID identifies a function-mode invocation. Distinct
+	// from ContextKeySessionID, which is reserved for stateful conversations.
+	ContextKeyInvocationID contextKey = "invocation_id"
 )
 
 // allContextKeys lists all context keys that should be extracted for logging.
@@ -81,6 +85,7 @@ var allContextKeys = []contextKey{
 	ContextKeyTool,
 	ContextKeyStage,
 	ContextKeyTraceID,
+	ContextKeyInvocationID,
 }
 
 // WithSessionID returns a new context with the session ID set.
@@ -136,6 +141,13 @@ func WithStage(ctx context.Context, stage string) context.Context {
 // WithTraceID returns a new context with the trace ID set.
 func WithTraceID(ctx context.Context, traceID string) context.Context {
 	return context.WithValue(ctx, ContextKeyTraceID, traceID)
+}
+
+// WithInvocationID returns a new context with the function-invocation ID
+// set. Distinct from WithSessionID so logs can tell stateful conversation
+// turns apart from stateless function calls.
+func WithInvocationID(ctx context.Context, invocationID string) context.Context {
+	return context.WithValue(ctx, ContextKeyInvocationID, invocationID)
 }
 
 // LoggingFields holds all standard logging context fields.

--- a/pkg/runtime/v1/runtime.pb.go
+++ b/pkg/runtime/v1/runtime.pb.go
@@ -984,6 +984,151 @@ func (x *MediaChunk) GetData() []byte {
 	return nil
 }
 
+// InvocationRequest carries a Function call from the facade.
+type InvocationRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// input_json is the raw JSON payload submitted by the caller. The facade
+	// has already validated this against AgentRuntime.spec.inputSchema; the
+	// runtime treats it as an opaque user message body.
+	InputJson string `protobuf:"bytes,1,opt,name=input_json,json=inputJson,proto3" json:"input_json,omitempty"`
+	// invocation_id is a UUID for this Function call, used for log and
+	// trace correlation. Assigned by the facade.
+	InvocationId string `protobuf:"bytes,2,opt,name=invocation_id,json=invocationId,proto3" json:"invocation_id,omitempty"`
+	// metadata carries optional key-value context (caller identity, auth
+	// subject, custom headers). Not interpreted by the runtime.
+	Metadata      map[string]string `protobuf:"bytes,3,rep,name=metadata,proto3" json:"metadata,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvocationRequest) Reset() {
+	*x = InvocationRequest{}
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvocationRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvocationRequest) ProtoMessage() {}
+
+func (x *InvocationRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvocationRequest.ProtoReflect.Descriptor instead.
+func (*InvocationRequest) Descriptor() ([]byte, []int) {
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *InvocationRequest) GetInputJson() string {
+	if x != nil {
+		return x.InputJson
+	}
+	return ""
+}
+
+func (x *InvocationRequest) GetInvocationId() string {
+	if x != nil {
+		return x.InvocationId
+	}
+	return ""
+}
+
+func (x *InvocationRequest) GetMetadata() map[string]string {
+	if x != nil {
+		return x.Metadata
+	}
+	return nil
+}
+
+// InvocationResponse carries the runtime's reply to the facade. On
+// success the facade then validates output_json against
+// AgentRuntime.spec.outputSchema before returning to the HTTP caller.
+type InvocationResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// output_json is the raw assistant text. The facade validates it
+	// against the output schema; if invalid, the facade returns HTTP 502
+	// with this raw payload in the response body (per Q2 lock on #1103).
+	OutputJson string `protobuf:"bytes,1,opt,name=output_json,json=outputJson,proto3" json:"output_json,omitempty"`
+	// usage contains token + cost statistics for the call.
+	Usage *Usage `protobuf:"bytes,2,opt,name=usage,proto3" json:"usage,omitempty"`
+	// duration_ms is the wall-clock time spent executing in the runtime.
+	DurationMs int32 `protobuf:"varint,3,opt,name=duration_ms,json=durationMs,proto3" json:"duration_ms,omitempty"`
+	// invocation_id echoes InvocationRequest.invocation_id for correlation.
+	InvocationId  string `protobuf:"bytes,4,opt,name=invocation_id,json=invocationId,proto3" json:"invocation_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *InvocationResponse) Reset() {
+	*x = InvocationResponse{}
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *InvocationResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*InvocationResponse) ProtoMessage() {}
+
+func (x *InvocationResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use InvocationResponse.ProtoReflect.Descriptor instead.
+func (*InvocationResponse) Descriptor() ([]byte, []int) {
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *InvocationResponse) GetOutputJson() string {
+	if x != nil {
+		return x.OutputJson
+	}
+	return ""
+}
+
+func (x *InvocationResponse) GetUsage() *Usage {
+	if x != nil {
+		return x.Usage
+	}
+	return nil
+}
+
+func (x *InvocationResponse) GetDurationMs() int32 {
+	if x != nil {
+		return x.DurationMs
+	}
+	return 0
+}
+
+func (x *InvocationResponse) GetInvocationId() string {
+	if x != nil {
+		return x.InvocationId
+	}
+	return ""
+}
+
 // HealthRequest is an empty message for health checks.
 type HealthRequest struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -993,7 +1138,7 @@ type HealthRequest struct {
 
 func (x *HealthRequest) Reset() {
 	*x = HealthRequest{}
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[12]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1005,7 +1150,7 @@ func (x *HealthRequest) String() string {
 func (*HealthRequest) ProtoMessage() {}
 
 func (x *HealthRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[12]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1018,7 +1163,7 @@ func (x *HealthRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthRequest.ProtoReflect.Descriptor instead.
 func (*HealthRequest) Descriptor() ([]byte, []int) {
-	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{12}
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{14}
 }
 
 // HealthResponse contains the health status of the runtime.
@@ -1034,7 +1179,7 @@ type HealthResponse struct {
 
 func (x *HealthResponse) Reset() {
 	*x = HealthResponse{}
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[13]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1046,7 +1191,7 @@ func (x *HealthResponse) String() string {
 func (*HealthResponse) ProtoMessage() {}
 
 func (x *HealthResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[13]
+	mi := &file_api_proto_runtime_v1_runtime_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1059,7 +1204,7 @@ func (x *HealthResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use HealthResponse.ProtoReflect.Descriptor instead.
 func (*HealthResponse) Descriptor() ([]byte, []int) {
-	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{13}
+	return file_api_proto_runtime_v1_runtime_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *HealthResponse) GetHealthy() bool {
@@ -1149,16 +1294,32 @@ const file_api_proto_runtime_v1_runtime_proto_rawDesc = "" +
 	"\bsequence\x18\x02 \x01(\x05R\bsequence\x12\x17\n" +
 	"\ais_last\x18\x03 \x01(\bR\x06isLast\x12\x1b\n" +
 	"\tmime_type\x18\x04 \x01(\tR\bmimeType\x12\x12\n" +
-	"\x04data\x18\x05 \x01(\fR\x04data\"\x0f\n" +
+	"\x04data\x18\x05 \x01(\fR\x04data\"\xe3\x01\n" +
+	"\x11InvocationRequest\x12\x1d\n" +
+	"\n" +
+	"input_json\x18\x01 \x01(\tR\tinputJson\x12#\n" +
+	"\rinvocation_id\x18\x02 \x01(\tR\finvocationId\x12M\n" +
+	"\bmetadata\x18\x03 \x03(\v21.omnia.runtime.v1.InvocationRequest.MetadataEntryR\bmetadata\x1a;\n" +
+	"\rMetadataEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xaa\x01\n" +
+	"\x12InvocationResponse\x12\x1f\n" +
+	"\voutput_json\x18\x01 \x01(\tR\n" +
+	"outputJson\x12-\n" +
+	"\x05usage\x18\x02 \x01(\v2\x17.omnia.runtime.v1.UsageR\x05usage\x12\x1f\n" +
+	"\vduration_ms\x18\x03 \x01(\x05R\n" +
+	"durationMs\x12#\n" +
+	"\rinvocation_id\x18\x04 \x01(\tR\finvocationId\"\x0f\n" +
 	"\rHealthRequest\"B\n" +
 	"\x0eHealthResponse\x12\x18\n" +
 	"\ahealthy\x18\x01 \x01(\bR\ahealthy\x12\x16\n" +
 	"\x06status\x18\x02 \x01(\tR\x06status*E\n" +
 	"\rToolExecution\x12\x19\n" +
 	"\x15TOOL_EXECUTION_SERVER\x10\x00\x12\x19\n" +
-	"\x15TOOL_EXECUTION_CLIENT\x10\x012\xaf\x01\n" +
+	"\x15TOOL_EXECUTION_CLIENT\x10\x012\x84\x02\n" +
 	"\x0eRuntimeService\x12P\n" +
-	"\bConverse\x12\x1f.omnia.runtime.v1.ClientMessage\x1a\x1f.omnia.runtime.v1.ServerMessage(\x010\x01\x12K\n" +
+	"\bConverse\x12\x1f.omnia.runtime.v1.ClientMessage\x1a\x1f.omnia.runtime.v1.ServerMessage(\x010\x01\x12S\n" +
+	"\x06Invoke\x12#.omnia.runtime.v1.InvocationRequest\x1a$.omnia.runtime.v1.InvocationResponse\x12K\n" +
 	"\x06Health\x12\x1f.omnia.runtime.v1.HealthRequest\x1a .omnia.runtime.v1.HealthResponseB7Z5github.com/altairalabs/omnia/pkg/runtime/v1;runtimev1b\x06proto3"
 
 var (
@@ -1174,27 +1335,30 @@ func file_api_proto_runtime_v1_runtime_proto_rawDescGZIP() []byte {
 }
 
 var file_api_proto_runtime_v1_runtime_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_api_proto_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+var file_api_proto_runtime_v1_runtime_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_api_proto_runtime_v1_runtime_proto_goTypes = []any{
-	(ToolExecution)(0),       // 0: omnia.runtime.v1.ToolExecution
-	(*ClientMessage)(nil),    // 1: omnia.runtime.v1.ClientMessage
-	(*ClientToolResult)(nil), // 2: omnia.runtime.v1.ClientToolResult
-	(*ServerMessage)(nil),    // 3: omnia.runtime.v1.ServerMessage
-	(*Chunk)(nil),            // 4: omnia.runtime.v1.Chunk
-	(*ToolCall)(nil),         // 5: omnia.runtime.v1.ToolCall
-	(*ToolResult)(nil),       // 6: omnia.runtime.v1.ToolResult
-	(*Done)(nil),             // 7: omnia.runtime.v1.Done
-	(*ContentPart)(nil),      // 8: omnia.runtime.v1.ContentPart
-	(*MediaContent)(nil),     // 9: omnia.runtime.v1.MediaContent
-	(*Usage)(nil),            // 10: omnia.runtime.v1.Usage
-	(*Error)(nil),            // 11: omnia.runtime.v1.Error
-	(*MediaChunk)(nil),       // 12: omnia.runtime.v1.MediaChunk
-	(*HealthRequest)(nil),    // 13: omnia.runtime.v1.HealthRequest
-	(*HealthResponse)(nil),   // 14: omnia.runtime.v1.HealthResponse
-	nil,                      // 15: omnia.runtime.v1.ClientMessage.MetadataEntry
+	(ToolExecution)(0),         // 0: omnia.runtime.v1.ToolExecution
+	(*ClientMessage)(nil),      // 1: omnia.runtime.v1.ClientMessage
+	(*ClientToolResult)(nil),   // 2: omnia.runtime.v1.ClientToolResult
+	(*ServerMessage)(nil),      // 3: omnia.runtime.v1.ServerMessage
+	(*Chunk)(nil),              // 4: omnia.runtime.v1.Chunk
+	(*ToolCall)(nil),           // 5: omnia.runtime.v1.ToolCall
+	(*ToolResult)(nil),         // 6: omnia.runtime.v1.ToolResult
+	(*Done)(nil),               // 7: omnia.runtime.v1.Done
+	(*ContentPart)(nil),        // 8: omnia.runtime.v1.ContentPart
+	(*MediaContent)(nil),       // 9: omnia.runtime.v1.MediaContent
+	(*Usage)(nil),              // 10: omnia.runtime.v1.Usage
+	(*Error)(nil),              // 11: omnia.runtime.v1.Error
+	(*MediaChunk)(nil),         // 12: omnia.runtime.v1.MediaChunk
+	(*InvocationRequest)(nil),  // 13: omnia.runtime.v1.InvocationRequest
+	(*InvocationResponse)(nil), // 14: omnia.runtime.v1.InvocationResponse
+	(*HealthRequest)(nil),      // 15: omnia.runtime.v1.HealthRequest
+	(*HealthResponse)(nil),     // 16: omnia.runtime.v1.HealthResponse
+	nil,                        // 17: omnia.runtime.v1.ClientMessage.MetadataEntry
+	nil,                        // 18: omnia.runtime.v1.InvocationRequest.MetadataEntry
 }
 var file_api_proto_runtime_v1_runtime_proto_depIdxs = []int32{
-	15, // 0: omnia.runtime.v1.ClientMessage.metadata:type_name -> omnia.runtime.v1.ClientMessage.MetadataEntry
+	17, // 0: omnia.runtime.v1.ClientMessage.metadata:type_name -> omnia.runtime.v1.ClientMessage.MetadataEntry
 	8,  // 1: omnia.runtime.v1.ClientMessage.parts:type_name -> omnia.runtime.v1.ContentPart
 	2,  // 2: omnia.runtime.v1.ClientMessage.client_tool_result:type_name -> omnia.runtime.v1.ClientToolResult
 	4,  // 3: omnia.runtime.v1.ServerMessage.chunk:type_name -> omnia.runtime.v1.Chunk
@@ -1206,15 +1370,19 @@ var file_api_proto_runtime_v1_runtime_proto_depIdxs = []int32{
 	10, // 9: omnia.runtime.v1.Done.usage:type_name -> omnia.runtime.v1.Usage
 	8,  // 10: omnia.runtime.v1.Done.parts:type_name -> omnia.runtime.v1.ContentPart
 	9,  // 11: omnia.runtime.v1.ContentPart.media:type_name -> omnia.runtime.v1.MediaContent
-	1,  // 12: omnia.runtime.v1.RuntimeService.Converse:input_type -> omnia.runtime.v1.ClientMessage
-	13, // 13: omnia.runtime.v1.RuntimeService.Health:input_type -> omnia.runtime.v1.HealthRequest
-	3,  // 14: omnia.runtime.v1.RuntimeService.Converse:output_type -> omnia.runtime.v1.ServerMessage
-	14, // 15: omnia.runtime.v1.RuntimeService.Health:output_type -> omnia.runtime.v1.HealthResponse
-	14, // [14:16] is the sub-list for method output_type
-	12, // [12:14] is the sub-list for method input_type
-	12, // [12:12] is the sub-list for extension type_name
-	12, // [12:12] is the sub-list for extension extendee
-	0,  // [0:12] is the sub-list for field type_name
+	18, // 12: omnia.runtime.v1.InvocationRequest.metadata:type_name -> omnia.runtime.v1.InvocationRequest.MetadataEntry
+	10, // 13: omnia.runtime.v1.InvocationResponse.usage:type_name -> omnia.runtime.v1.Usage
+	1,  // 14: omnia.runtime.v1.RuntimeService.Converse:input_type -> omnia.runtime.v1.ClientMessage
+	13, // 15: omnia.runtime.v1.RuntimeService.Invoke:input_type -> omnia.runtime.v1.InvocationRequest
+	15, // 16: omnia.runtime.v1.RuntimeService.Health:input_type -> omnia.runtime.v1.HealthRequest
+	3,  // 17: omnia.runtime.v1.RuntimeService.Converse:output_type -> omnia.runtime.v1.ServerMessage
+	14, // 18: omnia.runtime.v1.RuntimeService.Invoke:output_type -> omnia.runtime.v1.InvocationResponse
+	16, // 19: omnia.runtime.v1.RuntimeService.Health:output_type -> omnia.runtime.v1.HealthResponse
+	17, // [17:20] is the sub-list for method output_type
+	14, // [14:17] is the sub-list for method input_type
+	14, // [14:14] is the sub-list for extension type_name
+	14, // [14:14] is the sub-list for extension extendee
+	0,  // [0:14] is the sub-list for field type_name
 }
 
 func init() { file_api_proto_runtime_v1_runtime_proto_init() }
@@ -1235,7 +1403,7 @@ func file_api_proto_runtime_v1_runtime_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_proto_runtime_v1_runtime_proto_rawDesc), len(file_api_proto_runtime_v1_runtime_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   15,
+			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/runtime/v1/runtime_grpc.pb.go
+++ b/pkg/runtime/v1/runtime_grpc.pb.go
@@ -23,6 +23,7 @@ const _ = grpc.SupportPackageIsVersion9
 
 const (
 	RuntimeService_Converse_FullMethodName = "/omnia.runtime.v1.RuntimeService/Converse"
+	RuntimeService_Invoke_FullMethodName   = "/omnia.runtime.v1.RuntimeService/Invoke"
 	RuntimeService_Health_FullMethodName   = "/omnia.runtime.v1.RuntimeService/Health"
 )
 
@@ -38,6 +39,16 @@ type RuntimeServiceClient interface {
 	// The client sends messages and receives a stream of responses including
 	// text chunks, tool calls, tool results, and completion signals.
 	Converse(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[ClientMessage, ServerMessage], error)
+	// Invoke runs a one-shot, non-conversational Function call. The facade
+	// forwards a payload-in / payload-out request from POST /functions/{name}
+	// and waits for the full response. Used for function-mode AgentRuntimes
+	// (spec.mode == "function"); see #1102 / #1103.
+	//
+	// The runtime is schema-agnostic — the facade validates input_json against
+	// AgentRuntime.spec.inputSchema before calling, and validates output_json
+	// against spec.outputSchema after returning. The runtime just executes
+	// the pack once.
+	Invoke(ctx context.Context, in *InvocationRequest, opts ...grpc.CallOption) (*InvocationResponse, error)
 	// Health checks the runtime's readiness to handle requests.
 	Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error)
 }
@@ -63,6 +74,16 @@ func (c *runtimeServiceClient) Converse(ctx context.Context, opts ...grpc.CallOp
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type RuntimeService_ConverseClient = grpc.BidiStreamingClient[ClientMessage, ServerMessage]
 
+func (c *runtimeServiceClient) Invoke(ctx context.Context, in *InvocationRequest, opts ...grpc.CallOption) (*InvocationResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(InvocationResponse)
+	err := c.cc.Invoke(ctx, RuntimeService_Invoke_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *runtimeServiceClient) Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(HealthResponse)
@@ -85,6 +106,16 @@ type RuntimeServiceServer interface {
 	// The client sends messages and receives a stream of responses including
 	// text chunks, tool calls, tool results, and completion signals.
 	Converse(grpc.BidiStreamingServer[ClientMessage, ServerMessage]) error
+	// Invoke runs a one-shot, non-conversational Function call. The facade
+	// forwards a payload-in / payload-out request from POST /functions/{name}
+	// and waits for the full response. Used for function-mode AgentRuntimes
+	// (spec.mode == "function"); see #1102 / #1103.
+	//
+	// The runtime is schema-agnostic — the facade validates input_json against
+	// AgentRuntime.spec.inputSchema before calling, and validates output_json
+	// against spec.outputSchema after returning. The runtime just executes
+	// the pack once.
+	Invoke(context.Context, *InvocationRequest) (*InvocationResponse, error)
 	// Health checks the runtime's readiness to handle requests.
 	Health(context.Context, *HealthRequest) (*HealthResponse, error)
 	mustEmbedUnimplementedRuntimeServiceServer()
@@ -99,6 +130,9 @@ type UnimplementedRuntimeServiceServer struct{}
 
 func (UnimplementedRuntimeServiceServer) Converse(grpc.BidiStreamingServer[ClientMessage, ServerMessage]) error {
 	return status.Errorf(codes.Unimplemented, "method Converse not implemented")
+}
+func (UnimplementedRuntimeServiceServer) Invoke(context.Context, *InvocationRequest) (*InvocationResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method Invoke not implemented")
 }
 func (UnimplementedRuntimeServiceServer) Health(context.Context, *HealthRequest) (*HealthResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Health not implemented")
@@ -131,6 +165,24 @@ func _RuntimeService_Converse_Handler(srv interface{}, stream grpc.ServerStream)
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type RuntimeService_ConverseServer = grpc.BidiStreamingServer[ClientMessage, ServerMessage]
 
+func _RuntimeService_Invoke_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(InvocationRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(RuntimeServiceServer).Invoke(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: RuntimeService_Invoke_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(RuntimeServiceServer).Invoke(ctx, req.(*InvocationRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _RuntimeService_Health_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(HealthRequest)
 	if err := dec(in); err != nil {
@@ -156,6 +208,10 @@ var RuntimeService_ServiceDesc = grpc.ServiceDesc{
 	ServiceName: "omnia.runtime.v1.RuntimeService",
 	HandlerType: (*RuntimeServiceServer)(nil),
 	Methods: []grpc.MethodDesc{
+		{
+			MethodName: "Invoke",
+			Handler:    _RuntimeService_Invoke_Handler,
+		},
 		{
 			MethodName: "Health",
 			Handler:    _RuntimeService_Health_Handler,


### PR DESCRIPTION
## Summary

PR 2 of 7 for Functions Phase 1 (umbrella #1102, slicing #1103). Adds the runtime-side one-shot code path that backs function-mode AgentRuntimes.

Builds directly on the CRD surface that landed in #1104. The facade route (PR 3) is the first consumer; operator wiring (PR 4) activates it on pods; persistence (PR 5) records the invocations.

## What's new

**Proto** (`api/proto/runtime/v1/runtime.proto`)

- New `RuntimeService.Invoke(InvocationRequest) returns (InvocationResponse)` unary RPC.
- `InvocationRequest{input_json, invocation_id, metadata}` — `input_json` is opaque to the runtime; the facade has already validated it against \`AgentRuntime.spec.inputSchema\`.
- `InvocationResponse{output_json, usage, duration_ms, invocation_id}` — `output_json` is the raw assistant text; the facade validates against \`spec.outputSchema\` and on mismatch returns HTTP 502 with the raw body for debugging (per #1103 Q2).

**Runtime** (`internal/runtime/invoke.go`)

- `Server.Invoke` creates an ephemeral PromptKit conversation (not tracked in `s.conversations`), drains the SDK stream channel synchronously, and closes the conversation in a `defer`. No streaming back to the caller — the gRPC response is the single materialized result.
- Server-side tools work through the normal SDK loop. Client-side tool chunks are rejected with `codes.FailedPrecondition` — function mode has no WebSocket peer to fulfil them.
- Tracing spans wrap the invocation; LLM metrics (tokens, cost) attach to the LLM child span when the SDK Response reports them.
- All construction errors map to `codes.Internal`; missing required request fields to `codes.InvalidArgument`.

**Tests** (`invoke_test.go`)

6 tests: empty invocation_id, empty input_json, happy path with mock provider, ephemeral-conversation invariant (no leakage), three back-to-back calls staying independent, pack-open failure surfacing as Internal.

**api/CHANGELOG.md** updated for cross-team visibility (gRPC contract change).

## What's intentionally NOT here

- **Schema validation** lives in the facade (PR 3). Keeps the runtime stateless about which AgentRuntime it serves and avoids a synchronous CRD lookup per call.
- **Persistence**. PR 5 will add the \`function_invocations\` table + session-api endpoints.
- **`EffectiveMode()` consumers**. The runtime starts the same way for both modes — \`Invoke\` is just an additional method that function-mode clients can call. PR 4 (operator) will be the first to key behaviour off \`EffectiveMode()\`.

## Test plan

- [x] \`env GOWORK=off go test ./internal/runtime/...\` — passes (existing suite + 6 new invoke tests).
- [x] \`env GOWORK=off go build ./...\` — clean.
- [x] Pre-commit clean (vet, golangci-lint, observability boundaries, helm, codegen, manifest sync).
- [x] Proto regenerated; \`pkg/runtime/v1/runtime.pb.go\` + \`runtime_grpc.pb.go\` have \`Invoke\` and the new messages.

## Up next

- PR 3: Facade \`POST /functions/{name}\` HTTP route + schema validation.
- PR 4: Operator pod-shape mode awareness.
- PR 5: \`function_invocations\` persistence in session-api.
- PR 6: Dashboard catalog + invocation history.
- PR 7: Docs + example pack.