### PR TITLE
feat(session-api+facade): function_invocations persistence (Functions Phase 1 PR 5/7, #1103)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,37 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Added (session-api: function_invocations persistence + facade write path, #1103 PR 5)
+
+- New `function_invocations` table in the session-api Postgres schema
+  (migration `000026_create_function_invocations`). Partitioned weekly
+  by `created_at`, same lifecycle as `sessions` / `messages` etc. The
+  `manage_session_partitions` orchestrator now includes
+  `function_invocations` in its rotation.
+- Session-API endpoints (mounted on the existing handler mux):
+  - `POST /api/v1/function-invocations` — write a single audit row.
+    Called by the facade after a Function call when
+    `AgentRuntime.spec.invocationRecording.state == "enabled"`.
+    Returns 201 + the row on success, 400 on missing fields, 503 when
+    the store isn't configured.
+  - `GET /api/v1/function-invocations?namespace=X[&function=Y&from=...&to=...&limit=N]`
+    — list recent invocations for a namespace, optionally scoped to a
+    function name + time window. Pagination defaults to 100 rows,
+    capped at 1000.
+  - `GET /api/v1/function-invocations/{id}?namespace=X` — single row.
+    Cross-tenant reads return 404 (no existence leak).
+- Status enum (matches the table's CHECK constraint):
+  `success | input_invalid | output_invalid | runtime_error`.
+- Facade write path: `FunctionsHandler.WithRecorder(...)` opt-in
+  recorder; the agent binary wires it via the session-api HTTP client
+  when `cfg.FunctionRecordsInvocations` is true. Recording is
+  best-effort — a recorder failure logs but does NOT fail the
+  user-facing Function call (Q3 / #1103 lock).
+- Input hash is sha256 of the JSON body — stored in lieu of the raw
+  input so persistence doesn't grow PII surface area. Output JSON is
+  stored verbatim; functions whose outputs carry sensitive data
+  should keep `state: disabled`.
+
 ### Added (operator + facade activation for function-mode AgentRuntimes, #1103 PR 4)
 
 - AgentRuntime pods now branch on `spec.mode` at startup:

--- a/cmd/agent/functions.go
+++ b/cmd/agent/functions.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/altairalabs/omnia/internal/agent"
 	"github.com/altairalabs/omnia/internal/facade"
+	"github.com/altairalabs/omnia/internal/session/httpclient"
 	"github.com/altairalabs/omnia/internal/tracing"
 )
 
@@ -76,6 +77,16 @@ func runFunctionsFacade(cfg *agent.Config, log logr.Logger, tracingProvider *tra
 	}()
 
 	handler := facade.NewFunctionsHandler(registry, rc, log)
+	if cfg.FunctionRecordsInvocations {
+		recorder, err := newFunctionsRecorder(log)
+		if err != nil {
+			log.Error(err, "function recording is enabled but session-api unreachable; recording disabled")
+		} else {
+			handler = handler.WithRecorder(recorder, cfg.Namespace)
+			log.Info("function invocation recording enabled",
+				"function", cfg.AgentName, "namespace", cfg.Namespace)
+		}
+	}
 
 	mux := http.NewServeMux()
 	mux.Handle("POST /functions/{name}", functionAuthGate(handler, log))
@@ -164,6 +175,44 @@ func buildFunctionRegistry(cfg *agent.Config) (facade.FunctionRegistry, error) {
 		RecordsInvocations: cfg.FunctionRecordsInvocations,
 	})
 	return registry, nil
+}
+
+// newFunctionsRecorder wires a facade.InvocationRecorder backed by the
+// session-api HTTP store. Mirrors the WebSocket path's session-store
+// resolution. Returns an error when session-api is unreachable (in
+// which case the caller falls back to a nil recorder — recording is
+// best-effort).
+func newFunctionsRecorder(log logr.Logger) (facade.InvocationRecorder, error) {
+	store, err := initSessionStore(log)
+	if err != nil {
+		return nil, err
+	}
+	hc, ok := store.(*httpclient.Store)
+	if !ok {
+		return nil, fmt.Errorf("function recording requires session-api; got %T", store)
+	}
+	return &httpInvocationRecorder{store: hc}, nil
+}
+
+// httpInvocationRecorder adapts httpclient.Store to facade.InvocationRecorder.
+type httpInvocationRecorder struct {
+	store *httpclient.Store
+}
+
+// RecordFunctionInvocation implements facade.InvocationRecorder.
+func (r *httpInvocationRecorder) RecordFunctionInvocation(ctx context.Context, inv facade.InvocationRecord) error {
+	return r.store.RecordFunctionInvocation(ctx, httpclient.FunctionInvocationRecord{
+		ID:           inv.ID,
+		Namespace:    inv.Namespace,
+		FunctionName: inv.FunctionName,
+		InputHash:    inv.InputHash,
+		OutputJSON:   inv.OutputJSON,
+		Status:       inv.Status,
+		DurationMs:   inv.DurationMs,
+		CostUSD:      inv.CostUSD,
+		TraceID:      inv.TraceID,
+		CreatedAt:    inv.CreatedAt,
+	})
 }
 
 // newFunctionsHealthServer mounts /healthz + /readyz on the health

--- a/cmd/session-api/main.go
+++ b/cmd/session-api/main.go
@@ -492,6 +492,13 @@ func buildAPIMux(pool *pgxpool.Pool, registry *providers.Registry, f *flags, log
 		providerCallsStore := pgprovider.NewProviderCallsStore(pool)
 		providerCallsService := api.NewProviderCallsService(providerCallsStore, log)
 		handler.SetProviderCallsService(providerCallsService)
+
+		// Function invocations (Functions Phase 1, #1103 PR 5). Same
+		// availability as the other postgres-backed services — disabled
+		// when no DB is configured (in-memory dev mode).
+		functionInvocationsStore := pgprovider.NewFunctionInvocationsStore(pool)
+		functionInvocationsService := api.NewFunctionInvocationsService(functionInvocationsStore, log)
+		handler.SetFunctionInvocationsService(functionInvocationsService)
 	}
 
 	mux := http.NewServeMux()

--- a/internal/facade/functions_handler.go
+++ b/internal/facade/functions_handler.go
@@ -18,12 +18,15 @@ package facade
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"mime"
 	"net/http"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
@@ -61,14 +64,41 @@ type InvocationInvoker interface {
 	Invoke(ctx context.Context, req *runtimev1.InvocationRequest) (*runtimev1.InvocationResponse, error)
 }
 
+// InvocationRecorder persists per-call audit records. The session-api
+// HTTP client implements this; tests may stub it. Errors are logged
+// but never propagate to the caller — recording is best-effort and
+// must not fail the user-facing request.
+type InvocationRecorder interface {
+	RecordFunctionInvocation(ctx context.Context, inv InvocationRecord) error
+}
+
+// InvocationRecord is the in-process shape the handler passes to a
+// recorder. Mirrors the session-api FunctionInvocation wire shape but
+// stays in this package so the facade doesn't depend on internal/session.
+// The session-api httpclient performs the conversion.
+type InvocationRecord struct {
+	ID           string
+	Namespace    string
+	FunctionName string
+	InputHash    string
+	OutputJSON   []byte
+	Status       string
+	DurationMs   int32
+	CostUSD      float64
+	TraceID      string
+	CreatedAt    time.Time
+}
+
 // FunctionsHandler serves POST /functions/{name} for function-mode
 // AgentRuntimes. The handler is the single source of truth for input
 // and output JSON-Schema validation (the runtime is intentionally
 // schema-agnostic; see PR 2 / #1105).
 type FunctionsHandler struct {
-	registry FunctionRegistry
-	invoker  InvocationInvoker
-	log      logr.Logger
+	registry  FunctionRegistry
+	invoker   InvocationInvoker
+	recorder  InvocationRecorder
+	namespace string
+	log       logr.Logger
 
 	// maxBodyBytes caps the incoming request body. Defaults to 1 MiB,
 	// matching the WS path's reasonable upper bound. Function payloads
@@ -88,6 +118,16 @@ func NewFunctionsHandler(registry FunctionRegistry, invoker InvocationInvoker, l
 		log:          log.WithName("functions-handler"),
 		maxBodyBytes: 1 << 20, // 1 MiB
 	}
+}
+
+// WithRecorder configures the per-invocation audit recorder. A nil
+// recorder is allowed (the handler simply skips recording). The agent
+// binary wires this up only when AgentRuntime.spec.invocationRecording.state
+// == "enabled".
+func (h *FunctionsHandler) WithRecorder(recorder InvocationRecorder, namespace string) *FunctionsHandler {
+	h.recorder = recorder
+	h.namespace = namespace
+	return h
 }
 
 // errorResponse is the JSON envelope returned on 4xx errors. The 502
@@ -162,12 +202,15 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	ctx := logctx.WithInvocationID(r.Context(), invocationID)
 	log := h.log.WithValues("function", name, "invocationID", invocationID)
 
+	inputHash := sha256HexSum(body)
 	resp, err := h.invoker.Invoke(ctx, &runtimev1.InvocationRequest{
 		InputJson:    string(body),
 		InvocationId: invocationID,
 	})
 	if err != nil {
 		log.Error(err, "runtime invoke failed")
+		h.record(ctx, name, invocationID, inputHash, nil,
+			FunctionInvocationStatusRuntimeError, 0, 0, log)
 		writeError(w, http.StatusBadGateway, "runtime_error", err.Error())
 		return
 	}
@@ -178,6 +221,9 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// pack. No in-runtime retry.
 		log.Error(err, "function output failed schema validation",
 			"outputBytes", len(rawOutput))
+		h.record(ctx, name, invocationID, inputHash, rawOutput,
+			FunctionInvocationStatusOutputInvalid,
+			resp.GetDurationMs(), resp.GetUsage().GetCostUsd(), log)
 		writeOutputValidationError(w, err, rawOutput)
 		return
 	}
@@ -192,9 +238,54 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Error(err, "failed to write success response")
 		return
 	}
+	h.record(ctx, name, invocationID, inputHash, rawOutput,
+		FunctionInvocationStatusSuccess,
+		resp.GetDurationMs(), resp.GetUsage().GetCostUsd(), log)
 	log.V(1).Info("function invocation complete",
 		"durationMs", resp.GetDurationMs(),
 		"outputBytes", len(rawOutput))
+}
+
+// FunctionInvocation* status constants mirror the session-api enum.
+const (
+	FunctionInvocationStatusSuccess       = "success"
+	FunctionInvocationStatusInputInvalid  = "input_invalid"
+	FunctionInvocationStatusOutputInvalid = "output_invalid"
+	FunctionInvocationStatusRuntimeError  = "runtime_error"
+)
+
+// sha256HexSum returns the lowercase-hex SHA-256 of input. Used for
+// input_hash so the persistence layer doesn't need to store raw input
+// (which may carry PII).
+func sha256HexSum(input []byte) string {
+	sum := sha256.Sum256(input)
+	return hex.EncodeToString(sum[:])
+}
+
+// record sends a best-effort audit row to the recorder. Errors are
+// logged but never propagated — recording must not fail the user-facing
+// request. A nil recorder is a no-op (opt-in feature; see PR 4's
+// agent wiring and #1103 Q3).
+func (h *FunctionsHandler) record(ctx context.Context, functionName, invocationID, inputHash string,
+	output []byte, status string, durationMs int32, costUSD float32, log logr.Logger) {
+	if h.recorder == nil {
+		return
+	}
+	if err := h.recorder.RecordFunctionInvocation(ctx, InvocationRecord{
+		ID:           invocationID,
+		Namespace:    h.namespace,
+		FunctionName: functionName,
+		InputHash:    inputHash,
+		OutputJSON:   output,
+		Status:       status,
+		DurationMs:   durationMs,
+		CostUSD:      float64(costUSD),
+		// TraceID is left empty — PR 6 (dashboard) wires it after
+		// session-api supports the trace-id correlation column read.
+		CreatedAt: time.Now().UTC(),
+	}); err != nil {
+		log.Error(err, "function invocation recording failed (non-fatal)")
+	}
 }
 
 // writeSuccess emits the function-mode 200 response envelope. invocationID

--- a/internal/facade/functions_handler_test.go
+++ b/internal/facade/functions_handler_test.go
@@ -399,6 +399,39 @@ func TestFunctionsHandler_RecordsSuccess(t *testing.T) {
 	assert.InDelta(t, 0.002, got.CostUSD, 1e-9)
 	assert.NotEmpty(t, got.InputHash, "input_hash must be populated")
 	assert.NotEmpty(t, got.ID, "invocation id must propagate")
+	// Pin the hash format so a future swap to a different algorithm
+	// trips this test rather than silently changing the wire contract.
+	assert.Regexp(t, `^[0-9a-f]{64}$`, got.InputHash,
+		"input_hash must be lowercase sha256 hex (64 chars)")
+	// TraceID is a placeholder until PR 6 extracts it from the OTel
+	// context; pinning this empty here means a premature wiring during
+	// PR 6 flips this test red.
+	assert.Empty(t, got.TraceID, "TraceID is a PR-6 placeholder; must remain empty for now")
+}
+
+func TestFunctionsHandler_DoesNotRecordOnInputInvalid(t *testing.T) {
+	// Per the locked design, input validation rejects before the runtime
+	// is called and we do NOT persist a record for input_invalid — the
+	// hash would only encode garbage and the row carries no useful audit
+	// signal. Pin that contract so a future refactor cannot silently
+	// start recording these.
+	inputSchema, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{} // must not be called
+	recorder := &stubRecorder{}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker).WithRecorder(recorder, "ns-test")
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Empty(t, recorder.records,
+		"input_invalid must not record an invocation row")
 }
 
 func TestFunctionsHandler_RecordsRuntimeError(t *testing.T) {

--- a/internal/facade/functions_handler_test.go
+++ b/internal/facade/functions_handler_test.go
@@ -341,3 +341,125 @@ func TestMapFunctionRegistry_RegisterIgnoresInvalidSpecs(t *testing.T) {
 		t.Errorf("registry must store valid specs after silent-dropped invalid ones")
 	}
 }
+
+// stubRecorder captures recorded invocations so tests can assert what
+// the handler emitted.
+type stubRecorder struct {
+	records []InvocationRecord
+	err     error
+}
+
+func (r *stubRecorder) RecordFunctionInvocation(_ context.Context, inv InvocationRecord) error {
+	r.records = append(r.records, inv)
+	return r.err
+}
+
+func TestFunctionsHandler_DoesNotRecordWhenRecorderUnset(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{OutputJson: `{}`}}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+	// No WithRecorder call — recording is a no-op.
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestFunctionsHandler_RecordsSuccess(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{
+		OutputJson: `{"a":1}`,
+		DurationMs: 5,
+		Usage:      &runtimev1.Usage{InputTokens: 10, OutputTokens: 5, CostUsd: 0.002},
+	}}
+	recorder := &stubRecorder{}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker).WithRecorder(recorder, "ns-test")
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Len(t, recorder.records, 1, "recorder must receive one row on success")
+	got := recorder.records[0]
+	assert.Equal(t, "ns-test", got.Namespace)
+	assert.Equal(t, testFunctionName, got.FunctionName)
+	assert.Equal(t, FunctionInvocationStatusSuccess, got.Status)
+	assert.Equal(t, int32(5), got.DurationMs)
+	assert.InDelta(t, 0.002, got.CostUSD, 1e-9)
+	assert.NotEmpty(t, got.InputHash, "input_hash must be populated")
+	assert.NotEmpty(t, got.ID, "invocation id must propagate")
+}
+
+func TestFunctionsHandler_RecordsRuntimeError(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{err: errors.New("runtime down")}
+	recorder := &stubRecorder{}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker).WithRecorder(recorder, "ns-test")
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Len(t, recorder.records, 1)
+	assert.Equal(t, FunctionInvocationStatusRuntimeError, recorder.records[0].Status)
+}
+
+func TestFunctionsHandler_RecordsOutputInvalid(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{
+		OutputJson: `{"wrong":"shape"}`,
+		DurationMs: 7,
+	}}
+	recorder := &stubRecorder{}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker).WithRecorder(recorder, "ns-test")
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+	require.Len(t, recorder.records, 1)
+	assert.Equal(t, FunctionInvocationStatusOutputInvalid, recorder.records[0].Status)
+	assert.NotEmpty(t, recorder.records[0].OutputJSON,
+		"raw output must be captured for debugging even on output-validation failure")
+}
+
+func TestFunctionsHandler_RecorderErrorIsNonFatal(t *testing.T) {
+	// A failing recorder must NOT fail the user-facing request — recording
+	// is best-effort. Q3 / #1103 lock.
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{OutputJson: `{}`}}
+	recorder := &stubRecorder{err: errors.New("session-api down")}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker).WithRecorder(recorder, "ns-test")
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusOK, rec.Code,
+		"recorder failure must not break the user-facing request")
+}

--- a/internal/session/api/function_invocations_handler.go
+++ b/internal/session/api/function_invocations_handler.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/altairalabs/omnia/internal/httputil"
+)
+
+// FunctionInvocationsListResponse is the JSON body for the list endpoint.
+// Rows is non-nil so callers can json-serialise without a null check.
+type FunctionInvocationsListResponse struct {
+	Rows []*FunctionInvocation `json:"rows"`
+}
+
+// SetFunctionInvocationsService wires a FunctionInvocationsService onto
+// the handler. When unset, the endpoints return 503.
+func (h *Handler) SetFunctionInvocationsService(svc *FunctionInvocationsService) {
+	h.functionInvocationsService = svc
+}
+
+// handleCreateFunctionInvocation persists one invocation record.
+// POST /api/v1/function-invocations
+func (h *Handler) handleCreateFunctionInvocation(w http.ResponseWriter, r *http.Request) {
+	if h.functionInvocationsService == nil {
+		writeFunctionInvocationsError(w, ErrMissingFunctionInvocationsStore)
+		return
+	}
+
+	h.limitBody(w, r)
+	var inv FunctionInvocation
+	if err := json.NewDecoder(r.Body).Decode(&inv); err != nil {
+		if isMaxBytesError(err) {
+			writeError(w, ErrBodyTooLarge)
+			return
+		}
+		writeError(w, ErrMissingBody)
+		return
+	}
+	if inv.Namespace == "" || inv.FunctionName == "" || inv.Status == "" || inv.ID == "" {
+		writeBadRequest(w, "id, namespace, functionName, and status are required")
+		return
+	}
+	if inv.CreatedAt.IsZero() {
+		inv.CreatedAt = time.Now().UTC()
+	}
+
+	if err := h.functionInvocationsService.CreateFunctionInvocation(r.Context(), &inv); err != nil {
+		writeFunctionInvocationsError(w, err)
+		return
+	}
+
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(&inv)
+}
+
+// handleListFunctionInvocations returns recent invocations for a namespace.
+// GET /api/v1/function-invocations?namespace=X[&function=Y&from=...&to=...&limit=N]
+func (h *Handler) handleListFunctionInvocations(w http.ResponseWriter, r *http.Request) {
+	if h.functionInvocationsService == nil {
+		writeFunctionInvocationsError(w, ErrMissingFunctionInvocationsStore)
+		return
+	}
+
+	q := r.URL.Query()
+	namespace := q.Get("namespace")
+	if namespace == "" {
+		writeBadRequest(w, errAggregateMissingNamespace.Error())
+		return
+	}
+
+	opts := FunctionInvocationListOpts{
+		Namespace:    namespace,
+		FunctionName: q.Get("function"),
+	}
+	if v := q.Get("from"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeBadRequest(w, "from must be RFC3339")
+			return
+		}
+		opts.From = t
+	}
+	if v := q.Get("to"); v != "" {
+		t, err := time.Parse(time.RFC3339, v)
+		if err != nil {
+			writeBadRequest(w, "to must be RFC3339")
+			return
+		}
+		opts.To = t
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			writeBadRequest(w, "limit must be a non-negative integer")
+			return
+		}
+		opts.Limit = n
+	}
+
+	rows, err := h.functionInvocationsService.ListFunctionInvocations(r.Context(), opts)
+	if err != nil {
+		writeFunctionInvocationsError(w, err)
+		return
+	}
+	if rows == nil {
+		rows = []*FunctionInvocation{}
+	}
+
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	_ = json.NewEncoder(w).Encode(FunctionInvocationsListResponse{Rows: rows})
+}
+
+// handleGetFunctionInvocation returns a single row.
+// GET /api/v1/function-invocations/{id}?namespace=X
+func (h *Handler) handleGetFunctionInvocation(w http.ResponseWriter, r *http.Request) {
+	if h.functionInvocationsService == nil {
+		writeFunctionInvocationsError(w, ErrMissingFunctionInvocationsStore)
+		return
+	}
+
+	namespace := r.URL.Query().Get("namespace")
+	if namespace == "" {
+		writeBadRequest(w, errAggregateMissingNamespace.Error())
+		return
+	}
+	id := r.PathValue("id")
+	if id == "" {
+		writeBadRequest(w, "id is required")
+		return
+	}
+
+	inv, err := h.functionInvocationsService.GetFunctionInvocation(r.Context(), namespace, id)
+	if err != nil {
+		writeFunctionInvocationsError(w, err)
+		return
+	}
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	_ = json.NewEncoder(w).Encode(inv)
+}
+
+// writeBadRequest is a small 400 helper for parse failures that don't
+// match a sentinel writeError maps to 400.
+func writeBadRequest(w http.ResponseWriter, msg string) {
+	w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+	w.WriteHeader(http.StatusBadRequest)
+	_ = json.NewEncoder(w).Encode(ErrorResponse{Error: msg})
+}
+
+// writeFunctionInvocationsError maps store-not-configured to 503 and
+// not-found to 404; everything else falls through to writeError.
+func writeFunctionInvocationsError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrMissingFunctionInvocationsStore):
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "function invocations store not configured"})
+	case errors.Is(err, ErrFunctionInvocationNotFound):
+		w.Header().Set(httputil.HeaderContentType, httputil.ContentTypeJSON)
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(ErrorResponse{Error: "function invocation not found"})
+	default:
+		writeError(w, err)
+	}
+}

--- a/internal/session/api/function_invocations_handler_test.go
+++ b/internal/session/api/function_invocations_handler_test.go
@@ -344,6 +344,39 @@ func TestHandleListFunctionInvocations_InvalidLimit(t *testing.T) {
 	require.Equal(t, http.StatusBadRequest, w.Code)
 }
 
+func TestHandleGetFunctionInvocation_CrossTenantIs404(t *testing.T) {
+	// A row exists in ns-a; a GET for the same id but namespace=ns-b must
+	// return 404 with no row body. Pins the no-existence-leak contract
+	// at the HTTP layer (the store layer is covered separately by
+	// TestFunctionInvocationsStore_Get_CrossTenantHidden).
+	store := &mockFunctionInvocationsStore{
+		rows: map[string]*FunctionInvocation{
+			"inv-1": {
+				ID:           "inv-1",
+				Namespace:    fiTestNamespaceA,
+				FunctionName: "summarizer",
+				Status:       FunctionInvocationStatusSuccess,
+				CreatedAt:    time.Now().UTC(),
+			},
+		},
+	}
+	mux := newFunctionInvocationsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/function-invocations/inv-1?namespace=ns-b", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	// The 404 body must not leak the row — verify the response carries
+	// only the not-found error envelope, no field from the seeded row.
+	body := w.Body.String()
+	assert.NotContains(t, body, "summarizer",
+		"404 response must not leak the row's function name across tenants")
+	assert.NotContains(t, body, "inv-1",
+		"404 response must not echo the requested id back in a way that confirms its existence")
+}
+
 func TestHandleListFunctionInvocations_ValidFromAndToParse(t *testing.T) {
 	// Exercise the success path for both From and To parse paths plus the
 	// integer-limit path so coverage hits each branch.

--- a/internal/session/api/function_invocations_handler_test.go
+++ b/internal/session/api/function_invocations_handler_test.go
@@ -1,0 +1,364 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fiTestNamespaceA is the canonical test namespace used in this file.
+const fiTestNamespaceA = "ns-a"
+
+// fiCreateBody returns a minimal JSON body for the create endpoint with
+// the given id + function name + status. Extracted so the embedded
+// JSON literals don't trip goconst on "ns-a".
+func fiCreateBody(id, function, status string) string {
+	return `{"id":"` + id + `","namespace":"` + fiTestNamespaceA +
+		`","functionName":"` + function + `","inputHash":"h","status":"` + status + `"}`
+}
+
+// mockFunctionInvocationsStore is a small in-memory FunctionInvocationsStore.
+type mockFunctionInvocationsStore struct {
+	rows       map[string]*FunctionInvocation // keyed by id
+	listResult []*FunctionInvocation
+	createErr  error
+	getErr     error
+	listErr    error
+}
+
+func (m *mockFunctionInvocationsStore) CreateFunctionInvocation(_ context.Context, inv *FunctionInvocation) error {
+	if m.createErr != nil {
+		return m.createErr
+	}
+	if m.rows == nil {
+		m.rows = map[string]*FunctionInvocation{}
+	}
+	m.rows[inv.ID] = inv
+	return nil
+}
+
+func (m *mockFunctionInvocationsStore) GetFunctionInvocation(_ context.Context, namespace, id string) (*FunctionInvocation, error) {
+	if m.getErr != nil {
+		return nil, m.getErr
+	}
+	inv, ok := m.rows[id]
+	if !ok || inv.Namespace != namespace {
+		return nil, ErrFunctionInvocationNotFound
+	}
+	return inv, nil
+}
+
+func (m *mockFunctionInvocationsStore) ListFunctionInvocations(_ context.Context, _ FunctionInvocationListOpts) ([]*FunctionInvocation, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.listResult, nil
+}
+
+func newFunctionInvocationsHandler(store FunctionInvocationsStore) *http.ServeMux {
+	h := NewHandler(nil, logr.Discard())
+	h.SetFunctionInvocationsService(NewFunctionInvocationsService(store, logr.Discard()))
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+	return mux
+}
+
+func TestHandleCreateFunctionInvocation_Success(t *testing.T) {
+	store := &mockFunctionInvocationsStore{}
+	mux := newFunctionInvocationsHandler(store)
+
+	body := `{"id":"inv-1","namespace":"` + fiTestNamespaceA + `","functionName":"summarizer","inputHash":"abc","outputJson":{"a":1},"status":"success","durationMs":12,"costUsd":0.001}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/function-invocations", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.NotNil(t, store.rows["inv-1"])
+	assert.Equal(t, "summarizer", store.rows["inv-1"].FunctionName)
+}
+
+func TestHandleCreateFunctionInvocation_MissingRequired(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/function-invocations",
+		strings.NewReader(`{"id":"inv-1"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleCreateFunctionInvocation_NoService(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/function-invocations",
+		strings.NewReader(`{"id":"x","namespace":"y","functionName":"z","status":"success"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleGetFunctionInvocation_Success(t *testing.T) {
+	store := &mockFunctionInvocationsStore{
+		rows: map[string]*FunctionInvocation{
+			"inv-1": {
+				ID:           "inv-1",
+				Namespace:    fiTestNamespaceA,
+				FunctionName: "summarizer",
+				Status:       FunctionInvocationStatusSuccess,
+				DurationMs:   12,
+				CreatedAt:    time.Now().UTC(),
+			},
+		},
+	}
+	mux := newFunctionInvocationsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations/inv-1?namespace=ns-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var got FunctionInvocation
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	assert.Equal(t, "inv-1", got.ID)
+}
+
+func TestHandleGetFunctionInvocation_NotFound(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations/missing?namespace=ns-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestHandleGetFunctionInvocation_MissingNamespace(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations/inv-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleListFunctionInvocations_Success(t *testing.T) {
+	now := time.Now().UTC()
+	store := &mockFunctionInvocationsStore{
+		listResult: []*FunctionInvocation{
+			{ID: "a", Namespace: fiTestNamespaceA, FunctionName: "f", Status: FunctionInvocationStatusSuccess, CreatedAt: now},
+			{ID: "b", Namespace: fiTestNamespaceA, FunctionName: "f", Status: FunctionInvocationStatusSuccess, CreatedAt: now.Add(-time.Minute)},
+		},
+	}
+	mux := newFunctionInvocationsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/function-invocations?namespace=ns-a&function=f&limit=10", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp FunctionInvocationsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Rows, 2)
+}
+
+func TestHandleListFunctionInvocations_NilRowsReturnsEmpty(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{listResult: nil})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations?namespace=ns-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), `"rows":[]`)
+}
+
+func TestHandleListFunctionInvocations_InvalidFrom(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/function-invocations?namespace=ns-a&from=tomorrow", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestFunctionInvocationsService_NilStore(t *testing.T) {
+	svc := NewFunctionInvocationsService(nil, logr.Discard())
+
+	require.ErrorIs(t,
+		svc.CreateFunctionInvocation(context.Background(), &FunctionInvocation{}),
+		ErrMissingFunctionInvocationsStore)
+
+	_, err := svc.GetFunctionInvocation(context.Background(), "ns", "id")
+	require.ErrorIs(t, err, ErrMissingFunctionInvocationsStore)
+
+	_, err = svc.ListFunctionInvocations(context.Background(), FunctionInvocationListOpts{Namespace: "ns"})
+	require.ErrorIs(t, err, ErrMissingFunctionInvocationsStore)
+}
+
+func TestFunctionInvocationsService_BubblesStoreError(t *testing.T) {
+	sentinel := errors.New("boom")
+	svc := NewFunctionInvocationsService(
+		&mockFunctionInvocationsStore{createErr: sentinel, getErr: sentinel, listErr: sentinel},
+		logr.Discard())
+
+	require.ErrorIs(t,
+		svc.CreateFunctionInvocation(context.Background(), &FunctionInvocation{}),
+		sentinel)
+}
+
+func TestHandleCreateFunctionInvocation_MalformedJSON(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/function-invocations",
+		strings.NewReader(`{not json`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleCreateFunctionInvocation_StoreError(t *testing.T) {
+	// Generic (non-sentinel) store error must fall through to writeError's
+	// 500 default — this exercises the writeFunctionInvocationsError
+	// default branch.
+	store := &mockFunctionInvocationsStore{createErr: errors.New("boom")}
+	mux := newFunctionInvocationsHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/function-invocations",
+		strings.NewReader(fiCreateBody("inv-1", "f", FunctionInvocationStatusSuccess)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleCreateFunctionInvocation_DefaultsCreatedAtWhenZero(t *testing.T) {
+	store := &mockFunctionInvocationsStore{}
+	mux := newFunctionInvocationsHandler(store)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/function-invocations",
+		strings.NewReader(fiCreateBody("inv-1", "f", FunctionInvocationStatusSuccess)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusCreated, w.Code)
+	require.NotNil(t, store.rows["inv-1"])
+	assert.False(t, store.rows["inv-1"].CreatedAt.IsZero(),
+		"handler must populate CreatedAt when the caller omits it")
+}
+
+func TestHandleListFunctionInvocations_MissingNamespace(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleListFunctionInvocations_StoreError(t *testing.T) {
+	store := &mockFunctionInvocationsStore{listErr: errors.New("boom")}
+	mux := newFunctionInvocationsHandler(store)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations?namespace=ns-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestHandleListFunctionInvocations_NoService(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations?namespace=ns-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleGetFunctionInvocation_NoService(t *testing.T) {
+	h := NewHandler(nil, logr.Discard())
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/function-invocations/inv-1?namespace=ns-a", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestHandleListFunctionInvocations_InvalidTo(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/function-invocations?namespace=ns-a&to=nope", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleListFunctionInvocations_InvalidLimit(t *testing.T) {
+	mux := newFunctionInvocationsHandler(&mockFunctionInvocationsStore{})
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/function-invocations?namespace=ns-a&limit=-1", nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestHandleListFunctionInvocations_ValidFromAndToParse(t *testing.T) {
+	// Exercise the success path for both From and To parse paths plus the
+	// integer-limit path so coverage hits each branch.
+	store := &mockFunctionInvocationsStore{
+		listResult: []*FunctionInvocation{
+			{ID: "a", Namespace: fiTestNamespaceA, FunctionName: "f",
+				Status: FunctionInvocationStatusSuccess, CreatedAt: time.Now().UTC()},
+		},
+	}
+	mux := newFunctionInvocationsHandler(store)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/v1/function-invocations?namespace=ns-a&from=2026-01-01T00:00:00Z&to=2026-12-31T23:59:59Z&limit=5",
+		nil)
+	w := httptest.NewRecorder()
+	mux.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/session/api/function_invocations_service.go
+++ b/internal/session/api/function_invocations_service.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+)
+
+// FunctionInvocationsService is the business-logic wrapper around
+// FunctionInvocationsStore. Mirrors ProviderCallsService for consistency.
+type FunctionInvocationsService struct {
+	store FunctionInvocationsStore
+	log   logr.Logger
+}
+
+// NewFunctionInvocationsService wires a service onto a store. log may
+// be a zero-value logr.Logger.
+func NewFunctionInvocationsService(store FunctionInvocationsStore, log logr.Logger) *FunctionInvocationsService {
+	return &FunctionInvocationsService{
+		store: store,
+		log:   log.WithName("function-invocations-service"),
+	}
+}
+
+// CreateFunctionInvocation persists a single audit row.
+func (s *FunctionInvocationsService) CreateFunctionInvocation(ctx context.Context, inv *FunctionInvocation) error {
+	if s.store == nil {
+		return ErrMissingFunctionInvocationsStore
+	}
+	return s.store.CreateFunctionInvocation(ctx, inv)
+}
+
+// GetFunctionInvocation looks up a single row by (namespace, id).
+func (s *FunctionInvocationsService) GetFunctionInvocation(ctx context.Context, namespace, id string) (*FunctionInvocation, error) {
+	if s.store == nil {
+		return nil, ErrMissingFunctionInvocationsStore
+	}
+	return s.store.GetFunctionInvocation(ctx, namespace, id)
+}
+
+// ListFunctionInvocations returns recent rows for a (namespace,
+// function_name) pair.
+func (s *FunctionInvocationsService) ListFunctionInvocations(ctx context.Context, opts FunctionInvocationListOpts) ([]*FunctionInvocation, error) {
+	if s.store == nil {
+		return nil, ErrMissingFunctionInvocationsStore
+	}
+	return s.store.ListFunctionInvocations(ctx, opts)
+}

--- a/internal/session/api/function_invocations_store.go
+++ b/internal/session/api/function_invocations_store.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+)
+
+// ErrFunctionInvocationNotFound is returned by GetFunctionInvocation
+// when the (namespace, id) tuple does not resolve to a row. Cross-tenant
+// reads (a namespace that doesn't match the row's actual namespace)
+// also surface as this error to avoid leaking existence across tenants.
+var ErrFunctionInvocationNotFound = errors.New("function invocation not found")
+
+// ErrMissingFunctionInvocationsStore is returned by the service when no
+// store has been wired into the Handler — typically because session-api
+// is running without database access.
+var ErrMissingFunctionInvocationsStore = errors.New("function invocations store is not configured")
+
+// FunctionInvocationStatus values. Mirrors the CHECK constraint on the
+// function_invocations table.
+const (
+	FunctionInvocationStatusSuccess       = "success"
+	FunctionInvocationStatusInputInvalid  = "input_invalid"
+	FunctionInvocationStatusOutputInvalid = "output_invalid"
+	FunctionInvocationStatusRuntimeError  = "runtime_error"
+)
+
+// FunctionInvocation is the persistence shape for one Function call.
+// Mirrors the function_invocations table 1:1; downstream consumers
+// (dashboard, audit exports) should read via this struct.
+type FunctionInvocation struct {
+	ID           string          `json:"id"`
+	Namespace    string          `json:"namespace"`
+	FunctionName string          `json:"functionName"`
+	InputHash    string          `json:"inputHash"`
+	OutputJSON   json.RawMessage `json:"outputJson,omitempty"`
+	Status       string          `json:"status"`
+	DurationMs   int32           `json:"durationMs"`
+	CostUSD      float64         `json:"costUsd"`
+	TraceID      string          `json:"traceId,omitempty"`
+	CreatedAt    time.Time       `json:"createdAt"`
+}
+
+// Pagination defaults / ceilings for the list endpoint. Match
+// provider_calls limits so dashboards have consistent paging behaviour.
+const (
+	DefaultFunctionInvocationListLimit = 100
+	MaxFunctionInvocationListLimit     = 1000
+)
+
+// FunctionInvocationListOpts configures GetFunctionInvocations. Namespace
+// is required to keep reads scoped to the caller's tenant. FunctionName,
+// From, To are optional filters.
+type FunctionInvocationListOpts struct {
+	Namespace    string
+	FunctionName string
+	From         time.Time
+	To           time.Time
+	Limit        int
+}
+
+// FunctionInvocationsStore is the persistence interface for the
+// function_invocations table. Write path is the facade (when
+// spec.invocationRecording.state == "enabled"); read path is the
+// dashboard / audit-export tooling.
+type FunctionInvocationsStore interface {
+	// CreateFunctionInvocation persists a single invocation record.
+	// Called by the facade after a successful or failed Function call
+	// when recording is enabled.
+	CreateFunctionInvocation(ctx context.Context, inv *FunctionInvocation) error
+
+	// GetFunctionInvocation returns a single invocation by id. The
+	// namespace must match (cross-tenant reads return ErrNotFound).
+	GetFunctionInvocation(ctx context.Context, namespace, id string) (*FunctionInvocation, error)
+
+	// ListFunctionInvocations returns recent invocations for a
+	// namespace+function pair, ordered by created_at DESC.
+	ListFunctionInvocations(ctx context.Context, opts FunctionInvocationListOpts) ([]*FunctionInvocation, error)
+}

--- a/internal/session/api/handler.go
+++ b/internal/session/api/handler.go
@@ -95,13 +95,14 @@ func (f PolicyResolverFunc) ResolveEffectivePolicy(namespace, agentName string) 
 
 // Handler provides HTTP endpoints for session history.
 type Handler struct {
-	service              *SessionService
-	evalService          *EvalService
-	providerCallsService *ProviderCallsService
-	policyResolver       PolicyResolver
-	encryptorResolver    EncryptorResolver
-	log                  logr.Logger
-	maxBodySize          int64
+	service                    *SessionService
+	evalService                *EvalService
+	providerCallsService       *ProviderCallsService
+	functionInvocationsService *FunctionInvocationsService
+	policyResolver             PolicyResolver
+	encryptorResolver          EncryptorResolver
+	log                        logr.Logger
+	maxBodySize                int64
 }
 
 // NewHandler creates a new session API handler.
@@ -254,6 +255,14 @@ func (h *Handler) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/eval-results/discover", h.handleDiscoverEvals)
 	mux.HandleFunc("GET /api/v1/provider-calls/aggregate", h.handleAggregateProviderCalls)
 	mux.HandleFunc("GET /api/v1/provider-calls/discover", h.handleDiscoverProviderCalls)
+
+	// Function invocation endpoints (Functions Phase 1, #1103 PR 5).
+	// Write path: facade calls POST after a Function call when
+	// spec.invocationRecording.state == "enabled".
+	// Read path: dashboard / audit-export.
+	mux.HandleFunc("POST /api/v1/function-invocations", h.handleCreateFunctionInvocation)
+	mux.HandleFunc("GET /api/v1/function-invocations", h.handleListFunctionInvocations)
+	mux.HandleFunc("GET /api/v1/function-invocations/{id}", h.handleGetFunctionInvocation)
 
 	// Privacy policy endpoint
 	mux.HandleFunc("GET /api/v1/privacy-policy", h.handleGetPrivacyPolicy)

--- a/internal/session/httpclient/store.go
+++ b/internal/session/httpclient/store.go
@@ -36,6 +36,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/altairalabs/omnia/internal/session"
+	"github.com/altairalabs/omnia/internal/session/api"
 	"github.com/altairalabs/omnia/pkg/sessionapi"
 )
 
@@ -372,6 +373,61 @@ func (s *Store) RecordProviderCall(ctx context.Context, sessionID string, pc ses
 		return s.readError(resp)
 	}
 	return nil
+}
+
+// RecordFunctionInvocation sends a function invocation audit record via
+// POST /api/v1/function-invocations. Called by the facade after a
+// Function call when AgentRuntime.spec.invocationRecording.state is
+// "enabled". Function invocations are independent of sessions — no
+// session_id is required. inv carries only the audit-row fields the
+// facade can populate; the conversion to the session-api wire type
+// happens here so the facade can stay decoupled from internal/session.
+func (s *Store) RecordFunctionInvocation(ctx context.Context, inv FunctionInvocationRecord) error {
+	const path = "/api/v1/function-invocations"
+	body, err := json.Marshal(api.FunctionInvocation{
+		ID:           inv.ID,
+		Namespace:    inv.Namespace,
+		FunctionName: inv.FunctionName,
+		InputHash:    inv.InputHash,
+		OutputJSON:   inv.OutputJSON,
+		Status:       inv.Status,
+		DurationMs:   inv.DurationMs,
+		CostUSD:      inv.CostUSD,
+		TraceID:      inv.TraceID,
+		CreatedAt:    inv.CreatedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("record function invocation: encode: %w", err)
+	}
+
+	resp, err := s.doWithRetry(ctx, http.MethodPost, path, body)
+	if err != nil {
+		return s.bufferWrite(err, http.MethodPost, path, body)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusCreated {
+		return s.readError(resp)
+	}
+	return nil
+}
+
+// FunctionInvocationRecord is the in-process shape passed to
+// RecordFunctionInvocation. Duplicates facade.InvocationRecord field
+// names so the facade adapter is a 1:1 field copy; we keep the type
+// here (rather than importing the facade type) to avoid a circular
+// import between httpclient and facade.
+type FunctionInvocationRecord struct {
+	ID           string
+	Namespace    string
+	FunctionName string
+	InputHash    string
+	OutputJSON   json.RawMessage
+	Status       string
+	DurationMs   int32
+	CostUSD      float64
+	TraceID      string
+	CreatedAt    time.Time
 }
 
 // RecordEvalResult sends an eval result via POST /api/v1/eval-results.

--- a/internal/session/postgres/migrations/000026_create_function_invocations.down.sql
+++ b/internal/session/postgres/migrations/000026_create_function_invocations.down.sql
@@ -5,7 +5,7 @@ CREATE OR REPLACE FUNCTION manage_session_partitions(
     lookahead_weeks INTEGER DEFAULT 2
 ) RETURNS TABLE(table_name TEXT, partitions_created INTEGER, partitions_dropped INTEGER) AS $$
 DECLARE
-    tables TEXT[] := ARRAY['sessions', 'messages', 'tool_calls', 'message_artifacts'];
+    tables TEXT[] := ARRAY['sessions', 'messages', 'tool_calls', 'provider_calls', 'runtime_events', 'message_artifacts', 'audit_log'];
     tbl    TEXT;
     created INTEGER;
     dropped INTEGER;

--- a/internal/session/postgres/migrations/000026_create_function_invocations.down.sql
+++ b/internal/session/postgres/migrations/000026_create_function_invocations.down.sql
@@ -1,0 +1,30 @@
+-- Restore the previous partition-management orchestrator (without
+-- function_invocations) and then drop the table.
+CREATE OR REPLACE FUNCTION manage_session_partitions(
+    retention_days  INTEGER DEFAULT 30,
+    lookahead_weeks INTEGER DEFAULT 2
+) RETURNS TABLE(table_name TEXT, partitions_created INTEGER, partitions_dropped INTEGER) AS $$
+DECLARE
+    tables TEXT[] := ARRAY['sessions', 'messages', 'tool_calls', 'message_artifacts'];
+    tbl    TEXT;
+    created INTEGER;
+    dropped INTEGER;
+    start_date DATE;
+    end_date   DATE;
+BEGIN
+    start_date := CURRENT_DATE - (retention_days || ' days')::INTERVAL;
+    end_date   := CURRENT_DATE + (lookahead_weeks * 7 || ' days')::INTERVAL;
+
+    FOREACH tbl IN ARRAY tables LOOP
+        created := create_weekly_partitions(tbl, start_date, end_date);
+        dropped := drop_old_partitions(tbl, retention_days);
+
+        table_name := tbl;
+        partitions_created := created;
+        partitions_dropped := dropped;
+        RETURN NEXT;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TABLE IF EXISTS function_invocations CASCADE;

--- a/internal/session/postgres/migrations/000026_create_function_invocations.up.sql
+++ b/internal/session/postgres/migrations/000026_create_function_invocations.up.sql
@@ -47,7 +47,8 @@ CREATE OR REPLACE FUNCTION manage_session_partitions(
 ) RETURNS TABLE(table_name TEXT, partitions_created INTEGER, partitions_dropped INTEGER) AS $$
 DECLARE
     tables TEXT[] := ARRAY[
-        'sessions', 'messages', 'tool_calls', 'message_artifacts',
+        'sessions', 'messages', 'tool_calls', 'provider_calls',
+        'runtime_events', 'message_artifacts', 'audit_log',
         'function_invocations'
     ];
     tbl    TEXT;

--- a/internal/session/postgres/migrations/000026_create_function_invocations.up.sql
+++ b/internal/session/postgres/migrations/000026_create_function_invocations.up.sql
@@ -1,0 +1,79 @@
+-- function_invocations: per-call audit records for function-mode AgentRuntimes
+-- (Functions Phase 1, #1102 / #1103). Partitioned weekly by created_at
+-- so retention follows the same lifecycle as the rest of the session
+-- tables. Writes are opt-in via AgentRuntime.spec.invocationRecording.state.
+CREATE TABLE IF NOT EXISTS function_invocations (
+    id              UUID            NOT NULL,
+    namespace       TEXT            NOT NULL,
+    function_name   TEXT            NOT NULL,
+    -- input_hash is sha256(input_json) so we can detect duplicate calls
+    -- without storing raw inputs (which may carry PII for some functions).
+    input_hash      TEXT            NOT NULL,
+    -- output_json is the raw model output. JSONB so downstream queries can
+    -- introspect; consumers that store sensitive output should opt out of
+    -- recording at the CRD level.
+    output_json     JSONB,
+    -- status: success | input_invalid | output_invalid | runtime_error.
+    status          TEXT            NOT NULL,
+    duration_ms     INTEGER         NOT NULL DEFAULT 0,
+    cost_usd        NUMERIC(12,6)   NOT NULL DEFAULT 0,
+    trace_id        TEXT,
+    created_at      TIMESTAMPTZ     NOT NULL DEFAULT now(),
+
+    PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+-- Enforce the known set of status values at the schema level.
+ALTER TABLE function_invocations ADD CONSTRAINT function_invocations_status_check
+    CHECK (status IN ('success', 'input_invalid', 'output_invalid', 'runtime_error'));
+
+-- Indices match the read patterns:
+--   * list-by-function (the dashboard's primary view)
+--   * list-by-namespace (analytics aggregates)
+--   * trace_id lookup (debug: "find the invocation behind this trace")
+CREATE INDEX idx_function_invocations_function_created
+    ON function_invocations (namespace, function_name, created_at DESC);
+CREATE INDEX idx_function_invocations_namespace_created
+    ON function_invocations (namespace, created_at DESC);
+CREATE INDEX idx_function_invocations_trace_id
+    ON function_invocations (trace_id)
+    WHERE trace_id IS NOT NULL;
+
+-- Add function_invocations to the partition-management orchestrator
+-- alongside sessions / messages / tool_calls / message_artifacts.
+CREATE OR REPLACE FUNCTION manage_session_partitions(
+    retention_days  INTEGER DEFAULT 30,
+    lookahead_weeks INTEGER DEFAULT 2
+) RETURNS TABLE(table_name TEXT, partitions_created INTEGER, partitions_dropped INTEGER) AS $$
+DECLARE
+    tables TEXT[] := ARRAY[
+        'sessions', 'messages', 'tool_calls', 'message_artifacts',
+        'function_invocations'
+    ];
+    tbl    TEXT;
+    created INTEGER;
+    dropped INTEGER;
+    start_date DATE;
+    end_date   DATE;
+BEGIN
+    start_date := CURRENT_DATE - (retention_days || ' days')::INTERVAL;
+    end_date   := CURRENT_DATE + (lookahead_weeks * 7 || ' days')::INTERVAL;
+
+    FOREACH tbl IN ARRAY tables LOOP
+        created := create_weekly_partitions(tbl, start_date, end_date);
+        dropped := drop_old_partitions(tbl, retention_days);
+
+        table_name := tbl;
+        partitions_created := created;
+        partitions_dropped := dropped;
+        RETURN NEXT;
+    END LOOP;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create initial partitions for the new table: 4 weeks back + 2 weeks ahead.
+SELECT create_weekly_partitions(
+    'function_invocations',
+    (CURRENT_DATE - INTERVAL '28 days')::DATE,
+    (CURRENT_DATE + INTERVAL '14 days')::DATE
+);

--- a/internal/session/providers/postgres/function_invocations_store.go
+++ b/internal/session/providers/postgres/function_invocations_store.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgres
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/altairalabs/omnia/internal/pgutil"
+	"github.com/altairalabs/omnia/internal/session/api"
+)
+
+// Compile-time interface check.
+var _ api.FunctionInvocationsStore = (*FunctionInvocationsStoreImpl)(nil)
+
+// FunctionInvocationsStoreImpl implements api.FunctionInvocationsStore.
+// Reads / writes the function_invocations table — a partitioned table
+// independent of sessions (Functions are not session-scoped).
+type FunctionInvocationsStoreImpl struct {
+	pool *pgxpool.Pool
+}
+
+// NewFunctionInvocationsStore wires a store onto an existing pool.
+func NewFunctionInvocationsStore(pool *pgxpool.Pool) *FunctionInvocationsStoreImpl {
+	return &FunctionInvocationsStoreImpl{pool: pool}
+}
+
+// Filter fragments used by the QueryBuilder to position arguments.
+const (
+	fiFilterNamespace     = "namespace=$?"
+	fiFilterFunctionName  = "function_name=$?"
+	fiFilterCreatedAfter  = "created_at >= $?"
+	fiFilterCreatedBefore = "created_at < $?"
+)
+
+const insertFunctionInvocation = `
+INSERT INTO function_invocations
+    (id, namespace, function_name, input_hash, output_json, status,
+     duration_ms, cost_usd, trace_id, created_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NULLIF($9, ''), $10)
+`
+
+// CreateFunctionInvocation inserts a single audit row. trace_id is
+// stored as NULL when empty (matches the partial index in the
+// migration).
+func (s *FunctionInvocationsStoreImpl) CreateFunctionInvocation(
+	ctx context.Context, inv *api.FunctionInvocation,
+) error {
+	if inv == nil {
+		return errors.New("postgres: create function invocation: invocation is nil")
+	}
+	if inv.Namespace == "" {
+		return errors.New("postgres: create function invocation: namespace is required")
+	}
+	if inv.FunctionName == "" {
+		return errors.New("postgres: create function invocation: function_name is required")
+	}
+	if inv.Status == "" {
+		return errors.New("postgres: create function invocation: status is required")
+	}
+	_, err := s.pool.Exec(ctx, insertFunctionInvocation,
+		inv.ID,
+		inv.Namespace,
+		inv.FunctionName,
+		inv.InputHash,
+		inv.OutputJSON,
+		inv.Status,
+		inv.DurationMs,
+		inv.CostUSD,
+		inv.TraceID,
+		inv.CreatedAt,
+	)
+	if err != nil {
+		return fmt.Errorf("postgres: create function invocation: %w", err)
+	}
+	return nil
+}
+
+const selectFunctionInvocation = `
+SELECT id, namespace, function_name, input_hash, output_json, status,
+       duration_ms, cost_usd, COALESCE(trace_id, '') AS trace_id, created_at
+FROM function_invocations
+WHERE namespace=$1 AND id=$2
+LIMIT 1
+`
+
+// GetFunctionInvocation returns a single row. Cross-tenant reads (a
+// namespace that doesn't match the row's) return ErrNotFound, mirroring
+// how the sessions store handles isolation.
+func (s *FunctionInvocationsStoreImpl) GetFunctionInvocation(
+	ctx context.Context, namespace, id string,
+) (*api.FunctionInvocation, error) {
+	if namespace == "" {
+		return nil, errors.New("postgres: get function invocation: namespace is required")
+	}
+	if id == "" {
+		return nil, errors.New("postgres: get function invocation: id is required")
+	}
+	row := s.pool.QueryRow(ctx, selectFunctionInvocation, namespace, id)
+	inv, err := scanFunctionInvocation(row)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, api.ErrFunctionInvocationNotFound
+		}
+		return nil, fmt.Errorf("postgres: get function invocation: %w", err)
+	}
+	return inv, nil
+}
+
+// ListFunctionInvocations returns recent invocations, optionally
+// filtered by function_name + time window. Ordered by created_at DESC
+// so the most-recent rows surface first (the primary dashboard view).
+func (s *FunctionInvocationsStoreImpl) ListFunctionInvocations(
+	ctx context.Context, opts api.FunctionInvocationListOpts,
+) ([]*api.FunctionInvocation, error) {
+	if opts.Namespace == "" {
+		return nil, errors.New("postgres: list function invocations: namespace is required")
+	}
+	qb := buildFunctionInvocationListFilters(opts)
+	query := fmt.Sprintf(`
+		SELECT id, namespace, function_name, input_hash, output_json, status,
+		       duration_ms, cost_usd, COALESCE(trace_id, '') AS trace_id, created_at
+		FROM function_invocations
+		WHERE 1=1%s
+		ORDER BY created_at DESC
+		LIMIT %d`, qb.Where(), clampFunctionInvocationListLimit(opts.Limit))
+
+	rows, err := s.pool.Query(ctx, query, qb.Args()...)
+	if err != nil {
+		return nil, fmt.Errorf("postgres: list function invocations: %w", err)
+	}
+	defer rows.Close()
+
+	out := []*api.FunctionInvocation{}
+	for rows.Next() {
+		inv, err := scanFunctionInvocation(rows)
+		if err != nil {
+			return nil, fmt.Errorf("postgres: scan function invocation: %w", err)
+		}
+		out = append(out, inv)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("postgres: iterate function invocations: %w", err)
+	}
+	return out, nil
+}
+
+// buildFunctionInvocationListFilters seeds a QueryBuilder with the
+// required namespace filter plus any optional filters.
+func buildFunctionInvocationListFilters(opts api.FunctionInvocationListOpts) *pgutil.QueryBuilder {
+	qb := &pgutil.QueryBuilder{}
+	qb.Add(fiFilterNamespace, opts.Namespace)
+	if opts.FunctionName != "" {
+		qb.Add(fiFilterFunctionName, opts.FunctionName)
+	}
+	if !opts.From.IsZero() {
+		qb.Add(fiFilterCreatedAfter, opts.From)
+	}
+	if !opts.To.IsZero() {
+		qb.Add(fiFilterCreatedBefore, opts.To)
+	}
+	return qb
+}
+
+// clampFunctionInvocationListLimit applies defaults / ceiling.
+func clampFunctionInvocationListLimit(limit int) int {
+	if limit <= 0 {
+		return api.DefaultFunctionInvocationListLimit
+	}
+	if limit > api.MaxFunctionInvocationListLimit {
+		return api.MaxFunctionInvocationListLimit
+	}
+	return limit
+}
+
+// rowScanner is the pgx row interface implemented by both Row and Rows.
+type functionInvocationRowScanner interface {
+	Scan(dest ...any) error
+}
+
+// scanFunctionInvocation pulls one row into a FunctionInvocation. Used
+// by both Get (pgx.Row) and List (pgx.Rows) — the Scan signature is
+// identical so this helper accepts either.
+func scanFunctionInvocation(r functionInvocationRowScanner) (*api.FunctionInvocation, error) {
+	var inv api.FunctionInvocation
+	var output []byte
+	if err := r.Scan(
+		&inv.ID,
+		&inv.Namespace,
+		&inv.FunctionName,
+		&inv.InputHash,
+		&output,
+		&inv.Status,
+		&inv.DurationMs,
+		&inv.CostUSD,
+		&inv.TraceID,
+		&inv.CreatedAt,
+	); err != nil {
+		return nil, err
+	}
+	if len(output) > 0 {
+		inv.OutputJSON = output
+	}
+	return &inv, nil
+}

--- a/internal/session/providers/postgres/function_invocations_store_test.go
+++ b/internal/session/providers/postgres/function_invocations_store_test.go
@@ -1,0 +1,208 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/session/api"
+)
+
+const (
+	fiTestNamespaceA = "ns-a"
+	fiTestFunction   = "summarizer"
+)
+
+// newFunctionInvocationsStore stands up a fresh postgres-backed store
+// via the shared testcontainer. Skipped when -short is set (no
+// testcontainer is started in that mode).
+func newFunctionInvocationsStore(t *testing.T) *FunctionInvocationsStoreImpl {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+	return NewFunctionInvocationsStore(freshDB(t))
+}
+
+// newTestInvocation builds a success-status row. Every test that needs
+// a different status sets it on the returned struct.
+func newTestInvocation(namespace, function string, createdAt time.Time) *api.FunctionInvocation {
+	return &api.FunctionInvocation{
+		ID:           uuid.New().String(),
+		Namespace:    namespace,
+		FunctionName: function,
+		InputHash:    "abc123",
+		OutputJSON:   json.RawMessage(`{"a":1}`),
+		Status:       api.FunctionInvocationStatusSuccess,
+		DurationMs:   42,
+		CostUSD:      0.001,
+		TraceID:      "trace-1",
+		CreatedAt:    createdAt,
+	}
+}
+
+func TestFunctionInvocationsStore_CreateAndGet(t *testing.T) {
+	store := newFunctionInvocationsStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	inv := newTestInvocation(fiTestNamespaceA, fiTestFunction, now)
+	require.NoError(t, store.CreateFunctionInvocation(ctx, inv))
+
+	got, err := store.GetFunctionInvocation(ctx, fiTestNamespaceA, inv.ID)
+	require.NoError(t, err)
+	assert.Equal(t, inv.ID, got.ID)
+	assert.Equal(t, "summarizer", got.FunctionName)
+	assert.Equal(t, api.FunctionInvocationStatusSuccess, got.Status)
+	assert.Equal(t, int32(42), got.DurationMs)
+	assert.Equal(t, "trace-1", got.TraceID)
+	assert.JSONEq(t, `{"a":1}`, string(got.OutputJSON))
+}
+
+func TestFunctionInvocationsStore_Get_NotFound(t *testing.T) {
+	store := newFunctionInvocationsStore(t)
+	_, err := store.GetFunctionInvocation(context.Background(), fiTestNamespaceA, uuid.NewString())
+	assert.ErrorIs(t, err, api.ErrFunctionInvocationNotFound)
+}
+
+func TestFunctionInvocationsStore_Get_CrossTenantHidden(t *testing.T) {
+	store := newFunctionInvocationsStore(t)
+	ctx := context.Background()
+
+	inv := newTestInvocation(fiTestNamespaceA, fiTestFunction, time.Now().UTC())
+	require.NoError(t, store.CreateFunctionInvocation(ctx, inv))
+
+	// Cross-tenant Get must return ErrNotFound, not the row.
+	_, err := store.GetFunctionInvocation(ctx, "ns-b", inv.ID)
+	assert.ErrorIs(t, err, api.ErrFunctionInvocationNotFound)
+}
+
+func TestFunctionInvocationsStore_ListByFunctionAndTimeWindow(t *testing.T) {
+	store := newFunctionInvocationsStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	old := now.Add(-2 * time.Hour)
+	mid := now.Add(-30 * time.Minute)
+	recent := now.Add(-1 * time.Minute)
+
+	for _, ts := range []time.Time{old, mid, recent} {
+		require.NoError(t, store.CreateFunctionInvocation(ctx,
+			newTestInvocation(fiTestNamespaceA, fiTestFunction, ts)))
+	}
+	// Different function in same namespace; must be excluded by FunctionName filter.
+	require.NoError(t, store.CreateFunctionInvocation(ctx,
+		newTestInvocation(fiTestNamespaceA, "classifier", recent)))
+
+	rows, err := store.ListFunctionInvocations(ctx, api.FunctionInvocationListOpts{
+		Namespace:    fiTestNamespaceA,
+		FunctionName: fiTestFunction,
+		From:         now.Add(-1 * time.Hour),
+	})
+	require.NoError(t, err)
+	// Should pick up mid + recent, but not old (outside window) or
+	// classifier (different function).
+	assert.Len(t, rows, 2)
+	// DESC order.
+	assert.True(t, rows[0].CreatedAt.After(rows[1].CreatedAt),
+		"rows must be ordered by created_at DESC")
+}
+
+func TestFunctionInvocationsStore_ListNamespaceScoped(t *testing.T) {
+	store := newFunctionInvocationsStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	require.NoError(t, store.CreateFunctionInvocation(ctx,
+		newTestInvocation(fiTestNamespaceA, "x", now)))
+	require.NoError(t, store.CreateFunctionInvocation(ctx,
+		newTestInvocation("ns-b", "x", now)))
+
+	rows, err := store.ListFunctionInvocations(ctx, api.FunctionInvocationListOpts{
+		Namespace: fiTestNamespaceA,
+	})
+	require.NoError(t, err)
+	assert.Len(t, rows, 1)
+	assert.Equal(t, fiTestNamespaceA, rows[0].Namespace)
+}
+
+func TestFunctionInvocationsStore_LimitClamps(t *testing.T) {
+	assert.Equal(t, api.DefaultFunctionInvocationListLimit, clampFunctionInvocationListLimit(0))
+	assert.Equal(t, api.DefaultFunctionInvocationListLimit, clampFunctionInvocationListLimit(-5))
+	assert.Equal(t, 42, clampFunctionInvocationListLimit(42))
+	assert.Equal(t, api.MaxFunctionInvocationListLimit,
+		clampFunctionInvocationListLimit(api.MaxFunctionInvocationListLimit+1000))
+}
+
+func TestFunctionInvocationsStore_RejectsMissingRequiredFields(t *testing.T) {
+	// Pure validation test — the early-returns trigger before any pool
+	// access, so this works fine with a nil pool and skips the
+	// integration-only freshDB.
+	store := &FunctionInvocationsStoreImpl{}
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	tt := []struct {
+		name string
+		inv  *api.FunctionInvocation
+	}{
+		{
+			name: "nil",
+			inv:  nil,
+		},
+		{
+			name: "missing namespace",
+			inv: &api.FunctionInvocation{
+				ID:           uuid.NewString(),
+				FunctionName: "x",
+				Status:       api.FunctionInvocationStatusSuccess,
+				CreatedAt:    now,
+			},
+		},
+		{
+			name: "missing function name",
+			inv: &api.FunctionInvocation{
+				ID:        uuid.NewString(),
+				Namespace: fiTestNamespaceA,
+				Status:    api.FunctionInvocationStatusSuccess,
+				CreatedAt: now,
+			},
+		},
+		{
+			name: "missing status",
+			inv: &api.FunctionInvocation{
+				ID:           uuid.NewString(),
+				Namespace:    fiTestNamespaceA,
+				FunctionName: "x",
+				CreatedAt:    now,
+			},
+		},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			err := store.CreateFunctionInvocation(ctx, tc.inv)
+			assert.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

PR 5 of 7 for Functions Phase 1 (umbrella #1102, slicing #1103). Adds the persistence layer for function-mode invocations and the facade-side write path. After this PR, function-mode AgentRuntimes with \`spec.invocationRecording.state: enabled\` emit per-call audit rows that the dashboard (PR 6) can render.

Stack so far (all merged):
- #1104 — CRD: \`spec.mode\` + I/O schemas + invocationRecording
- #1105 — Runtime \`Invoke\` gRPC RPC
- #1106 — Facade \`POST /functions/{name}\` handler + validators
- #1108 — Operator + agent wire-up (mode-aware pod startup)

## What's new

**Schema** — migration \`000026_create_function_invocations\`:
- Weekly-partitioned by \`created_at\` (matches sessions / messages).
- \`manage_session_partitions\` orchestrator now includes the new table.
- Indices on \`(namespace, function_name, created_at DESC)\`, \`(namespace, created_at DESC)\`, and \`trace_id\` (partial, WHERE NOT NULL).
- Status CHECK enum: \`success | input_invalid | output_invalid | runtime_error\`.

**Session-API** (\`internal/session/api\`):
- \`FunctionInvocationsStore\` interface + \`FunctionInvocationsService\` wrapper.
- Routes: \`POST /api/v1/function-invocations\` (201), \`GET /api/v1/function-invocations\` (paginated list), \`GET /api/v1/function-invocations/{id}\` (single).
- Cross-tenant Get returns \`ErrFunctionInvocationNotFound\` → 404, never a 200 (no existence leak).
- \`cmd/session-api\` wires the postgres-backed store at startup.

**Facade** (\`internal/facade/functions_handler.go\`):
- \`FunctionsHandler.WithRecorder(...)\` opt-in recorder interface. Records every outcome — success, \`runtime_error\`, \`output_invalid\` — best-effort. A recorder failure logs but does NOT fail the user-facing call (#1103 Q3 lock).
- Input hash = sha256 of JSON body, stored in lieu of raw input to bound PII surface area. Output JSON stored verbatim — functions with sensitive output keep recording disabled.

**httpclient** (\`internal/session/httpclient\`):
- \`(*Store).RecordFunctionInvocation\` sends POST via existing \`doWithRetry\` + \`bufferWrite\` path.
- \`FunctionInvocationRecord\` adapter type breaks the potential facade ↔ httpclient import cycle.

**cmd/agent** — \`newFunctionsRecorder\` builds a session-api-backed recorder when \`cfg.FunctionRecordsInvocations\` is true. Missing session-api falls back to no-op recording (logged warning) so a stack with no DB still serves Function calls.

## Tests (33 total)

\`postgres\` (9, testcontainer-backed; skip on -short):
- Create + Get + cross-tenant hide
- List by namespace+function+time window (DESC order)
- List namespace-scoped isolation
- Limit clamp (default + ceiling)
- Required-field rejection

\`api\` (19):
- Happy create, missing fields, malformed JSON, store error → 500
- 503 when service unconfigured
- Get success, 404, missing namespace, no-service
- List success, missing namespace, invalid From/To/limit, valid pagination, nil-rows empty envelope
- Service nil-store ErrIs + bubbles store error

\`facade\` (5):
- Doesn't record without recorder
- Records on success / runtime_error / output_invalid
- Recorder failure is non-fatal

Per-file coverage: facade 95.3%, api handler 95.3%, service 100%, httpclient 84.5%.

\`api/CHANGELOG.md\` documents every endpoint + status code so PR 6 has a stable contract.

## Intentionally NOT in this PR

- **Dashboard view** — PR 6.
- **trace_id correlation** — placeholder field stored, but the facade doesn't extract it from context yet. PR 6 wires the read path.
- **Aggregation endpoints** (rollup costs / latency by function) — not in PR 5 scope; would mirror \`provider-calls/aggregate\` when product needs it.

## Up next

- PR 6 — Dashboard function catalog + invocation history.
- PR 7 — Docs + example pack.