### PR TITLE
feat(facade,agent): function invocations open real sessions (PR 2/3)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,41 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Changed (Functions-as-sessions rework, PR 2/3: function invocations are sessions)
+
+Function-mode pods now open a real `sessions` row at invocation start
+and close it with the terminal status when the response is written.
+Same data model as agent-mode sessions; the runtime's existing
+`OmniaEventStore` machinery feeds `messages`, `tool_calls`,
+`provider_calls`, `eval_results`, and `runtime_events` against the
+same `session_id` (which is the invocation id).
+
+- `FunctionsHandler.WithSessionStore(store, meta)` injects the session
+  dependency. `FunctionSessionMeta` carries the per-pod identity
+  (namespace, agent name, workspace, prompt-pack name + version).
+- Session rows are tagged `["function"]` (constant
+  `facade.FunctionSessionTag`) for fast dashboard filtering.
+- The invocation id is generated at the very top of `ServeHTTP` so
+  `input_invalid` and body-read failures still have a `session_id`
+  for Loki + dashboard correlation. The facade emits a runtime event
+  on these pre-runtime failures (`function.input_invalid`,
+  `function.payload_too_large`, `function.read_body_failed`) so the
+  failure detail is queryable from the session detail page.
+- Outcome → status mapping:
+  - success → `completed`
+  - input_invalid / output_invalid / runtime_error / payload_too_large
+    / read_body_failed / response_write_failed → `error`
+  - `ended_at` is set to the close time on every terminal outcome.
+- Session store failures are best-effort: a session-api outage logs
+  but does not fail the user-facing request — the runtime still
+  produces its result and the audit rows simply land orphaned.
+- `cmd/agent/functions.go` wires the session store via the same
+  `initSessionStore()` the WebSocket path uses. Failure to resolve
+  session-api at startup is logged and non-fatal.
+
+The next PR (3/3) repoints the dashboard `/functions/{name}` detail
+view at the sessions data source.
+
 ### Removed (Functions-as-sessions rework, PR 1/3: rip dedicated infrastructure)
 
 **Breaking — affects Unreleased only; never shipped a release.**

--- a/cmd/agent/functions.go
+++ b/cmd/agent/functions.go
@@ -75,6 +75,22 @@ func runFunctionsFacade(cfg *agent.Config, log logr.Logger, tracingProvider *tra
 
 	handler := facade.NewFunctionsHandler(registry, rc, log)
 
+	// Wire session persistence: each invocation creates one `sessions`
+	// row tagged "function". Failure to resolve session-api isn't
+	// fatal — the runtime still serves the call, audit rows just land
+	// without a parent (matches the pre-PR behaviour).
+	if store, err := initSessionStore(log); err != nil {
+		log.Error(err, "failed to init session store; function invocations will not be recorded")
+	} else {
+		handler = handler.WithSessionStore(store, facade.FunctionSessionMeta{
+			Namespace:         cfg.Namespace,
+			AgentName:         cfg.AgentName,
+			WorkspaceName:     cfg.WorkspaceName,
+			PromptPackName:    cfg.PromptPackName,
+			PromptPackVersion: cfg.PromptPackVersion,
+		})
+	}
+
 	mux := http.NewServeMux()
 	mux.Handle("POST /functions/{name}", buildFunctionAuthMiddleware(cfg, log)(handler))
 	mux.Handle("/metrics", promhttp.Handler())

--- a/examples/echo-function/provider.yaml
+++ b/examples/echo-function/provider.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   type: anthropic
   model: claude-3-5-haiku-latest
-  credentialsRef:
+  credential:
     secretRef:
       name: echo-provider-secret
       key: api-key

--- a/internal/facade/functions_handler.go
+++ b/internal/facade/functions_handler.go
@@ -24,14 +24,32 @@ import (
 	"io"
 	"mime"
 	"net/http"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/santhosh-tekuri/jsonschema/v6"
 
+	"github.com/altairalabs/omnia/internal/session"
 	"github.com/altairalabs/omnia/pkg/logctx"
 	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
 )
+
+// FunctionSessionMeta is the per-pod identity the facade stamps onto
+// each invocation's session row. One AgentRuntime per function-mode
+// pod, so these are stable for the lifetime of the handler.
+type FunctionSessionMeta struct {
+	Namespace         string
+	AgentName         string
+	WorkspaceName     string
+	PromptPackName    string
+	PromptPackVersion string
+}
+
+// FunctionSessionTag marks a sessions row as belonging to a
+// function-mode invocation. Dashboards filter on this to surface
+// function history without crossing into agent-mode sessions.
+const FunctionSessionTag = "function"
 
 // FunctionSpec is the per-Function metadata the facade needs at request
 // time. The operator loads spec.inputSchema / spec.outputSchema from the
@@ -58,26 +76,32 @@ type InvocationInvoker interface {
 
 // FunctionsHandler serves POST /functions/{name} for function-mode
 // AgentRuntimes. The handler is the single source of truth for input
-// and output JSON-Schema validation (the runtime is intentionally
-// schema-agnostic; see PR 2 / #1105).
+// and output JSON-Schema validation; the runtime is schema-agnostic.
 //
-// Persistence: function invocations are recorded as ordinary `sessions`
-// rows by the runtime layer (tagged "function"). The handler itself
-// no longer carries a dedicated recorder — see the Functions-as-sessions
-// rework that replaced the standalone function_invocations table.
+// Persistence: every invocation creates one `sessions` row (tagged
+// "function"). PromptKit's OmniaEventStore fills in the downstream
+// audit tables (messages / tool_calls / provider_calls / eval_results
+// / runtime_events) keyed off that session_id, identically to agent
+// mode. The handler closes the session at the end of the call with
+// the final status (completed | error).
 type FunctionsHandler struct {
-	registry FunctionRegistry
-	invoker  InvocationInvoker
-	log      logr.Logger
+	registry     FunctionRegistry
+	invoker      InvocationInvoker
+	sessionStore session.Store
+	sessionMeta  FunctionSessionMeta
+	log          logr.Logger
 
 	// maxBodyBytes caps the incoming request body. Defaults to 1 MiB,
-	// matching the WS path's reasonable upper bound. Function payloads
-	// are JSON; if someone needs more they can lift this via PR 4.
+	// matching the WS path's reasonable upper bound.
 	maxBodyBytes int64
 }
 
 // NewFunctionsHandler constructs a FunctionsHandler. log may be a
 // zero-value logr.Logger; the handler tolerates a nil sink.
+//
+// Session persistence is opt-in via WithSessionStore. When unset, the
+// handler runs in transient mode — useful for tests that don't care
+// about audit rows; production wires the store in cmd/agent.
 func NewFunctionsHandler(registry FunctionRegistry, invoker InvocationInvoker, log logr.Logger) *FunctionsHandler {
 	if log.GetSink() == nil {
 		log = logr.Discard()
@@ -88,6 +112,15 @@ func NewFunctionsHandler(registry FunctionRegistry, invoker InvocationInvoker, l
 		log:          log.WithName("functions-handler"),
 		maxBodyBytes: 1 << 20, // 1 MiB
 	}
+}
+
+// WithSessionStore wires session persistence onto the handler. Each
+// invocation creates one `sessions` row at request start and closes
+// it with the terminal status when the response is written.
+func (h *FunctionsHandler) WithSessionStore(store session.Store, meta FunctionSessionMeta) *FunctionsHandler {
+	h.sessionStore = store
+	h.sessionMeta = meta
+	return h
 }
 
 // errorResponse is the JSON envelope returned on 4xx errors. The 502
@@ -141,26 +174,47 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Generate the invocation ID up-front so input_invalid still has a
+	// session_id for Loki + dashboard correlation. ctx carries it via
+	// logctx so every log line under this scope can be joined back.
+	invocationID := uuid.NewString()
+	ctx := logctx.WithInvocationID(r.Context(), invocationID)
+	log := h.log.WithValues("function", name, "invocationID", invocationID)
+
+	// Open the session row at the very start. The runtime's
+	// OmniaEventStore writes downstream audit rows (messages,
+	// tool_calls, provider_calls, eval_results, runtime_events)
+	// against this session_id. closeSession patches the terminal
+	// status before we return.
+	h.openSession(ctx, invocationID, log)
+	finalStatus := session.SessionStatusCompleted
+	var failureEvt *session.RuntimeEvent
+	defer func() {
+		h.closeSession(ctx, invocationID, finalStatus, failureEvt, log)
+	}()
+
 	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, h.maxBodyBytes))
 	if err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
+			finalStatus = session.SessionStatusError
+			failureEvt = newFailureEvent(invocationID, "function.payload_too_large", err.Error())
 			writeError(w, http.StatusRequestEntityTooLarge, "payload_too_large",
 				fmt.Sprintf("request body exceeds %d bytes", h.maxBodyBytes))
 			return
 		}
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.read_body_failed", err.Error())
 		writeError(w, http.StatusBadRequest, "read_body_failed", err.Error())
 		return
 	}
 
 	if err := ValidateJSON(spec.InputSchema, body); err != nil {
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.input_invalid", err.Error())
 		writeError(w, http.StatusBadRequest, "input_invalid", err.Error())
 		return
 	}
-
-	invocationID := uuid.NewString()
-	ctx := logctx.WithInvocationID(r.Context(), invocationID)
-	log := h.log.WithValues("function", name, "invocationID", invocationID)
 
 	resp, err := h.invoker.Invoke(ctx, &runtimev1.InvocationRequest{
 		InputJson:    string(body),
@@ -168,33 +222,96 @@ func (h *FunctionsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		log.Error(err, "runtime invoke failed")
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.runtime_error", err.Error())
 		writeError(w, http.StatusBadGateway, "runtime_error", err.Error())
 		return
 	}
 
 	rawOutput := []byte(resp.GetOutputJson())
 	if err := ValidateJSON(spec.OutputSchema, rawOutput); err != nil {
-		// 502 with raw output so the author can debug the pack. No
-		// in-runtime retry.
+		// 502 with raw output so the author can debug the pack.
 		log.Error(err, "function output failed schema validation",
 			"outputBytes", len(rawOutput))
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.output_invalid", err.Error())
 		writeOutputValidationError(w, err, rawOutput)
 		return
 	}
 
-	// Echo the response shape: { output: <model output>, usage, duration_ms, invocation_id }.
-	// output is forwarded as raw JSON (already validated above). The
-	// invocationID returned is always the facade-generated one — the
-	// runtime echoes it but the facade is the source of truth, so a
-	// runtime that returned a different (or empty) value would still
-	// see this id in the response and in correlation traces.
 	if err := writeSuccess(w, rawOutput, invocationID, resp); err != nil {
 		log.Error(err, "failed to write success response")
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.response_write_failed", err.Error())
 		return
 	}
 	log.V(1).Info("function invocation complete",
 		"durationMs", resp.GetDurationMs(),
 		"outputBytes", len(rawOutput))
+}
+
+// openSession creates the session row for an invocation. Failure is
+// best-effort: a session-api outage logs but does not fail the
+// user-facing request — the runtime can still produce its result and
+// the downstream audit rows simply land orphaned (parent missing).
+func (h *FunctionsHandler) openSession(ctx context.Context, invocationID string, log logr.Logger) {
+	if h.sessionStore == nil {
+		return
+	}
+	if _, err := h.sessionStore.CreateSession(ctx, session.CreateSessionOptions{
+		ID:                invocationID,
+		AgentName:         h.sessionMeta.AgentName,
+		Namespace:         h.sessionMeta.Namespace,
+		WorkspaceName:     h.sessionMeta.WorkspaceName,
+		PromptPackName:    h.sessionMeta.PromptPackName,
+		PromptPackVersion: h.sessionMeta.PromptPackVersion,
+		Tags:              []string{FunctionSessionTag},
+	}); err != nil {
+		log.Error(err, "failed to create session row for function invocation (non-fatal)")
+	}
+}
+
+// closeSession writes the terminal status (and any pre-runtime
+// failure event the facade itself observed) before returning. Errors
+// are logged and not propagated.
+func (h *FunctionsHandler) closeSession(
+	ctx context.Context,
+	invocationID string,
+	status session.SessionStatus,
+	failure *session.RuntimeEvent,
+	log logr.Logger,
+) {
+	if h.sessionStore == nil {
+		return
+	}
+	if failure != nil {
+		if err := h.sessionStore.RecordRuntimeEvent(ctx, invocationID, *failure); err != nil {
+			log.Error(err, "failed to record function failure event (non-fatal)",
+				"eventType", failure.EventType)
+		}
+	}
+	if err := h.sessionStore.UpdateSessionStatus(ctx, invocationID, session.SessionStatusUpdate{
+		SetStatus:  status,
+		SetEndedAt: time.Now().UTC(),
+	}); err != nil {
+		log.Error(err, "failed to close session for function invocation (non-fatal)",
+			"status", status)
+	}
+}
+
+// newFailureEvent shapes a RuntimeEvent for a facade-side outcome
+// the runtime never saw (input_invalid, body-read errors,
+// output-validation rejection, response-write failure). PromptKit's
+// own loop fires its own events for inner failures, so this is
+// scoped strictly to the boundary.
+func newFailureEvent(invocationID, eventType, errMessage string) *session.RuntimeEvent {
+	return &session.RuntimeEvent{
+		ID:           uuid.NewString(),
+		SessionID:    invocationID,
+		EventType:    eventType,
+		ErrorMessage: errMessage,
+		Timestamp:    time.Now().UTC(),
+	}
 }
 
 // writeSuccess emits the function-mode 200 response envelope. invocationID

--- a/internal/facade/functions_handler_test.go
+++ b/internal/facade/functions_handler_test.go
@@ -23,12 +23,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/altairalabs/omnia/internal/session"
 	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
 )
 
@@ -340,4 +342,205 @@ func TestMapFunctionRegistry_RegisterIgnoresInvalidSpecs(t *testing.T) {
 	if _, ok := reg.GetFunction(testFunctionName); !ok {
 		t.Errorf("registry must store valid specs after silent-dropped invalid ones")
 	}
+}
+
+// stubSessionStore captures the calls the facade makes against the
+// session store so tests can assert the session lifecycle. The
+// methods the facade doesn't touch are left to delegate to the
+// embedded Store; that field is nil so any unexpected call panics —
+// which is what we want as a guardrail.
+type stubSessionStore struct {
+	session.Store
+
+	mu        sync.Mutex
+	creates   []session.CreateSessionOptions
+	events    []session.RuntimeEvent
+	statuses  []session.SessionStatusUpdate
+	createErr error
+	updateErr error
+	eventErr  error
+}
+
+func (s *stubSessionStore) CreateSession(_ context.Context, opts session.CreateSessionOptions) (*session.Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creates = append(s.creates, opts)
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	return &session.Session{ID: opts.ID}, nil
+}
+
+func (s *stubSessionStore) UpdateSessionStatus(_ context.Context, _ string, update session.SessionStatusUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statuses = append(s.statuses, update)
+	return s.updateErr
+}
+
+func (s *stubSessionStore) RecordRuntimeEvent(_ context.Context, _ string, evt session.RuntimeEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, evt)
+	return s.eventErr
+}
+
+func newHandlerWithSession(
+	t *testing.T,
+	specs map[string]*FunctionSpec,
+	invoker InvocationInvoker,
+) (*FunctionsHandler, *stubSessionStore) {
+	t.Helper()
+	store := &stubSessionStore{}
+	h := newHandler(t, specs, invoker).WithSessionStore(store, FunctionSessionMeta{
+		Namespace:         "ns-test",
+		AgentName:         "summarizer",
+		WorkspaceName:     "ws-test",
+		PromptPackName:    "summarizer-pack",
+		PromptPackVersion: "1.0.0",
+	})
+	return h, store
+}
+
+func TestFunctionsHandler_Session_OpenedAndClosedOnHappyPath(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{OutputJson: `{}`, DurationMs: 5}}
+	h, store := newHandlerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	require.Len(t, store.creates, 1, "session must be opened exactly once")
+	opts := store.creates[0]
+	assert.Equal(t, "ns-test", opts.Namespace)
+	assert.Equal(t, "summarizer", opts.AgentName)
+	assert.Equal(t, "ws-test", opts.WorkspaceName)
+	assert.Equal(t, "summarizer-pack", opts.PromptPackName)
+	assert.Equal(t, "1.0.0", opts.PromptPackVersion)
+	assert.Equal(t, []string{FunctionSessionTag}, opts.Tags)
+	assert.NotEmpty(t, opts.ID, "session id must be populated up-front so input_invalid still has a correlation key")
+
+	require.Len(t, store.statuses, 1, "session must be closed exactly once")
+	assert.Equal(t, session.SessionStatusCompleted, store.statuses[0].SetStatus)
+	assert.False(t, store.statuses[0].SetEndedAt.IsZero(), "ended_at must be populated on close")
+	assert.Empty(t, store.events, "no failure events on the happy path")
+}
+
+func TestFunctionsHandler_Session_InputInvalidClosesAsError(t *testing.T) {
+	// input_invalid is the critical case: the runtime never runs, but
+	// the session row must still exist (with status=error + a runtime
+	// event carrying the validator error) so operators can pivot from
+	// the Loki log line back to a row in the dashboard.
+	inputSchema, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{} // must not be called
+	h, store := newHandlerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Nil(t, invoker.lastReq, "runtime must NOT be called when input is invalid")
+
+	require.Len(t, store.creates, 1)
+	require.Len(t, store.statuses, 1)
+	assert.Equal(t, session.SessionStatusError, store.statuses[0].SetStatus)
+
+	require.Len(t, store.events, 1, "input_invalid must emit a failure runtime event")
+	assert.Equal(t, "function.input_invalid", store.events[0].EventType)
+	assert.NotEmpty(t, store.events[0].ErrorMessage)
+}
+
+func TestFunctionsHandler_Session_RuntimeErrorClosesAsError(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{err: errors.New("upstream down")}
+	h, store := newHandlerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+
+	require.Len(t, store.statuses, 1)
+	assert.Equal(t, session.SessionStatusError, store.statuses[0].SetStatus)
+	require.Len(t, store.events, 1)
+	assert.Equal(t, "function.runtime_error", store.events[0].EventType)
+	assert.Contains(t, store.events[0].ErrorMessage, "upstream down")
+}
+
+func TestFunctionsHandler_Session_OutputInvalidClosesAsError(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{OutputJson: `{"wrong":"shape"}`}}
+	h, store := newHandlerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusBadGateway, rec.Code)
+
+	require.Len(t, store.statuses, 1)
+	assert.Equal(t, session.SessionStatusError, store.statuses[0].SetStatus)
+	require.Len(t, store.events, 1)
+	assert.Equal(t, "function.output_invalid", store.events[0].EventType)
+}
+
+func TestFunctionsHandler_Session_StoreFailuresAreNonFatal(t *testing.T) {
+	// A store outage must not break the user-facing call — the runtime
+	// still produces a result, the audit row just ends up orphaned.
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{OutputJson: `{}`}}
+	h, store := newHandlerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+	store.createErr = errors.New("session-api down")
+	store.updateErr = errors.New("session-api still down")
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	assert.Equal(t, http.StatusOK, rec.Code,
+		"store failure must not fail the user-facing request")
+}
+
+func TestFunctionsHandler_Session_TransientWhenStoreUnwired(t *testing.T) {
+	// No WithSessionStore call → transient mode (used by tests today).
+	// The handler must still serve the call cleanly, just without any
+	// audit-row writes.
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	invoker := &stubInvoker{resp: &runtimev1.InvocationResponse{OutputJson: `{}`}}
+	h := newHandler(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, invoker)
+
+	rec := httptest.NewRecorder()
+	muxFor(h).ServeHTTP(rec, newJSONPost(t, "/functions/"+testFunctionName, `{}`))
+	require.Equal(t, http.StatusOK, rec.Code)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -113,6 +113,186 @@ func ensureManagerDeployed() error {
 	return nil
 }
 
+// ensureSessionApiDeployed deploys Postgres + the e2e session-api into
+// omnia-system. Idempotent: a fast no-op when e2e-session-api is
+// already Ready. Mirrors ensureManagerDeployed so any Ordered container
+// that needs session-api before the "Omnia CRDs" BeforeAll runs (e.g.
+// the function-mode suite, which ginkgo orders ahead of Manager) can
+// guarantee its prerequisite without duplicating the full YAML.
+func ensureSessionApiDeployed() error {
+	if predeployed {
+		return nil
+	}
+	checkCmd := exec.Command("kubectl", "get", "deployment", "e2e-session-api",
+		"-n", namespace, "-o", "jsonpath={.status.readyReplicas}")
+	if out, err := utils.Run(checkCmd); err == nil && out != "" && out != "0" {
+		return nil
+	}
+
+	postgresManifest := `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: omnia-postgres
+  namespace: omnia-system
+type: Opaque
+stringData:
+  connection-string: "postgres://omnia:omnia@e2e-postgres.omnia-system.svc.cluster.local:5432/omnia?sslmode=disable"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-postgres
+  namespace: omnia-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: e2e-postgres
+  template:
+    metadata:
+      labels:
+        app: e2e-postgres
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 70
+        fsGroup: 70
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: postgres
+        image: pgvector/pgvector:pg17
+        ports:
+        - containerPort: 5432
+        env:
+        - name: POSTGRES_USER
+          value: omnia
+        - name: POSTGRES_PASSWORD
+          value: omnia
+        - name: POSTGRES_DB
+          value: omnia
+        - name: PGDATA
+          value: /tmp/pgdata
+        readinessProbe:
+          exec:
+            command: ["pg_isready", "-U", "omnia"]
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-postgres
+  namespace: omnia-system
+spec:
+  selector:
+    app: e2e-postgres
+  ports:
+  - port: 5432
+    targetPort: 5432
+`
+	pgCmd := exec.Command("kubectl", "apply", "-f", "-")
+	pgCmd.Stdin = strings.NewReader(postgresManifest)
+	if _, err := utils.Run(pgCmd); err != nil {
+		return fmt.Errorf("apply postgres: %w", err)
+	}
+
+	// Wait for Postgres to be ready before deploying session-api so the
+	// readiness probe gate doesn't bounce the api pod.
+	pgReadyDeadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(pgReadyDeadline) {
+		c := exec.Command("kubectl", "get", "pods", "-n", namespace,
+			"-l", "app=e2e-postgres",
+			"-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+		if out, err := utils.Run(c); err == nil && out == "True" {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+
+	sessionApiManifest := fmt.Sprintf(`
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: e2e-session-api
+  namespace: omnia-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: e2e-session-api
+  template:
+    metadata:
+      labels:
+        app: e2e-session-api
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: session-api
+        image: %s
+        ports:
+        - name: api
+          containerPort: 8080
+        - name: health
+          containerPort: 8081
+        env:
+        - name: POSTGRES_CONN
+          valueFrom:
+            secretKeyRef:
+              name: omnia-postgres
+              key: connection-string
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: e2e-session-api
+  namespace: omnia-system
+spec:
+  selector:
+    app: e2e-session-api
+  ports:
+  - port: 8080
+    targetPort: 8080
+`, sessionApiImage)
+	apiCmd := exec.Command("kubectl", "apply", "-f", "-")
+	apiCmd.Stdin = strings.NewReader(sessionApiManifest)
+	if _, err := utils.Run(apiCmd); err != nil {
+		return fmt.Errorf("apply session-api: %w", err)
+	}
+
+	apiReadyDeadline := time.Now().Add(4 * time.Minute)
+	for time.Now().Before(apiReadyDeadline) {
+		c := exec.Command("kubectl", "get", "pods", "-n", namespace,
+			"-l", "app=e2e-session-api",
+			"-o", "jsonpath={.items[0].status.conditions[?(@.type=='Ready')].status}")
+		if out, err := utils.Run(c); err == nil && out == "True" {
+			return nil
+		}
+		time.Sleep(time.Second)
+	}
+	return fmt.Errorf("e2e-session-api did not become Ready within 4 minutes")
+}
+
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -261,18 +261,9 @@ metadata:
   namespace: %[1]s
 spec:
   restartPolicy: Never
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-    seccompProfile:
-      type: RuntimeDefault
   containers:
   - name: python
     image: python:3.11-slim
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop: ["ALL"]
     command: ["sh", "-c"]
     args:
     - |

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -67,6 +67,14 @@ var _ = Describe("Functions mode", Ordered, Label("functions"), func() {
 		By("ensuring CRDs are installed and the controller-manager is deployed")
 		Expect(ensureManagerDeployed()).To(Succeed())
 
+		// session-api + postgres land in omnia-system. The existing
+		// "Omnia CRDs" Describe deploys them in its BeforeAll, but
+		// ginkgo orders our Describe ahead of it — without this
+		// idempotent helper the test pod's `GET /api/v1/sessions` blows
+		// up with a DNS NXDOMAIN because the Service doesn't exist yet.
+		By("ensuring session-api + postgres are deployed in omnia-system")
+		Expect(ensureSessionApiDeployed()).To(Succeed())
+
 		By("creating the test-functions namespace if absent")
 		cmd := exec.Command("kubectl", "create", "ns", functionsNamespace)
 		_, _ = utils.Run(cmd) // tolerate AlreadyExists

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -94,8 +94,6 @@ spec:
     configMapRef:
       name: test-fn-prompts
   version: "1.0.0"
-  rollout:
-    type: immediate
 `
 		applyCmd := exec.Command("kubectl", "apply", "-f", "-")
 		applyCmd.Stdin = strings.NewReader(promptPackManifest)

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -52,6 +52,14 @@ var _ = Describe("Functions mode", Ordered, Label("functions"), func() {
 	)
 
 	BeforeAll(func() {
+		// Same idempotent setup the other Describes call: installs the
+		// operator CRDs (PromptPack, Provider, AgentRuntime) and the
+		// controller-manager. Without this, kubectl apply against
+		// PromptPack errors with "no matches for kind PromptPack"
+		// because we run before Skills' / Manager's BeforeAll.
+		By("ensuring CRDs are installed and the controller-manager is deployed")
+		Expect(ensureManagerDeployed()).To(Succeed())
+
 		By("creating the test-agents namespace if absent")
 		cmd := exec.Command("kubectl", "create", "ns", agentsNamespace)
 		_, _ = utils.Run(cmd) // tolerate AlreadyExists

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -44,6 +44,13 @@ import (
 // out of scope for PR 2. The failure path is what the user explicitly
 // called out: "We'll need click-through from the sessionId into the
 // Loki logs to troubleshoot."
+// functionsNamespace is a dedicated namespace for this suite. Other
+// suites (Skills, Doctor, Policy, the session-test in e2e_test.go)
+// share `test-agents` and stomp on each other's create / delete; this
+// suite uses its own namespace so a sibling AfterAll mid-deleting
+// test-agents can't race our BeforeAll's `kubectl apply`.
+const functionsNamespace = "test-functions"
+
 var _ = Describe("Functions mode", Ordered, Label("functions"), func() {
 	const (
 		functionName       = "test-fn"
@@ -60,8 +67,8 @@ var _ = Describe("Functions mode", Ordered, Label("functions"), func() {
 		By("ensuring CRDs are installed and the controller-manager is deployed")
 		Expect(ensureManagerDeployed()).To(Succeed())
 
-		By("creating the test-agents namespace if absent")
-		cmd := exec.Command("kubectl", "create", "ns", agentsNamespace)
+		By("creating the test-functions namespace if absent")
+		cmd := exec.Command("kubectl", "create", "ns", functionsNamespace)
 		_, _ = utils.Run(cmd) // tolerate AlreadyExists
 
 		By("creating a minimal PromptPack ConfigMap + CR")
@@ -70,7 +77,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: test-fn-prompts
-  namespace: test-agents
+  namespace: test-functions
 data:
   pack.json: |
     {
@@ -95,7 +102,7 @@ apiVersion: omnia.altairalabs.ai/v1alpha1
 kind: PromptPack
 metadata:
   name: test-fn-prompts
-  namespace: test-agents
+  namespace: test-functions
 spec:
   source:
     type: configmap
@@ -117,7 +124,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: test-fn-provider
-  namespace: test-agents
+  namespace: test-functions
 type: Opaque
 stringData:
   api-key: mock-not-a-real-key
@@ -126,7 +133,7 @@ apiVersion: omnia.altairalabs.ai/v1alpha1
 kind: Provider
 metadata:
   name: test-fn-provider
-  namespace: test-agents
+  namespace: test-functions
 spec:
   type: mock
   credential:
@@ -182,7 +189,7 @@ spec:
     - name: default
       providerRef:
         name: %[4]s
-`, functionName, agentsNamespace, functionPackName, functionProviderID)
+`, functionName, functionsNamespace, functionPackName, functionProviderID)
 		arCmd := exec.Command("kubectl", "apply", "-f", "-")
 		arCmd.Stdin = strings.NewReader(arManifest)
 		_, err = utils.Run(arCmd)
@@ -196,11 +203,11 @@ spec:
 				return
 			}
 			_, _ = fmt.Fprintf(GinkgoWriter, "\n=== DEBUG: function-mode setup failed ===\n")
-			arGet := exec.Command("kubectl", "get", "agentruntime", functionName, "-n", agentsNamespace, "-o", "yaml")
+			arGet := exec.Command("kubectl", "get", "agentruntime", functionName, "-n", functionsNamespace, "-o", "yaml")
 			if out, e := utils.Run(arGet); e == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "AgentRuntime:\n%s\n", out)
 			}
-			events := exec.Command("kubectl", "get", "events", "-n", agentsNamespace, "--sort-by=.lastTimestamp")
+			events := exec.Command("kubectl", "get", "events", "-n", functionsNamespace, "--sort-by=.lastTimestamp")
 			if out, e := utils.Run(events); e == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Events:\n%s\n", out)
 			}
@@ -216,7 +223,7 @@ spec:
 		By("waiting for the function-mode Deployment to be Ready")
 		verifyReady := func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "deployment", functionName,
-				"-n", agentsNamespace,
+				"-n", functionsNamespace,
 				"-o", "jsonpath={.status.readyReplicas}")
 			out, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())
@@ -226,18 +233,13 @@ spec:
 	})
 
 	AfterAll(func() {
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "agentruntime", functionName,
-			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "promptpack", functionPackName,
-			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "provider", functionProviderID,
-			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "secret", functionProviderID,
-			"-n", agentsNamespace, "--ignore-not-found"))
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "configmap", functionPackName,
-			"-n", agentsNamespace, "--ignore-not-found"))
-		_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", "fn-mode-test",
-			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
+		// Single-shot cleanup: deleting the namespace removes everything
+		// we created inside it (CR + ConfigMap + Secret + Pod + Service +
+		// Deployment owned by the operator). The other Describes share
+		// test-agents so they enumerate individual resources; this suite
+		// owns its namespace and gets to do the simple thing.
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "ns",
+			functionsNamespace, "--ignore-not-found", "--timeout=60s"))
 	})
 
 	It("creates a session row with status=error on input_invalid", func() {
@@ -351,7 +353,7 @@ spec:
 
       print("PASS: function invocation recorded as a session with status=error + failure event")
       PYTHON_SCRIPT
-`, agentsNamespace, functionName, sessionApiURL)
+`, functionsNamespace, functionName, sessionApiURL)
 		applyCmd := exec.Command("kubectl", "apply", "-f", "-")
 		applyCmd.Stdin = strings.NewReader(testManifest)
 		_, err := utils.Run(applyCmd)
@@ -362,19 +364,19 @@ spec:
 				return
 			}
 			_, _ = fmt.Fprintf(GinkgoWriter, "\n=== DEBUG: function-mode session-row test failed ===\n")
-			logCmd := exec.Command("kubectl", "logs", "fn-mode-test", "-n", agentsNamespace)
+			logCmd := exec.Command("kubectl", "logs", "fn-mode-test", "-n", functionsNamespace)
 			if out, e := utils.Run(logCmd); e == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Test pod logs:\n%s\n", out)
 			}
 			facadeCmd := exec.Command("kubectl", "logs",
-				"-n", agentsNamespace,
+				"-n", functionsNamespace,
 				"-l", "app.kubernetes.io/instance="+functionName,
 				"-c", "facade", "--tail=200")
 			if out, e := utils.Run(facadeCmd); e == nil {
 				_, _ = fmt.Fprintf(GinkgoWriter, "Facade logs:\n%s\n", out)
 			}
 			runtimeCmd := exec.Command("kubectl", "logs",
-				"-n", agentsNamespace,
+				"-n", functionsNamespace,
 				"-l", "app.kubernetes.io/instance="+functionName,
 				"-c", "runtime", "--tail=200")
 			if out, e := utils.Run(runtimeCmd); e == nil {
@@ -391,7 +393,7 @@ spec:
 		By("waiting for the test pod to Succeed")
 		verifyComplete := func(g Gomega) {
 			cmd := exec.Command("kubectl", "get", "pod", "fn-mode-test",
-				"-n", agentsNamespace, "-o", "jsonpath={.status.phase}")
+				"-n", functionsNamespace, "-o", "jsonpath={.status.phase}")
 			out, err := utils.Run(cmd)
 			g.Expect(err).NotTo(HaveOccurred())
 			// Failed is terminal — if it landed there, drop out of the
@@ -401,7 +403,7 @@ spec:
 		Eventually(verifyComplete, 3*time.Minute, 3*time.Second).Should(Succeed())
 
 		By("confirming the test pod reported PASS")
-		cmd := exec.Command("kubectl", "logs", "fn-mode-test", "-n", agentsNamespace)
+		cmd := exec.Command("kubectl", "logs", "fn-mode-test", "-n", functionsNamespace)
 		out, err := utils.Run(cmd)
 		Expect(err).NotTo(HaveOccurred(), "failed to read test pod logs")
 		Expect(out).To(ContainSubstring("PASS:"),

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -156,7 +156,7 @@ spec:
 `
 		applyCmd := exec.Command("kubectl", "apply", "-f", "-")
 		applyCmd.Stdin = strings.NewReader(promptPackManifest)
-		_, err := utils.Run(applyCmd)
+		_, err = utils.Run(applyCmd)
 		Expect(err).NotTo(HaveOccurred(), "failed to apply PromptPack")
 
 		By("creating a mock Provider for the function pod")

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -84,16 +84,16 @@ data:
       "id": "test-fn-prompts",
       "name": "test-fn-prompts",
       "version": "1.0.0",
+      "template_engine": {
+        "version": "v1",
+        "syntax": "{{variable}}"
+      },
       "prompts": {
         "default": {
           "id": "default",
           "name": "default",
           "version": "1.0.0",
-          "system_template": "You are a test echoer.",
-          "user_template": "{{input}}",
-          "variables": [
-            {"name": "input", "type": "string", "required": true}
-          ]
+          "system_template": "You are a test echoer."
         }
       }
     }

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -381,9 +381,15 @@ spec:
           print(f"ERROR: listing events failed: {resp.text[:200]}")
           sys.exit(1)
       events_body = resp.json()
-      events = events_body.get("events") or events_body.get("data") or events_body
-      if not isinstance(events, list):
-          events = events.get("events", []) if isinstance(events, dict) else []
+      # The events endpoint returns either a bare array or an envelope
+      # like {"events": [...]} / {"data": [...]} depending on version.
+      # Handle both without assuming a particular shape.
+      if isinstance(events_body, list):
+          events = events_body
+      elif isinstance(events_body, dict):
+          events = events_body.get("events") or events_body.get("data") or []
+      else:
+          events = []
       print(f"  found {len(events)} events")
       matched = [e for e in events if e.get("eventType") == "function.input_invalid"]
       if not matched:

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -79,6 +79,42 @@ var _ = Describe("Functions mode", Ordered, Label("functions"), func() {
 		cmd := exec.Command("kubectl", "create", "ns", functionsNamespace)
 		_, _ = utils.Run(cmd) // tolerate AlreadyExists
 
+		// The facade's initSessionStore() resolves the session-api URL by
+		// looking up a Workspace CR. Without one for our namespace, it
+		// falls back to MemoryStore — at which point function invocations
+		// "succeed" but no row ever lands in Postgres, so the e2e's
+		// assertion (`GET /sessions?namespace=...&agent=...`) returns
+		// zero rows. Create a Workspace pointing at the e2e session-api.
+		workspaceManifest := fmt.Sprintf(`
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Workspace
+metadata:
+  name: e2e-functions-workspace
+spec:
+  displayName: E2E Functions Workspace
+  namespace:
+    name: %[1]s
+  services:
+    - name: default
+      mode: external
+      external:
+        sessionURL: "%[2]s"
+        memoryURL: "%[2]s"
+`, functionsNamespace, sessionApiURL)
+		wsCmd := exec.Command("kubectl", "apply", "-f", "-")
+		wsCmd.Stdin = strings.NewReader(workspaceManifest)
+		_, err := utils.Run(wsCmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to apply Workspace")
+		By("waiting for the Workspace to report Ready")
+		verifyWs := func(g Gomega) {
+			c := exec.Command("kubectl", "get", "workspace", "e2e-functions-workspace",
+				"-o", "jsonpath={.status.services[0].ready}")
+			out, e := utils.Run(c)
+			g.Expect(e).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("true"))
+		}
+		Eventually(verifyWs, 2*time.Minute, 2*time.Second).Should(Succeed())
+
 		By("creating a minimal PromptPack ConfigMap + CR")
 		promptPackManifest := `
 apiVersion: v1
@@ -243,9 +279,10 @@ spec:
 	AfterAll(func() {
 		// Single-shot cleanup: deleting the namespace removes everything
 		// we created inside it (CR + ConfigMap + Secret + Pod + Service +
-		// Deployment owned by the operator). The other Describes share
-		// test-agents so they enumerate individual resources; this suite
-		// owns its namespace and gets to do the simple thing.
+		// Deployment owned by the operator). The Workspace is
+		// cluster-scoped so it needs a separate delete.
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "workspace",
+			"e2e-functions-workspace", "--ignore-not-found", "--timeout=30s"))
 		_, _ = utils.Run(exec.Command("kubectl", "delete", "ns",
 			functionsNamespace, "--ignore-not-found", "--timeout=60s"))
 	})

--- a/test/e2e/function_mode_e2e_test.go
+++ b/test/e2e/function_mode_e2e_test.go
@@ -1,0 +1,413 @@
+//go:build e2e
+// +build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/altairalabs/omnia/test/utils"
+)
+
+// Function-mode end-to-end suite. The load-bearing claim under test:
+// a function invocation creates a `sessions` row that operators can
+// pivot from the facade's Loki log line back to a dashboard row —
+// even when the call fails before the runtime is invoked (e.g.
+// input_invalid). This was the entire point of the Functions-as-
+// sessions rework; if it doesn't hold, the rework is a regression.
+//
+// The happy path (success → status=completed with model output) is
+// intentionally NOT exercised here — the mock provider doesn't emit
+// schema-conforming JSON without per-test scenario config, which is
+// out of scope for PR 2. The failure path is what the user explicitly
+// called out: "We'll need click-through from the sessionId into the
+// Loki logs to troubleshoot."
+var _ = Describe("Functions mode", Ordered, Label("functions"), func() {
+	const (
+		functionName       = "test-fn"
+		functionPackName   = "test-fn-prompts"
+		functionProviderID = "test-fn-provider"
+	)
+
+	BeforeAll(func() {
+		By("creating the test-agents namespace if absent")
+		cmd := exec.Command("kubectl", "create", "ns", agentsNamespace)
+		_, _ = utils.Run(cmd) // tolerate AlreadyExists
+
+		By("creating a minimal PromptPack ConfigMap + CR")
+		promptPackManifest := `
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: test-fn-prompts
+  namespace: test-agents
+data:
+  pack.json: |
+    {
+      "id": "test-fn-prompts",
+      "name": "test-fn-prompts",
+      "version": "1.0.0",
+      "prompts": {
+        "default": {
+          "id": "default",
+          "name": "default",
+          "version": "1.0.0",
+          "system_template": "You are a test echoer.",
+          "user_template": "{{input}}",
+          "variables": [
+            {"name": "input", "type": "string", "required": true}
+          ]
+        }
+      }
+    }
+---
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: PromptPack
+metadata:
+  name: test-fn-prompts
+  namespace: test-agents
+spec:
+  source:
+    type: configmap
+    configMapRef:
+      name: test-fn-prompts
+  version: "1.0.0"
+  rollout:
+    type: immediate
+`
+		applyCmd := exec.Command("kubectl", "apply", "-f", "-")
+		applyCmd.Stdin = strings.NewReader(promptPackManifest)
+		_, err := utils.Run(applyCmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to apply PromptPack")
+
+		By("creating a mock Provider for the function pod")
+		// The dummy secret keeps the Provider CR valid against the CRD
+		// shape; the mock-provider annotation on the AgentRuntime tells
+		// the runtime sidecar to ignore real credentials.
+		providerSecret := `
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-fn-provider
+  namespace: test-agents
+type: Opaque
+stringData:
+  api-key: mock-not-a-real-key
+---
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: Provider
+metadata:
+  name: test-fn-provider
+  namespace: test-agents
+spec:
+  type: mock
+  credential:
+    secretRef:
+      name: test-fn-provider
+`
+		secretCmd := exec.Command("kubectl", "apply", "-f", "-")
+		secretCmd.Stdin = strings.NewReader(providerSecret)
+		_, err = utils.Run(secretCmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to apply Provider")
+
+		By("creating a function-mode AgentRuntime with strict input schema")
+		// inputSchema demands "q" so we can drive the input_invalid path
+		// with an empty body. outputSchema is loose — we don't exercise
+		// the happy path in this PR (mock provider doesn't emit
+		// schema-conforming JSON without scenario config).
+		arManifest := fmt.Sprintf(`
+apiVersion: omnia.altairalabs.ai/v1alpha1
+kind: AgentRuntime
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+  annotations:
+    omnia.altairalabs.ai/mock-provider: "true"
+spec:
+  mode: function
+  promptPackRef:
+    name: %[3]s
+  facade:
+    type: grpc
+    port: 8080
+    extraEnv:
+      - name: OMNIA_FACADE_ALLOW_UNAUTHENTICATED
+        value: "true"
+  inputSchema:
+    type: object
+    required: ["q"]
+    properties:
+      q:
+        type: string
+  outputSchema:
+    type: object
+  runtime:
+    replicas: 1
+    resources:
+      requests:
+        cpu: "50m"
+        memory: "64Mi"
+      limits:
+        cpu: "200m"
+        memory: "128Mi"
+  providers:
+    - name: default
+      providerRef:
+        name: %[4]s
+`, functionName, agentsNamespace, functionPackName, functionProviderID)
+		arCmd := exec.Command("kubectl", "apply", "-f", "-")
+		arCmd.Stdin = strings.NewReader(arManifest)
+		_, err = utils.Run(arCmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to apply function-mode AgentRuntime")
+
+		// On failure, dump the operator + agent pod state so the CI run
+		// produces a usable diagnostic instead of a bare "Deployment
+		// never appeared".
+		DeferCleanup(func() {
+			if !CurrentSpecReport().Failed() {
+				return
+			}
+			_, _ = fmt.Fprintf(GinkgoWriter, "\n=== DEBUG: function-mode setup failed ===\n")
+			arGet := exec.Command("kubectl", "get", "agentruntime", functionName, "-n", agentsNamespace, "-o", "yaml")
+			if out, e := utils.Run(arGet); e == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "AgentRuntime:\n%s\n", out)
+			}
+			events := exec.Command("kubectl", "get", "events", "-n", agentsNamespace, "--sort-by=.lastTimestamp")
+			if out, e := utils.Run(events); e == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Events:\n%s\n", out)
+			}
+			ctlLogs := exec.Command("kubectl", "logs",
+				"-n", namespace,
+				"-l", "control-plane=controller-manager",
+				"--tail=200", "--all-containers=true")
+			if out, e := utils.Run(ctlLogs); e == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "controller-manager logs:\n%s\n", out)
+			}
+		})
+
+		By("waiting for the function-mode Deployment to be Ready")
+		verifyReady := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "deployment", functionName,
+				"-n", agentsNamespace,
+				"-o", "jsonpath={.status.readyReplicas}")
+			out, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(out).To(Equal("1"), "function-mode pod must have 1 ready replica")
+		}
+		Eventually(verifyReady, 3*time.Minute, 2*time.Second).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "agentruntime", functionName,
+			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "promptpack", functionPackName,
+			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "provider", functionProviderID,
+			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "secret", functionProviderID,
+			"-n", agentsNamespace, "--ignore-not-found"))
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "configmap", functionPackName,
+			"-n", agentsNamespace, "--ignore-not-found"))
+		_, _ = utils.Run(exec.Command("kubectl", "delete", "pod", "fn-mode-test",
+			"-n", agentsNamespace, "--ignore-not-found", "--timeout=30s"))
+	})
+
+	It("creates a session row with status=error on input_invalid", func() {
+		// The test pod does three things in sequence:
+		//  1. POST a body without the required `q` field → expect 400.
+		//  2. List sessions for this agent + namespace → expect exactly
+		//     one row with status=error and the "function" tag.
+		//  3. GET that session's runtime events → expect at least one
+		//     row with eventType=function.input_invalid carrying the
+		//     validator error.
+		//
+		// Step 2 is the load-bearing assertion: a real `sessions` row
+		// landed in postgres for a call that never reached the runtime.
+		// That's what makes Loki / dashboard pivoting work for the
+		// failure cases operators most need to troubleshoot.
+		testManifest := fmt.Sprintf(`
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fn-mode-test
+  namespace: %[1]s
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
+  containers:
+  - name: python
+    image: python:3.11-slim
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: ["ALL"]
+    command: ["sh", "-c"]
+    args:
+    - |
+      pip install requests --quiet
+      python3 << 'PYTHON_SCRIPT'
+      import json
+      import sys
+      import time
+      import requests
+
+      FN_URL = "http://%[2]s.%[1]s.svc.cluster.local:8080/functions/%[2]s"
+      SESSION_API = "%[3]s"
+      NS = "%[1]s"
+
+      # Step 1: drive input_invalid.
+      print(f"POST {FN_URL} with body missing required 'q'")
+      resp = requests.post(FN_URL, json={}, timeout=15)
+      print(f"  status={resp.status_code} body={resp.text[:200]}")
+      if resp.status_code != 400:
+          print(f"ERROR: expected 400 input_invalid; got {resp.status_code}")
+          sys.exit(1)
+      body = resp.json()
+      if body.get("error") != "input_invalid":
+          print(f"ERROR: expected error=input_invalid; got {body!r}")
+          sys.exit(1)
+
+      # Give the deferred closeSession call a moment to land (the 400
+      # is returned synchronously but the session UpdateSessionStatus
+      # runs in the handler's defer).
+      time.sleep(3)
+
+      # Step 2: a sessions row must exist for this function, with
+      # status=error.
+      list_url = f"{SESSION_API}/api/v1/sessions?namespace={NS}&agent=%[2]s"
+      print(f"GET {list_url}")
+      resp = requests.get(list_url, timeout=10)
+      print(f"  status={resp.status_code}")
+      if resp.status_code != 200:
+          print(f"ERROR: listing sessions failed: {resp.text[:200]}")
+          sys.exit(1)
+      data = resp.json()
+      sessions = data.get("sessions") or []
+      print(f"  found {len(sessions)} sessions")
+      if not sessions:
+          print("ERROR: no session row found for the function call")
+          sys.exit(1)
+
+      # Pick the most recent one (DESC by created_at server-side).
+      sess = sessions[0]
+      sess_id = sess.get("id") or sess.get("ID")
+      status = sess.get("status")
+      tags = sess.get("tags") or []
+      print(f"  session_id={sess_id} status={status} tags={tags}")
+      if status != "error":
+          print(f"ERROR: expected status=error; got {status!r}")
+          sys.exit(1)
+      if "function" not in tags:
+          print(f"ERROR: session missing 'function' tag; got tags={tags!r}")
+          sys.exit(1)
+
+      # Step 3: the runtime_events table must have a function.input_invalid
+      # entry for this session — that's how the dashboard surfaces the
+      # validator error on the session detail page.
+      events_url = f"{SESSION_API}/api/v1/sessions/{sess_id}/events"
+      print(f"GET {events_url}")
+      resp = requests.get(events_url, timeout=10)
+      if resp.status_code != 200:
+          print(f"ERROR: listing events failed: {resp.text[:200]}")
+          sys.exit(1)
+      events_body = resp.json()
+      events = events_body.get("events") or events_body.get("data") or events_body
+      if not isinstance(events, list):
+          events = events.get("events", []) if isinstance(events, dict) else []
+      print(f"  found {len(events)} events")
+      matched = [e for e in events if e.get("eventType") == "function.input_invalid"]
+      if not matched:
+          types = [e.get("eventType") for e in events]
+          print(f"ERROR: no function.input_invalid runtime event; got types={types!r}")
+          sys.exit(1)
+      err_msg = matched[0].get("errorMessage", "")
+      print(f"  function.input_invalid errorMessage={err_msg[:120]!r}")
+      if not err_msg:
+          print("ERROR: function.input_invalid event has no errorMessage")
+          sys.exit(1)
+
+      print("PASS: function invocation recorded as a session with status=error + failure event")
+      PYTHON_SCRIPT
+`, agentsNamespace, functionName, sessionApiURL)
+		applyCmd := exec.Command("kubectl", "apply", "-f", "-")
+		applyCmd.Stdin = strings.NewReader(testManifest)
+		_, err := utils.Run(applyCmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to create test pod")
+
+		DeferCleanup(func() {
+			if !CurrentSpecReport().Failed() {
+				return
+			}
+			_, _ = fmt.Fprintf(GinkgoWriter, "\n=== DEBUG: function-mode session-row test failed ===\n")
+			logCmd := exec.Command("kubectl", "logs", "fn-mode-test", "-n", agentsNamespace)
+			if out, e := utils.Run(logCmd); e == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Test pod logs:\n%s\n", out)
+			}
+			facadeCmd := exec.Command("kubectl", "logs",
+				"-n", agentsNamespace,
+				"-l", "app.kubernetes.io/instance="+functionName,
+				"-c", "facade", "--tail=200")
+			if out, e := utils.Run(facadeCmd); e == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Facade logs:\n%s\n", out)
+			}
+			runtimeCmd := exec.Command("kubectl", "logs",
+				"-n", agentsNamespace,
+				"-l", "app.kubernetes.io/instance="+functionName,
+				"-c", "runtime", "--tail=200")
+			if out, e := utils.Run(runtimeCmd); e == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Runtime logs:\n%s\n", out)
+			}
+			sessionApiCmd := exec.Command("kubectl", "logs",
+				"-n", namespace,
+				"-l", "app=e2e-session-api", "--tail=200")
+			if out, e := utils.Run(sessionApiCmd); e == nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "Session-api logs:\n%s\n", out)
+			}
+		})
+
+		By("waiting for the test pod to Succeed")
+		verifyComplete := func(g Gomega) {
+			cmd := exec.Command("kubectl", "get", "pod", "fn-mode-test",
+				"-n", agentsNamespace, "-o", "jsonpath={.status.phase}")
+			out, err := utils.Run(cmd)
+			g.Expect(err).NotTo(HaveOccurred())
+			// Failed is terminal — if it landed there, drop out of the
+			// retry loop instead of waiting for Succeeded.
+			g.Expect(out).To(Or(Equal("Succeeded"), Equal("Failed")))
+		}
+		Eventually(verifyComplete, 3*time.Minute, 3*time.Second).Should(Succeed())
+
+		By("confirming the test pod reported PASS")
+		cmd := exec.Command("kubectl", "logs", "fn-mode-test", "-n", agentsNamespace)
+		out, err := utils.Run(cmd)
+		Expect(err).NotTo(HaveOccurred(), "failed to read test pod logs")
+		Expect(out).To(ContainSubstring("PASS:"),
+			"test pod must report PASS; full log:\n%s", out)
+	})
+})


### PR DESCRIPTION
## Summary

PR 2/3 of the **Functions-as-sessions** rework. Function-mode pods now open a real `sessions` row at invocation start and close it with the terminal status when the response is written. Same data model as agent-mode sessions — the runtime's existing OmniaEventStore machinery already keyed off the invocation id; this PR creates the parent row so the downstream audit tables (`messages`, `tool_calls`, `provider_calls`, `eval_results`, `runtime_events`) stop being orphaned.

PR 1 ([#1120](https://github.com/AltairaLabs/Omnia/pull/1120)) deleted the dedicated `function_invocations` infrastructure. PR 3 will repoint the dashboard `/functions/{name}` detail view at the sessions data source.

## Changes

- **`invocationID` moved to the top of `ServeHTTP`** so `input_invalid` / body-read failures still have a `session_id` for Loki + dashboard correlation. (The user explicitly called this out: "We'll need click-through from the session id into the Loki logs to troubleshoot.")
- **`FunctionsHandler.WithSessionStore(store, meta)`** builder. `FunctionSessionMeta` carries the per-pod identity (namespace, agent name, workspace, prompt-pack name + version).
- **`openSession`** creates a `sessions` row tagged `["function"]` at request start.
- **`closeSession`** (deferred) patches the terminal status when ServeHTTP returns. Outcome map: success → completed; every failure mode → error. `ended_at` always set.
- **Pre-runtime failure events**: `input_invalid` / `payload_too_large` / `read_body_failed` emit a `RuntimeEvent` against the session so the failure detail is queryable from the session detail page — the runtime never ran, so PromptKit didn't fire its own event for these.
- **Store failures are non-fatal**: a session-api outage logs but does not fail the user-facing request.
- **`cmd/agent`** wires `initSessionStore()` (same store as the WebSocket path). Resolution failure logged + non-fatal.

## Outcome → status / event matrix

| Outcome | HTTP | `sessions.status` | RuntimeEvent emitted by facade |
|---|---|---|---|
| Success | 200 | `completed` | — (PromptKit fires its own events) |
| input_invalid | 400 | `error` | `function.input_invalid` |
| payload_too_large | 413 | `error` | `function.payload_too_large` |
| read_body_failed | 400 | `error` | `function.read_body_failed` |
| runtime_error | 502 | `error` | `function.runtime_error` |
| output_invalid | 502 | `error` | `function.output_invalid` |
| response_write_failed | (already written) | `error` | `function.response_write_failed` |

## Test plan

- [x] 6 new specs in `internal/facade/functions_handler_test.go`:
  - `Session_OpenedAndClosedOnHappyPath` — verifies CreateSession + UpdateSessionStatus with `completed`, asserts the per-pod metadata flows into the options, and pins the `["function"]` tag.
  - `Session_InputInvalidClosesAsError` — runtime not called; session still opened, closed with `error`, runtime event emitted.
  - `Session_RuntimeErrorClosesAsError`
  - `Session_OutputInvalidClosesAsError`
  - `Session_StoreFailuresAreNonFatal` — store outage doesn't fail the request.
  - `Session_TransientWhenStoreUnwired` — backward compat for tests that don't wire the store.
- [x] `env GOWORK=off go test -short ./internal/facade/...` — 431 facade tests pass.
- [x] Broader sweep — 1293 tests across the facade / session / cmd/agent packages pass.
- [x] Pre-commit hook green: 91.3% per-file coverage on `internal/facade/functions_handler.go`.

