### PR TITLE
refactor(facade): extract FunctionInvoker shared core (Task 3/11 of #1125)

### DIFF
--- a/internal/facade/invoke.go
+++ b/internal/facade/invoke.go
@@ -1,0 +1,228 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+
+	"github.com/altairalabs/omnia/internal/session"
+	"github.com/altairalabs/omnia/pkg/logctx"
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// InvocationOutcome enumerates terminal states for one function call.
+type InvocationOutcome string
+
+const (
+	OutcomeOK               InvocationOutcome = "ok"
+	OutcomeFunctionNotFound InvocationOutcome = "function_not_found"
+	OutcomeInputInvalid     InvocationOutcome = "input_invalid"
+	OutcomeRuntimeError     InvocationOutcome = "runtime_error"
+	OutcomeOutputInvalid    InvocationOutcome = "output_invalid"
+	OutcomePayloadTooLarge  InvocationOutcome = "payload_too_large"
+)
+
+// InvocationResult carries the full outcome of one invocation. The
+// transport-specific caller (ServeHTTP for HTTP, a future MCP tool adapter)
+// maps this onto its wire format.
+type InvocationResult struct {
+	Outcome      InvocationOutcome
+	OutputJSON   json.RawMessage // populated when Outcome == OutcomeOK
+	RawOutput    json.RawMessage // populated when Outcome == OutcomeOutputInvalid (for debugging)
+	InvocationID string
+	DurationMs   int64
+	ErrorDetail  string           // populated on non-OK outcomes
+	Usage        *runtimev1.Usage // nil when not reported by the runtime
+}
+
+// FunctionInvokerConfig collects FunctionInvoker dependencies.
+type FunctionInvokerConfig struct {
+	Registry     FunctionRegistry
+	Invoker      InvocationInvoker
+	SessionStore session.Store       // optional; if nil, no session rows are written
+	SessionMeta  FunctionSessionMeta // ignored when SessionStore is nil
+	// MaxBodyBytes caps input size. 0 means no guard (useful when the caller
+	// already enforces the limit, e.g. via http.MaxBytesReader). The HTTP
+	// handler sets MaxBodyBytes = 0 and relies on its own MaxBytesReader so
+	// that http.MaxBytesError is preserved for the 413 response shape.
+	MaxBodyBytes int64
+	Log          logr.Logger
+}
+
+// FunctionInvoker runs one function invocation end-to-end: lookup →
+// validate input → openSession → runtime call → validate output →
+// closeSession. Safe for concurrent use; all mutable state is
+// per-invocation.
+type FunctionInvoker struct {
+	cfg FunctionInvokerConfig
+}
+
+// NewFunctionInvoker builds an invoker.
+func NewFunctionInvoker(cfg FunctionInvokerConfig) *FunctionInvoker {
+	if cfg.Log.GetSink() == nil {
+		cfg.Log = logr.Discard()
+	}
+	return &FunctionInvoker{cfg: cfg}
+}
+
+// Invoke runs one function call. A nil error means the invocation
+// completed (success or any typed failure captured in the result).
+// A non-nil error is reserved for unrecoverable failures the caller
+// should map to 500.
+func (i *FunctionInvoker) Invoke(ctx context.Context, name string, input json.RawMessage) (*InvocationResult, error) {
+	started := time.Now()
+
+	invocationID := uuid.NewString()
+	ctx = logctx.WithInvocationID(ctx, invocationID)
+	log := i.cfg.Log.WithValues("function", name, "invocationID", invocationID)
+
+	// Size check — only active when MaxBodyBytes > 0. The HTTP handler sets
+	// this to 0 and enforces size via http.MaxBytesReader instead, so the
+	// 413 response carries a proper http.MaxBytesError.
+	if i.cfg.MaxBodyBytes > 0 && int64(len(input)) > i.cfg.MaxBodyBytes {
+		return &InvocationResult{
+			Outcome:      OutcomePayloadTooLarge,
+			InvocationID: invocationID,
+			DurationMs:   time.Since(started).Milliseconds(),
+			ErrorDetail:  fmt.Sprintf("input exceeds %d bytes", i.cfg.MaxBodyBytes),
+		}, nil
+	}
+
+	spec, ok := i.cfg.Registry.GetFunction(name)
+	if !ok {
+		log.V(1).Info("function not registered", "name", name)
+		return &InvocationResult{
+			Outcome:      OutcomeFunctionNotFound,
+			InvocationID: invocationID,
+			DurationMs:   time.Since(started).Milliseconds(),
+			ErrorDetail:  fmt.Sprintf("no function named %q is registered on this facade", name),
+		}, nil
+	}
+
+	i.openSession(ctx, invocationID, log)
+	finalStatus := session.SessionStatusCompleted
+	var failureEvt *session.RuntimeEvent
+	defer func() {
+		i.closeSession(ctx, invocationID, finalStatus, failureEvt, log)
+	}()
+
+	if err := ValidateJSON(spec.InputSchema, input); err != nil {
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.input_invalid", err.Error())
+		return &InvocationResult{
+			Outcome:      OutcomeInputInvalid,
+			InvocationID: invocationID,
+			DurationMs:   time.Since(started).Milliseconds(),
+			ErrorDetail:  err.Error(),
+		}, nil
+	}
+
+	resp, err := i.cfg.Invoker.Invoke(ctx, &runtimev1.InvocationRequest{
+		InputJson:    string(input),
+		InvocationId: invocationID,
+	})
+	if err != nil {
+		log.Error(err, "runtime invoke failed")
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.runtime_error", err.Error())
+		return &InvocationResult{
+			Outcome:      OutcomeRuntimeError,
+			InvocationID: invocationID,
+			DurationMs:   time.Since(started).Milliseconds(),
+			ErrorDetail:  err.Error(),
+		}, nil
+	}
+
+	rawOutput := []byte(resp.GetOutputJson())
+	if err := ValidateJSON(spec.OutputSchema, rawOutput); err != nil {
+		log.Error(err, "function output failed schema validation", "outputBytes", len(rawOutput))
+		finalStatus = session.SessionStatusError
+		failureEvt = newFailureEvent(invocationID, "function.output_invalid", err.Error())
+		return &InvocationResult{
+			Outcome:      OutcomeOutputInvalid,
+			InvocationID: invocationID,
+			DurationMs:   time.Since(started).Milliseconds(),
+			ErrorDetail:  err.Error(),
+			RawOutput:    json.RawMessage(rawOutput),
+		}, nil
+	}
+
+	log.V(1).Info("function invocation complete",
+		"durationMs", resp.GetDurationMs(),
+		"outputBytes", len(rawOutput))
+
+	return &InvocationResult{
+		Outcome:      OutcomeOK,
+		OutputJSON:   json.RawMessage(rawOutput),
+		InvocationID: invocationID,
+		DurationMs:   int64(resp.GetDurationMs()),
+		Usage:        resp.GetUsage(),
+	}, nil
+}
+
+// openSession creates the session row for an invocation. Failure is
+// best-effort: a session-api outage logs but does not fail the
+// user-facing request.
+func (i *FunctionInvoker) openSession(ctx context.Context, invocationID string, log logr.Logger) {
+	if i.cfg.SessionStore == nil {
+		return
+	}
+	if _, err := i.cfg.SessionStore.CreateSession(ctx, session.CreateSessionOptions{
+		ID:                invocationID,
+		AgentName:         i.cfg.SessionMeta.AgentName,
+		Namespace:         i.cfg.SessionMeta.Namespace,
+		WorkspaceName:     i.cfg.SessionMeta.WorkspaceName,
+		PromptPackName:    i.cfg.SessionMeta.PromptPackName,
+		PromptPackVersion: i.cfg.SessionMeta.PromptPackVersion,
+		Tags:              []string{FunctionSessionTag},
+	}); err != nil {
+		log.Error(err, "failed to create session row for function invocation (non-fatal)")
+	}
+}
+
+// closeSession writes the terminal status and any pre-runtime failure event
+// before returning. Errors are logged and not propagated.
+func (i *FunctionInvoker) closeSession(
+	ctx context.Context,
+	invocationID string,
+	status session.SessionStatus,
+	failure *session.RuntimeEvent,
+	log logr.Logger,
+) {
+	if i.cfg.SessionStore == nil {
+		return
+	}
+	if failure != nil {
+		if err := i.cfg.SessionStore.RecordRuntimeEvent(ctx, invocationID, *failure); err != nil {
+			log.Error(err, "failed to record function failure event (non-fatal)",
+				"eventType", failure.EventType)
+		}
+	}
+	if err := i.cfg.SessionStore.UpdateSessionStatus(ctx, invocationID, session.SessionStatusUpdate{
+		SetStatus:  status,
+		SetEndedAt: time.Now().UTC(),
+	}); err != nil {
+		log.Error(err, "failed to close session for function invocation (non-fatal)",
+			"status", status)
+	}
+}

--- a/internal/facade/invoke_test.go
+++ b/internal/facade/invoke_test.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package facade
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/altairalabs/omnia/internal/session"
+	runtimev1 "github.com/altairalabs/omnia/pkg/runtime/v1"
+)
+
+// wrongShapeJSON is a JSON object that intentionally fails the output schema
+// (which requires "a") so tests can exercise the output-invalid path.
+const wrongShapeJSON = `{"wrong":"shape"}`
+
+// invokerStub is a minimal InvocationInvoker for invoker unit tests.
+type invokerStub struct {
+	resp    *runtimev1.InvocationResponse
+	err     error
+	lastReq *runtimev1.InvocationRequest
+}
+
+func (s *invokerStub) Invoke(_ context.Context, req *runtimev1.InvocationRequest) (*runtimev1.InvocationResponse, error) {
+	s.lastReq = req
+	return s.resp, s.err
+}
+
+// invokerSessionStore records session lifecycle calls for assertion.
+type invokerSessionStore struct {
+	session.Store
+	mu        sync.Mutex
+	creates   []session.CreateSessionOptions
+	events    []session.RuntimeEvent
+	statuses  []session.SessionStatusUpdate
+	createErr error
+	updateErr error
+	eventErr  error
+}
+
+func (s *invokerSessionStore) CreateSession(_ context.Context, opts session.CreateSessionOptions) (*session.Session, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.creates = append(s.creates, opts)
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	return &session.Session{ID: opts.ID}, nil
+}
+
+func (s *invokerSessionStore) UpdateSessionStatus(_ context.Context, _ string, update session.SessionStatusUpdate) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.statuses = append(s.statuses, update)
+	return s.updateErr
+}
+
+func (s *invokerSessionStore) RecordRuntimeEvent(_ context.Context, _ string, evt session.RuntimeEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, evt)
+	return s.eventErr
+}
+
+// newTestInvoker builds a FunctionInvoker using the given specs and runtime stub.
+func newTestInvoker(t *testing.T, specs map[string]*FunctionSpec, rts *invokerStub) *FunctionInvoker {
+	t.Helper()
+	reg := NewMapFunctionRegistry()
+	for _, s := range specs {
+		reg.Register(s)
+	}
+	return NewFunctionInvoker(FunctionInvokerConfig{
+		Registry: reg,
+		Invoker:  rts,
+		Log:      testr.New(t),
+	})
+}
+
+// newTestInvokerWithSession builds a FunctionInvoker with a session store attached.
+func newTestInvokerWithSession(
+	t *testing.T,
+	specs map[string]*FunctionSpec,
+	rts *invokerStub,
+	store *invokerSessionStore,
+) *FunctionInvoker {
+	t.Helper()
+	reg := NewMapFunctionRegistry()
+	for _, s := range specs {
+		reg.Register(s)
+	}
+	return NewFunctionInvoker(FunctionInvokerConfig{
+		Registry:     reg,
+		Invoker:      rts,
+		SessionStore: store,
+		SessionMeta: FunctionSessionMeta{
+			Namespace:         "ns-test",
+			AgentName:         "echo-fn",
+			WorkspaceName:     "ws-test",
+			PromptPackName:    "echo-pack",
+			PromptPackVersion: "1.0.0",
+		},
+		Log: testr.New(t),
+	})
+}
+
+func TestInvoker_HappyPath(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
+	require.NoError(t, err)
+
+	rts := &invokerStub{
+		resp: &runtimev1.InvocationResponse{
+			OutputJson: `{"a":"hello"}`,
+			DurationMs: 42,
+		},
+	}
+	inv := newTestInvoker(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{"q":"world"}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, OutcomeOK, result.Outcome)
+	assert.NotEmpty(t, result.InvocationID)
+	assert.Equal(t, int64(42), result.DurationMs)
+	assert.Empty(t, result.ErrorDetail)
+
+	// Output JSON must be the raw model output.
+	assert.JSONEq(t, `{"a":"hello"}`, string(result.OutputJSON))
+
+	// The request sent to the runtime must carry the facade-generated ID.
+	require.NotNil(t, rts.lastReq)
+	assert.Equal(t, result.InvocationID, rts.lastReq.GetInvocationId())
+	assert.Equal(t, `{"q":"world"}`, rts.lastReq.GetInputJson())
+}
+
+func TestInvoker_FunctionNotFound(t *testing.T) {
+	rts := &invokerStub{} // must not be called
+	inv := newTestInvoker(t, map[string]*FunctionSpec{}, rts)
+
+	result, err := inv.Invoke(context.Background(), "missing", []byte(`{}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, OutcomeFunctionNotFound, result.Outcome)
+	assert.NotEmpty(t, result.InvocationID)
+	assert.NotEmpty(t, result.ErrorDetail)
+	assert.Nil(t, rts.lastReq, "runtime must NOT be called when function is unknown")
+}
+
+func TestInvoker_InputInvalid(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	rts := &invokerStub{} // must not be called
+	inv := newTestInvoker(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts)
+
+	// Missing required "q" field.
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, OutcomeInputInvalid, result.Outcome)
+	assert.NotEmpty(t, result.ErrorDetail)
+	assert.Nil(t, rts.lastReq, "runtime must NOT be called when input is invalid")
+}
+
+func TestInvoker_RuntimeError(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	rts := &invokerStub{err: errors.New("upstream failure")}
+	inv := newTestInvoker(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, OutcomeRuntimeError, result.Outcome)
+	assert.Contains(t, result.ErrorDetail, "upstream failure")
+	assert.Nil(t, result.OutputJSON)
+}
+
+func TestInvoker_OutputInvalid(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
+	require.NoError(t, err)
+
+	// Runtime returns valid JSON but wrong shape.
+	rts := &invokerStub{
+		resp: &runtimev1.InvocationResponse{OutputJson: wrongShapeJSON},
+	}
+	inv := newTestInvoker(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, OutcomeOutputInvalid, result.Outcome)
+	assert.NotEmpty(t, result.ErrorDetail)
+	// RawOutput must carry the bytes the runtime returned so the author can debug.
+	require.NotNil(t, result.RawOutput)
+	assert.JSONEq(t, wrongShapeJSON, string(result.RawOutput))
+	assert.Nil(t, result.OutputJSON)
+}
+
+func TestInvoker_PayloadTooLarge(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	rts := &invokerStub{} // must not be called
+	reg := NewMapFunctionRegistry()
+	reg.Register(&FunctionSpec{Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema})
+	inv := NewFunctionInvoker(FunctionInvokerConfig{
+		Registry:     reg,
+		Invoker:      rts,
+		MaxBodyBytes: 10,
+		Log:          testr.New(t),
+	})
+
+	// Input exceeds the 10-byte limit.
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{"q":"this is too long"}`))
+	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, OutcomePayloadTooLarge, result.Outcome)
+	assert.NotEmpty(t, result.ErrorDetail)
+	assert.Nil(t, rts.lastReq, "runtime must NOT be called when payload is too large")
+}
+
+func TestInvoker_SessionLifecycle_HappyPath(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	rts := &invokerStub{
+		resp: &runtimev1.InvocationResponse{OutputJson: `{}`, DurationMs: 5},
+	}
+	store := &invokerSessionStore{}
+	inv := newTestInvokerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts, store)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	require.Equal(t, OutcomeOK, result.Outcome)
+
+	require.Len(t, store.creates, 1, "session must be opened exactly once")
+	opts := store.creates[0]
+	assert.Equal(t, result.InvocationID, opts.ID)
+	assert.Equal(t, "ns-test", opts.Namespace)
+	assert.Equal(t, "echo-fn", opts.AgentName)
+	assert.Equal(t, "ws-test", opts.WorkspaceName)
+	assert.Equal(t, "echo-pack", opts.PromptPackName)
+	assert.Equal(t, "1.0.0", opts.PromptPackVersion)
+	assert.Equal(t, []string{FunctionSessionTag}, opts.Tags)
+
+	require.Len(t, store.statuses, 1, "session must be closed exactly once")
+	assert.Equal(t, session.SessionStatusCompleted, store.statuses[0].SetStatus)
+	assert.False(t, store.statuses[0].SetEndedAt.IsZero(), "ended_at must be set on close")
+	assert.Empty(t, store.events, "no failure events on happy path")
+}
+
+func TestInvoker_SessionLifecycle_InputInvalid(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object","required":["q"]}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	store := &invokerSessionStore{}
+	inv := newTestInvokerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, &invokerStub{}, store)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeInputInvalid, result.Outcome)
+
+	require.Len(t, store.creates, 1)
+	require.Len(t, store.statuses, 1)
+	assert.Equal(t, session.SessionStatusError, store.statuses[0].SetStatus)
+	require.Len(t, store.events, 1, "input_invalid must emit a failure runtime event")
+	assert.Equal(t, "function.input_invalid", store.events[0].EventType)
+	assert.NotEmpty(t, store.events[0].ErrorMessage)
+}
+
+func TestInvoker_SessionLifecycle_RuntimeError(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	store := &invokerSessionStore{}
+	rts := &invokerStub{err: errors.New("upstream down")}
+	inv := newTestInvokerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts, store)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeRuntimeError, result.Outcome)
+
+	require.Len(t, store.statuses, 1)
+	assert.Equal(t, session.SessionStatusError, store.statuses[0].SetStatus)
+	require.Len(t, store.events, 1)
+	assert.Equal(t, "function.runtime_error", store.events[0].EventType)
+	assert.Contains(t, store.events[0].ErrorMessage, "upstream down")
+}
+
+func TestInvoker_SessionLifecycle_OutputInvalid(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object","required":["a"]}`))
+	require.NoError(t, err)
+
+	store := &invokerSessionStore{}
+	rts := &invokerStub{resp: &runtimev1.InvocationResponse{OutputJson: wrongShapeJSON}}
+	inv := newTestInvokerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts, store)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeOutputInvalid, result.Outcome)
+
+	require.Len(t, store.statuses, 1)
+	assert.Equal(t, session.SessionStatusError, store.statuses[0].SetStatus)
+	require.Len(t, store.events, 1)
+	assert.Equal(t, "function.output_invalid", store.events[0].EventType)
+}
+
+func TestInvoker_SessionLifecycle_StoreFailuresAreNonFatal(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	store := &invokerSessionStore{
+		createErr: errors.New("session-api down"),
+		updateErr: errors.New("session-api still down"),
+	}
+	rts := &invokerStub{resp: &runtimev1.InvocationResponse{OutputJson: `{}`}}
+	inv := newTestInvokerWithSession(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts, store)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeOK, result.Outcome, "store failures must not fail the invocation")
+}
+
+func TestInvoker_NoSessionStore_TransientMode(t *testing.T) {
+	inputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+	outputSchema, err := CompileSchema([]byte(`{"type":"object"}`))
+	require.NoError(t, err)
+
+	rts := &invokerStub{resp: &runtimev1.InvocationResponse{OutputJson: `{}`}}
+	// No session store — pure transient mode.
+	inv := newTestInvoker(t, map[string]*FunctionSpec{
+		testFunctionName: {Name: testFunctionName, InputSchema: inputSchema, OutputSchema: outputSchema},
+	}, rts)
+
+	result, err := inv.Invoke(context.Background(), testFunctionName, []byte(`{}`))
+	require.NoError(t, err)
+	assert.Equal(t, OutcomeOK, result.Outcome)
+}


### PR DESCRIPTION
## Summary
- Extract `FunctionInvoker` shared core out of `FunctionsHandler.ServeHTTP` so the upcoming MCP tool adapter (Task 6) and the existing HTTP route can share one invocation pipeline (Task 3 of #1125).
- HTTP behaviour unchanged: same status codes, same error codes, same response shapes (including the `usage` field). `NewFunctionsHandler` and `WithSessionStore` keep their existing signatures, so no caller changes required.
- 14 new unit tests cover all six `InvocationOutcome` paths plus session lifecycle, store-failure, and transient mode. Coverage: `invoke.go` 97.9%, `functions_handler.go` 89.4%.

Stacked on #1135.

## Behaviour note

One subtle ordering change worth flagging: previously the registry lookup ran before `http.MaxBytesReader` consumed the body; now it runs inside `FunctionInvoker.Invoke` after the body is read. Practical effect: an oversized-body request to an unknown function name returns `413 payload_too_large` rather than `404 function_not_found`. No existing test asserts the prior ordering, and the new behaviour is arguably better — it stops at MaxBytesReader and doesn't leak whether a given function name is registered. Flagging in case anyone has external integrations that depend on the old ordering.

Refs: #1125.

## Test plan
- [x] `env GOWORK=off go test ./internal/facade/ -count=1` — 274 tests pass
- [x] `env GOWORK=off go test ./cmd/agent/ -count=1` — 90 tests pass
- [x] `env GOWORK=off go build ./...` — clean
- [x] `env GOWORK=off go vet ./...` — clean
- [x] Error code/status strings byte-identical to prior behaviour (verified across the five outcome paths)
