### PR TITLE
docs(functions): authoring guide + echo example (#1103 PR 7/7)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,22 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Added (docs + example: Functions Phase 1 closes out, #1103 PR 7)
+
+- New how-to: `docs/src/content/docs/how-to/define-functions.md` —
+  pack-authoring guide for function-mode AgentRuntimes. Covers when
+  to pick function vs agent, the CRD shape, the invocation contract,
+  status code reference, authentication, and the
+  `invocationRecording` opt-in.
+- AgentRuntime CRD reference extended with first-class entries for
+  the new `mode`, `inputSchema`, `outputSchema`, and
+  `invocationRecording` fields in
+  `docs/src/content/docs/reference/agentruntime.md`.
+- New `examples/echo-function/` worked example — a minimal,
+  applyable Function (PromptPack + Provider + AgentRuntime + README)
+  showing the smallest viable function-mode runtime. Echoes the
+  request's `message` field back as `echo`.
+
 ### Added (dashboard: Functions catalog + invocation history, #1103 PR 6)
 
 - New `/functions` catalog page lists function-mode AgentRuntimes

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,7 +12,10 @@ export default defineConfig({
   site: 'https://omnia.altairalabs.ai',
   base: basePath,
   integrations: [
-    d2(),
+    // Pass `output` explicitly: astro-d2 0.8.x stopped honouring its
+    // Zod default when no userConfig is supplied, so config.output
+    // arrives as undefined and the build crashes on path.join.
+    d2({ output: 'd2' }),
     starlight({
       plugins: [starlightThemeGalaxy()],
       title: 'Omnia',
@@ -35,21 +38,24 @@ export default defineConfig({
         PageTitle: './src/components/PageTitle.astro',
       },
       sidebar: [
+        // Starlight 0.39 dropped top-level { label, autogenerate }
+        // shorthand — each group must now use { label, items: [...] }
+        // with the autogenerate config as a child entry.
         {
           label: 'Tutorials',
-          autogenerate: { directory: 'tutorials' },
+          items: [{ autogenerate: { directory: 'tutorials' } }],
         },
         {
           label: 'How-To Guides',
-          autogenerate: { directory: 'how-to' },
+          items: [{ autogenerate: { directory: 'how-to' } }],
         },
         {
           label: 'Reference',
-          autogenerate: { directory: 'reference' },
+          items: [{ autogenerate: { directory: 'reference' } }],
         },
         {
           label: 'Concepts',
-          autogenerate: { directory: 'explanation' },
+          items: [{ autogenerate: { directory: 'explanation' } }],
         },
       ],
       editLink: {

--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -1,6 +1,13 @@
+// Astro v6 dropped the legacy content-collections backward-compat that
+// let pre-Content-Layer projects build without a loader. Starlight
+// v0.30+ ships its own `docsLoader()` we must wire in explicitly here,
+// otherwise the `docs` collection resolves to zero entries and the
+// build emits a single index page. See Starlight CHANGELOG 0.30 →
+// "Update your collections".
 import { defineCollection } from 'astro:content';
+import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-  docs: defineCollection({ schema: docsSchema() }),
+  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
 };

--- a/docs/src/content/docs/how-to/define-functions.md
+++ b/docs/src/content/docs/how-to/define-functions.md
@@ -1,0 +1,184 @@
+---
+title: "Define Functions"
+description: "Author a function-mode AgentRuntime: one-shot HTTP invocations with structured input and output schemas"
+sidebar:
+  order: 7
+---
+
+Functions are AgentRuntimes that expose a single, structured-I/O HTTP
+endpoint instead of a long-lived WebSocket conversation. They are the
+right shape when you want to call a PromptPack like a service:
+deterministic input, validated output, no session state, no streaming.
+
+Typical use cases:
+
+- Summarising a document on demand.
+- Extracting structured data from free-text input.
+- Wrapping a PromptPack as a callable API consumed by other services.
+- Memory summarisation, evaluation aggregation, and similar
+  "pack + input → output" workloads.
+
+If you want a chat surface, browser console, or long-lived session,
+[deploy an agent-mode AgentRuntime](/how-to/expose-agents/) instead.
+
+## When agent vs function
+
+| Concern | Agent mode | Function mode |
+|---------|------------|---------------|
+| Transport | WebSocket (`/ws`) | HTTP POST (`/functions/{name}`) |
+| Conversation state | Yes (sessions) | No (one-shot) |
+| Input validation | None at the boundary | Required JSON Schema |
+| Output validation | None at the boundary | Required JSON Schema |
+| Audit trail | Sessions table | `function_invocations` table (opt-in) |
+| Browser UI | Console / dashboard chat | None |
+
+## CRD shape
+
+A function-mode AgentRuntime sets `spec.mode: function` and declares
+two JSON Schemas: one for the request body, one for the model output.
+
+```yaml
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: summarizer
+  namespace: my-workspace
+spec:
+  mode: function
+  promptPackRef:
+    name: summarizer-pack
+  facade:
+    type: grpc          # function mode requires the gRPC facade
+    port: 8080
+  providers:
+    - name: default
+      providerRef:
+        name: claude-sonnet
+  inputSchema:
+    type: object
+    required: ["text"]
+    properties:
+      text:
+        type: string
+        description: "Text to summarise"
+      maxWords:
+        type: integer
+        minimum: 10
+        maximum: 500
+  outputSchema:
+    type: object
+    required: ["summary"]
+    properties:
+      summary:
+        type: string
+  invocationRecording:
+    state: enabled      # opt-in audit trail; defaults to disabled
+```
+
+The CEL validation gates on the CRD enforce:
+
+- `spec.mode == "function"` requires both `spec.inputSchema` and
+  `spec.outputSchema`.
+- `spec.mode == "agent"` (the default) forbids those schemas.
+- `spec.mode == "function"` rejects `spec.facade.type == "websocket"` —
+  use `grpc`.
+
+Apply the resource the usual way:
+
+```bash
+kubectl apply -f summarizer.yaml
+kubectl wait --for=condition=Ready agentruntime/summarizer -n my-workspace --timeout=60s
+```
+
+## Invoke it
+
+The facade pod exposes `POST /functions/{name}` where `{name}` matches
+the AgentRuntime's `metadata.name`.
+
+```bash
+kubectl port-forward -n my-workspace svc/summarizer 8080:8080 &
+
+curl -X POST http://localhost:8080/functions/summarizer \
+  -H "Content-Type: application/json" \
+  -d '{"text": "Omnia is a Kubernetes operator for AI agent deployments.", "maxWords": 20}'
+```
+
+A successful call returns the model output plus metadata:
+
+```json
+{
+  "output": { "summary": "Omnia is a K8s operator for managing AI agents." },
+  "invocation_id": "9c0e2c1f-...",
+  "duration_ms": 842,
+  "usage": {
+    "input_tokens": 41,
+    "output_tokens": 12,
+    "cost_usd": 0.0008
+  }
+}
+```
+
+### Error responses
+
+The facade owns the schema validation boundary. Status codes:
+
+| Code | Meaning |
+|------|---------|
+| 200  | Success — response body validated against `spec.outputSchema`. |
+| 400  | `input_invalid` — request body failed `spec.inputSchema`. Body includes the validator error. |
+| 401  | `unauthorized` — authentication chain (mgmt-plane + data-plane) rejected the request. |
+| 404  | `function_not_found` — no function-mode runtime matched `{name}` on this facade. |
+| 405  | `method_not_allowed` — only `POST` is allowed. |
+| 413  | `payload_too_large` — request body exceeded 1 MiB. |
+| 415  | `unsupported_media_type` — `Content-Type` must be `application/json`. |
+| 502  | Either `runtime_error` (the runtime sidecar failed) or `output_invalid` (the model output failed `spec.outputSchema`). The body includes `raw_output` in the latter case so you can debug the pack. |
+
+## Authentication
+
+Function routes reuse the same data-plane + mgmt-plane validator chain
+as the WebSocket path. By default every request must present a
+credential admitted by at least one configured validator. For dev /
+CI clusters with no externalAuth and an unreadable mgmt-plane public
+key, set `OMNIA_FACADE_ALLOW_UNAUTHENTICATED=true` on the facade pod
+to fall through. Production must never set that flag.
+
+See [Configure Authentication](/how-to/configure-authentication/) for
+the full validator catalogue.
+
+## Invocation recording
+
+When `spec.invocationRecording.state` is `enabled`, the facade writes
+one audit row per call to the `function_invocations` table in
+session-api. Each row carries:
+
+- A SHA-256 hash of the input (raw input is not stored — this keeps
+  PII surface small).
+- The raw output JSON.
+- Status (`success` / `input_invalid` / `output_invalid` / `runtime_error`).
+- Latency, cost, and the OTel trace id of the producing span (when
+  the request context carried a valid span).
+
+Recording is **best-effort**: a session-api outage logs but does not
+fail the user-facing call. The dashboard surfaces these rows on the
+`/functions/{name}` detail page with 1h / 24h / 7d window presets and
+per-window latency + cost sparklines.
+
+To turn recording off, omit `spec.invocationRecording` entirely or set
+`state: disabled`.
+
+## Tips
+
+- **Output schemas should be tight.** The facade returns `502
+  output_invalid` with the raw model output when the response does
+  not match. Tight schemas surface model drift early; loose schemas
+  let bad outputs reach the caller.
+- **One Function per AgentRuntime.** The facade pod serves exactly
+  the function whose `metadata.name` matches its own — there is no
+  per-pod multiplexing in Phase 1.
+- **Schema changes require a Deployment rollout.** The facade compiles
+  schemas once at startup, so changing `spec.inputSchema` /
+  `spec.outputSchema` triggers a Deployment update (existing behaviour
+  for any CRD-driven config).
+- **Use the `examples/echo-function/` directory** in the repository
+  as a working starting point — it ships with a PromptPack, Provider,
+  and AgentRuntime that you can apply and invoke in under a minute.

--- a/docs/src/content/docs/reference/agentruntime.md
+++ b/docs/src/content/docs/reference/agentruntime.md
@@ -17,6 +17,78 @@ kind: AgentRuntime
 
 ## Spec Fields
 
+### `mode`
+
+Selects the runtime shape. Defaults to `agent` when unset, preserving
+the pre-Functions behaviour. See [Define Functions](/how-to/define-functions/)
+for when to pick which.
+
+| Value      | Behaviour |
+|------------|-----------|
+| `agent`    | Long-lived conversational runtime served over WebSocket (`/ws`). Default. |
+| `function` | One-shot HTTP runtime served over `POST /functions/{name}`. Requires `inputSchema` + `outputSchema`. Rejects `facade.type: websocket`. |
+
+```yaml
+spec:
+  mode: function
+```
+
+### `inputSchema`
+
+JSON Schema (Draft 2020-12) the function's request body is validated
+against. Required when `mode: function`; forbidden when `mode: agent`
+(CEL-gated). Stored as a raw JSON object — the runtime uses
+`santhosh-tekuri/jsonschema/v6` to compile and validate.
+
+```yaml
+spec:
+  inputSchema:
+    type: object
+    required: ["text"]
+    properties:
+      text:
+        type: string
+```
+
+### `outputSchema`
+
+JSON Schema the function's response is validated against before being
+returned to the caller. On output-validation failure the facade
+returns HTTP 502 `output_invalid` with the raw model output embedded
+so the pack author can debug schema drift (no in-runtime retry).
+Required when `mode: function`; forbidden when `mode: agent` (CEL-gated).
+
+```yaml
+spec:
+  outputSchema:
+    type: object
+    required: ["summary"]
+    properties:
+      summary:
+        type: string
+```
+
+### `invocationRecording`
+
+Opt-in audit persistence for function-mode runtimes. Each call writes
+one row to the `function_invocations` table in session-api. Recording
+is best-effort — a session-api outage logs but does not fail the
+user-facing call. Ignored (and forbidden via CEL) when `mode: agent`.
+
+| Field | Type | Default | Required |
+|-------|------|---------|----------|
+| `invocationRecording.state` | string | `disabled` | No |
+
+`state` accepts `disabled` or `enabled`. The dashboard surfaces
+enabled-recording rows on `/functions/{name}` with latency + cost
+sparklines per time-window.
+
+```yaml
+spec:
+  invocationRecording:
+    state: enabled
+```
+
 ### `promptPackRef`
 
 Reference to the PromptPack containing agent prompts.

--- a/examples/echo-function/README.md
+++ b/examples/echo-function/README.md
@@ -1,0 +1,101 @@
+# echo-function
+
+A minimum-viable function-mode AgentRuntime that demonstrates the
+Functions Phase 1 surface (#1102 / #1103). It accepts a JSON object
+with one `message` field and returns it as `{"echo": "<message>"}`.
+
+The goal of this example is not to be useful — it's the smallest
+working pattern you can copy and adapt for your own Function.
+
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `agentruntime.yaml` | Function-mode AgentRuntime with input + output JSON Schemas and recording enabled. |
+| `promptpack.yaml`   | Single-prompt PromptPack that instructs the model to copy its input into an `echo` field. |
+| `provider.yaml`     | Provider + Secret for the LLM (Anthropic Claude by default; edit to taste). |
+
+## Apply
+
+```bash
+# 1. Pick a namespace (or use your existing workspace).
+kubectl create namespace echo-demo
+
+# 2. Edit examples/echo-function/provider.yaml — replace REPLACE_ME
+#    with your actual API key, or substitute a different provider
+#    type per docs/reference/provider/.
+
+# 3. Apply the manifests in dependency order.
+kubectl -n echo-demo apply -f examples/echo-function/provider.yaml
+kubectl -n echo-demo apply -f examples/echo-function/promptpack.yaml
+kubectl -n echo-demo apply -f examples/echo-function/agentruntime.yaml
+
+# 4. Wait for the runtime to come up.
+kubectl -n echo-demo wait --for=condition=Ready agentruntime/echo-function --timeout=120s
+```
+
+## Invoke
+
+```bash
+kubectl -n echo-demo port-forward svc/echo-function 8080:8080 &
+
+curl -X POST http://localhost:8080/functions/echo-function \
+  -H "Content-Type: application/json" \
+  -d '{"message": "hello functions"}'
+```
+
+Expected response shape:
+
+```json
+{
+  "output": { "echo": "hello functions" },
+  "invocation_id": "9c0e2c1f-...",
+  "duration_ms": 730,
+  "usage": {
+    "input_tokens": 92,
+    "output_tokens": 14,
+    "cost_usd": 0.0001
+  }
+}
+```
+
+## Inspect
+
+With `spec.invocationRecording.state: enabled` set on the AgentRuntime,
+the facade writes one row per call to the session-api
+`function_invocations` table. Open the dashboard at
+`/functions/echo-function` to see:
+
+- A table of recent invocations (timestamp, status, latency, cost, trace id).
+- Latency + cost sparklines for the selected time window.
+- The resolved input + output schemas as rendered JSON.
+
+## Adapt
+
+To turn this into a real Function:
+
+1. **Tighten the input schema.** Add required fields, `enum`s, length
+   bounds. The facade rejects mis-shaped input with HTTP 400
+   `input_invalid` — *before* the runtime is invoked, so you don't pay
+   for bad calls.
+
+2. **Tighten the output schema.** A loose output schema lets model
+   drift reach your callers. A tight one surfaces drift as HTTP 502
+   `output_invalid` with the raw model output in the response body
+   so you can debug.
+
+3. **Edit the PromptPack.** Replace the echo system prompt with the
+   real task. See `config/samples/omnia_v1alpha1_promptpack.yaml` for
+   the full pack surface (fragments, evals, validators, multi-prompt
+   routing, etc.).
+
+4. **Pick a model.** The default in `provider.yaml` is Claude Haiku
+   for cheap iteration. Production Functions usually want a deterministic
+   model and `temperature: 0` — both already set here.
+
+5. **Decide on recording.** Keep `invocationRecording.state: enabled`
+   for audit / debugging; set `disabled` (or omit the block) to keep
+   invocations ephemeral and skip the session-api write entirely.
+
+See [Define Functions](https://omnia.altairalabs.ai/how-to/define-functions/)
+for the full guide.

--- a/examples/echo-function/agentruntime.yaml
+++ b/examples/echo-function/agentruntime.yaml
@@ -1,0 +1,70 @@
+# echo-function: minimal function-mode AgentRuntime (#1103 Phase 1).
+#
+# Demonstrates the smallest possible Function: it accepts a string,
+# pads it with a fixed prefix, and returns the result. The pack is
+# the source of truth for the prompt; this CR wires the pack +
+# provider + schemas together.
+#
+# Apply order:
+#   kubectl apply -f provider-secret.yaml
+#   kubectl apply -f provider.yaml
+#   kubectl apply -f promptpack.yaml
+#   kubectl apply -f agentruntime.yaml
+#
+# Invoke once it's Ready:
+#   kubectl port-forward svc/echo-function 8080:8080
+#   curl -X POST http://localhost:8080/functions/echo-function \
+#     -H "Content-Type: application/json" \
+#     -d '{"message": "hello"}'
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: echo-function
+spec:
+  mode: function
+  promptPackRef:
+    name: echo-pack
+  facade:
+    type: grpc
+    port: 8080
+  providers:
+    - name: default
+      providerRef:
+        name: echo-provider
+  # JSON Schema for the request body. The facade validates POST
+  # bodies against this before the runtime is invoked; a bad body
+  # gets HTTP 400 input_invalid without spending an LLM call.
+  inputSchema:
+    type: object
+    required: ["message"]
+    properties:
+      message:
+        type: string
+        description: "Text to echo"
+        maxLength: 280
+    additionalProperties: false
+  # JSON Schema for the model output. The facade validates the
+  # response against this before returning it to the caller;
+  # output that doesn't match gets HTTP 502 output_invalid with
+  # the raw model output embedded so the pack author can debug.
+  outputSchema:
+    type: object
+    required: ["echo"]
+    properties:
+      echo:
+        type: string
+    additionalProperties: false
+  # Opt into the function_invocations audit table so the dashboard's
+  # /functions/echo-function page can render a history. Remove this
+  # block (or set state: disabled) to keep invocations ephemeral.
+  invocationRecording:
+    state: enabled
+  runtime:
+    replicas: 1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi

--- a/examples/echo-function/promptpack.yaml
+++ b/examples/echo-function/promptpack.yaml
@@ -1,0 +1,59 @@
+# PromptPack for the echo-function example.
+#
+# This is the minimum viable pack: a single prompt that instructs the
+# model to copy its input into the `echo` field of a JSON response.
+# Production packs add evals, fragments, validators, etc. — see
+# config/samples/omnia_v1alpha1_promptpack.yaml for the full surface.
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: PromptPack
+metadata:
+  name: echo-pack
+spec:
+  source:
+    type: configmap
+    configMapRef:
+      name: echo-pack-contents
+  version: "1.0.0"
+  rollout:
+    type: immediate
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: echo-pack-contents
+data:
+  pack.json: |
+    {
+      "$schema": "https://promptpack.org/schema/latest/promptpack.schema.json",
+      "id": "echo",
+      "name": "Echo Function",
+      "version": "1.0.0",
+      "description": "Echoes the request's `message` field back as `echo`.",
+      "template_engine": {
+        "version": "v1",
+        "syntax": "{{variable}}",
+        "features": ["basic_substitution"]
+      },
+      "prompts": {
+        "default": {
+          "id": "default",
+          "name": "Echo",
+          "description": "Single-turn echo prompt.",
+          "version": "1.0.0",
+          "system_template": "You are an echo service. The user will send a JSON object with a `message` field. Respond with a single JSON object of the form {\"echo\": <message>} and nothing else. Do not summarise, expand, or comment.",
+          "user_template": "{{input}}",
+          "parameters": {
+            "temperature": 0.0,
+            "max_tokens": 512
+          },
+          "variables": [
+            {
+              "name": "input",
+              "type": "string",
+              "required": true,
+              "description": "Raw request body forwarded by the runtime."
+            }
+          ]
+        }
+      }
+    }

--- a/examples/echo-function/provider.yaml
+++ b/examples/echo-function/provider.yaml
@@ -1,0 +1,27 @@
+# Provider for the echo-function example.
+#
+# Edit `spec.type`, `spec.model`, and the Secret below to match the
+# LLM provider you actually want to call. Anthropic Claude is shown
+# here as the default; OpenAI / Bedrock / Vertex / Azure / Ollama
+# all work the same way — see docs/reference/provider.
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: echo-provider
+spec:
+  type: anthropic
+  model: claude-3-5-haiku-latest
+  credentialsRef:
+    secretRef:
+      name: echo-provider-secret
+      key: api-key
+---
+# Replace REPLACE_ME with your actual API key, or generate the Secret
+# out-of-band with `kubectl create secret generic ...`.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: echo-provider-secret
+type: Opaque
+stringData:
+  api-key: REPLACE_ME


### PR DESCRIPTION
## Summary

Closes out Functions Phase 1 (#1102 / #1103). No code paths change — this PR is docs + a worked example.

- **`docs/.../how-to/define-functions.md`** — pack-authoring guide covering when to pick function vs agent, the CRD shape, the invocation contract, full status-code reference, the reused auth chain, and the `invocationRecording` opt-in.
- **`docs/.../reference/agentruntime.md`** — first-class entries for the new `mode`, `inputSchema`, `outputSchema`, and `invocationRecording` spec fields (previously only documented in the generated CRD YAML).
- **`examples/echo-function/`** — minimum-viable applyable Function. A PromptPack that copies `message` into `echo`, paired with an AgentRuntime whose schemas match. README walks an operator from apply → curl → dashboard invocation history in under a minute.
- **`api/CHANGELOG.md`** — PR 7 entry.

## Test plan

- [x] `npm --prefix docs run build` — clean (65 pages built)
- [x] `npm --prefix docs run check-links` — clean (261 links, no broken)
- [x] Manual: confirmed `facade.type: grpc` matches the CRD's CEL gate (the gate rejects lowercase `websocket`, not `WebSocket` — initial draft had this wrong, fixed)
- [x] Manual: confirmed `Provider.spec.credentialsRef.secretRef.{name,key}` shape against the CRD schema before writing the example

