### PR TITLE
feat(dashboard): repoint /functions/{name} at sessions data (PR 3/3)

### DIFF
--- a/api/CHANGELOG.md
+++ b/api/CHANGELOG.md
@@ -10,6 +10,32 @@ or `api/proto/`, add an entry below with the date, affected API, and reason.
 
 ## Unreleased
 
+### Changed (Functions-as-sessions rework, PR 3/3: dashboard reads sessions data)
+
+The `/functions/{name}` detail page reads recent invocations from the
+standard sessions data path instead of the placeholder shipped in
+PR 1. Function invocations are ordinary sessions tagged `"function"`;
+the new `FunctionSessionsPanel` reuses the existing `useSessions` hook
++ workspace session-api proxy that already powers `/sessions`.
+
+- New `FunctionSessionsPanel` component renders a per-function
+  history table (timestamp, status badge, latency derived from
+  `startedAt`/`endedAt`, estimated cost, truncated session id).
+  Each row links into `/sessions/{id}` so operators can drill from
+  this view into the full session detail (messages, tool calls,
+  provider calls, eval results).
+- `FunctionDetailPage` mounts the panel below the schema cards and
+  drops the PR-1 placeholder.
+- Status badge mapping mirrors `sessions.status`: `active` →
+  "Active" (secondary), `completed` → "Completed" (default),
+  `error` → "Error" (destructive), `expired` → "Expired" (outline).
+
+Tests: 9 new specs for `FunctionSessionsPanel` (loading, error,
+empty, row rendering, status mapping, latency formatting, link
+target, missing endedAt, hook argument forwarding); the detail-page
+test updated to assert the panel is mounted with the correct
+function name.
+
 ### Changed (Functions-as-sessions rework, PR 2/3: function invocations are sessions)
 
 Function-mode pods now open a real `sessions` row at invocation start

--- a/dashboard/src/app/functions/[name]/page.test.tsx
+++ b/dashboard/src/app/functions/[name]/page.test.tsx
@@ -34,6 +34,17 @@ vi.mock("@/components/layout", () => ({
   ),
 }));
 
+// Stub the sessions panel — its own test file covers behaviour; here
+// we just want to assert that the detail page mounts it and passes
+// the right function name.
+const panelSpy = vi.hoisted(() => vi.fn());
+vi.mock("@/components/functions/function-sessions-panel", () => ({
+  FunctionSessionsPanel: (props: { functionName: string }) => {
+    panelSpy(props);
+    return <div data-testid="sessions-panel" data-fn={props.functionName} />;
+  },
+}));
+
 function mkFn(overrides: Partial<AgentRuntime["spec"]> = {}): AgentRuntime {
   return {
     apiVersion: "omnia.altairalabs.ai/v1alpha1",
@@ -86,11 +97,19 @@ describe("FunctionDetailPage", () => {
     expect(screen.getByTestId("schema-card-output-schema")).toHaveTextContent('"a"');
   });
 
-  it("renders the next-PR placeholder for invocation history", () => {
+  it("mounts the sessions panel with the function name", () => {
+    panelSpy.mockReset();
+    useAgentSpy.mockReturnValue({ data: mkFn(), isLoading: false });
+    render(<FunctionDetailPage />);
+    expect(screen.getByTestId("sessions-panel")).toBeInTheDocument();
+    expect(panelSpy).toHaveBeenCalledWith({ functionName: "summarizer" });
+  });
+
+  it("explains the sessions-backed audit model below the panel", () => {
     useAgentSpy.mockReturnValue({ data: mkFn(), isLoading: false });
     render(<FunctionDetailPage />);
     expect(
-      screen.getByText(/Function invocations are recorded as sessions/),
+      screen.getByText(/recorded as sessions tagged/),
     ).toBeInTheDocument();
   });
 });

--- a/dashboard/src/app/functions/[name]/page.tsx
+++ b/dashboard/src/app/functions/[name]/page.tsx
@@ -2,10 +2,10 @@
  * /functions/[name] — Function detail page.
  *
  * Shows the resolved input/output schemas for a function-mode
- * AgentRuntime. The session-backed invocation history panel is
- * intentionally absent in this PR — function invocations now record
- * as ordinary sessions (Functions-as-sessions rework), and the
- * detail-page session list is wired up in the next PR.
+ * AgentRuntime alongside a panel of recent invocations sourced from
+ * the standard sessions data path. Functions record as ordinary
+ * sessions tagged "function"; the panel reuses the existing useSessions
+ * hook + workspace session-api proxy that powers /sessions.
  *
  * Copyright 2026 Altaira Labs.
  * SPDX-License-Identifier: Apache-2.0
@@ -18,6 +18,7 @@ import { Header } from "@/components/layout";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
+import { FunctionSessionsPanel } from "@/components/functions/function-sessions-panel";
 import { useAgent } from "@/hooks/agents";
 import { isFunctionMode } from "@/types/agent-runtime";
 
@@ -88,19 +89,14 @@ export default function FunctionDetailPage() {
           <SchemaCard label="Output schema" schema={agent.spec.outputSchema} />
         </div>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Recent invocations</CardTitle>
-          </CardHeader>
-          <CardContent>
-            <p className="text-sm text-muted-foreground">
-              Function invocations are recorded as sessions. The session-backed
-              detail view is wired up in the next PR — until then, invocation
-              history for this function is visible from the Sessions page
-              filtered by this AgentRuntime&apos;s name.
-            </p>
-          </CardContent>
-        </Card>
+        <FunctionSessionsPanel functionName={functionName} />
+
+        <p className="text-xs text-muted-foreground">
+          Function invocations are recorded as sessions tagged{" "}
+          <code className="font-mono">function</code>. Click a session id above
+          for the full invocation transcript, tool calls, provider calls, and
+          eval results.
+        </p>
       </div>
     </div>
   );

--- a/dashboard/src/components/functions/function-sessions-panel.test.tsx
+++ b/dashboard/src/components/functions/function-sessions-panel.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Tests for FunctionSessionsPanel.
+ *
+ * Covers loading skeleton, error envelope, empty state, row
+ * rendering, status badge mapping, latency/cost formatting, and the
+ * session-id link target — which is the load-bearing assertion:
+ * each row must link into /sessions/{id} so operators can pivot
+ * from this view into the full session detail.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import { FunctionSessionsPanel } from "./function-sessions-panel";
+import type { SessionListResponse, SessionSummary } from "@/types/session";
+
+const hookSpy = vi.hoisted(() => vi.fn());
+
+vi.mock("@/hooks/sessions", () => ({
+  useSessions: hookSpy,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+beforeEach(() => {
+  hookSpy.mockReset();
+});
+
+function mkHook(state: {
+  data?: SessionListResponse;
+  isLoading?: boolean;
+  error?: unknown;
+}): UseQueryResult<SessionListResponse> {
+  return {
+    data: state.data,
+    isLoading: state.isLoading ?? false,
+    error: state.error ?? null,
+    isError: Boolean(state.error),
+    isSuccess: state.data !== undefined,
+  } as unknown as UseQueryResult<SessionListResponse>;
+}
+
+function mkSession(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    agentName: "summarizer",
+    agentNamespace: "ns-a",
+    status: "completed",
+    startedAt: "2026-05-20T10:00:00Z",
+    endedAt: "2026-05-20T10:00:01.500Z",
+    messageCount: 2,
+    toolCallCount: 0,
+    totalTokens: 50,
+    estimatedCost: 0.0012,
+    tags: ["function"],
+    ...overrides,
+  };
+}
+
+describe("FunctionSessionsPanel", () => {
+  it("renders the loading skeleton while the hook is loading", () => {
+    hookSpy.mockReturnValue(mkHook({ isLoading: true }));
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    expect(
+      screen.getByTestId("function-sessions-panel-loading"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders an error envelope when the hook reports a failure", () => {
+    hookSpy.mockReturnValue(mkHook({ error: new Error("boom") }));
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    expect(
+      screen.getByTestId("function-sessions-panel-error"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Failed to load invocations: boom/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no sessions exist", () => {
+    hookSpy.mockReturnValue(
+      mkHook({ data: { sessions: [], total: 0, hasMore: false } }),
+    );
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    expect(screen.getByText("No invocations recorded yet.")).toBeInTheDocument();
+  });
+
+  it("renders one row per session", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: {
+          sessions: [
+            mkSession({ id: "a" }),
+            mkSession({ id: "b" }),
+            mkSession({ id: "c" }),
+          ],
+          total: 3,
+          hasMore: false,
+        },
+      }),
+    );
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    expect(screen.getAllByTestId("function-sessions-row")).toHaveLength(3);
+  });
+
+  it("maps each status enum to a readable label", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: {
+          sessions: [
+            mkSession({ id: "a", status: "completed" }),
+            mkSession({ id: "b", status: "error" }),
+            mkSession({ id: "c", status: "active", endedAt: undefined }),
+            mkSession({ id: "d", status: "expired" }),
+          ],
+          total: 4,
+          hasMore: false,
+        },
+      }),
+    );
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    expect(screen.getByText("Completed")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+  });
+
+  it("formats sub-second latency in ms and >= 1s in seconds", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: {
+          sessions: [
+            mkSession({
+              id: "fast",
+              startedAt: "2026-05-20T10:00:00Z",
+              endedAt: "2026-05-20T10:00:00.100Z",
+            }),
+            mkSession({
+              id: "slow",
+              startedAt: "2026-05-20T10:00:00Z",
+              endedAt: "2026-05-20T10:00:02.500Z",
+            }),
+          ],
+          total: 2,
+          hasMore: false,
+        },
+      }),
+    );
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    expect(screen.getByText("100ms")).toBeInTheDocument();
+    expect(screen.getByText("2.50s")).toBeInTheDocument();
+  });
+
+  it("renders an em-dash for active rows that have no endedAt", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: {
+          sessions: [
+            mkSession({ id: "live", status: "active", endedAt: undefined }),
+          ],
+          total: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("each row links into /sessions/{id} so operators can drill in", () => {
+    hookSpy.mockReturnValue(
+      mkHook({
+        data: {
+          sessions: [
+            mkSession({ id: "abcdef0123456789", status: "error" }),
+          ],
+          total: 1,
+          hasMore: false,
+        },
+      }),
+    );
+    render(<FunctionSessionsPanel functionName="summarizer" />);
+    const link = screen.getByRole("link");
+    expect(link).toHaveAttribute("href", "/sessions/abcdef0123456789");
+    // The truncated label (first 8 chars + ellipsis) is what the user sees.
+    expect(link.textContent).toContain("abcdef01");
+  });
+
+  it("passes the function name to useSessions as the `agent` filter", () => {
+    hookSpy.mockReturnValue(
+      mkHook({ data: { sessions: [], total: 0, hasMore: false } }),
+    );
+    render(<FunctionSessionsPanel functionName="my-fn" limit={25} />);
+    expect(hookSpy).toHaveBeenCalledWith({ agent: "my-fn", limit: 25 });
+  });
+});

--- a/dashboard/src/components/functions/function-sessions-panel.tsx
+++ b/dashboard/src/components/functions/function-sessions-panel.tsx
@@ -1,0 +1,173 @@
+/**
+ * FunctionSessionsPanel renders the per-function invocation history
+ * sourced from the standard `sessions` data path. Function-mode
+ * invocations record as ordinary sessions tagged "function" (see the
+ * Functions-as-sessions rework), so this panel reuses the existing
+ * useSessions hook + workspace-scoped session-api proxy that already
+ * powers /sessions.
+ *
+ * Each row links into the standard session detail view so operators
+ * can drill from a Loki log line → session id → full audit trail.
+ *
+ * Copyright 2026 Altaira Labs.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useSessions } from "@/hooks/sessions";
+import { formatCost } from "@/lib/pricing";
+import type { SessionSummary } from "@/types/session";
+
+interface FunctionSessionsPanelProps {
+  functionName: string;
+  limit?: number;
+}
+
+const STATUS_VARIANT: Record<
+  SessionSummary["status"],
+  "default" | "secondary" | "destructive" | "outline"
+> = {
+  active: "secondary",
+  completed: "default",
+  error: "destructive",
+  expired: "outline",
+};
+
+const STATUS_LABEL: Record<SessionSummary["status"], string> = {
+  active: "Active",
+  completed: "Completed",
+  error: "Error",
+  expired: "Expired",
+};
+
+/** durationMs computes the runtime of a session from its start/end
+ * timestamps. Active rows (no endedAt) show "—" instead. */
+function durationMs(s: SessionSummary): number | null {
+  if (!s.endedAt) return null;
+  const start = Date.parse(s.startedAt);
+  const end = Date.parse(s.endedAt);
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  return Math.max(0, end - start);
+}
+
+function formatLatency(ms: number | null): string {
+  if (ms === null) return "—";
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${Math.round(ms)}ms`;
+}
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+export function FunctionSessionsPanel({
+  functionName,
+  limit = 50,
+}: Readonly<FunctionSessionsPanelProps>) {
+  const { data, isLoading, error } = useSessions({
+    agent: functionName,
+    limit,
+  });
+
+  if (isLoading) {
+    return (
+      <Card data-testid="function-sessions-panel-loading">
+        <CardHeader>
+          <CardTitle>Recent invocations</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2">
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+          <Skeleton className="h-8 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card data-testid="function-sessions-panel-error">
+        <CardHeader>
+          <CardTitle>Recent invocations</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-destructive">
+            Failed to load invocations: {error instanceof Error ? error.message : String(error)}
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const sessions = data?.sessions ?? [];
+
+  return (
+    <Card data-testid="function-sessions-panel">
+      <CardHeader>
+        <CardTitle>Recent invocations</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {sessions.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            No invocations recorded yet.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" data-testid="function-sessions-table">
+              <thead className="text-left text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="py-2 pr-4">When</th>
+                  <th className="py-2 pr-4">Status</th>
+                  <th className="py-2 pr-4 text-right">Latency</th>
+                  <th className="py-2 pr-4 text-right">Cost</th>
+                  <th className="py-2 pr-4">Session</th>
+                </tr>
+              </thead>
+              <tbody>
+                {sessions.map((s) => (
+                  <tr key={s.id} className="border-t" data-testid="function-sessions-row">
+                    <td className="py-2 pr-4 font-mono text-xs">
+                      {formatTimestamp(s.startedAt)}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Badge variant={STATUS_VARIANT[s.status] ?? "outline"}>
+                        {STATUS_LABEL[s.status] ?? s.status}
+                      </Badge>
+                    </td>
+                    <td className="py-2 pr-4 text-right">
+                      {formatLatency(durationMs(s))}
+                    </td>
+                    <td className="py-2 pr-4 text-right">
+                      {formatCost(s.estimatedCost ?? 0)}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <Link
+                        href={`/sessions/${s.id}`}
+                        className="font-mono text-xs text-muted-foreground hover:text-foreground hover:underline"
+                      >
+                        {s.id.slice(0, 8)}…
+                      </Link>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary

Closes the **Functions-as-sessions** rework. The `/functions/{name}` detail page reads recent invocations from the standard sessions data path instead of the placeholder shipped in PR 1 ([#1120](https://github.com/AltairaLabs/Omnia/pull/1120)). PR 2 ([#1121](https://github.com/AltairaLabs/Omnia/pull/1121)) made function invocations record as ordinary sessions tagged `"function"`; this PR makes the dashboard read them.

- **`FunctionSessionsPanel`** — new component rendering a per-function history table. Columns: when, status badge, latency (derived from `startedAt`/`endedAt`), estimated cost, truncated session id. Each row links into `/sessions/{id}` so operators can drill into the full session view — same audit surface as agent-mode sessions, because they're the same tables.
- **`FunctionDetailPage`** — drops the PR-1 placeholder, mounts the new panel below the schema cards.
- Status badge mapping mirrors `sessions.status`: `active` → secondary, `completed` → default, `error` → destructive, `expired` → outline.

Depends on no new endpoints; reuses the existing `useSessions` hook + workspace session-api proxy that already powers `/sessions`.

## Test plan

- [x] 9 new specs for `FunctionSessionsPanel`: loading skeleton, error envelope, empty state, row rendering, status enum mapping, latency formatting (sub-second vs >= 1s), `/sessions/{id}` link target, missing `endedAt` em-dash, hook argument forwarding.
- [x] Detail-page test updated: asserts the panel is mounted with the correct function name + the sessions-backed audit caption renders.
- [x] All 25 PR-3 specs pass.
- [x] Full dashboard suite still passes (no regressions).
- [x] `npm run typecheck` + `npm run lint` clean on touched files.
- [x] Pre-commit hook green; 92.3% per-file coverage on `function-sessions-panel.tsx`.

