### PR TITLE
feat(dashboard): Functions catalog + invocation history (#1103 PR 6/7)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,31 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Added (dashboard: Functions catalog + invocation history, #1103 PR 6)
+
+- New `/functions` catalog page lists function-mode AgentRuntimes
+  (filtered client-side from the existing AgentRuntime list — no new
+  operator endpoint). Each card shows the namespace, recording opt-in
+  state, and a top-level field count for `inputSchema` / `outputSchema`.
+- New `/functions/{name}` detail page renders the resolved input /
+  output schemas alongside a panel of recent invocations sourced from
+  session-api's `function_invocations` rows. Time-window presets:
+  1h / 24h / 7d. Latency and cost sparklines aggregate the loaded
+  window; the table shows timestamp, status, latency, cost, and a
+  truncated trace id per row.
+- Workspace-scoped proxy routes added:
+  - `GET /api/workspaces/{name}/function-invocations[?function=&from=&to=&limit=]`
+    → `SESSION_API_URL/api/v1/function-invocations?namespace={name}[&…]`
+  - `GET /api/workspaces/{name}/function-invocations/{id}`
+    → `SESSION_API_URL/api/v1/function-invocations/{id}?namespace={name}`
+  The proxy pins the session-api `namespace` query param to the
+  workspace name — a malicious caller cannot read another tenant's
+  rows by overriding the query string.
+- `AgentRuntimeSpec` hand-written type extended with `mode`,
+  `inputSchema`, `outputSchema`, `invocationRecording` (already present
+  in the generated types since PR 1 / #1104). `isFunctionMode(spec)`
+  helper exported for catalog filtering.
+
 ### Added (session-api: function_invocations persistence + facade write path, #1103 PR 5)
 
 - New `function_invocations` table in the session-api Postgres schema

--- a/dashboard/src/app/api/workspaces/[name]/function-invocations/[id]/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/function-invocations/[id]/route.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the single function-invocation proxy route.
+ *
+ * Pins: workspace name pinned to session-api's namespace filter,
+ * URL encoding for the id segment, 503 / 502 fallbacks.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({ getUser: vi.fn() }));
+vi.mock("@/lib/auth/workspace-authz", () => ({ checkWorkspaceAccess: vi.fn() }));
+vi.mock("@/lib/k8s/service-url-resolver", () => ({ resolveServiceURLs: vi.fn() }));
+
+const mockUser = {
+  id: "u1",
+  provider: "oauth" as const,
+  username: "u",
+  email: "u@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function makeRequest(id = "inv-1"): NextRequest {
+  return new NextRequest(
+    `http://localhost:3000/api/workspaces/test-ws/function-invocations/${encodeURIComponent(id)}`,
+    { method: "GET" },
+  );
+}
+
+function makeContext(id = "inv-1") {
+  return { params: Promise.resolve({ name: "test-ws", id }) };
+}
+
+async function setupAuth() {
+  const { getUser } = await import("@/lib/auth");
+  const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+  const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+  vi.mocked(resolveServiceURLs).mockResolvedValue({
+    sessionURL: "https://session-api:8080",
+    memoryURL: "https://memory-api:8080",
+  });
+  vi.mocked(getUser).mockResolvedValue(mockUser);
+  vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+    granted: true,
+    role: "viewer",
+    permissions: viewerPermissions,
+  });
+}
+
+describe("GET /api/workspaces/[name]/function-invocations/[id]", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.resetAllMocks());
+
+  it("forwards (namespace=workspace, id) to session-api", async () => {
+    await setupAuth();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          id: "inv-1",
+          namespace: "test-ws",
+          functionName: "summarizer",
+          status: "success",
+        }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+    expect(response.status).toBe(200);
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toBe(
+      "https://session-api:8080/api/v1/function-invocations/inv-1?namespace=test-ws",
+    );
+  });
+
+  it("encodes ids with slashes / special chars in the path", async () => {
+    await setupAuth();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+
+    const { GET } = await import("./route");
+    await GET(makeRequest("id/with-slash"), makeContext("id/with-slash"));
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/function-invocations/id%2Fwith-slash");
+  });
+
+  it("returns 503 when session-api URL is unresolved", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+    vi.mocked(resolveServiceURLs).mockResolvedValue(null);
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+    expect(response.status).toBe(503);
+  });
+
+  it("returns 502 on session-api connection failure", async () => {
+    await setupAuth();
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.details).toContain("ECONNREFUSED");
+  });
+
+  it("propagates the upstream status (e.g. 404 cross-tenant)", async () => {
+    await setupAuth();
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      json: () => Promise.resolve({ error: "function invocation not found" }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+    expect(response.status).toBe(404);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/function-invocations/[id]/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/function-invocations/[id]/route.ts
@@ -1,0 +1,66 @@
+/**
+ * Workspace single function-invocation proxy route.
+ *
+ * GET /api/workspaces/{name}/function-invocations/{id}
+ *   -> SESSION_API_URL/api/v1/function-invocations/{id}?namespace={name}
+ *
+ * Returns one invocation row. Cross-workspace reads (an id that belongs
+ * to a different namespace) resolve to 404 — the session-api layer
+ * enforces tenant isolation by treating namespace mismatch as missing,
+ * not unauthorised, so existence does not leak across tenants.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { resolveServiceURLs } from "@/lib/k8s/service-url-resolver";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+
+type Params = { name: string; id: string };
+
+export const GET = withWorkspaceAccess<Params>(
+  "viewer",
+  async (
+    _request: NextRequest,
+    context: WorkspaceRouteContext<Params>,
+    _access: WorkspaceAccess,
+    _user: User,
+  ): Promise<NextResponse> => {
+    const { name, id } = await context.params;
+
+    const urls = await resolveServiceURLs(name);
+    if (!urls) {
+      return NextResponse.json(
+        { error: "Session API not configured" },
+        { status: 503 },
+      );
+    }
+
+    const baseUrl = urls.sessionURL.endsWith("/")
+      ? urls.sessionURL.slice(0, -1)
+      : urls.sessionURL;
+    const targetUrl =
+      `${baseUrl}/api/v1/function-invocations/${encodeURIComponent(id)}` +
+      `?namespace=${encodeURIComponent(name)}`;
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { Accept: "application/json" },
+      });
+      const data = await response.json();
+      return NextResponse.json(data, { status: response.status });
+    } catch (error) {
+      console.error("Session API function-invocation proxy error:", error);
+      return NextResponse.json(
+        {
+          error: "Failed to connect to Session API",
+          details: error instanceof Error ? error.message : String(error),
+        },
+        { status: 502 },
+      );
+    }
+  },
+);

--- a/dashboard/src/app/api/workspaces/[name]/function-invocations/route.test.ts
+++ b/dashboard/src/app/api/workspaces/[name]/function-invocations/route.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the workspace function-invocations list proxy route.
+ *
+ * Pins: workspace name pinned to session-api's namespace filter,
+ * forwarded params, 503 on URL-resolve miss, 502 on session-api
+ * connection failure, and the security invariant that a caller
+ * cannot override the namespace via the query string.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/auth", () => ({ getUser: vi.fn() }));
+vi.mock("@/lib/auth/workspace-authz", () => ({ checkWorkspaceAccess: vi.fn() }));
+vi.mock("@/lib/k8s/service-url-resolver", () => ({ resolveServiceURLs: vi.fn() }));
+
+const mockUser = {
+  id: "u1",
+  provider: "oauth" as const,
+  username: "u",
+  email: "u@example.com",
+  groups: ["users"],
+  role: "viewer" as const,
+};
+const viewerPermissions = { read: true, write: false, delete: false, manageMembers: false };
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+function makeRequest(qs = ""): NextRequest {
+  const sep = qs ? "?" : "";
+  return new NextRequest(
+    `http://localhost:3000/api/workspaces/test-ws/function-invocations${sep}${qs}`,
+    { method: "GET" },
+  );
+}
+
+function makeContext() {
+  return { params: Promise.resolve({ name: "test-ws" }) };
+}
+
+async function setupAuth() {
+  const { getUser } = await import("@/lib/auth");
+  const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+  const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+  vi.mocked(resolveServiceURLs).mockResolvedValue({
+    sessionURL: "https://session-api:8080",
+    memoryURL: "https://memory-api:8080",
+  });
+  vi.mocked(getUser).mockResolvedValue(mockUser);
+  vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+    granted: true,
+    role: "viewer",
+    permissions: viewerPermissions,
+  });
+}
+
+describe("GET /api/workspaces/[name]/function-invocations", () => {
+  beforeEach(() => vi.resetModules());
+  afterEach(() => vi.resetAllMocks());
+
+  it("pins namespace to the workspace name and forwards optional filters", async () => {
+    await setupAuth();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ rows: [] }),
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(
+      makeRequest("function=summarizer&from=2026-05-01T00:00:00Z&limit=50"),
+      makeContext(),
+    );
+    expect(response.status).toBe(200);
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("https://session-api:8080/api/v1/function-invocations?");
+    expect(url).toContain("namespace=test-ws");
+    expect(url).toContain("function=summarizer");
+    expect(url).toContain("from=2026-05-01T00%3A00%3A00Z");
+    expect(url).toContain("limit=50");
+  });
+
+  it("refuses to forward a caller-supplied namespace override", async () => {
+    await setupAuth();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ rows: [] }),
+    });
+
+    const { GET } = await import("./route");
+    // Malicious caller passes ?namespace=other-tenant — the proxy must
+    // ignore it and keep namespace pinned to the workspace name.
+    await GET(makeRequest("namespace=other-tenant"), makeContext());
+
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("namespace=test-ws");
+    expect(url).not.toContain("namespace=other-tenant");
+  });
+
+  it("returns 503 with empty rows when session-api URL is unresolved", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+    vi.mocked(resolveServiceURLs).mockResolvedValue(null);
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+    expect(response.status).toBe(503);
+    const body = await response.json();
+    expect(body.rows).toEqual([]);
+  });
+
+  it("returns 502 on session-api connection failure", async () => {
+    await setupAuth();
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const { GET } = await import("./route");
+    const response = await GET(makeRequest(), makeContext());
+    expect(response.status).toBe(502);
+    const body = await response.json();
+    expect(body.rows).toEqual([]);
+    expect(body.details).toContain("ECONNREFUSED");
+  });
+
+  it("strips trailing slash on the session-api base URL", async () => {
+    const { getUser } = await import("@/lib/auth");
+    const { checkWorkspaceAccess } = await import("@/lib/auth/workspace-authz");
+    const { resolveServiceURLs } = await import("@/lib/k8s/service-url-resolver");
+    vi.mocked(resolveServiceURLs).mockResolvedValue({
+      sessionURL: "https://session-api:8080/",
+      memoryURL: "https://memory-api:8080",
+    });
+    vi.mocked(getUser).mockResolvedValue(mockUser);
+    vi.mocked(checkWorkspaceAccess).mockResolvedValue({
+      granted: true,
+      role: "viewer",
+      permissions: viewerPermissions,
+    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ rows: [] }),
+    });
+
+    const { GET } = await import("./route");
+    await GET(makeRequest(), makeContext());
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url.startsWith("https://session-api:8080/api/v1/")).toBe(true);
+  });
+});

--- a/dashboard/src/app/api/workspaces/[name]/function-invocations/route.ts
+++ b/dashboard/src/app/api/workspaces/[name]/function-invocations/route.ts
@@ -1,0 +1,79 @@
+/**
+ * Workspace function-invocations list proxy route.
+ *
+ * GET /api/workspaces/{name}/function-invocations[?function=&from=&to=&limit=]
+ *   -> SESSION_API_URL/api/v1/function-invocations?namespace={name}[&...]
+ *
+ * Returns the per-call audit rows persisted by function-mode
+ * AgentRuntimes (Functions Phase 1, #1102 / #1103 PR 5). The workspace
+ * name pins the session-api namespace filter, so cross-workspace reads
+ * are impossible at the proxy layer.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { withWorkspaceAccess, type WorkspaceRouteContext } from "@/lib/auth/workspace-guard";
+import { resolveServiceURLs } from "@/lib/k8s/service-url-resolver";
+import type { WorkspaceAccess } from "@/types/workspace";
+import type { User } from "@/lib/auth/types";
+
+type Params = { name: string };
+
+/** Query-string params we forward to session-api. We deliberately
+ * re-build the URL rather than passing the caller's raw query string
+ * so a malicious caller can't override `namespace` to read another
+ * tenant's rows. */
+const FORWARDED_PARAMS = ["function", "from", "to", "limit"] as const;
+
+export const GET = withWorkspaceAccess<Params>(
+  "viewer",
+  async (
+    request: NextRequest,
+    context: WorkspaceRouteContext<Params>,
+    _access: WorkspaceAccess,
+    _user: User,
+  ): Promise<NextResponse> => {
+    const { name } = await context.params;
+
+    const urls = await resolveServiceURLs(name);
+    if (!urls) {
+      return NextResponse.json(
+        { error: "Session API not configured", rows: [] },
+        { status: 503 },
+      );
+    }
+
+    const incoming = request.nextUrl.searchParams;
+    const qs = new URLSearchParams();
+    qs.set("namespace", name);
+    for (const key of FORWARDED_PARAMS) {
+      const v = incoming.get(key);
+      if (v) qs.set(key, v);
+    }
+
+    const baseUrl = urls.sessionURL.endsWith("/")
+      ? urls.sessionURL.slice(0, -1)
+      : urls.sessionURL;
+    const targetUrl = `${baseUrl}/api/v1/function-invocations?${qs}`;
+
+    try {
+      const response = await fetch(targetUrl, {
+        headers: { Accept: "application/json" },
+      });
+      const data = await response.json();
+      return NextResponse.json(data, { status: response.status });
+    } catch (error) {
+      console.error("Session API function-invocations list proxy error:", error);
+      return NextResponse.json(
+        {
+          error: "Failed to connect to Session API",
+          details: error instanceof Error ? error.message : String(error),
+          rows: [],
+        },
+        { status: 502 },
+      );
+    }
+  },
+);

--- a/dashboard/src/app/functions/[name]/page.test.tsx
+++ b/dashboard/src/app/functions/[name]/page.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * Tests for the /functions/[name] detail page.
+ *
+ * The page is also orchestration — resolve the AgentRuntime by name,
+ * guard against agent-mode runtimes, render the invocations panel
+ * when recording is enabled, render an opt-in nag when it's not.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import FunctionDetailPage from "./page";
+import type { AgentRuntime } from "@/types";
+
+const useAgentSpy = vi.hoisted(() => vi.fn());
+const useWorkspaceSpy = vi.hoisted(() => vi.fn());
+const useParamsSpy = vi.hoisted(() => vi.fn());
+const panelSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/agents", () => ({
+  useAgent: useAgentSpy,
+}));
+
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: useWorkspaceSpy,
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: useParamsSpy,
+}));
+
+vi.mock("@/components/layout", () => ({
+  Header: ({ title, description }: { title: React.ReactNode; description?: React.ReactNode }) => (
+    <div>
+      <h1>{title}</h1>
+      {description ? <p>{description}</p> : null}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/functions/function-invocations-panel", () => ({
+  FunctionInvocationsPanel: (props: { workspace: string; functionName: string; windowMs: number }) => {
+    panelSpy(props);
+    return <div data-testid="invocations-panel" data-window={props.windowMs} />;
+  },
+}));
+
+function mkFn(overrides: Partial<AgentRuntime["spec"]> = {}): AgentRuntime {
+  return {
+    apiVersion: "omnia.altairalabs.ai/v1alpha1",
+    kind: "AgentRuntime",
+    metadata: { name: "summarizer", namespace: "ns-a", uid: "uid-1" },
+    spec: {
+      mode: "function",
+      promptPackRef: { name: "pack" },
+      facade: { type: "grpc" as never },
+      inputSchema: { type: "object", properties: { q: { type: "string" } } },
+      outputSchema: { type: "object", properties: { a: { type: "string" } } },
+      invocationRecording: { state: "enabled" },
+      ...overrides,
+    },
+  };
+}
+
+beforeEach(() => {
+  useAgentSpy.mockReset();
+  useWorkspaceSpy.mockReset();
+  useParamsSpy.mockReset();
+  panelSpy.mockReset();
+
+  useParamsSpy.mockReturnValue({ name: "summarizer" });
+  useWorkspaceSpy.mockReturnValue({ currentWorkspace: { name: "ws" } });
+});
+
+describe("FunctionDetailPage", () => {
+  it("shows a loading skeleton while useAgent is loading", () => {
+    useAgentSpy.mockReturnValue({ data: undefined, isLoading: true });
+    render(<FunctionDetailPage />);
+    expect(screen.getByText("summarizer")).toBeInTheDocument();
+    expect(screen.queryByTestId("invocations-panel")).not.toBeInTheDocument();
+  });
+
+  it("shows a 'not found' state when the runtime does not exist", () => {
+    useAgentSpy.mockReturnValue({ data: null, isLoading: false });
+    render(<FunctionDetailPage />);
+    expect(screen.getByText("Function not found")).toBeInTheDocument();
+  });
+
+  it("rejects agent-mode AgentRuntimes with a friendly message", () => {
+    useAgentSpy.mockReturnValue({
+      data: mkFn({ mode: "agent" }),
+      isLoading: false,
+    });
+    render(<FunctionDetailPage />);
+    expect(screen.getByText("This AgentRuntime is not a Function")).toBeInTheDocument();
+    expect(screen.queryByTestId("invocations-panel")).not.toBeInTheDocument();
+  });
+
+  it("renders the invocations panel when recording is enabled", () => {
+    useAgentSpy.mockReturnValue({ data: mkFn(), isLoading: false });
+    render(<FunctionDetailPage />);
+    expect(screen.getByTestId("invocations-panel")).toBeInTheDocument();
+    const last = panelSpy.mock.calls.at(-1)?.[0];
+    expect(last.workspace).toBe("ws");
+    expect(last.functionName).toBe("summarizer");
+    // Default window is 24h
+    expect(last.windowMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("renders the opt-in nag when recording is disabled", () => {
+    useAgentSpy.mockReturnValue({
+      data: mkFn({ invocationRecording: { state: "disabled" } }),
+      isLoading: false,
+    });
+    render(<FunctionDetailPage />);
+    expect(
+      screen.getByText(/Invocation recording is disabled/),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId("invocations-panel")).not.toBeInTheDocument();
+  });
+
+  it("changes the panel windowMs when a different time-window preset is clicked", () => {
+    useAgentSpy.mockReturnValue({ data: mkFn(), isLoading: false });
+    render(<FunctionDetailPage />);
+    fireEvent.click(screen.getByTestId("window-7d"));
+    const last = panelSpy.mock.calls.at(-1)?.[0];
+    expect(last.windowMs).toBe(7 * 24 * 60 * 60 * 1000);
+  });
+
+  it("renders both schemas in their respective cards", () => {
+    useAgentSpy.mockReturnValue({ data: mkFn(), isLoading: false });
+    render(<FunctionDetailPage />);
+    // Both cards should display the JSON-stringified schema; assert via
+    // a substring match on a property name the test fixture uses.
+    expect(screen.getByTestId("schema-card-input-schema")).toHaveTextContent('"q"');
+    expect(screen.getByTestId("schema-card-output-schema")).toHaveTextContent('"a"');
+  });
+});

--- a/dashboard/src/app/functions/[name]/page.tsx
+++ b/dashboard/src/app/functions/[name]/page.tsx
@@ -1,0 +1,173 @@
+/**
+ * /functions/[name] — Function detail page (#1103 PR 6).
+ *
+ * Shows the resolved input/output schemas and a panel of recent
+ * invocations sourced from session-api's function_invocations table.
+ * The workspace context provides the namespace; the URL provides
+ * the function name.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { Header } from "@/components/layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { FunctionInvocationsPanel } from "@/components/functions/function-invocations-panel";
+import { useAgent } from "@/hooks/agents";
+import { useWorkspace } from "@/contexts/workspace-context";
+import { isFunctionMode } from "@/types/agent-runtime";
+
+type WindowPreset = "1h" | "24h" | "7d";
+
+const WINDOW_MS: Record<WindowPreset, number> = {
+  "1h": 60 * 60 * 1000,
+  "24h": 24 * 60 * 60 * 1000,
+  "7d": 7 * 24 * 60 * 60 * 1000,
+};
+
+export default function FunctionDetailPage() {
+  const params = useParams<{ name: string }>();
+  const functionName = params?.name ?? "";
+  const { currentWorkspace } = useWorkspace();
+  const workspace = currentWorkspace?.name ?? "";
+
+  const [windowPreset, setWindowPreset] = useState<WindowPreset>("24h");
+
+  const { data: agent, isLoading } = useAgent(functionName);
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col h-full">
+        <Header title={functionName} />
+        <div className="p-6">
+          <Skeleton className="h-[200px] w-full rounded-lg" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!agent) {
+    return (
+      <div className="flex flex-col h-full">
+        <Header title={functionName} description="Function not found" />
+        <div className="p-6">
+          <p className="text-muted-foreground">
+            No AgentRuntime named <code className="font-mono">{functionName}</code> exists in
+            this workspace.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!isFunctionMode(agent.spec)) {
+    return (
+      <div className="flex flex-col h-full">
+        <Header
+          title={functionName}
+          description="This AgentRuntime is not a Function"
+        />
+        <div className="p-6">
+          <p className="text-muted-foreground">
+            <code className="font-mono">{functionName}</code> is mode{" "}
+            <Badge variant="outline">{agent.spec.mode ?? "agent"}</Badge>. The
+            functions view only surfaces runtimes with{" "}
+            <code className="font-mono">spec.mode: function</code>.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const recording = agent.spec.invocationRecording?.state === "enabled";
+
+  return (
+    <div className="flex flex-col h-full">
+      <Header
+        title={functionName}
+        description={`Function in ${agent.metadata.namespace ?? "default"}`}
+      />
+
+      <div className="flex-1 p-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <div className="flex gap-2">
+            <Badge variant="default">Function</Badge>
+            <Badge variant={recording ? "default" : "outline"}>
+              {recording ? "Recording" : "Ephemeral"}
+            </Badge>
+          </div>
+          <div className="flex gap-1 rounded-md border bg-muted p-1">
+            {(Object.keys(WINDOW_MS) as WindowPreset[]).map((preset) => (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => setWindowPreset(preset)}
+                className={
+                  "rounded-sm px-3 py-1 text-xs font-medium transition-colors " +
+                  (windowPreset === preset
+                    ? "bg-background text-foreground shadow-sm"
+                    : "text-muted-foreground hover:text-foreground")
+                }
+                data-testid={`window-${preset}`}
+              >
+                {preset}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <SchemaCard label="Input schema" schema={agent.spec.inputSchema} />
+          <SchemaCard label="Output schema" schema={agent.spec.outputSchema} />
+        </div>
+
+        {recording ? (
+          <FunctionInvocationsPanel
+            workspace={workspace}
+            functionName={functionName}
+            windowMs={WINDOW_MS[windowPreset]}
+          />
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle>Recent invocations</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Invocation recording is disabled. Set{" "}
+                <code className="font-mono">spec.invocationRecording.state: enabled</code>{" "}
+                on this AgentRuntime to retain audit rows.
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface SchemaCardProps {
+  label: string;
+  schema?: Record<string, unknown>;
+}
+
+function SchemaCard({ label, schema }: Readonly<SchemaCardProps>) {
+  return (
+    <Card data-testid={`schema-card-${label.toLowerCase().replaceAll(/\s+/g, "-")}`}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <pre className="overflow-auto rounded-md bg-muted p-3 text-xs">
+          {schema ? JSON.stringify(schema, null, 2) : "—"}
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dashboard/src/app/functions/page.test.tsx
+++ b/dashboard/src/app/functions/page.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Tests for the /functions catalog page.
+ *
+ * The page is mostly orchestration — filter useAgents() down to
+ * function-mode rows, render FunctionCard for each. Tests pin: the
+ * agent-mode filter, the namespace filter integration, the empty
+ * state, and the loading skeleton.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import FunctionsPage from "./page";
+import type { AgentRuntime } from "@/types";
+
+const agentsSpy = vi.hoisted(() => vi.fn());
+const workspaceSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/agents", () => ({
+  useAgents: agentsSpy,
+}));
+
+vi.mock("@/contexts/workspace-context", () => ({
+  useWorkspace: workspaceSpy,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+// Stub the layout Header — it pulls in WorkspaceSwitcher, UserMenu and
+// the next-themes provider, none of which we need for this page's
+// filter logic.
+vi.mock("@/components/layout", () => ({
+  Header: ({ title, description }: { title: React.ReactNode; description?: React.ReactNode }) => (
+    <div>
+      <h1>{title}</h1>
+      {description ? <p>{description}</p> : null}
+    </div>
+  ),
+}));
+
+// Stub NamespaceFilter — its popover internals (Radix) need a portal
+// host the JSDOM environment doesn't supply by default. The page-level
+// test only cares that the function-mode rows are filtered correctly.
+vi.mock("@/components/filters", () => ({
+  NamespaceFilter: () => <div data-testid="namespace-filter-stub" />,
+}));
+
+beforeEach(() => {
+  agentsSpy.mockReset();
+  workspaceSpy.mockReset();
+  workspaceSpy.mockReturnValue({ isLoading: false, currentWorkspace: { name: "ws" } });
+});
+
+function mkAgent(
+  name: string,
+  mode: "agent" | "function" | undefined,
+  namespace = "ns-a",
+): AgentRuntime {
+  return {
+    apiVersion: "omnia.altairalabs.ai/v1alpha1",
+    kind: "AgentRuntime",
+    metadata: { name, namespace, uid: `uid-${name}` },
+    spec: {
+      mode,
+      promptPackRef: { name: "pack" },
+      facade: { type: "grpc" as never },
+    },
+  };
+}
+
+describe("FunctionsPage", () => {
+  it("shows the loading skeleton while agents are loading", () => {
+    agentsSpy.mockReturnValue({ data: undefined, isLoading: true });
+    render(<FunctionsPage />);
+    // The Skeleton component doesn't expose a role, but it does have the
+    // grid layout structure — check the heading is present and no cards
+    // are rendered (loading state suppresses them).
+    expect(screen.getByText("Functions")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("function-card")).toHaveLength(0);
+  });
+
+  it("filters out agent-mode runtimes — only function-mode rows render", () => {
+    agentsSpy.mockReturnValue({
+      data: [
+        mkAgent("summarizer", "function"),
+        mkAgent("chatbot", "agent"),
+        mkAgent("classifier", "function"),
+        mkAgent("legacy", undefined), // unset mode == agent default
+      ],
+      isLoading: false,
+    });
+    render(<FunctionsPage />);
+    const cards = screen.getAllByTestId("function-card");
+    expect(cards).toHaveLength(2);
+    expect(screen.getByText("summarizer")).toBeInTheDocument();
+    expect(screen.getByText("classifier")).toBeInTheDocument();
+    expect(screen.queryByText("chatbot")).not.toBeInTheDocument();
+    expect(screen.queryByText("legacy")).not.toBeInTheDocument();
+  });
+
+  it("renders the empty state when no function-mode runtimes exist", () => {
+    agentsSpy.mockReturnValue({
+      data: [mkAgent("chatbot", "agent")], // agent-mode only
+      isLoading: false,
+    });
+    render(<FunctionsPage />);
+    expect(
+      screen.getByText("No function-mode AgentRuntimes found."),
+    ).toBeInTheDocument();
+  });
+
+  it("sorts function rows alphabetically by name", () => {
+    agentsSpy.mockReturnValue({
+      data: [
+        mkAgent("zeta", "function"),
+        mkAgent("alpha", "function"),
+        mkAgent("middle", "function"),
+      ],
+      isLoading: false,
+    });
+    render(<FunctionsPage />);
+    const cards = screen.getAllByTestId("function-card");
+    const names = cards.map((c) => c.querySelector("div")?.textContent ?? "");
+    expect(names[0]).toContain("alpha");
+    expect(names[1]).toContain("middle");
+    expect(names[2]).toContain("zeta");
+  });
+
+  it("falls back gracefully when useAgents returns undefined data", () => {
+    agentsSpy.mockReturnValue({ data: undefined, isLoading: false });
+    render(<FunctionsPage />);
+    expect(screen.getByText("No function-mode AgentRuntimes found.")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/app/functions/page.tsx
+++ b/dashboard/src/app/functions/page.tsx
@@ -1,0 +1,120 @@
+/**
+ * /functions — Functions Phase 1 catalog page (#1103 PR 6).
+ *
+ * Lists function-mode AgentRuntimes. Reuses useAgents() and filters
+ * down to spec.mode === "function" rather than calling a dedicated
+ * endpoint — the function-mode rows are a strict subset of the
+ * existing AgentRuntime list.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import { Header } from "@/components/layout";
+import { NamespaceFilter } from "@/components/filters";
+import { FunctionCard } from "@/components/functions/function-card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useAgents } from "@/hooks/agents";
+import { useWorkspace } from "@/contexts/workspace-context";
+import { isFunctionMode } from "@/types/agent-runtime";
+
+function renderLoadingSkeleton() {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+      {["sk-1", "sk-2", "sk-3", "sk-4", "sk-5", "sk-6"].map((id) => (
+        <Skeleton key={id} className="h-[160px] rounded-lg" />
+      ))}
+    </div>
+  );
+}
+
+export default function FunctionsPage() {
+  const [selectedNamespaces, setSelectedNamespaces] = useState<string[]>([]);
+
+  const { isLoading: isWorkspaceLoading } = useWorkspace();
+  const { data: agents, isLoading: isAgentsLoading } = useAgents();
+  const isLoading = isWorkspaceLoading || isAgentsLoading;
+
+  const handleNamespaceChange = useCallback((namespaces: string[]) => {
+    setSelectedNamespaces(namespaces);
+  }, []);
+
+  // Only function-mode runtimes appear on this page; agent-mode rows
+  // belong to /agents and would just add noise here.
+  const functions = useMemo(
+    () => (agents ?? []).filter((a) => isFunctionMode(a.spec)),
+    [agents],
+  );
+
+  // Build the namespace filter dropdown from the function set only —
+  // showing namespaces that contain no functions would be misleading.
+  const namespaces = useMemo(
+    () => [
+      ...new Set(
+        functions
+          .map((a) => a.metadata.namespace)
+          .filter((ns): ns is string => Boolean(ns)),
+      ),
+    ],
+    [functions],
+  );
+
+  const visible = useMemo(() => {
+    const filtered =
+      selectedNamespaces.length === 0
+        ? functions
+        : functions.filter(
+            (a) => a.metadata.namespace && selectedNamespaces.includes(a.metadata.namespace),
+          );
+    return [...filtered].sort((a, b) =>
+      (a.metadata.name || "").localeCompare(b.metadata.name || ""),
+    );
+  }, [functions, selectedNamespaces]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <Header
+        title="Functions"
+        description="One-shot PromptPack invocations with structured input and output schemas."
+      />
+
+      <div className="flex-1 p-6 space-y-6">
+        <div className="flex items-center justify-between">
+          <NamespaceFilter
+            namespaces={namespaces}
+            selectedNamespaces={selectedNamespaces}
+            onSelectionChange={handleNamespaceChange}
+          />
+        </div>
+
+        {isLoading && renderLoadingSkeleton()}
+
+        {!isLoading && visible.length > 0 && (
+          <div
+            className="grid gap-4 md:grid-cols-2 lg:grid-cols-3"
+            data-testid="functions-grid"
+          >
+            {visible.map((fn) => (
+              <FunctionCard key={fn.metadata.uid ?? fn.metadata.name} fn={fn} />
+            ))}
+          </div>
+        )}
+
+        {!isLoading && visible.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-12 text-center">
+            <p className="text-muted-foreground">
+              No function-mode AgentRuntimes found.
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              Set <code className="font-mono">spec.mode: function</code> on an
+              AgentRuntime to register it here.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/components/functions/function-card.test.tsx
+++ b/dashboard/src/components/functions/function-card.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for FunctionCard.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FunctionCard } from "./function-card";
+import type { AgentRuntime } from "@/types";
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+function mkFn(overrides: Partial<AgentRuntime> = {}): AgentRuntime {
+  return {
+    apiVersion: "omnia.altairalabs.ai/v1alpha1",
+    kind: "AgentRuntime",
+    metadata: {
+      name: "summarizer",
+      namespace: "ns-a",
+      uid: "uid-1",
+    },
+    spec: {
+      mode: "function",
+      promptPackRef: { name: "summarizer-pack" },
+      facade: { type: "grpc" as never },
+      inputSchema: {
+        type: "object",
+        properties: { q: { type: "string" }, k: { type: "integer" } },
+      },
+      outputSchema: {
+        type: "object",
+        properties: { a: { type: "string" } },
+      },
+      invocationRecording: { state: "enabled" },
+    },
+    ...overrides,
+  };
+}
+
+describe("FunctionCard", () => {
+  it("renders the function name + namespace", () => {
+    render(<FunctionCard fn={mkFn()} />);
+    expect(screen.getByText("summarizer")).toBeInTheDocument();
+    expect(screen.getByText("ns-a")).toBeInTheDocument();
+  });
+
+  it("shows Recording badge when invocationRecording.state is enabled", () => {
+    render(<FunctionCard fn={mkFn()} />);
+    expect(screen.getByText("Recording")).toBeInTheDocument();
+  });
+
+  it("shows Ephemeral badge when recording is disabled or unset", () => {
+    render(
+      <FunctionCard
+        fn={mkFn({
+          spec: {
+            ...mkFn().spec,
+            invocationRecording: { state: "disabled" },
+          },
+        })}
+      />,
+    );
+    expect(screen.getByText("Ephemeral")).toBeInTheDocument();
+  });
+
+  it("counts top-level schema properties on each side", () => {
+    render(<FunctionCard fn={mkFn()} />);
+    // 2 input properties, 1 output property
+    expect(screen.getByText("2 fields")).toBeInTheDocument();
+    expect(screen.getByText("1 field")).toBeInTheDocument();
+  });
+
+  it("renders 0 fields when schemas are missing or malformed", () => {
+    const fn = mkFn({
+      spec: {
+        ...mkFn().spec,
+        inputSchema: undefined,
+        outputSchema: { type: "array" }, // no .properties
+      },
+    });
+    render(<FunctionCard fn={fn} />);
+    // Both should read "0 fields"
+    const zeros = screen.getAllByText("0 fields");
+    expect(zeros).toHaveLength(2);
+  });
+
+  it("links to the detail page with the namespace in the query string", () => {
+    render(<FunctionCard fn={mkFn()} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/functions/summarizer?namespace=ns-a");
+  });
+
+  it("defaults to 'default' namespace in the URL when metadata.namespace is unset", () => {
+    const fn = mkFn();
+    fn.metadata.namespace = undefined;
+    render(<FunctionCard fn={fn} />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/functions/summarizer?namespace=default");
+  });
+});

--- a/dashboard/src/components/functions/function-card.tsx
+++ b/dashboard/src/components/functions/function-card.tsx
@@ -1,0 +1,68 @@
+/**
+ * FunctionCard renders one row of the /functions catalog. Compact
+ * presentation focused on the function's contract — name, namespace,
+ * input/output schema summary, recording opt-in — with click-through
+ * to the detail page. Unlike AgentCard, there are no scale controls
+ * or live cost spark; the detail page does the heavier read.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { AgentRuntime } from "@/types";
+
+interface FunctionCardProps {
+  fn: AgentRuntime;
+}
+
+/** schemaFieldCount returns the number of top-level keys under
+ * schema.properties, or 0 when the schema isn't a properties-style
+ * object. Used purely as a UI hint — the schema is opaque otherwise. */
+function schemaFieldCount(schema: Record<string, unknown> | undefined): number {
+  if (!schema) return 0;
+  const props = schema.properties;
+  if (props && typeof props === "object" && !Array.isArray(props)) {
+    return Object.keys(props).length;
+  }
+  return 0;
+}
+
+export function FunctionCard({ fn }: Readonly<FunctionCardProps>) {
+  const { metadata, spec } = fn;
+  const namespace = metadata.namespace ?? "default";
+  const recording = spec.invocationRecording?.state === "enabled";
+  const inputFields = schemaFieldCount(spec.inputSchema);
+  const outputFields = schemaFieldCount(spec.outputSchema);
+
+  return (
+    <Link href={`/functions/${metadata.name}?namespace=${namespace}`}>
+      <Card
+        className="transition-colors hover:bg-muted/50"
+        data-testid="function-card"
+      >
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="text-base font-medium">{metadata.name}</CardTitle>
+            <Badge variant={recording ? "default" : "outline"} className="shrink-0">
+              {recording ? "Recording" : "Ephemeral"}
+            </Badge>
+          </div>
+          <p className="text-xs text-muted-foreground">{namespace}</p>
+        </CardHeader>
+        <CardContent className="text-sm">
+          <dl className="grid grid-cols-2 gap-x-3 gap-y-1">
+            <dt className="text-muted-foreground">Input</dt>
+            <dd>{inputFields} field{inputFields === 1 ? "" : "s"}</dd>
+            <dt className="text-muted-foreground">Output</dt>
+            <dd>{outputFields} field{outputFields === 1 ? "" : "s"}</dd>
+          </dl>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/dashboard/src/components/functions/function-invocations-panel.test.tsx
+++ b/dashboard/src/components/functions/function-invocations-panel.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for FunctionInvocationsPanel.
+ *
+ * Covers: loading skeleton, error envelope, summary stats (averages,
+ * totals), table row rendering, status badge mapping, and the empty
+ * state for recording-enabled functions that simply have no rows yet.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { FunctionInvocationsPanel } from "./function-invocations-panel";
+import type { FunctionInvocation } from "@/lib/data/function-invocations-service";
+
+const hookSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/use-function-invocations", () => ({
+  useFunctionInvocations: hookSpy,
+}));
+
+beforeEach(() => {
+  hookSpy.mockReset();
+});
+
+/** mkHook returns a stub UseQueryResult shape that covers the union
+ * branches the panel switches on. */
+function mkHook(
+  state: { data?: FunctionInvocation[]; isLoading?: boolean; error?: unknown },
+): UseQueryResult<FunctionInvocation[]> {
+  return {
+    data: state.data,
+    isLoading: state.isLoading ?? false,
+    error: state.error ?? null,
+    // The panel doesn't read these but the type demands them.
+    isError: Boolean(state.error),
+    isSuccess: state.data !== undefined,
+  } as unknown as UseQueryResult<FunctionInvocation[]>;
+}
+
+function mkRow(overrides: Partial<FunctionInvocation> = {}): FunctionInvocation {
+  return {
+    id: "inv-1",
+    namespace: "ns-a",
+    functionName: "summarizer",
+    inputHash: "abc",
+    status: "success",
+    durationMs: 100,
+    costUsd: 0.001,
+    createdAt: "2026-05-20T10:00:00Z",
+    ...overrides,
+  };
+}
+
+const props = {
+  workspace: "ws",
+  functionName: "summarizer",
+  windowMs: 24 * 60 * 60 * 1000,
+};
+
+describe("FunctionInvocationsPanel", () => {
+  it("renders the loading skeleton while the hook is loading", () => {
+    hookSpy.mockReturnValue(mkHook({ isLoading: true }));
+    render(<FunctionInvocationsPanel {...props} />);
+    expect(screen.getByTestId("function-invocations-panel-loading")).toBeInTheDocument();
+  });
+
+  it("renders an error message when the hook reports a failure", () => {
+    hookSpy.mockReturnValue(mkHook({ error: new Error("boom") }));
+    render(<FunctionInvocationsPanel {...props} />);
+    expect(screen.getByTestId("function-invocations-panel-error")).toBeInTheDocument();
+    expect(screen.getByText(/Failed to load invocations: boom/)).toBeInTheDocument();
+  });
+
+  it("renders the empty state when the window has no rows", () => {
+    hookSpy.mockReturnValue(mkHook({ data: [] }));
+    render(<FunctionInvocationsPanel {...props} />);
+    expect(
+      screen.getByText("No invocations recorded in this window."),
+    ).toBeInTheDocument();
+  });
+
+  it("renders one table row per invocation", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: [
+          mkRow({ id: "inv-1", durationMs: 100, costUsd: 0.001 }),
+          mkRow({ id: "inv-2", durationMs: 200, costUsd: 0.002 }),
+        ],
+      }),
+    );
+    render(<FunctionInvocationsPanel {...props} />);
+    const rows = screen.getAllByTestId("function-invocations-row");
+    expect(rows).toHaveLength(2);
+  });
+
+  it("summarises stats across all loaded rows", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: [
+          mkRow({ id: "a", durationMs: 100, costUsd: 0.001 }),
+          mkRow({ id: "b", durationMs: 300, costUsd: 0.003 }),
+        ],
+      }),
+    );
+    render(<FunctionInvocationsPanel {...props} />);
+    // 2 invocations total
+    expect(screen.getByText("2")).toBeInTheDocument();
+    // Average latency = 200ms
+    expect(screen.getByText("200ms")).toBeInTheDocument();
+    // Total cost = $0.004
+    expect(screen.getByText("$0.0040")).toBeInTheDocument();
+  });
+
+  it("maps each status enum to a readable label", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: [
+          mkRow({ id: "a", status: "success" }),
+          mkRow({ id: "b", status: "input_invalid" }),
+          mkRow({ id: "c", status: "output_invalid" }),
+          mkRow({ id: "d", status: "runtime_error" }),
+        ],
+      }),
+    );
+    render(<FunctionInvocationsPanel {...props} />);
+    expect(screen.getByText("Success")).toBeInTheDocument();
+    expect(screen.getByText("Input Invalid")).toBeInTheDocument();
+    expect(screen.getByText("Output Invalid")).toBeInTheDocument();
+    expect(screen.getByText("Runtime Error")).toBeInTheDocument();
+  });
+
+  it("formats sub-second latency in ms and >= 1s latency in seconds", () => {
+    hookSpy.mockReturnValue(
+      mkHook({ data: [mkRow({ durationMs: 1500 })] }),
+    );
+    render(<FunctionInvocationsPanel {...props} />);
+    // Cell + avg both show 1.50s
+    expect(screen.getAllByText("1.50s").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders an em-dash when traceId is missing", () => {
+    hookSpy.mockReturnValue(
+      mkHook({ data: [mkRow({ traceId: undefined })] }),
+    );
+    render(<FunctionInvocationsPanel {...props} />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("truncates long trace ids to the leading 12 chars", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: [mkRow({ traceId: "0102030405060708090a0b0c0d0e0f10" })],
+      }),
+    );
+    render(<FunctionInvocationsPanel {...props} />);
+    expect(screen.getByText("010203040506")).toBeInTheDocument();
+  });
+});

--- a/dashboard/src/components/functions/function-invocations-panel.tsx
+++ b/dashboard/src/components/functions/function-invocations-panel.tsx
@@ -1,0 +1,239 @@
+/**
+ * FunctionInvocationsPanel renders the per-function audit history.
+ *
+ * Two horizontal sparklines (latency + cost) over the loaded window,
+ * then a chronological table of the most recent rows. Time window
+ * is controlled by the parent via the `windowMs` prop so the panel
+ * stays stateless and reusable.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import { useMemo } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Sparkline } from "@/components/ui/sparkline";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useFunctionInvocations } from "@/hooks/use-function-invocations";
+import { formatCost } from "@/lib/pricing";
+import type {
+  FunctionInvocation,
+  FunctionInvocationStatus,
+} from "@/lib/data/function-invocations-service";
+
+interface FunctionInvocationsPanelProps {
+  workspace: string;
+  functionName: string;
+  /** Window size in milliseconds; rows older than (now - windowMs)
+   * are not requested. Caller picks the preset (24h / 7d / 30d). */
+  windowMs: number;
+  /** Cap rows returned. session-api clamps server-side to 1000. */
+  limit?: number;
+}
+
+const STATUS_VARIANT: Record<FunctionInvocationStatus, "default" | "secondary" | "destructive" | "outline"> = {
+  success: "default",
+  input_invalid: "outline",
+  output_invalid: "destructive",
+  runtime_error: "destructive",
+};
+
+const STATUS_LABEL: Record<FunctionInvocationStatus, string> = {
+  success: "Success",
+  input_invalid: "Input Invalid",
+  output_invalid: "Output Invalid",
+  runtime_error: "Runtime Error",
+};
+
+/** statsFromRows computes the summary that headlines the panel. The
+ * sparkline arrays are in chronological order (oldest first) so the
+ * eye reads left → right as time → present. */
+function statsFromRows(rows: FunctionInvocation[]) {
+  if (rows.length === 0) {
+    return {
+      count: 0,
+      avgLatencyMs: 0,
+      totalCost: 0,
+      latencySeries: [] as Array<{ value: number }>,
+      costSeries: [] as Array<{ value: number }>,
+    };
+  }
+  // Session-api returns DESC by created_at; reverse so the sparkline
+  // reads chronologically rather than as a recency cliff.
+  const chrono = [...rows].reverse();
+  const latencySeries = chrono.map((r) => ({ value: r.durationMs }));
+  const costSeries = chrono.map((r) => ({ value: r.costUsd }));
+  const totalCost = rows.reduce((acc, r) => acc + r.costUsd, 0);
+  const avgLatencyMs = rows.reduce((acc, r) => acc + r.durationMs, 0) / rows.length;
+  return {
+    count: rows.length,
+    avgLatencyMs,
+    totalCost,
+    latencySeries,
+    costSeries,
+  };
+}
+
+function formatLatency(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function FunctionInvocationsPanel({
+  workspace,
+  functionName,
+  windowMs,
+  limit = 100,
+}: Readonly<FunctionInvocationsPanelProps>) {
+  // Recompute on every render so the window slides forward in time
+  // without needing a refetch trigger; the query key only cares about
+  // the resolved ISO bounds.
+  const now = new Date();
+  const fromIso = useMemo(
+    () => new Date(now.getTime() - windowMs).toISOString(),
+    // `now` is intentionally NOT in deps — we want a fresh bound each
+    // render but we still want the query key to be stable enough that
+    // re-renders inside the same minute don't trigger a refetch.
+    // Truncate to the minute so the key churns once per minute, not
+    // on every paint.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [Math.floor(now.getTime() / 60_000), windowMs],
+  );
+
+  const { data, isLoading, error } = useFunctionInvocations({
+    workspace,
+    functionName,
+    fromIso,
+    limit,
+  });
+
+  const rows = useMemo(() => data ?? [], [data]);
+  const stats = useMemo(() => statsFromRows(rows), [rows]);
+
+  if (isLoading) {
+    return (
+      <Card data-testid="function-invocations-panel-loading">
+        <CardHeader>
+          <CardTitle>Recent invocations</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card data-testid="function-invocations-panel-error">
+        <CardHeader>
+          <CardTitle>Recent invocations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">
+            Failed to load invocations: {error instanceof Error ? error.message : String(error)}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid="function-invocations-panel">
+      <CardHeader>
+        <CardTitle>Recent invocations</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="grid grid-cols-3 gap-4">
+          <Stat label="Invocations" value={String(stats.count)} />
+          <Stat
+            label="Avg latency"
+            value={formatLatency(stats.avgLatencyMs)}
+            sparkline={
+              <Sparkline data={stats.latencySeries} strokeColor="#3B82F6" width={120} height={32} />
+            }
+          />
+          <Stat
+            label="Total cost"
+            value={formatCost(stats.totalCost)}
+            sparkline={
+              <Sparkline data={stats.costSeries} strokeColor="#10B981" width={120} height={32} />
+            }
+          />
+        </div>
+
+        {rows.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No invocations recorded in this window.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" data-testid="function-invocations-table">
+              <thead className="text-left text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="py-2 pr-4">When</th>
+                  <th className="py-2 pr-4">Status</th>
+                  <th className="py-2 pr-4 text-right">Latency</th>
+                  <th className="py-2 pr-4 text-right">Cost</th>
+                  <th className="py-2 pr-4">Trace</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((row) => (
+                  <tr key={row.id} className="border-t" data-testid="function-invocations-row">
+                    <td className="py-2 pr-4 font-mono text-xs">
+                      {formatTimestamp(row.createdAt)}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Badge variant={STATUS_VARIANT[row.status] ?? "outline"}>
+                        {STATUS_LABEL[row.status] ?? row.status}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-4 text-right">{formatLatency(row.durationMs)}</td>
+                    <td className="py-2 pr-4 text-right">{formatCost(row.costUsd)}</td>
+                    <td className="py-2 pr-4 font-mono text-xs text-muted-foreground">
+                      {row.traceId ? row.traceId.slice(0, 12) : "—"}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+interface StatProps {
+  label: string;
+  value: string;
+  sparkline?: React.ReactNode;
+}
+
+function Stat({ label, value, sparkline }: Readonly<StatProps>) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-lg font-semibold">{value}</p>
+      {sparkline ? <div className="mt-1">{sparkline}</div> : null}
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -23,6 +23,7 @@ import {
   Brain,
   BookOpen,
   BarChart3,
+  Zap,
 } from "lucide-react";
 
 interface NavItem {
@@ -36,6 +37,7 @@ const navigation: NavItem[] = [
   { name: "Overview", href: "/", icon: LayoutDashboard },
   { name: "Topology", href: "/topology", icon: Network },
   { name: "Agents", href: "/agents", icon: Bot },
+  { name: "Functions", href: "/functions", icon: Zap },
   { name: "Console", href: "/console", icon: Terminal },
   { name: "PromptPacks", href: "/promptpacks", icon: FileText },
   { name: "Skills", href: "/skills", icon: BookOpen },

--- a/dashboard/src/hooks/use-function-invocations.test.tsx
+++ b/dashboard/src/hooks/use-function-invocations.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Tests for useFunctionInvocations.
+ *
+ * Covers:
+ *  - query key shape (so cache entries don't bleed between filters)
+ *  - enablement: hook is disabled when workspace is empty
+ *  - happy path: rows flow from the service into hook state
+ *  - error path: the hook reports error state on rejection
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { useFunctionInvocations } from "./use-function-invocations";
+import type { FunctionInvocation } from "@/lib/data/function-invocations-service";
+
+const SAMPLE_ROW: FunctionInvocation = {
+  id: "inv-1",
+  namespace: "ns-a",
+  functionName: "summarizer",
+  inputHash: "abc",
+  status: "success",
+  durationMs: 42,
+  costUsd: 0.001,
+  createdAt: "2026-05-20T10:00:00Z",
+};
+
+const fetchSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/data/function-invocations-service", async () => {
+  const actual = await vi.importActual<
+    typeof import("@/lib/data/function-invocations-service")
+  >("@/lib/data/function-invocations-service");
+  return {
+    ...actual,
+    fetchFunctionInvocations: fetchSpy,
+  };
+});
+
+function newWrapper() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  Wrapper.displayName = "QueryWrapper";
+  return Wrapper;
+}
+
+beforeEach(() => {
+  fetchSpy.mockReset();
+});
+
+describe("useFunctionInvocations", () => {
+  it("does not fetch when workspace is empty", () => {
+    fetchSpy.mockResolvedValueOnce([]);
+    const { result } = renderHook(
+      () => useFunctionInvocations({ workspace: "" }),
+      { wrapper: newWrapper() },
+    );
+    expect(result.current.isFetching).toBe(false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns rows from the service on the happy path", async () => {
+    fetchSpy.mockResolvedValueOnce([SAMPLE_ROW]);
+    const { result } = renderHook(
+      () =>
+        useFunctionInvocations({
+          workspace: "ws",
+          functionName: "summarizer",
+          fromIso: "2026-05-19T00:00:00Z",
+          limit: 100,
+        }),
+      { wrapper: newWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(result.current.data).toEqual([SAMPLE_ROW]);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const call = fetchSpy.mock.calls[0][0];
+    expect(call.workspace).toBe("ws");
+    expect(call.functionName).toBe("summarizer");
+    expect(call.from).toBeInstanceOf(Date);
+    expect(call.from.toISOString()).toBe("2026-05-19T00:00:00.000Z");
+    expect(call.limit).toBe(100);
+  });
+
+  it("surfaces service errors on the error path", async () => {
+    fetchSpy.mockRejectedValueOnce(new Error("boom"));
+    const { result } = renderHook(
+      () => useFunctionInvocations({ workspace: "ws" }),
+      { wrapper: newWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+    expect(result.current.error).toEqual(new Error("boom"));
+  });
+
+  it("invalidates cache when filters change (no row bleed across views)", async () => {
+    // First fetch — summarizer
+    fetchSpy.mockResolvedValueOnce([{ ...SAMPLE_ROW, functionName: "summarizer" }]);
+    const { result, rerender } = renderHook(
+      ({ fn }: { fn: string }) =>
+        useFunctionInvocations({ workspace: "ws", functionName: fn }),
+      { wrapper: newWrapper(), initialProps: { fn: "summarizer" } },
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0].functionName).toBe("summarizer");
+
+    // Second fetch — classifier; the rerender must trigger a NEW query
+    // (different key) rather than show stale summarizer rows.
+    fetchSpy.mockResolvedValueOnce([{ ...SAMPLE_ROW, functionName: "classifier" }]);
+    rerender({ fn: "classifier" });
+    await waitFor(() => {
+      expect(result.current.data?.[0].functionName).toBe("classifier");
+    });
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/dashboard/src/hooks/use-function-invocations.ts
+++ b/dashboard/src/hooks/use-function-invocations.ts
@@ -1,0 +1,53 @@
+/**
+ * Hook for fetching function-invocation audit rows from session-api.
+ *
+ * Consumes the workspace-scoped proxy added in #1103 PR 6 that fronts
+ * GET /api/v1/function-invocations. The workspace name is pinned to
+ * the namespace filter server-side so cross-tenant reads are impossible.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchFunctionInvocations,
+  type FunctionInvocation,
+  type FunctionInvocationListParams,
+} from "@/lib/data/function-invocations-service";
+import { DEFAULT_STALE_TIME } from "@/lib/query-config";
+
+export type UseFunctionInvocationsParams = Omit<FunctionInvocationListParams, "from" | "to"> & {
+  /** Optional time window. When unset, session-api returns the most
+   * recent rows up to `limit`. Passed through as ISO strings to
+   * stabilise the query key (Date references churn on every render). */
+  fromIso?: string;
+  toIso?: string;
+};
+
+/**
+ * Fetch invocation rows for a workspace, optionally scoped to one
+ * function name + time window.
+ *
+ * The query key includes every filter so stale entries don't bleed
+ * across views (e.g. switching from "summarizer" to "classifier"
+ * should not show summarizer rows while the new query loads).
+ */
+export function useFunctionInvocations(params: UseFunctionInvocationsParams) {
+  const { workspace, functionName, limit, fromIso, toIso } = params;
+  return useQuery<FunctionInvocation[]>({
+    queryKey: ["function-invocations", workspace, functionName ?? null, fromIso ?? null, toIso ?? null, limit ?? null],
+    queryFn: () =>
+      fetchFunctionInvocations({
+        workspace,
+        functionName,
+        limit,
+        from: fromIso ? new Date(fromIso) : undefined,
+        to: toIso ? new Date(toIso) : undefined,
+      }),
+    staleTime: DEFAULT_STALE_TIME,
+    enabled: Boolean(workspace),
+  });
+}

--- a/dashboard/src/lib/data/function-invocations-service.test.ts
+++ b/dashboard/src/lib/data/function-invocations-service.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for function-invocations-service.
+ *
+ * Covers URL composition (workspace name encoding, optional filters,
+ * absence of the "?" when no params), envelope unwrapping, and error
+ * propagation on non-2xx. Mock-to-contract: the mocked response shape
+ * mirrors the Go FunctionInvocation struct's json tags so a tag
+ * rename in Go would fail these tests immediately.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  fetchFunctionInvocations,
+  fetchFunctionInvocation,
+} from "./function-invocations-service";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+const SAMPLE_ROW = {
+  id: "00000000-0000-0000-0000-000000000001",
+  namespace: "ns-a",
+  functionName: "summarizer",
+  inputHash: "abc",
+  outputJson: { a: 1 },
+  status: "success" as const,
+  durationMs: 42,
+  costUsd: 0.001,
+  traceId: "0102030405060708090a0b0c0d0e0f10",
+  createdAt: "2026-05-20T10:00:00Z",
+};
+
+describe("fetchFunctionInvocations", () => {
+  it("builds the workspace-scoped URL with every optional filter", async () => {
+    const fakeFetch = vi.fn(
+      async () => new Response(JSON.stringify({ rows: [SAMPLE_ROW] }), { status: 200 }),
+    );
+
+    const rows = await fetchFunctionInvocations(
+      {
+        workspace: "test-ws",
+        functionName: "summarizer",
+        from: new Date("2026-05-19T00:00:00Z"),
+        to: new Date("2026-05-20T00:00:00Z"),
+        limit: 50,
+      },
+      fakeFetch as unknown as typeof fetch,
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual(SAMPLE_ROW);
+
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url.startsWith("/api/workspaces/test-ws/function-invocations?")).toBe(true);
+    expect(url).toContain("function=summarizer");
+    expect(url).toContain("from=2026-05-19T00%3A00%3A00.000Z");
+    expect(url).toContain("to=2026-05-20T00%3A00%3A00.000Z");
+    expect(url).toContain("limit=50");
+  });
+
+  it("omits the query string entirely when no filters are passed", async () => {
+    const fakeFetch = vi.fn(
+      async () => new Response(JSON.stringify({ rows: [] }), { status: 200 }),
+    );
+    await fetchFunctionInvocations(
+      { workspace: "ws" },
+      fakeFetch as unknown as typeof fetch,
+    );
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toBe("/api/workspaces/ws/function-invocations");
+  });
+
+  it("encodes workspace names with special characters in the path", async () => {
+    const fakeFetch = vi.fn(
+      async () => new Response(JSON.stringify({ rows: [] }), { status: 200 }),
+    );
+    await fetchFunctionInvocations(
+      { workspace: "ws/with-slash" },
+      fakeFetch as unknown as typeof fetch,
+    );
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toContain("/api/workspaces/ws%2Fwith-slash/");
+  });
+
+  it("returns [] when the body has no rows field", async () => {
+    const fakeFetch = vi.fn(
+      async () => new Response(JSON.stringify({}), { status: 200 }),
+    );
+    const rows = await fetchFunctionInvocations(
+      { workspace: "ws" },
+      fakeFetch as unknown as typeof fetch,
+    );
+    expect(rows).toEqual([]);
+  });
+
+  it("throws when the proxy returns a non-2xx", async () => {
+    const fakeFetch = vi.fn(
+      async () => new Response("{}", { status: 503, statusText: "Service Unavailable" }),
+    );
+    await expect(
+      fetchFunctionInvocations(
+        { workspace: "ws" },
+        fakeFetch as unknown as typeof fetch,
+      ),
+    ).rejects.toThrow(/503/);
+  });
+
+  it("forwards limit=0 as an explicit filter, not as 'omitted'", async () => {
+    // Edge case: limit=0 means "the caller really wants zero rows back".
+    // It must reach the URL — `if (params.limit)` would have silently
+    // dropped this. The service uses `!== undefined` to guard against that.
+    const fakeFetch = vi.fn(
+      async () => new Response(JSON.stringify({ rows: [] }), { status: 200 }),
+    );
+    await fetchFunctionInvocations(
+      { workspace: "ws", limit: 0 },
+      fakeFetch as unknown as typeof fetch,
+    );
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toContain("limit=0");
+  });
+});
+
+describe("fetchFunctionInvocation", () => {
+  it("encodes the id in the path", async () => {
+    const fakeFetch = vi.fn(
+      async () => new Response(JSON.stringify(SAMPLE_ROW), { status: 200 }),
+    );
+    const row = await fetchFunctionInvocation(
+      "ws",
+      "id/with-slash",
+      fakeFetch as unknown as typeof fetch,
+    );
+    expect(row).toEqual(SAMPLE_ROW);
+    const url = String((fakeFetch.mock.calls as unknown as [string][])[0][0]);
+    expect(url).toBe("/api/workspaces/ws/function-invocations/id%2Fwith-slash");
+  });
+
+  it("throws when the proxy returns 404", async () => {
+    const fakeFetch = vi.fn(
+      async () => new Response("{}", { status: 404, statusText: "Not Found" }),
+    );
+    await expect(
+      fetchFunctionInvocation("ws", "missing", fakeFetch as unknown as typeof fetch),
+    ).rejects.toThrow(/404/);
+  });
+});

--- a/dashboard/src/lib/data/function-invocations-service.ts
+++ b/dashboard/src/lib/data/function-invocations-service.ts
@@ -1,0 +1,106 @@
+/**
+ * Function-invocations service: structured (session-api) read path for
+ * the per-call audit rows persisted by function-mode AgentRuntimes
+ * (Functions Phase 1, #1102 / #1103 PR 5).
+ *
+ * Mirrors the provider-calls service shape — functional module, no
+ * class, fetch is injected so tests don't need to mock global fetch.
+ *
+ * See CLAUDE.md → Observability Boundaries: function invocations are
+ * product data, not operational, so they live in session-api and not
+ * Prometheus.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** FunctionInvocationStatus mirrors the CHECK constraint on the
+ * function_invocations table. */
+export type FunctionInvocationStatus =
+  | "success"
+  | "input_invalid"
+  | "output_invalid"
+  | "runtime_error";
+
+/** FunctionInvocation is the per-call audit row returned by session-api.
+ * Field names match the Go FunctionInvocation struct's json tags exactly
+ * — changes there must flow through here. */
+export interface FunctionInvocation {
+  id: string;
+  namespace: string;
+  functionName: string;
+  inputHash: string;
+  /** Raw model output. Optional because runtime_error rows have no
+   * output to persist. */
+  outputJson?: unknown;
+  status: FunctionInvocationStatus;
+  durationMs: number;
+  costUsd: number;
+  /** W3C trace id of the OTel span that produced this invocation.
+   * Empty when no span was bound to the request context. */
+  traceId?: string;
+  createdAt: string;
+}
+
+export interface FunctionInvocationListParams {
+  /** Workspace name. Pinned to `namespace` server-side. Required. */
+  workspace: string;
+  /** Optional function-name filter — restricts to one Function within
+   * the namespace. */
+  functionName?: string;
+  /** RFC3339 timestamps for the time-window filter. */
+  from?: Date;
+  to?: Date;
+  /** Limit defaults to session-api's 100; capped at 1000. */
+  limit?: number;
+}
+
+/** FunctionInvocationsListResponse matches the Go-side envelope
+ * returned by GET /api/v1/function-invocations. */
+interface FunctionInvocationsListResponse {
+  rows?: FunctionInvocation[];
+}
+
+/**
+ * Fetch recent function invocations for a workspace. Returns the rows
+ * directly (drops the response envelope); throws on non-2xx so React
+ * Query can surface the failure.
+ */
+export async function fetchFunctionInvocations(
+  params: FunctionInvocationListParams,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FunctionInvocation[]> {
+  const qs = new URLSearchParams();
+  if (params.functionName) qs.set("function", params.functionName);
+  if (params.from) qs.set("from", params.from.toISOString());
+  if (params.to) qs.set("to", params.to.toISOString());
+  if (params.limit !== undefined) qs.set("limit", String(params.limit));
+
+  const query = qs.toString();
+  const suffix = query ? `?${query}` : "";
+  const url = `/api/workspaces/${encodeURIComponent(params.workspace)}/function-invocations${suffix}`;
+  const resp = await fetchImpl(url, { headers: { Accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`function-invocations-list: ${resp.status} ${resp.statusText}`);
+  }
+  const body = (await resp.json()) as FunctionInvocationsListResponse;
+  return body.rows ?? [];
+}
+
+/**
+ * Fetch one invocation by id, scoped to the workspace.
+ * Throws on non-2xx (including 404) so the caller can distinguish
+ * "missing" from "error" via the message.
+ */
+export async function fetchFunctionInvocation(
+  workspace: string,
+  id: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<FunctionInvocation> {
+  const url = `/api/workspaces/${encodeURIComponent(workspace)}/function-invocations/${encodeURIComponent(id)}`;
+  const resp = await fetchImpl(url, { headers: { Accept: "application/json" } });
+  if (!resp.ok) {
+    throw new Error(`function-invocation: ${resp.status} ${resp.statusText}`);
+  }
+  return (await resp.json()) as FunctionInvocation;
+}

--- a/dashboard/src/types/agent-runtime.test.ts
+++ b/dashboard/src/types/agent-runtime.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests for the small helpers in agent-runtime.ts. Most of the file is
+ * type declarations (no runtime); the only executable code that needs
+ * coverage is getDefaultProviderRef and isFunctionMode.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  getDefaultProviderRef,
+  isFunctionMode,
+  type AgentRuntimeSpec,
+} from "./agent-runtime";
+
+function mkSpec(overrides: Partial<AgentRuntimeSpec> = {}): AgentRuntimeSpec {
+  return {
+    promptPackRef: { name: "pack" },
+    facade: { type: "grpc" as never },
+    ...overrides,
+  };
+}
+
+describe("isFunctionMode", () => {
+  it("returns true when spec.mode === 'function'", () => {
+    expect(isFunctionMode(mkSpec({ mode: "function" }))).toBe(true);
+  });
+
+  it("returns false when spec.mode === 'agent'", () => {
+    expect(isFunctionMode(mkSpec({ mode: "agent" }))).toBe(false);
+  });
+
+  it("returns false when spec.mode is unset (legacy default = agent)", () => {
+    expect(isFunctionMode(mkSpec())).toBe(false);
+  });
+});
+
+describe("getDefaultProviderRef", () => {
+  it("returns undefined when no providers are configured", () => {
+    expect(getDefaultProviderRef(mkSpec())).toBeUndefined();
+  });
+
+  it("returns the provider named 'default' when present", () => {
+    const ref = getDefaultProviderRef(
+      mkSpec({
+        providers: [
+          { name: "primary", providerRef: { name: "openai-1" } },
+          { name: "default", providerRef: { name: "anthropic-1" } },
+        ],
+      }),
+    );
+    expect(ref).toEqual({ name: "anthropic-1" });
+  });
+
+  it("falls back to the first provider when none is named 'default'", () => {
+    const ref = getDefaultProviderRef(
+      mkSpec({
+        providers: [{ name: "primary", providerRef: { name: "openai-1" } }],
+      }),
+    );
+    expect(ref).toEqual({ name: "openai-1" });
+  });
+});

--- a/dashboard/src/types/agent-runtime.ts
+++ b/dashboard/src/types/agent-runtime.ts
@@ -191,8 +191,24 @@ export interface ConsoleConfig {
   mediaRequirements?: MediaRequirements;
 }
 
+/** AgentRuntimeMode discriminates between the long-lived conversational
+ * runtime (agent) and the one-shot structured-I/O function runtime
+ * (function). Functions Phase 1 (#1102 / #1103 PR 1) introduced
+ * "function"; existing CRs default to "agent". */
+export type AgentRuntimeMode = "agent" | "function";
+
+/** InvocationRecordingState toggles whether function-mode runtimes
+ * persist a per-call audit row to session-api. Defaults to "disabled". */
+export type InvocationRecordingState = "disabled" | "enabled";
+
+export interface InvocationRecordingConfig {
+  state?: InvocationRecordingState;
+}
+
 // Spec
 export interface AgentRuntimeSpec {
+  /** mode selects the runtime shape. Defaults to "agent" when unset. */
+  mode?: AgentRuntimeMode;
   framework?: FrameworkConfig;
   promptPackRef: PromptPackRef;
   facade: FacadeConfig;
@@ -202,6 +218,22 @@ export interface AgentRuntimeSpec {
   providers?: NamedProviderRef[];
   console?: ConsoleConfig;
   evals?: EvalConfig;
+  /** inputSchema is the JSON Schema the function's request body is
+   * validated against. Required when spec.mode === "function". */
+  inputSchema?: Record<string, unknown>;
+  /** outputSchema is the JSON Schema the function's response is
+   * validated against. Required when spec.mode === "function". */
+  outputSchema?: Record<string, unknown>;
+  /** invocationRecording opts into per-call audit persistence. Ignored
+   * for mode === "agent". */
+  invocationRecording?: InvocationRecordingConfig;
+}
+
+/** isFunctionMode returns true when the runtime is declared as a
+ * Function. Used by the dashboard's catalog filter and the deploy
+ * wizard's conditional schema editors. */
+export function isFunctionMode(spec: AgentRuntimeSpec): boolean {
+  return spec.mode === "function";
 }
 
 export interface EvalConfig {


### PR DESCRIPTION
## Summary

Adds the dashboard surface for function-mode AgentRuntimes — the read-only side of #1103 PR 6. The deploy-wizard mode toggle is held back for a separate follow-up PR so this one stays reviewable.

- **`/functions` catalog** — lists function-mode AgentRuntimes via the existing `useAgents()` hook + a client-side `isFunctionMode(spec)` filter (no new operator endpoint). Cards show namespace, recording opt-in, and top-level schema field counts.
- **`/functions/{name}` detail** — input + output schemas in `<pre>` cards alongside `FunctionInvocationsPanel`. Time window presets (1h / 24h / 7d) gate the loaded rows. Latency + cost sparklines aggregate the window; the table shows when / status / latency / cost / truncated trace id per row.
- **Workspace proxy routes** — `GET /api/workspaces/{name}/function-invocations[?…]` and `.../{id}` proxy to session-api. The proxy pins the session-api `namespace` filter to the workspace name; a caller-supplied `?namespace=other-tenant` override is dropped (security regression test pins this).
- **Types** — `AgentRuntimeSpec` hand-written type extended with `mode`, `inputSchema`, `outputSchema`, `invocationRecording` (already in the generated types since PR 1 / #1104). `isFunctionMode(spec)` helper exported.
- **Sidebar** — gains a Functions entry right after Agents.

## Test plan

- [x] 50 new vitest specs (service, hook, components, pages, proxy routes) — all pass
- [x] Per-file coverage on changed code:
  - `app/api/.../function-invocations/[id]/route.ts`: 100%
  - `app/api/.../function-invocations/route.ts`: 100%
  - `components/functions/function-card.tsx`: 100%
  - `components/functions/function-invocations-panel.tsx`: 97.2%
  - `hooks/use-function-invocations.ts`: 100%
  - `lib/data/function-invocations-service.ts`: 100%
- [x] `npm run lint` clean on touched files
- [x] `npm run typecheck` passes
- [x] Pre-commit hook green
