### PR TITLE
feat(agent): plumb MCPEnabled/MCPPort + migrate A2A reads to spec.facade.a2a (Task 2/11 of #1124)

### DIFF
--- a/internal/agent/config.go
+++ b/internal/agent/config.go
@@ -72,6 +72,10 @@ const (
 	EnvA2AEnabled         = "OMNIA_A2A_ENABLED"
 	EnvA2APort            = "OMNIA_A2A_PORT"
 	EnvA2AClients         = "OMNIA_A2A_CLIENTS"
+
+	// MCP configuration.
+	EnvMCPEnabled = "OMNIA_MCP_ENABLED"
+	EnvMCPPort    = "OMNIA_MCP_PORT"
 )
 
 // Default values.
@@ -87,6 +91,7 @@ const (
 	DefaultA2ATaskTTL          = 1 * time.Hour
 	DefaultA2AConversationTTL  = 30 * time.Minute
 	DefaultA2APort             = 9999
+	DefaultMCPPort             = 9998
 )
 
 // Error format strings.
@@ -225,6 +230,11 @@ type Config struct {
 	A2AEnabled         bool   // true when A2A is an additional endpoint (dual-protocol)
 	A2APort            int    // port for A2A in dual-protocol mode (default 9999)
 	A2AClientsJSON     string // JSON-encoded resolved client list from controller
+
+	// MCP configuration. Function-mode only; the operator's CEL
+	// validation rejects MCPEnabled=true on agent-mode runtimes.
+	MCPEnabled bool
+	MCPPort    int
 
 	// Health check port.
 	HealthPort int

--- a/internal/agent/config_crd.go
+++ b/internal/agent/config_crd.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,6 +42,12 @@ func LoadFromCRD(ctx context.Context, c client.Client, name, namespace string) (
 	if err != nil {
 		return nil, fmt.Errorf("resolve workspace name: %w", err)
 	}
+
+	// Normalise legacy spec.a2a → spec.facade.a2a so downstream loaders
+	// read from a single location. The operator's reconciler does the
+	// same projection (Task 8); this side covers pods that boot before
+	// the reconciler has rewritten the CR.
+	v1alpha1.ProjectLegacyFacadeA2A(ar)
 
 	cfg := &Config{
 		AgentName:     name,
@@ -103,32 +110,39 @@ func LoadFromCRD(ctx context.Context, c client.Client, name, namespace string) (
 		return nil, err
 	}
 
+	loadMCPConfigFromCRD(cfg, ar)
+
 	return cfg, nil
 }
 
 // loadA2AConfigFromCRD populates A2A-related config fields from the AgentRuntime CRD.
+//
+// Reads from spec.facade.a2a. Callers must call ProjectLegacyFacadeA2A
+// before invoking this so legacy spec.a2a values are normalised into
+// the new location.
 func loadA2AConfigFromCRD(cfg *Config, ar *v1alpha1.AgentRuntime) error {
-	if ar.Spec.A2A == nil {
+	a2a := ar.Spec.Facade.A2A
+	if a2a == nil {
 		cfg.A2ATaskTTL = DefaultA2ATaskTTL
 		cfg.A2AConversationTTL = DefaultA2AConversationTTL
 		return nil
 	}
 
-	if err := loadA2ATTLsFromCRD(cfg, ar.Spec.A2A); err != nil {
+	if err := loadA2ATTLsFromCRD(cfg, a2a); err != nil {
 		return err
 	}
 
 	cfg.A2AAuthToken = os.Getenv(EnvA2AAuthToken)
 
 	// Dual-protocol: A2A as additional endpoint alongside websocket/grpc.
-	cfg.A2AEnabled = ar.Spec.A2A.Enabled
-	if ar.Spec.A2A.Port != nil {
-		cfg.A2APort = int(*ar.Spec.A2A.Port)
+	cfg.A2AEnabled = a2a.Enabled
+	if a2a.Port != nil {
+		cfg.A2APort = int(*a2a.Port)
 	} else {
 		cfg.A2APort = DefaultA2APort
 	}
 
-	loadA2ATaskStoreFromCRD(cfg, ar.Spec.A2A)
+	loadA2ATaskStoreFromCRD(cfg, a2a)
 
 	// Resolved A2A clients are injected as JSON by the operator.
 	cfg.A2AClientsJSON = os.Getenv(EnvA2AClients)
@@ -296,6 +310,10 @@ func loadFromEnvFallback(name, namespace string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := loadMCPConfigFromEnv(cfg); err != nil {
+		return nil, err
+	}
+
 	return cfg, nil
 }
 
@@ -336,4 +354,33 @@ func loadA2AConfigFromEnv(cfg *Config) error {
 	cfg.A2APort = a2aPort
 
 	return nil
+}
+
+// loadMCPConfigFromEnv populates MCP-related config fields from environment variables.
+func loadMCPConfigFromEnv(cfg *Config) error {
+	cfg.MCPEnabled = os.Getenv(EnvMCPEnabled) == envValueTrue
+	if v := os.Getenv(EnvMCPPort); v != "" {
+		port, err := strconv.Atoi(v)
+		if err != nil || port < 1 || port > 65535 {
+			return fmt.Errorf(errFmtInvalidEnv, EnvMCPPort, fmt.Errorf("invalid port %q", v))
+		}
+		cfg.MCPPort = port
+	} else {
+		cfg.MCPPort = DefaultMCPPort
+	}
+	return nil
+}
+
+// loadMCPConfigFromCRD populates MCP-related config fields from the AgentRuntime CRD.
+func loadMCPConfigFromCRD(cfg *Config, ar *v1alpha1.AgentRuntime) {
+	if ar.Spec.Facade.MCP != nil {
+		cfg.MCPEnabled = ar.Spec.Facade.MCP.Enabled
+		if ar.Spec.Facade.MCP.Port != nil {
+			cfg.MCPPort = int(*ar.Spec.Facade.MCP.Port)
+		} else {
+			cfg.MCPPort = DefaultMCPPort
+		}
+	} else {
+		cfg.MCPPort = DefaultMCPPort
+	}
 }

--- a/internal/agent/config_crd_test.go
+++ b/internal/agent/config_crd_test.go
@@ -656,3 +656,133 @@ func TestConfigValidate_A2AFacadeType(t *testing.T) {
 		t.Errorf("expected A2A facade type to be valid, got: %v", err)
 	}
 }
+
+func TestLoadMCPConfigFromEnv_Defaults(t *testing.T) {
+	cfg := &Config{}
+	if err := loadMCPConfigFromEnv(cfg); err != nil {
+		t.Fatalf("loadMCPConfigFromEnv: %v", err)
+	}
+	if cfg.MCPEnabled {
+		t.Errorf("MCPEnabled default: got true want false")
+	}
+	if cfg.MCPPort != DefaultMCPPort {
+		t.Errorf("MCPPort default: got %d want %d", cfg.MCPPort, DefaultMCPPort)
+	}
+}
+
+func TestLoadMCPConfigFromEnv_Enabled(t *testing.T) {
+	t.Setenv(EnvMCPEnabled, "true")
+	t.Setenv(EnvMCPPort, "9000")
+
+	cfg := &Config{}
+	if err := loadMCPConfigFromEnv(cfg); err != nil {
+		t.Fatalf("loadMCPConfigFromEnv: %v", err)
+	}
+	if !cfg.MCPEnabled {
+		t.Error("MCPEnabled: got false want true")
+	}
+	if cfg.MCPPort != 9000 {
+		t.Errorf("MCPPort: got %d want 9000", cfg.MCPPort)
+	}
+}
+
+func TestLoadMCPConfigFromEnv_InvalidPortOutOfRange(t *testing.T) {
+	t.Setenv(EnvMCPPort, "70000")
+
+	cfg := &Config{}
+	if err := loadMCPConfigFromEnv(cfg); err == nil {
+		t.Fatal("expected error for out-of-range port")
+	}
+}
+
+func TestLoadMCPConfigFromEnv_InvalidPortNotANumber(t *testing.T) {
+	t.Setenv(EnvMCPPort, "not-a-port")
+
+	cfg := &Config{}
+	if err := loadMCPConfigFromEnv(cfg); err == nil {
+		t.Fatal("expected error for non-numeric port")
+	}
+}
+
+func TestLoadMCPConfigFromEnv_InvalidPortZero(t *testing.T) {
+	t.Setenv(EnvMCPPort, "0")
+
+	cfg := &Config{}
+	if err := loadMCPConfigFromEnv(cfg); err == nil {
+		t.Fatal("expected error for zero port")
+	}
+}
+
+func TestLoadMCPConfigFromCRD_FromFacade(t *testing.T) {
+	port := int32(9500)
+	ar := newFakeAgentRuntime("fn", "default", v1alpha1.AgentRuntimeSpec{
+		PromptPackRef: v1alpha1.PromptPackRef{Name: "p"},
+		Mode:          "function",
+		Facade: v1alpha1.FacadeConfig{
+			Type: v1alpha1.FacadeTypeGRPC,
+			MCP:  &v1alpha1.MCPConfig{Enabled: true, Port: &port},
+		},
+	})
+	c := fake.NewClientBuilder().WithScheme(k8s.Scheme()).WithRuntimeObjects(ar, testNamespace(ar.Namespace)).Build()
+
+	cfg, err := LoadFromCRD(context.Background(), c, "fn", "default")
+	if err != nil {
+		t.Fatalf("LoadFromCRD: %v", err)
+	}
+	if !cfg.MCPEnabled {
+		t.Error("MCPEnabled: got false want true")
+	}
+	if cfg.MCPPort != 9500 {
+		t.Errorf("MCPPort: got %d want 9500", cfg.MCPPort)
+	}
+}
+
+func TestLoadMCPConfigFromCRD_DefaultPortWhenUnset(t *testing.T) {
+	ar := newFakeAgentRuntime("fn", "default", v1alpha1.AgentRuntimeSpec{
+		PromptPackRef: v1alpha1.PromptPackRef{Name: "p"},
+		Mode:          "function",
+		Facade: v1alpha1.FacadeConfig{
+			Type: v1alpha1.FacadeTypeGRPC,
+			MCP:  &v1alpha1.MCPConfig{Enabled: true},
+		},
+	})
+	c := fake.NewClientBuilder().WithScheme(k8s.Scheme()).WithRuntimeObjects(ar, testNamespace(ar.Namespace)).Build()
+
+	cfg, err := LoadFromCRD(context.Background(), c, "fn", "default")
+	if err != nil {
+		t.Fatalf("LoadFromCRD: %v", err)
+	}
+	if cfg.MCPPort != DefaultMCPPort {
+		t.Errorf("MCPPort default: got %d want %d", cfg.MCPPort, DefaultMCPPort)
+	}
+}
+
+func TestLoadFromEnvFallback_InvalidMCPPort(t *testing.T) {
+	t.Setenv(EnvMCPPort, "99999")
+	_, err := loadFromEnvFallback("agent", "ns")
+	if err == nil {
+		t.Fatal("expected error for invalid MCP port in env fallback")
+	}
+}
+
+func TestLoadMCPConfigFromCRD_NilMCP(t *testing.T) {
+	ar := newFakeAgentRuntime("fn", "default", v1alpha1.AgentRuntimeSpec{
+		PromptPackRef: v1alpha1.PromptPackRef{Name: "p"},
+		Facade: v1alpha1.FacadeConfig{
+			Type: v1alpha1.FacadeTypeWebSocket,
+			// MCP is nil
+		},
+	})
+	c := fake.NewClientBuilder().WithScheme(k8s.Scheme()).WithRuntimeObjects(ar, testNamespace(ar.Namespace)).Build()
+
+	cfg, err := LoadFromCRD(context.Background(), c, "fn", "default")
+	if err != nil {
+		t.Fatalf("LoadFromCRD: %v", err)
+	}
+	if cfg.MCPEnabled {
+		t.Error("MCPEnabled: got true want false")
+	}
+	if cfg.MCPPort != DefaultMCPPort {
+		t.Errorf("MCPPort default: got %d want %d", cfg.MCPPort, DefaultMCPPort)
+	}
+}


### PR DESCRIPTION
## Summary
- Plumb `MCPEnabled`/`MCPPort` through the agent binary's `Config` struct from both env (`OMNIA_MCP_ENABLED`, `OMNIA_MCP_PORT`) and the AgentRuntime CRD (`spec.facade.mcp.{enabled,port}`). Default port 9998 (Task 2 of #1124).
- Migrate the existing agent-side A2A reads to `spec.facade.a2a` via the `ProjectLegacyFacadeA2A` projection helper landed in #1134. Eliminates the `Spec.A2A is deprecated` warnings introduced by that PR. Legacy CRs with top-level `spec.a2a` still work — the projection runs at the top of `LoadFromCRD`.

No callers consume the new MCP fields yet — Task 7 (#1129) wires `runFunctionsFacade` to start the MCP server when enabled. This PR is pure plumbing.

Stacked on #1134. Refs: #1124.

## Test plan
- [x] `env GOWORK=off go test ./internal/agent/ -count=1` — passes (141 tests)
- [x] New cases cover: defaults, env-driven custom port, env out-of-range, env non-numeric, env zero, CRD with port, CRD default-port-when-unset, CRD with nil MCP
- [x] Coverage: `config.go` 97.6%, `config_crd.go` 91.2%
- [x] `env GOWORK=off go build ./...` — clean
- [x] Existing A2A CRD tests still pass through the projection path
