### PR TITLE
feat(facade): POST /functions/{name} HTTP route (Functions Phase 1 PR 3/7, #1103)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,34 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Added (facade HTTP: POST /functions/{name} for function-mode AgentRuntimes, #1103 PR 3)
+
+- `POST /functions/{name}` on the facade HTTP port — entry point for
+  function-mode AgentRuntime invocations. Server-to-server only; not
+  reachable from browsers via the same WebSocket auth path (the existing
+  facade auth chain still applies once PR 4 wires the route into
+  `cmd/agent/websocket.go`).
+- Request: `Content-Type: application/json`, body validated against
+  `AgentRuntime.spec.inputSchema` (santhosh-tekuri/jsonschema/v6).
+  Request body capped at 1 MiB.
+- Success response (200): `{ output, invocation_id, duration_ms, usage{input_tokens, output_tokens, cost_usd} }`.
+  `output` is the model's raw JSON, already validated against
+  `spec.outputSchema`.
+- Error responses use a uniform JSON envelope `{ error, detail }`:
+  - 400 `input_invalid` — payload failed inputSchema. Runtime not called.
+  - 400 `missing_function_name` — empty `{name}` path segment.
+  - 400 `read_body_failed` — body read error.
+  - 404 `function_not_found` — no function-mode AgentRuntime with that
+    name on this facade (also returned for mode=agent runtimes to avoid
+    enumeration).
+  - 405 `method_not_allowed` — only POST is accepted.
+  - 413 `payload_too_large` — body exceeded 1 MiB cap.
+  - 415 `unsupported_media_type` — Content-Type must be application/json.
+  - 502 `runtime_error` — runtime gRPC Invoke returned an error.
+  - 502 `output_invalid` — model output failed outputSchema. Envelope
+    includes `raw_output` (JSON if valid; JSON string otherwise) so the
+    function author can debug (per #1103 Q2).
+
 ### Added (runtime gRPC: Invoke for function-mode AgentRuntimes, #1103 PR 2)
 
 - `RuntimeService.Invoke(InvocationRequest) returns (InvocationResponse)` — new

--- a/go.mod
+++ b/go.mod
@@ -199,6 +199,7 @@ require (
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/redis/go-redis/extra/rediscmd/v9 v9.18.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/segmentio/asm v1.1.3 // indirect
 	github.com/segmentio/encoding v0.5.4 // indirect
 	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -509,6 +509,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/segmentio/asm v1.1.3 h1:WM03sfUOENvvKexOLp+pCqgb/WDjsi7EK8gIsICtzhc=
 github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQy1EJg=
 github.com/segmentio/encoding v0.5.4 h1:OW1VRern8Nw6ITAtwSZ7Idrl3MXCFwXHPgqESYfvNt0=

--- a/internal/facade/functions_handler.go
+++ b/internal/facade/functions_handler.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/altairalabs/omnia/pkg/logctx"
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// FunctionSpec is the per-Function metadata the facade needs at request
+// time. The operator loads spec.inputSchema / spec.outputSchema from the
+// AgentRuntime CRD and CompileSchema's them once at startup (PR 4 wiring;
+// for PR 3, the registry is populated by tests and out-of-band callers).
+//
+// RecordsInvocations mirrors AgentRuntime.spec.invocationRecording.state
+// == "enabled"; PR 5 (session-api persistence) is the first consumer.
+type FunctionSpec struct {
+	Name               string
+	InputSchema        *jsonschema.Schema
+	OutputSchema       *jsonschema.Schema
+	RecordsInvocations bool
+}
+
+// FunctionRegistry returns the FunctionSpec for a given function-mode
+// AgentRuntime by name. Returns (nil, false) when no such function
+// exists or when the AgentRuntime is mode=agent.
+type FunctionRegistry interface {
+	GetFunction(name string) (*FunctionSpec, bool)
+}
+
+// InvocationInvoker is the subset of the runtime gRPC client used by
+// FunctionsHandler. Pulled out as an interface so tests can substitute a
+// mock without standing up a real gRPC server.
+type InvocationInvoker interface {
+	Invoke(ctx context.Context, req *runtimev1.InvocationRequest) (*runtimev1.InvocationResponse, error)
+}
+
+// FunctionsHandler serves POST /functions/{name} for function-mode
+// AgentRuntimes. The handler is the single source of truth for input
+// and output JSON-Schema validation (the runtime is intentionally
+// schema-agnostic; see PR 2 / #1105).
+type FunctionsHandler struct {
+	registry FunctionRegistry
+	invoker  InvocationInvoker
+	log      logr.Logger
+
+	// maxBodyBytes caps the incoming request body. Defaults to 1 MiB,
+	// matching the WS path's reasonable upper bound. Function payloads
+	// are JSON; if someone needs more they can lift this via PR 4.
+	maxBodyBytes int64
+}
+
+// NewFunctionsHandler constructs a FunctionsHandler. log may be a
+// zero-value logr.Logger; the handler tolerates a nil sink.
+func NewFunctionsHandler(registry FunctionRegistry, invoker InvocationInvoker, log logr.Logger) *FunctionsHandler {
+	if log.GetSink() == nil {
+		log = logr.Discard()
+	}
+	return &FunctionsHandler{
+		registry:     registry,
+		invoker:      invoker,
+		log:          log.WithName("functions-handler"),
+		maxBodyBytes: 1 << 20, // 1 MiB
+	}
+}
+
+// errorResponse is the JSON envelope returned on 4xx errors. The 502
+// output-validation case is special and includes the raw model output
+// in raw_output so authors can debug (per #1103 Q2 lock).
+type errorResponse struct {
+	Error     string          `json:"error"`
+	Detail    string          `json:"detail,omitempty"`
+	RawOutput json.RawMessage `json:"raw_output,omitempty"`
+}
+
+// ServeHTTP routes POST /functions/{name}. Non-POST is 405, unknown name
+// (or agent-mode runtime) is 404. Per the WS endpoint convention, the
+// agent name comes from the path; the namespace + workspace are bound
+// to the facade pod's identity.
+func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		w.Header().Set("Allow", http.MethodPost)
+		writeError(w, http.StatusMethodNotAllowed, "method_not_allowed", "use POST")
+		return
+	}
+
+	name := r.PathValue("name")
+	if name == "" {
+		writeError(w, http.StatusBadRequest, "missing_function_name",
+			"function name is required in the URL path")
+		return
+	}
+
+	spec, ok := h.registry.GetFunction(name)
+	if !ok {
+		// Distinguish "not configured" from "wrong mode" in logs but use
+		// 404 for both — leaking the existence of agent-mode runtimes
+		// at a function-mode endpoint isn't useful and authoring tools
+		// shouldn't depend on that distinction.
+		h.log.V(1).Info("function not registered", "name", name)
+		writeError(w, http.StatusNotFound, "function_not_found",
+			fmt.Sprintf("no function named %q is registered on this facade", name))
+		return
+	}
+
+	ctype := r.Header.Get("Content-Type")
+	if ctype != "" && ctype != "application/json" {
+		writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type",
+			"Content-Type must be application/json")
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, h.maxBodyBytes))
+	if err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			writeError(w, http.StatusRequestEntityTooLarge, "payload_too_large",
+				fmt.Sprintf("request body exceeds %d bytes", h.maxBodyBytes))
+			return
+		}
+		writeError(w, http.StatusBadRequest, "read_body_failed", err.Error())
+		return
+	}
+
+	if err := ValidateJSON(spec.InputSchema, body); err != nil {
+		writeError(w, http.StatusBadRequest, "input_invalid", err.Error())
+		return
+	}
+
+	invocationID := uuid.NewString()
+	ctx := logctx.WithInvocationID(r.Context(), invocationID)
+	log := h.log.WithValues("function", name, "invocationID", invocationID)
+
+	resp, err := h.invoker.Invoke(ctx, &runtimev1.InvocationRequest{
+		InputJson:    string(body),
+		InvocationId: invocationID,
+	})
+	if err != nil {
+		log.Error(err, "runtime invoke failed")
+		writeError(w, http.StatusBadGateway, "runtime_error", err.Error())
+		return
+	}
+
+	rawOutput := []byte(resp.GetOutputJson())
+	if err := ValidateJSON(spec.OutputSchema, rawOutput); err != nil {
+		// Per #1103 Q2: 502 with raw output so the author can debug the
+		// pack. No in-runtime retry.
+		log.Error(err, "function output failed schema validation",
+			"outputBytes", len(rawOutput))
+		writeOutputValidationError(w, err, rawOutput)
+		return
+	}
+
+	// Echo the response shape: { output: <model output>, usage, duration_ms, invocation_id }.
+	// output is forwarded as raw JSON (already validated above).
+	if err := writeSuccess(w, rawOutput, resp); err != nil {
+		log.Error(err, "failed to write success response")
+	}
+}
+
+// writeSuccess emits the function-mode 200 response envelope.
+func writeSuccess(w http.ResponseWriter, rawOutput []byte, resp *runtimev1.InvocationResponse) error {
+	envelope := map[string]any{
+		"output":        json.RawMessage(rawOutput),
+		"invocation_id": resp.GetInvocationId(),
+		"duration_ms":   resp.GetDurationMs(),
+	}
+	if u := resp.GetUsage(); u != nil {
+		envelope["usage"] = map[string]any{
+			"input_tokens":  u.GetInputTokens(),
+			"output_tokens": u.GetOutputTokens(),
+			"cost_usd":      u.GetCostUsd(),
+		}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	return json.NewEncoder(w).Encode(envelope)
+}
+
+// writeError writes a uniform JSON error envelope.
+func writeError(w http.ResponseWriter, status int, code, detail string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(errorResponse{
+		Error:  code,
+		Detail: detail,
+	})
+}
+
+// writeOutputValidationError writes a 502 with the raw model output
+// embedded so the function author can diagnose schema drift. If the
+// raw output isn't valid JSON we still include it as a JSON string for
+// debugging.
+func writeOutputValidationError(w http.ResponseWriter, validationErr error, rawOutput []byte) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadGateway)
+	body := errorResponse{
+		Error:  "output_invalid",
+		Detail: validationErr.Error(),
+	}
+	// Pass the raw output through as JSON if possible; otherwise as a
+	// JSON string. Either way the author can read it from the response.
+	if json.Valid(rawOutput) {
+		body.RawOutput = json.RawMessage(rawOutput)
+	} else {
+		s, _ := json.Marshal(string(rawOutput))
+		body.RawOutput = s
+	}
+	_ = json.NewEncoder(w).Encode(body)
+}
+
+// MapFunctionRegistry is a trivial map-backed FunctionRegistry useful
+// for tests and bootstrap wiring. The operator (PR 4) will replace this
+// with a live, CRD-backed implementation.
+type MapFunctionRegistry struct {
+	specs map[string]*FunctionSpec
+}
+
+// NewMapFunctionRegistry returns an empty MapFunctionRegistry.
+func NewMapFunctionRegistry() *MapFunctionRegistry {
+	return &MapFunctionRegistry{specs: make(map[string]*FunctionSpec)}
+}
+
+// Register adds or replaces a FunctionSpec under its Name.
+func (r *MapFunctionRegistry) Register(spec *FunctionSpec) {
+	if spec == nil || spec.Name == "" {
+		return
+	}
+	r.specs[spec.Name] = spec
+}
+
+// GetFunction implements FunctionRegistry.
+func (r *MapFunctionRegistry) GetFunction(name string) (*FunctionSpec, bool) {
+	spec, ok := r.specs[name]
+	return spec, ok
+}

--- a/internal/facade/functions_handler.go
+++ b/internal/facade/functions_handler.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -128,11 +129,16 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	ctype := r.Header.Get("Content-Type")
-	if ctype != "" && ctype != "application/json" {
-		writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type",
-			"Content-Type must be application/json")
-		return
+	// Parse the media type so application/json; charset=utf-8 (default for
+	// many HTTP clients) is accepted. Only the bare media type is checked;
+	// parameters like charset are ignored.
+	if rawCT := r.Header.Get("Content-Type"); rawCT != "" {
+		mediaType, _, err := mime.ParseMediaType(rawCT)
+		if err != nil || mediaType != "application/json" {
+			writeError(w, http.StatusUnsupportedMediaType, "unsupported_media_type",
+				"Content-Type must be application/json")
+			return
+		}
 	}
 
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, h.maxBodyBytes))
@@ -177,17 +183,28 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Echo the response shape: { output: <model output>, usage, duration_ms, invocation_id }.
-	// output is forwarded as raw JSON (already validated above).
-	if err := writeSuccess(w, rawOutput, resp); err != nil {
+	// output is forwarded as raw JSON (already validated above). The
+	// invocationID returned is always the facade-generated one — the
+	// runtime echoes it but the facade is the source of truth, so a
+	// runtime that returned a different (or empty) value would still
+	// see this id in the response and in correlation traces.
+	if err := writeSuccess(w, rawOutput, invocationID, resp); err != nil {
 		log.Error(err, "failed to write success response")
+		return
 	}
+	log.V(1).Info("function invocation complete",
+		"durationMs", resp.GetDurationMs(),
+		"outputBytes", len(rawOutput))
 }
 
-// writeSuccess emits the function-mode 200 response envelope.
-func writeSuccess(w http.ResponseWriter, rawOutput []byte, resp *runtimev1.InvocationResponse) error {
+// writeSuccess emits the function-mode 200 response envelope. invocationID
+// is the facade-authoritative UUID generated when the request arrived;
+// it is the value returned to the caller regardless of what the runtime
+// echoed back in resp.GetInvocationId().
+func writeSuccess(w http.ResponseWriter, rawOutput []byte, invocationID string, resp *runtimev1.InvocationResponse) error {
 	envelope := map[string]any{
 		"output":        json.RawMessage(rawOutput),
-		"invocation_id": resp.GetInvocationId(),
+		"invocation_id": invocationID,
 		"duration_ms":   resp.GetDurationMs(),
 	}
 	if u := resp.GetUsage(); u != nil {

--- a/internal/facade/functions_handler_test.go
+++ b/internal/facade/functions_handler_test.go
@@ -1,0 +1,290 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// testFunctionName is reused across handler tests. Extracted to satisfy
+// goconst (string was duplicated ~14 times).
+const testFunctionName = "echo"
+
+// stubInvoker captures the runtime call inputs and returns a fixed
+// response or error. The struct's exported fields are read-only after
+// the handler returns so test assertions can inspect them.
+type stubInvoker struct {
+	resp *runtimev1.InvocationResponse
+	err  error
+
+	lastReq *runtimev1.InvocationRequest
+}
+
+func (s *stubInvoker) Invoke(_ context.Context, req *runtimev1.InvocationRequest) (*runtimev1.InvocationResponse, error) {
+	s.lastReq = req
+	return s.resp, s.err
+}
+
+func newHandler(t *testing.T, specs map[string]*FunctionSpec, invoker InvocationInvoker) *FunctionsHandler {
+	t.Helper()
+	reg := NewMapFunctionRegistry()
+	for _, s := range specs {
+		reg.Register(s)
+	}
+	return NewFunctionsHandler(reg, invoker, logr.Discard())
+}
+
+func newJSONPost(t *testing.T, path, body string) *http.Request {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	return req
+}
+
+// muxFor mounts the handler under POST /functions/{name} so PathValue
+// resolution works exactly as it will in production.
+func muxFor(h *FunctionsHandler) http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("POST /functions/{name}", h)
+	mux.Handle("/functions/{name}", h) // also serve non-POST to allow 405 testing
+	return mux
+}
+
+func TestFunctionsHandler_HappyPath(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{
+		resp: &runtimev1.InvocationResponse{
+			OutputJson:   `{"a":"42"}`,
+			DurationMs:   17,
+			InvocationId: "ignored-server-side",
+			Usage:        &runtimev1.Usage{InputTokens: 12, OutputTokens: 3, CostUsd: 0.0004},
+		},
+	}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{"q":"hi"}`))
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
+	assert.Equal(t, map[string]any{"a": "42"}, body["output"])
+	assert.Equal(t, float64(17), body["duration_ms"])
+	assert.NotEmpty(t, body["invocation_id"], "facade should generate a fresh invocation_id")
+
+	require.NotNil(t, invoker.lastReq)
+	assert.Equal(t, `{"q":"hi"}`, invoker.lastReq.GetInputJson())
+	assert.NotEmpty(t, invoker.lastReq.GetInvocationId(),
+		"facade must send an invocation_id to the runtime")
+}
+
+func TestFunctionsHandler_InputValidationFails(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{} // should not be called
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	// Missing the required "q" field.
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Nil(t, invoker.lastReq, "runtime must NOT be called when input is invalid")
+
+	var resp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "input_invalid", resp.Error)
+}
+
+func TestFunctionsHandler_OutputValidationFails_502WithRawOutput(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
+	require.NoError(t, err)
+
+	// Model returned valid JSON but missing the "a" field — schema fail.
+	invoker := &stubInvoker{
+		resp: &runtimev1.InvocationResponse{
+			OutputJson: `{"wrong":"shape"}`,
+		},
+	}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	var resp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "output_invalid", resp.Error)
+
+	// The raw model output must be embedded so the function author can
+	// debug what the pack actually emitted. Per #1103 Q2.
+	require.NotNil(t, resp.RawOutput)
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal(resp.RawOutput, &raw))
+	assert.Equal(t, map[string]any{"wrong": "shape"}, raw)
+}
+
+func TestFunctionsHandler_OutputValidationFails_NonJSONRawOutput(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	// Model returned a plain string, not JSON. Validator should reject;
+	// raw output should still be visible (as a JSON string) in the body.
+	invoker := &stubInvoker{
+		resp: &runtimev1.InvocationResponse{
+			OutputJson: `not actually json`,
+		},
+	}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	var resp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "output_invalid", resp.Error)
+	require.NotNil(t, resp.RawOutput)
+	var asString string
+	require.NoError(t, json.Unmarshal(resp.RawOutput, &asString))
+	assert.Equal(t, "not actually json", asString)
+}
+
+func TestFunctionsHandler_RuntimeError(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{err: errors.New("simulated upstream failure")}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	var resp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "runtime_error", resp.Error)
+	assert.Contains(t, resp.Detail, "simulated upstream failure")
+}
+
+func TestFunctionsHandler_UnknownFunctionIs404(t *testing.T) {
+	h := newHandler(t, map[string]*FunctionSpec{}, &stubInvoker{})
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/missing", `{}`))
+
+	require.Equal(t, http.StatusNotFound, rec.Code)
+	var resp errorResponse
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+	assert.Equal(t, "function_not_found", resp.Error)
+}
+
+func TestFunctionsHandler_RejectsNonPOST(t *testing.T) {
+	h := newHandler(t, map[string]*FunctionSpec{}, &stubInvoker{})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/functions/echo", nil)
+	muxFor(h).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+	assert.Equal(t, http.MethodPost, rec.Header().Get("Allow"))
+}
+
+func TestFunctionsHandler_RejectsWrongContentType(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, &stubInvoker{})
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/functions/echo", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "text/plain")
+	muxFor(h).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusUnsupportedMediaType, rec.Code)
+}
+
+func TestFunctionsHandler_BodyTooLarge(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, &stubInvoker{})
+	// Tighten the cap so we don't have to build a 1 MiB body.
+	h.maxBodyBytes = 32
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName,
+		`{"q":"`+strings.Repeat("x", 64)+`"}`))
+
+	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+}
+
+func TestFunctionsHandler_BlankFunctionNameIs400(t *testing.T) {
+	h := newHandler(t, map[string]*FunctionSpec{}, &stubInvoker{})
+
+	// http.ServeMux will 404 a path that doesn't have {name} bound, so
+	// drive the handler directly with no PathValue.
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/functions/", strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json")
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+}

--- a/internal/facade/functions_handler_test.go
+++ b/internal/facade/functions_handler_test.go
@@ -82,11 +82,14 @@ func TestFunctionsHandler_HappyPath(t *testing.T) {
 	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
 	require.NoError(t, err)
 
+	// Set the runtime stub to echo a DIFFERENT invocation_id (or even an
+	// empty one) so the test pins down that the response carries the
+	// facade's authoritative id, not whatever the runtime sends back.
 	invoker := &stubInvoker{
 		resp: &runtimev1.InvocationResponse{
 			OutputJson:   `{"a":"42"}`,
 			DurationMs:   17,
-			InvocationId: "ignored-server-side",
+			InvocationId: "runtime-tried-to-override",
 			Usage:        &runtimev1.Usage{InputTokens: 12, OutputTokens: 3, CostUsd: 0.0004},
 		},
 	}
@@ -104,12 +107,41 @@ func TestFunctionsHandler_HappyPath(t *testing.T) {
 	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &body))
 	assert.Equal(t, map[string]any{"a": "42"}, body["output"])
 	assert.Equal(t, float64(17), body["duration_ms"])
-	assert.NotEmpty(t, body["invocation_id"], "facade should generate a fresh invocation_id")
+
+	responseID, ok := body["invocation_id"].(string)
+	require.True(t, ok, "invocation_id must be a string")
+	assert.NotEmpty(t, responseID, "facade must generate an invocation_id")
+	assert.NotEqual(t, "runtime-tried-to-override", responseID,
+		"facade is authoritative on invocation_id; runtime's echo must not leak into the response")
 
 	require.NotNil(t, invoker.lastReq)
 	assert.Equal(t, `{"q":"hi"}`, invoker.lastReq.GetInputJson())
-	assert.NotEmpty(t, invoker.lastReq.GetInvocationId(),
-		"facade must send an invocation_id to the runtime")
+	// Round-trip invariant: the id the facade sent to the runtime must be
+	// the same id it returned to the caller.
+	assert.Equal(t, responseID, invoker.lastReq.GetInvocationId(),
+		"facade must send the same invocation_id to the runtime that it returns to the caller")
+}
+
+func TestFunctionsHandler_AcceptsApplicationJSONWithCharsetSuffix(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{
+		resp: &runtimev1.InvocationResponse{OutputJson: `{}`},
+	}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	req := httptest.NewRequest(http.MethodPost, "/functions/"+testFunctionName, strings.NewReader(`{}`))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code,
+		"Content-Type with a charset parameter must be accepted")
 }
 
 func TestFunctionsHandler_InputValidationFails(t *testing.T) {
@@ -276,15 +308,36 @@ func TestFunctionsHandler_BodyTooLarge(t *testing.T) {
 	require.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 }
 
-func TestFunctionsHandler_BlankFunctionNameIs400(t *testing.T) {
+func TestFunctionsHandler_BlankPathValueIs400(t *testing.T) {
+	// Defensive: production mounts the handler under "POST /functions/{name}"
+	// so a blank PathValue is impossible in practice. This test pins the
+	// handler's own guard against a misconfigured mux that hands it a
+	// request with no {name} bound.
 	h := newHandler(t, map[string]*FunctionSpec{}, &stubInvoker{})
 
-	// http.ServeMux will 404 a path that doesn't have {name} bound, so
-	// drive the handler directly with no PathValue.
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest(http.MethodPost, "/functions/", strings.NewReader(`{}`))
 	req.Header.Set("Content-Type", "application/json")
 	h.ServeHTTP(rec, req)
 
 	require.Equal(t, http.StatusBadRequest, rec.Code)
+}
+
+func TestMapFunctionRegistry_RegisterIgnoresInvalidSpecs(t *testing.T) {
+	reg := NewMapFunctionRegistry()
+
+	// nil spec is silently dropped.
+	reg.Register(nil)
+	// empty Name is silently dropped.
+	reg.Register(&FunctionSpec{Name: ""})
+
+	if _, ok := reg.GetFunction(""); ok {
+		t.Errorf("registry must not store a spec with empty Name")
+	}
+	// A valid registration still works after the bad ones — verify the
+	// silent-drop branches didn't poison the registry's internal map.
+	reg.Register(&FunctionSpec{Name: testFunctionName})
+	if _, ok := reg.GetFunction(testFunctionName); !ok {
+		t.Errorf("registry must store valid specs after silent-dropped invalid ones")
+	}
 }

--- a/internal/facade/functions_schema.go
+++ b/internal/facade/functions_schema.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// CompileSchema compiles a raw JSON Schema (draft-2020-12) for use by the
+// function-mode request/response validators. The schemaBytes payload must
+// be the AgentRuntime spec.inputSchema or spec.outputSchema field as
+// stored in the CRD; both are opaque JSON objects.
+//
+// Returns an opaque compiled schema usable with ValidateJSON, or an error
+// if the input is not a valid JSON Schema.
+func CompileSchema(schemaBytes []byte) (*jsonschema.Schema, error) {
+	if len(schemaBytes) == 0 {
+		return nil, fmt.Errorf("schema is empty")
+	}
+	var raw any
+	if err := json.Unmarshal(schemaBytes, &raw); err != nil {
+		return nil, fmt.Errorf("schema is not valid JSON: %w", err)
+	}
+	c := jsonschema.NewCompiler()
+	// Resource URL is required by the compiler; use a stable opaque name.
+	const resource = "spec://omnia/agentruntime/schema.json"
+	if err := c.AddResource(resource, raw); err != nil {
+		return nil, fmt.Errorf("schema add resource: %w", err)
+	}
+	compiled, err := c.Compile(resource)
+	if err != nil {
+		return nil, fmt.Errorf("schema compile: %w", err)
+	}
+	return compiled, nil
+}
+
+// ValidateJSON validates a raw JSON payload against a compiled schema.
+// payload must be valid JSON; if it isn't, the JSON error is returned
+// directly. Schema validation failures are wrapped with the offending
+// path so the caller can surface useful 4xx detail.
+func ValidateJSON(schema *jsonschema.Schema, payload []byte) error {
+	if schema == nil {
+		// No schema configured — treat as accept-anything. The handler
+		// upstream gates on FunctionSpec presence, so a nil schema here
+		// is a misconfiguration (not a runtime "validate everything").
+		return fmt.Errorf("validator not configured")
+	}
+	if len(bytes.TrimSpace(payload)) == 0 {
+		return fmt.Errorf("payload is empty")
+	}
+	var raw any
+	if err := json.Unmarshal(payload, &raw); err != nil {
+		return fmt.Errorf("payload is not valid JSON: %w", err)
+	}
+	if err := schema.Validate(raw); err != nil {
+		return fmt.Errorf("payload does not satisfy schema: %w", err)
+	}
+	return nil
+}

--- a/internal/facade/functions_schema_test.go
+++ b/internal/facade/functions_schema_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCompileSchema_Valid(t *testing.T) {
+	s, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	assert.NotNil(t, s)
+}
+
+func TestCompileSchema_Empty(t *testing.T) {
+	_, err := CompileSchema(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestCompileSchema_BadJSON(t *testing.T) {
+	_, err := CompileSchema([]byte(`{not json`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestCompileSchema_InvalidSchema(t *testing.T) {
+	// "type" must be a string or array of strings; an integer is rejected
+	// during compile.
+	_, err := CompileSchema([]byte(`{"type":42}`))
+	require.Error(t, err)
+}
+
+func TestValidateJSON_HappyPath(t *testing.T) {
+	s, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+
+	assert.NoError(t, ValidateJSON(s, []byte(`{"q":"x"}`)))
+}
+
+func TestValidateJSON_NilSchema(t *testing.T) {
+	err := ValidateJSON(nil, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
+func TestValidateJSON_EmptyPayload(t *testing.T) {
+	s, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	err = ValidateJSON(s, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestValidateJSON_BadJSON(t *testing.T) {
+	s, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	err = ValidateJSON(s, []byte(`{not json`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestValidateJSON_SchemaViolation(t *testing.T) {
+	s, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+
+	err = ValidateJSON(s, []byte(`{}`))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "does not satisfy schema")
+}

--- a/internal/facade/runtime_client.go
+++ b/internal/facade/runtime_client.go
@@ -121,6 +121,13 @@ func (c *RuntimeClient) Converse(ctx context.Context) (runtimev1.RuntimeService_
 	return c.client.Converse(ctx)
 }
 
+// Invoke runs a one-shot Function call through the runtime. The facade's
+// FunctionsHandler is the sole consumer; agent-mode flows continue to
+// use Converse.
+func (c *RuntimeClient) Invoke(ctx context.Context, req *runtimev1.InvocationRequest) (*runtimev1.InvocationResponse, error) {
+	return c.client.Invoke(ctx, req)
+}
+
 // Health checks the runtime's health status.
 func (c *RuntimeClient) Health(ctx context.Context) (*runtimev1.HealthResponse, error) {
 	return c.client.Health(ctx, &runtimev1.HealthRequest{})


### PR DESCRIPTION
## Summary

PR 3 of 7 for Functions Phase 1 (umbrella #1102, slicing #1103). Lands the facade-side HTTP route that connects browser/server callers to the runtime \`Invoke\` RPC that shipped in #1105.

Per #1103 Q5 — JSON-Schema validation lives in the facade, not the runtime. The runtime is schema-agnostic.

## What's new

**Schema validator** (\`internal/facade/functions_schema.go\`) — \`CompileSchema\` + \`ValidateJSON\` wrap santhosh-tekuri/jsonschema/v6 (draft-2020-12). Schemas are compiled once and reused per request.

**Handler** (\`internal/facade/functions_handler.go\`) — \`FunctionsHandler\` serves \`POST /functions/{name}\` with the full request lifecycle:
1. Method gate (POST only → 405).
2. Function lookup by name (404 if missing or mode≠function; agent-mode runtimes 404 rather than 405 to avoid enumeration).
3. \`Content-Type: application/json\` strictness (415 otherwise).
4. 1 MiB body cap via \`http.MaxBytesReader\` (413 otherwise).
5. **Input validation** against \`spec.inputSchema\` (400 \`input_invalid\`; **runtime is NOT called**).
6. UUIDv4 \`invocation_id\` generated facade-side; \`logctx.WithInvocationID\` propagates it into the gRPC client.
7. **Output validation** against \`spec.outputSchema\` (502 \`output_invalid\` with embedded \`raw_output\` per #1103 Q2 lock).
8. Success envelope: \`{ output, invocation_id, duration_ms, usage{input_tokens, output_tokens, cost_usd} }\`.

**Registry types** — \`FunctionSpec\`, \`FunctionRegistry\`, \`MapFunctionRegistry\`. PR 4 (operator) will swap the map for a CRD-backed implementation; this PR's map suffices for tests and bootstrap wiring.

**InvocationInvoker interface** — Just \`Invoke(ctx, req) → resp, err\`. Mocked in tests; in production it's the existing \`*RuntimeClient\`, which gains a one-line wrapper around \`c.client.Invoke\`.

## Tests (19 total)

\`functions_schema_test.go\` (9):
- Compile: valid / empty / bad-JSON / invalid-schema.
- Validate: happy / nil-schema / empty-payload / bad-JSON / schema violation.

\`functions_handler_test.go\` (10):
- Happy path (200 + envelope).
- Input invalid → 400 \`input_invalid\`; runtime **not** called.
- Output invalid (valid JSON) → 502 with \`raw_output\` as object.
- Output invalid (non-JSON) → 502 with \`raw_output\` as JSON string.
- Runtime gRPC error → 502 \`runtime_error\`.
- Unknown function → 404.
- Non-POST → 405 with \`Allow: POST\`.
- Wrong content-type → 415.
- Body over cap → 413.
- Blank function name → 400.

## CHANGELOG

\`api/CHANGELOG.md\` documents every error envelope code so downstream consumers (PR 4 operator, PR 5 session-api persistence, PR 6 dashboard) can build against a stable contract.

## Per-file coverage

- \`functions_handler.go\`: 94.2%
- \`functions_schema.go\`: 95.7%
- \`runtime_client.go\`: 86.0%

## Intentionally NOT in this PR

- **Operator wiring** (mounting the handler on the cmd/agent mux, deciding which port to listen on, building the registry from the CRD). That's PR 4 — the locked decision (#1103 Q1) is \"same pod shape, mode-aware facade\", and the wiring is more naturally landed alongside the operator changes.
- **Invocation persistence** to session-api. PR 5.
- **Auth chain reuse** for the function route. Will be added in PR 4 when the route mounts onto the main mux.

## Up next

- PR 4: Operator pod-shape mode awareness; mount this handler.
- PR 5: \`function_invocations\` persistence in session-api.
- PR 6: Dashboard catalog + invocation history.
- PR 7: Docs + example pack.